### PR TITLE
Recognise dataview completion tag format

### DIFF
--- a/src/Task.ts
+++ b/src/Task.ts
@@ -85,7 +85,8 @@ export class Task {
     public static readonly startDateRegex = /🛫 ?(\d{4}-\d{2}-\d{2})$/u;
     public static readonly scheduledDateRegex = /[⏳⌛] ?(\d{4}-\d{2}-\d{2})$/u;
     public static readonly dueDateRegex = /[📅📆🗓] ?(\d{4}-\d{2}-\d{2})$/u;
-    public static readonly doneDateRegex = /✅ ?(\d{4}-\d{2}-\d{2})$/u;
+    public static readonly doneDateRegex =
+        /\[?✅ ?:{0,2} ?(\d{4}-\d{2}-\d{2})\]?$/u;
     public static readonly recurrenceRegex = /🔁 ?([a-zA-Z0-9, !]+)$/iu;
 
     // Regex to match all hash tags, basically hash followed by anything but the characters in the negation.

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -129,6 +129,39 @@ describe('parsing', () => {
         ).toStrictEqual(true);
         expect(task!.blockLink).toEqual(' ^my-precious');
     });
+
+    it('also works with dataview completed tag [✅:: 2022-06-05]', () => {
+        // Arrange
+        const line =
+            '- [x] this is a ✅ done task 🗓 2021-09-12 [✅:: 2022-06-05] ^my-precious  ';
+        const path = 'this/is a path/to a/file.md';
+        const sectionStart = 1337;
+        const sectionIndex = 1209;
+        const precedingHeader = 'Eloquent Section';
+
+        // Act
+        const task = Task.fromLine({
+            line,
+            path,
+            sectionStart,
+            sectionIndex,
+            precedingHeader,
+        });
+
+        // Assert
+        expect(task).not.toBeNull();
+        expect(task!.description).toEqual('this is a ✅ done task');
+        expect(task!.status).toStrictEqual(Status.Done);
+        expect(task!.dueDate).not.toBeNull();
+        expect(
+            task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD')),
+        ).toStrictEqual(true);
+        expect(task!.doneDate).not.toBeNull();
+        expect(
+            task!.doneDate!.isSame(moment('2022-06-05', 'YYYY-MM-DD')),
+        ).toStrictEqual(true);
+        expect(task!.blockLink).toEqual(' ^my-precious');
+    });
 });
 
 type TagParsingExpectations = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR changes obsidian tasks so it can parse a dataview tag for completion date, e.g.`[✅:: 2022-06-05]`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Using a mix of dataview and obsidian task views, when ticking a task in dataview as complete, the complete date is not parsed by obsidian-tasks. This adds a bit of friction an forces me to think about if I'm completing the task correctly, otherwise obsidian tasks filters on completion date don't work.

A slight regex change, and setting "Automatic Task Completion Field" in dataview to ✅ solves this problem.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Added a single new test, all other tests still pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)

## Further work

I've added this functionality quickly as it's interrupting my work flow. Ideally, time will be spent to also:

 - update the surrounding regex to support standard dataview tag structure for other fields where sensible
 - update dataview to support obsidian-tasks' syntax
 - update docs

I might consider doing this at a future date if there's interest.