### PR TITLE
docs: Fix occasional incorrect images in user docs & plugin store.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ For changes in each release, please check the releases page: <https://github.com
 - _All screenshots assume the [global filter](#filtering-checklist-items) `#task` which is not set by default (see also [installation](#installation))._
 - _The theme is default Obsidian theme._
 
-![ACME Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/acme.png)
+![ACME Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/resources/screenshots/acme.png)
 The `ACME` note has some tasks.
 
-![Important Project Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/important_project.png)
+![Important Project Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/resources/screenshots/important_project.png)
 The `Important Project` note also has some tasks.
 
-![Tasks Queries](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/tasks_queries.png)
+![Tasks Queries](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/resources/screenshots/tasks_queries.png)
 The `Tasks` note gathers all tasks from the vault and displays them using queries.
 
-![Create or Edit Modal](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/modal.png)
+![Create or Edit Modal](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/resources/screenshots/modal.png)
 The `Tasks: Create or edit` command helps you when editing a task.
 
 ## Installation

--- a/docs/advanced/notifications.md
+++ b/docs/advanced/notifications.md
@@ -13,7 +13,7 @@ This utilizes the standard Tasks date (as the due date) and can be extended with
 Further, a default reminder can be enabled based on the Tasks' 'Due Date'.
 To enable this make sure obsidian-reminder has enabled the tasks plugin format as below:
 
-![obsidian-reminder setting](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/reminder.png)
+![obsidian-reminder setting](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/resources/screenshots/reminder.png)
 _Note that this is a screenshot of the reminder plugin's settings and not Tasks._
 
 ## Where to add the reminder date

--- a/docs/getting-started/create-or-edit-task.md
+++ b/docs/getting-started/create-or-edit-task.md
@@ -23,7 +23,7 @@ has_toc: false
 
 ## Introduction
 
-![Create or Edit Modal](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/modal.png)
+![Create or Edit Modal](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/resources/screenshots/modal.png)
 The `Tasks: Create or edit` command helps you when adding or editing a task.
 
 ## Opening the 'Create or edit Task' Modal

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,14 +42,14 @@ For changes in each release, please check the [releases page](https://github.com
 - *All screenshots assume the global filter `#task` which is not set by default (see also "Getting Started").*
 - *The theme is default Obsidian theme.*
 
-![ACME Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/acme.png)
+![ACME Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/resources/screenshots/acme.png)
 The `ACME` note has some tasks.
 
-![Important Project Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/important_project.png)
+![Important Project Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/resources/screenshots/important_project.png)
 The `Important Project` note also has some tasks.
 
-![Tasks Queries](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/tasks_queries.png)
+![Tasks Queries](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/resources/screenshots/tasks_queries.png)
 The `Tasks` note gathers all tasks from the vault and displays them using queries.
 
-![Create or Edit Modal](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/modal.png)
+![Create or Edit Modal](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/resources/screenshots/modal.png)
 The `Tasks: Create or edit` command helps you when editing a task.

--- a/docs/queries/grouping.md
+++ b/docs/queries/grouping.md
@@ -100,14 +100,14 @@ The order of operations ensures that grouping does not modify which tasks are di
 
 Here is an example Tasks result, without any `group by` commands:
 
-![Tasks Ungrouped](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/tasks_ungrouped.png)
+![Tasks Ungrouped](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/resources/screenshots/tasks_ungrouped.png)
 Tasks not grouped.
 
 ### After
 
 And here is what this might look like, when grouped by folder, filename and heading:
 
-![Tasks Grouped](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/main/resources/screenshots/tasks_grouped.png)
+![Tasks Grouped](https://github.com/obsidian-tasks-group/obsidian-tasks/raw/gh-pages/resources/screenshots/tasks_grouped.png)
 Tasks grouped.
 
 ---


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

The User Guide and README.md were showing images from the main branch, whereas the docs are published from the gh-pages branch.

This meant that if existing screenshots were updated on main, they would be shown in the documentation and community plugin store, prior to the new feature being released to users.

For consistency, I've opted for making all images shown in this repo from the gh-pages repo, including the README. This fixes the related problem that the Obsidian Community Plugin store was showing an image of a feature that has not yet been released.

## Motivation

This fixes #778.
