### PR TITLE
feat: Allow capital letters in abbreviations for dates in Create or edit Task modal

### DIFF
--- a/src/DateAbbreviations.ts
+++ b/src/DateAbbreviations.ts
@@ -1,7 +1,7 @@
 // Abbreviations for entering dates with chrono
 // MAINTENANCE NOTE:
 //      If adding more abbreviations, please review datePlaceholder in src/ui/EditTask.svelte
-export default {
+const abbreviations = {
     td: 'today',
     tm: 'tomorrow',
     yd: 'yesterday',
@@ -10,3 +10,18 @@ export default {
     weekend: 'sat',
     we: 'sat',
 };
+
+/**
+ * Expand any recognised abbreviations for dates.
+ *
+ * Important: the abbreviation is only expanded if it is foolowed by a space.
+ *
+ * For example, 'td ' is expanded to 'today'
+ * @param date
+ */
+export function doAutocomplete(date: string): string {
+    for (const [key, val] of Object.entries(abbreviations)) {
+        date = date.replace(RegExp(`\\b${key}\\s`), val);
+    }
+    return date;
+}

--- a/src/DateAbbreviations.ts
+++ b/src/DateAbbreviations.ts
@@ -21,7 +21,7 @@ const abbreviations = {
  */
 export function doAutocomplete(date: string): string {
     for (const [key, val] of Object.entries(abbreviations)) {
-        date = date.replace(RegExp(`\\b${key}\\s`), val);
+        date = date.replace(RegExp(`\\b${key}\\s`, 'i'), val);
     }
     return date;
 }

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -4,7 +4,7 @@
     import { Recurrence } from '../Recurrence';
     import { getSettings } from '../Settings';
     import { Priority, Status, Task } from '../Task';
-    import DateAbbreviations from '../DateAbbreviations';
+    import { doAutocomplete } from '../DateAbbreviations';
 
     export let task: Task;
     export let onSubmit: (updatedTasks: Task[]) => void | Promise<void>;
@@ -39,12 +39,6 @@
     // 'weekend' abbreviation ommitted due to lack of space.
     let datePlaceholder = "Try 'Monday' or 'tomorrow', or [td|tm|yd|tw|nw|we] then space.";
 
-    function doAutocomplete(date: string): string {
-        for (let [key, val] of Object.entries(DateAbbreviations)) {
-            date = date.replace(RegExp(`\\b${key}\\s`), val);
-        }
-        return date;
-    }
 
     function parseDate(
         type: 'start' | 'scheduled' | 'due' | 'done',

--- a/tests/DateAbbreviations.test.ts
+++ b/tests/DateAbbreviations.test.ts
@@ -1,0 +1,13 @@
+import { doAutocomplete } from '../src/DateAbbreviations';
+
+describe('DateAbbreviations', () => {
+    it('should expand abbreviations', () => {
+        expect(doAutocomplete('td ')).toEqual('today');
+        expect(doAutocomplete('tm ')).toEqual('tomorrow');
+        expect(doAutocomplete('yd ')).toEqual('yesterday');
+        expect(doAutocomplete('tw ')).toEqual('this week');
+        expect(doAutocomplete('nw ')).toEqual('next week');
+        expect(doAutocomplete('weekend ')).toEqual('sat');
+        expect(doAutocomplete('we ')).toEqual('sat');
+    });
+});

--- a/tests/DateAbbreviations.test.ts
+++ b/tests/DateAbbreviations.test.ts
@@ -10,4 +10,14 @@ describe('DateAbbreviations', () => {
         expect(doAutocomplete('weekend ')).toEqual('sat');
         expect(doAutocomplete('we ')).toEqual('sat');
     });
+
+    it('should expand abbreviations with capital letters', () => {
+        expect(doAutocomplete('Td ')).toEqual('today');
+        expect(doAutocomplete('tM ')).toEqual('tomorrow');
+        expect(doAutocomplete('WeekEnd ')).toEqual('sat');
+    });
+
+    it('should not expand other words', () => {
+        expect(doAutocomplete('sunshine ')).toEqual('sunshine ');
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Move the date abbreviation expansion code out of .svelte file to allow it to be tested
2. Write passing tests for existing date abbreviation expansion code
3. Write failing tests for expansion of abbreviations with capitals
4. Make the regular expression for date abbreviation expansion code case-insensitive

## Motivation and Context

Fixes #768 - so that the feature is useful on devices that capitalise the first letter typed in text boxes, such as on my iPad.

## How has this been tested?

1. By writing unit tests
2. By testing it on a Mac

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
