### PR TITLE
chore: Update commonmarker to 0.23.4

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.17.13)
+    commonmarker (0.23.4)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.9)
     dnsruby (1.61.7)


### PR DESCRIPTION
Fixes Integer overflow in cmark-gfm table parsing extension leads to heap memory corruption
