### PR TITLE
docs: Indicate when 1.6.0 features were released

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,29 @@ The documentation resides under the `./docs` directory.
 It consists of markdown files, which [Jekyll](https://jekyllrb.com/) will transform into web pages that you can view at <https://obsidian-tasks-group.github.io/obsidian-tasks/> .
 In the simplest case, you can update the existing markdown file and create a pull request (PR) with your changes.
 
+### Version numbers in documentation
+
+We have introduced version markers to the documentation, to show users in which version a specific feature was introduced.
+This means that newly written documentation should be tagged with a placeholder, which will be replaced with the actual
+version upon release.
+
+There are 2 styles of placeholders used through the documentation, Please pick the one that
+fits your text better. (If in doubt, take a look at the existing version tags for other features.)
+
+- `> Introduced in Tasks X.Y.Z`
+  - This placeholder is usually used after a section heading.
+- `> X (Y and Z) was introduced in Tasks X.Y.Z`
+  - This placeholder is used when you need to tag a sub-part of something, for example a list.
+
+### How the documentation is generated
+
 We use [GitHub pages](https://pages.github.com/) for our documentation.
 You can read more about it at their [official documentation](https://docs.github.com/en/pages).
 
 To generate the documentation site on your machine,
 see [docs/README.md](docs/README.md).
+
+### Documentation and branches
 
 For documentation changes to show up at <https://obsidian-tasks-group.github.io/obsidian-tasks/> , they must be in the `gh-pages` branch.
 If you want to see your changes available immediately and not only after the next release, you should make your changes on the `gh-pages` branch.
@@ -116,14 +134,15 @@ Obsidian writes the changes to disk at its own pace.
     - Backwards incompatible change: increase major version
     - New functionality: increase minor version
     - Only bug fixes: increase patch version
-3. Check the current version of the obsidian dependency in `package.json` (e.g. `0.13.21`)
-4. Run `./release.sh <new tasks version> <obsidian version>`
+3. Having decided on the new version, replace all `X.Y.Z` in the documentation with the new version number.
+4. Check the current version of the obsidian dependency in `package.json` (e.g. `0.13.21`)
+5. Run `./release.sh <new tasks version> <obsidian version>`
     - Make sure there are no uncommitted changes. Stash them if necessary.
-5. Wait for [GitHub Actions](https://github.com/obsidian-tasks-group/obsidian-tasks/actions/workflows/release.yml) to create the new release
-6. Update the release description with the changes of the release
+6. Wait for [GitHub Actions](https://github.com/obsidian-tasks-group/obsidian-tasks/actions/workflows/release.yml) to create the new release
+7. Update the release description with the changes of the release
     - On the release page, GitHub provides a button to auto-generate release notes which works nicely.
     - Also update the attached zip file by adding the version number to the end of the name after the dash (e.g. `obsidian-tasks-1.4.1.zip`)
-7. Optional: Post to
+8. Optional: Post to
     - Obsidian Discord
     - r/ObsidianMD on Reddit
     - etc.

--- a/docs/advanced/styling.md
+++ b/docs/advanced/styling.md
@@ -19,3 +19,5 @@ following styles are available.
 | tasks-edit                | This is applied to the SPAN that wraps the edit button/icon shown next to the task that opens the task edit UI. |
 | task-list-item-checkbox   | This is applied to the INPUT element for the task.                                                              |
 | tasks-group-heading       | This is applied to H4, H5 and H6 group headings                                                                 |
+
+> `tasks-group-heading` was introduced in Tasks 1.6.0.

--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -92,6 +92,8 @@ Instead you would have two queries, one for each condition:
 - `has start date`
 - `starts (before|after|on) <date>`
 
+> `has start date` was Introduced in Tasks 1.6.0.
+
 When filtering queries by [start date]({{ site.baseurl }}{% link getting-started/dates.md %}#-start),
 the result will include tasks without a start date.
 This way, you can use the start date as a filter to filter out any tasks that you cannot yet work on.
@@ -108,11 +110,15 @@ Such filter could be:
 - `has scheduled date`
 - `scheduled (before|after|on) <date>`
 
+> `has scheduled date` was introduced in Tasks 1.6.0.
+
 ### Due Date
 
 - `no due date`
 - `has due date`
 - `due (before|after|on) <date>`
+
+> `has due date` was introduced in Tasks 1.6.0.
 
 ### Happens
 
@@ -153,6 +159,8 @@ because the tasks starts before tomorrow. Only one of the dates needs to match.
   - When this is set, the result list will only include tasks that are not indented in their file. It will only show tasks that are top level list items in their list.
 
 ### Tags
+
+> Introduced in Tasks 1.6.0.
 
 - `tags (include|do not include) <tag>` (Alternative grammar `tag (includes|does not include) <tag>` matching description syntax)
   - Matches case-insensitive (disregards capitalization).

--- a/docs/queries/grouping.md
+++ b/docs/queries/grouping.md
@@ -22,6 +22,8 @@ parent: Queries
 
 ## Basics
 
+> Introduced in Tasks 1.6.0.
+
 By default, Tasks displays tasks in a single list.
 
 To divide the matching tasks up with headings, you can add `group by` lines to the query.

--- a/docs/queries/sorting.md
+++ b/docs/queries/sorting.md
@@ -74,6 +74,8 @@ For example, when you `sort by done reverse` and your query results contain task
 
 ## Tag sorting
 
+> Introduced in Tasks 1.6.0.
+
 If you want to sort by tags, by default it will sort by the first tag found in the description. If you want to sort by a tag that comes after that then you can specify the index at the end of the query. All tasks should have the same amount of tags for optimal sorting and the tags in the same order. The index starts from 1 which is also the default.
 
 For example this query will sort by the second tag found in the description.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Edit CONTRIBUTING.md to document a new still of comment in the documentation to indicate when features, or parts of features, were added.
- Apply this style to the docs of features released in 1.6.0.

## Motivation and Context

There was a bit of support traffic after the 1.6.0 release, when users tried using newly-released features, and had not known they needed to update their Tasks plugin.

This may help a little.

## How has this been tested?

Unfortunately I am unable to build the documentation on a Mac, as I get:

> + docker run --rm -it --volume /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/docs:/docs:Z --publish 4000:4000 obsidian-tasks-docs:latest
> Could not find nokogiri-1.13.6-x86_64-linux in any of the sources

_Logged in #732._

~~So I've previewed the changes in a Markdown editor, and am merging this to the `gh-pages` first, to see the published pages and check the style looks OK.~~

Bad idea to push to the `gh-pages` branch, as that will merge in all changes made on `main` since the last release.

I'll just put this on main for now, and review the formatting after the next release. The information content is at least an improvement.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation only

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
