### PR TITLE
Expose render methods

### DIFF
--- a/src/InlineRenderer.ts
+++ b/src/InlineRenderer.ts
@@ -10,7 +10,7 @@ export class InlineRenderer {
         );
     }
 
-    private renderer = this.markdownPostProcessor.bind(this);
+    public renderer = this.markdownPostProcessor.bind(this);
 
     private async markdownPostProcessor(
         element: HTMLElement,

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -28,7 +28,7 @@ export class QueryRenderer {
         );
     }
 
-    private renderer = this.addQueryRenderChild.bind(this);
+    public renderer = this.addQueryRenderChild.bind(this);
 
     private async addQueryRenderChild(
         source: string,

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,8 @@ import { SettingsTab } from './SettingsTab';
 
 export default class TasksPlugin extends Plugin {
     private cache: Cache | undefined;
-    private inlineRenderer: InlineRenderer | undefined;
-    private queryRenderer: QueryRenderer | undefined;
+    public inlineRenderer: InlineRenderer | undefined;
+    public queryRenderer: QueryRenderer | undefined;
 
     async onload() {
         console.log('loading plugin "tasks"');


### PR DESCRIPTION
This is in regard to the discussion here: https://github.com/schemar/obsidian-tasks/discussions/361

This PR exposes the rendering methods for the query and inline renderer classes. It allows usage of the methods externally like this:

```js
const code = "due after 2021-10-20"
const el = document.createElement("div");
const ctx = new Component();
const renderer = this.app.plugins.getPlugin("obsidian-tasks-plugin").queryRenderer.renderer
renderer(code, el, ctx);
```