### PR TITLE
feat: Add date abbreviations to 'Create or edit Task' modal

### DIFF
--- a/src/Abbrev.ts
+++ b/src/Abbrev.ts
@@ -1,0 +1,10 @@
+// Abbreviations for entering dates with chrono
+export default {
+    td: 'today',
+    tm: 'tomorrow',
+    yd: 'yesterday',
+    tw: 'this week',
+    nw: 'next week',
+    weekend: 'sat',
+    we: 'sat',
+};

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -36,6 +36,13 @@
     let parsedRecurrence: string = '';
     let parsedDone: string = '';
 
+    function doAutocomplete(date: string): string {
+        for (let [key, val] of Object.entries(Abbrev)) {
+            date = date.replace(RegExp(`\\b${key}\\s`), val);
+        }
+        return date;
+    }
+
     function parseDate(
         type: 'start' | 'scheduled' | 'due' | 'done',
         date: string,
@@ -43,9 +50,6 @@
     ): string {
         if (!date) {
             return `<i>no ${type} date</i>`;
-        }
-        for (let [key, val] of Object.entries(Abbrev)) {
-            date = date.replace(RegExp(`\\b${key}\\b`), val);
         }
         const parsed = chrono.parseDate(date, forwardDate, {
             forwardDate: forwardDate != undefined,
@@ -57,6 +61,9 @@
     }
 
     $: {
+        console.log(editableTask.startDate);
+        editableTask.startDate = doAutocomplete(editableTask.startDate);
+        console.log(editableTask.startDate);
         parsedStartDate = parseDate(
             'start',
             editableTask.startDate,
@@ -65,6 +72,7 @@
     }
 
     $: {
+        editableTask.scheduledDate = doAutocomplete(editableTask.scheduledDate);
         parsedScheduledDate = parseDate(
             'scheduled',
             editableTask.scheduledDate,
@@ -73,6 +81,7 @@
     }
 
     $: {
+        editableTask.dueDate = doAutocomplete(editableTask.dueDate);
         parsedDueDate = parseDate('due', editableTask.dueDate, new Date());
     }
 

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -45,10 +45,8 @@
             return `<i>no ${type} date</>`;
         }
         for (let [key, val] of Object.entries(Abbrev)) {
-            console.log(key + val);
             date = date.replace(RegExp(`\\b${key}\\b`), val);
         }
-        console.log(date);
         const parsed = chrono.parseDate(date, forwardDate, {
             forwardDate: forwardDate != undefined,
         });

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -42,7 +42,7 @@
         forwardDate: Date | undefined = undefined,
     ): string {
         if (!date) {
-            return `<i>no ${type} date</>`;
+            return `<i>no ${type} date</i>`;
         }
         for (let [key, val] of Object.entries(Abbrev)) {
             date = date.replace(RegExp(`\\b${key}\\b`), val);
@@ -53,7 +53,7 @@
         if (parsed !== null) {
             return window.moment(parsed).format('YYYY-MM-DD');
         }
-        return `<i>invalid ${type} date</>`;
+        return `<i>invalid ${type} date</i>`;
     }
 
     $: {

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -4,6 +4,7 @@
     import { Recurrence } from '../Recurrence';
     import { getSettings } from '../Settings';
     import { Priority, Status, Task } from '../Task';
+    import Abbrev from '../Abbrev';
 
     export let task: Task;
     export let onSubmit: (updatedTasks: Task[]) => void | Promise<void>;
@@ -35,59 +36,46 @@
     let parsedRecurrence: string = '';
     let parsedDone: string = '';
 
-    $: {
-        if (!editableTask.startDate) {
-            parsedStartDate = '<i>no start date</>';
-        } else {
-            const parsed = chrono.parseDate(
-                editableTask.startDate,
-                new Date(),
-                {
-                    forwardDate: true,
-                },
-            );
-            if (parsed !== null) {
-                parsedStartDate = window.moment(parsed).format('YYYY-MM-DD');
-            } else {
-                parsedStartDate = '<i>invalid start date</i>';
-            }
+    function parseDate(
+        type: 'start' | 'scheduled' | 'due' | 'done',
+        date: string,
+        forwardDate: Date | undefined = undefined,
+    ): string {
+        if (!date) {
+            return `<i>no ${type} date</>`;
         }
+        for (let [key, val] of Object.entries(Abbrev)) {
+            console.log(key + val);
+            date = date.replace(RegExp(`\\b${key}\\b`), val);
+        }
+        console.log(date);
+        const parsed = chrono.parseDate(date, forwardDate, {
+            forwardDate: forwardDate != undefined,
+        });
+        if (parsed !== null) {
+            return window.moment(parsed).format('YYYY-MM-DD');
+        }
+        return `<i>invalid ${type} date</>`;
     }
 
     $: {
-        if (!editableTask.scheduledDate) {
-            parsedScheduledDate = '<i>no scheduled date</>';
-        } else {
-            const parsed = chrono.parseDate(
-                editableTask.scheduledDate,
-                new Date(),
-                {
-                    forwardDate: true,
-                },
-            );
-            if (parsed !== null) {
-                parsedScheduledDate = window
-                    .moment(parsed)
-                    .format('YYYY-MM-DD');
-            } else {
-                parsedScheduledDate = '<i>invalid scheduled date</i>';
-            }
-        }
+        parsedStartDate = parseDate(
+            'start',
+            editableTask.startDate,
+            new Date(),
+        );
     }
 
     $: {
-        if (!editableTask.dueDate) {
-            parsedDueDate = '<i>no due date</>';
-        } else {
-            const parsed = chrono.parseDate(editableTask.dueDate, new Date(), {
-                forwardDate: true,
-            });
-            if (parsed !== null) {
-                parsedDueDate = window.moment(parsed).format('YYYY-MM-DD');
-            } else {
-                parsedDueDate = '<i>invalid due date</i>';
-            }
-        }
+        parsedScheduledDate = parseDate(
+            'scheduled',
+            editableTask.scheduledDate,
+            new Date(),
+        );
+    }
+
+    $: {
+        parsedDueDate = parseDate('due', editableTask.dueDate, new Date());
     }
 
     $: {
@@ -106,16 +94,7 @@
     }
 
     $: {
-        if (!editableTask.doneDate) {
-            parsedDone = '<i>no done date</i>';
-        } else {
-            const parsed = chrono.parseDate(editableTask.doneDate);
-            if (parsed !== null) {
-                parsedDone = window.moment(parsed).format('YYYY-MM-DD');
-            } else {
-                parsedDone = '<i>invalid done date</i>';
-            }
-        }
+        parsedDone = parseDate('done', editableTask.doneDate);
     }
 
     onMount(() => {


### PR DESCRIPTION
Adds a quicker way to insert dates in the GUI with abbreviations
Best way would probably to extend chrono, but a small table with Regex replacements does the job easily:
```js
{
    td: 'today',
    tm: 'tomorrow',
    yd: 'yesterday',
    tw: 'this week',
    nw: 'next week',
    weekend: 'sat',
    we: 'sat',
}
```
Additionally I refactored the date parsing into its own function.
