### PR TITLE
Recognize date backlinks

### DIFF
--- a/src/Task.ts
+++ b/src/Task.ts
@@ -52,10 +52,14 @@ export class Task {
     // The following regexes end with `$` because they will be matched and
     // removed from the end until none are left.
     public static readonly priorityRegex = /([⏫🔼🔽])$/u;
-    public static readonly startDateRegex = /🛫 ?(\d{4}-\d{2}-\d{2})$/u;
-    public static readonly scheduledDateRegex = /[⏳⌛] ?(\d{4}-\d{2}-\d{2})$/u;
-    public static readonly dueDateRegex = /[📅📆🗓] ?(\d{4}-\d{2}-\d{2})$/u;
-    public static readonly doneDateRegex = /✅ ?(\d{4}-\d{2}-\d{2})$/u;
+    public static readonly startDateRegex =
+        /🛫 ?(?:\[\[)?(\d{4}-\d{2}-\d{2})(?:\]\])?$/u;
+    public static readonly scheduledDateRegex =
+        /[⏳⌛] ?(?:\[\[)?(\d{4}-\d{2}-\d{2})(?:\]\])?$/u;
+    public static readonly dueDateRegex =
+        /[📅📆🗓] ?(?:\[\[)?(\d{4}-\d{2}-\d{2})(?:\]\])?$/u;
+    public static readonly doneDateRegex =
+        /✅ ?(?:\[\[)?(\d{4}-\d{2}-\d{2})(?:\]\])?$/u;
     public static readonly recurrenceRegex = /🔁([a-zA-Z0-9, !]+)$/u;
     public static readonly blockLinkRegex = / \^[a-zA-Z0-9-]+$/u;
 


### PR DESCRIPTION
First, thank you very much for your work on this plugin!

This PR changes Obsidian Tasks to recognize dates as backlinks (i.e., in Done, Due, and Scheduled dates). It does not change the plugin itself to _generate_ backlinks (I figured that that could come later, if it were a desired feature). Rather, the use-case I have in mind is for anyone using the _query_ functionality of the plugin, but generating task text outside of the plugin.

All tests still pass. Backlink markers are included in non-capture groups and are marked as optional in the relevant date regexes.