### PR TITLE
obsidian-reminders modal

### DIFF
--- a/src/Commands/CreateOrEdit.ts
+++ b/src/Commands/CreateOrEdit.ts
@@ -80,6 +80,7 @@ const taskFromLine = ({ line, path }: { line: string; path: string }): Task => {
             sectionIndex: 0,
             precedingHeader: null,
             blockLink: '',
+            reminderTime: null,
         });
     }
 
@@ -107,6 +108,7 @@ const taskFromLine = ({ line, path }: { line: string; path: string }): Task => {
         scheduledDate: null,
         dueDate: null,
         doneDate: null,
+        reminderTime: null,
         recurrence: null,
         // We don't need the following fields to edit here in the editor.
         sectionStart: 0,

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -1,11 +1,13 @@
 export interface Settings {
     globalFilter: string;
     removeGlobalFilter: boolean;
+    reminder: boolean; //To activate the reminder input
 }
 
 const defaultSettings: Settings = {
     globalFilter: '',
     removeGlobalFilter: false,
+    reminder: false,
 };
 
 let settings: Settings = { ...defaultSettings };

--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -64,5 +64,25 @@ export class SettingsTab extends PluginSettingTab {
                         await this.plugin.saveSettings();
                     });
             });
+
+        containerEl.createEl('div', {
+            cls: 'setting-item-description',
+            text: 'Enable reminder on edit/create task (requires obsidian-reminder plugin)',
+        });
+
+        new Setting(containerEl)
+            .setName('Enable reminder on edit/creat task')
+            .setDesc(
+                'Enable reminder on edit/create task (requires obsidian-reminder plugin)',
+            )
+            .addToggle((toggle) => {
+                const settings = getSettings();
+
+                toggle.setValue(settings.reminder).onChange(async (value) => {
+                    updateSettings({ reminder: value });
+
+                    await this.plugin.saveSettings();
+                });
+            });
     }
 }

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -320,7 +320,7 @@
                 bind:value={editableTask.recurrenceRule}
                 id="description"
                 type="text"
-                placeholder="I've changed this"
+                placeholder="Try 'every 2 weeks on Thursday'."
             />
             <code>🔁 {@html parsedRecurrence}</code>
         </div>

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -180,7 +180,9 @@
             var elem = document.getElementById('task-modal-reminder');
 
             if (elem) {
-                elem.parentNode.removeChild(elem);
+                if (elem.parentNode) {
+                    elem.parentNode.removeChild(elem);
+                }
             }
         }
         setTimeout(() => {

--- a/styles.css
+++ b/styles.css
@@ -6,8 +6,8 @@
 /* Pencil icon. */
 .tasks-edit {
     background-color: var(--text-faint);
-    mask-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20aria-hidden%3D%22true%22%20focusable%3D%22false%22%20width%3D%221em%22%20height%3D%221em%22%20style%3D%22-ms-transform%3A%20rotate(360deg)%3B%20-webkit-transform%3A%20rotate(360deg)%3B%20transform%3A%20rotate(360deg)%3B%22%20preserveAspectRatio%3D%22xMidYMid%20meet%22%20viewBox%3D%220%200%201536%201536%22%3E%3Cpath%20d%3D%22M363%201408l91-91l-235-235l-91%2091v107h128v128h107zm523-928q0-22-22-22q-10%200-17%207l-542%20542q-7%207-7%2017q0%2022%2022%2022q10%200%2017-7l542-542q7-7%207-17zm-54-192l416%20416l-832%20832H0v-416zm683%2096q0%2053-37%2090l-166%20166l-416-416l166-165q36-38%2090-38q53%200%2091%2038l235%20234q37%2039%2037%2091z%22%20fill%3D%22%23626262%22%2F%3E%3C%2Fsvg%3E");
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20aria-hidden%3D%22true%22%20focusable%3D%22false%22%20width%3D%221em%22%20height%3D%221em%22%20style%3D%22-ms-transform%3A%20rotate(360deg)%3B%20-webkit-transform%3A%20rotate(360deg)%3B%20transform%3A%20rotate(360deg)%3B%22%20preserveAspectRatio%3D%22xMidYMid%20meet%22%20viewBox%3D%220%200%201536%201536%22%3E%3Cpath%20d%3D%22M363%201408l91-91l-235-235l-91%2091v107h128v128h107zm523-928q0-22-22-22q-10%200-17%207l-542%20542q-7%207-7%2017q0%2022%2022%2022q10%200%2017-7l542-542q7-7%207-17zm-54-192l416%20416l-832%20832H0v-416zm683%2096q0%2053-37%2090l-166%20166l-416-416l166-165q36-38%2090-38q53%200%2091%2038l235%20234q37%2039%2037%2091z%22%20fill%3D%22%23626262%22%2F%3E%3C%2Fsvg%3E");
+    mask-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20aria-hidden%3D%22true%22%20focusable%3D%22false%22%20width%3D%221em%22%20height%3D%221em%22%20style%3D%22-ms-transform%3A%20rotate(360deg)%3B%20-webkit-transform%3A%20rotate(360deg)%3B%20transform%3A%20rotate(360deg)%3B%22%20preserveAspectRatio%3D%22xMidYMid%20meet%22%20viewBox%3D%220%200%201536%201536%22%3E%3Cpath%20d%3D%22M363%201408l91-91l-235-235l-91%2091v107h128v128h107zm523-928q0-22-22-22q-10%200-17%207l-542%20542q-7%207-7%2017q0%2022%2022%2022q10%200%2017-7l542-542q7-7%207-17zm-54-192l416%20416l-832%20832H0v-416zm683%2096q0%2053-37%2090l-166%20166l-416-416l166-165q36-38%2090-38q53%200%2091%2038l235%20234q37%2039%2037%2091z%22%20fill%3D%22%23626262%22%2F%3E%3C%2Fsvg%3E');
+    -webkit-mask-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20aria-hidden%3D%22true%22%20focusable%3D%22false%22%20width%3D%221em%22%20height%3D%221em%22%20style%3D%22-ms-transform%3A%20rotate(360deg)%3B%20-webkit-transform%3A%20rotate(360deg)%3B%20transform%3A%20rotate(360deg)%3B%22%20preserveAspectRatio%3D%22xMidYMid%20meet%22%20viewBox%3D%220%200%201536%201536%22%3E%3Cpath%20d%3D%22M363%201408l91-91l-235-235l-91%2091v107h128v128h107zm523-928q0-22-22-22q-10%200-17%207l-542%20542q-7%207-7%2017q0%2022%2022%2022q10%200%2017-7l542-542q7-7%207-17zm-54-192l416%20416l-832%20832H0v-416zm683%2096q0%2053-37%2090l-166%20166l-416-416l166-165q36-38%2090-38q53%200%2091%2038l235%20234q37%2039%2037%2091z%22%20fill%3D%22%23626262%22%2F%3E%3C%2Fsvg%3E');
     display: inline-block;
     width: 1em;
     height: 1em;
@@ -36,7 +36,7 @@
     margin: 5px 0 5px 0;
 }
 
-.tasks-modal input[type=text] {
+.tasks-modal input[type='text'] {
     width: 100%;
 }
 

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -23,6 +23,7 @@ describe('Query', () => {
                     doneDate: null,
                     recurrence: null,
                     blockLink: '',
+                    reminderTime: null,
                 }),
                 new Task({
                     status: Status.Todo,
@@ -40,6 +41,7 @@ describe('Query', () => {
                     doneDate: null,
                     recurrence: null,
                     blockLink: '',
+                    reminderTime: null,
                 }),
             ];
             const input = 'path includes ab/c d';


### PR DESCRIPTION
I love this plugin, I've been using it for a long time. It has almost everything that I wanted from obsidian (I came from a Notion environment), however, I wanted to have reminders for my tasks.

Using the workaround described [here](https://schemar.github.io/obsidian-tasks/advanced/notifications/), I decided to modify the modal when creating/editing task with an option to add a reminder from obsidian-reminder plugin.

It uses the alarm clock emoji, the panel now looks like this:

![image](https://user-images.githubusercontent.com/32461753/143670730-0819ec98-d2ff-4109-ad36-53d41f1a61fa.png)

The created task looks like this:

![image](https://user-images.githubusercontent.com/32461753/143670735-f6688eb6-3a0d-48b1-ba54-4eda442c074d.png)

And the reminders plugin automatically recognizes the task as reminder:

![image](https://user-images.githubusercontent.com/32461753/143670751-c34a9686-7426-45f3-9635-5c714ac92d92.png)

As not everybody uses obsidian-reminders, I added an option to hide the reminders input in the create/edit task modal. It is hidden by default:

![image](https://user-images.githubusercontent.com/32461753/143670808-f28e4b38-6a88-42a4-8f86-4c0fd11a1f6d.png)

If it is false, it leaves the modal as before.


Thanks for this awesome plugin, I hope you like this.

