### PR TITLE
docs: Fix 'How does Tasks handle status changes?' formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,15 +97,15 @@ You can toggle a task‘s status by:
 
 The code is located as follows:
 
-- For 1.: ``./src/Commands/ToggleDone.ts`
-- 2. and 4. use a checkbox created by `Task.toLi()`. There, the checkbox gets a click event handler.
+- For 1.: `./src/Commands/ToggleDone.ts`
+- Numbers 2. and 4. use a checkbox created by `Task.toLi()`. There, the checkbox gets a click event handler.
 - For 3.: `./src/LivePreviewExtension.ts`
 
 Toggle behavior:
 
-- 1. toggles the line directly where the cursor is. In the file inside Obsidian‘s vault.
-- The click event listener of 2. and 4. uses File::replaceTaskWithTasks(). That, in turn, updates the file in Obsidian‘s Vault (like 1, but it needs to find the correct line).
-- 3. toggles the line directly where the checkbox is. On the „document“ of CodeMirror (the library that Obsidian uses to show text on screen). That, in turn, updates the file in Obsidian‘s Vault, somehow.
+- Number 1. toggles the line directly where the cursor is. In the file inside Obsidian‘s vault.
+- The click event listener of 2. and 4. uses `File::replaceTaskWithTasks()`. That, in turn, updates the file in Obsidian‘s Vault (like 1, but it needs to find the correct line).
+- Number 3. toggles the line directly where the checkbox is. On the „document“ of CodeMirror (the library that Obsidian uses to show text on screen). That, in turn, updates the file in Obsidian‘s Vault, somehow.
 
 Obsidian writes the changes to disk at its own pace.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Some of the text in CONTRIBUTING was hard to read, due to numbers being interpreted as ordered lists.

## How has this been tested?

By rendering the Markdown in WebStorm and GitHub site.

## Screenshots (if appropriate):

### Before:

![image](https://user-images.githubusercontent.com/4840096/171625459-bdf9c816-bc76-42e2-a0b2-87a5ca365d57.png)

### After:

![image](https://user-images.githubusercontent.com/4840096/171625704-e851e82b-2637-4c8e-b506-62c2ee6ad62c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
