### PR TITLE
fix: Unable to find section, when title has tag inside (#654)

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -297,10 +297,12 @@ class QueryRenderChild extends MarkdownRenderChild {
         }
 
         if (task.precedingHeader !== null) {
-            link.href = link.href + '#' + task.precedingHeader;
+            link.href = link.href + '#' + task.precedingHeader.replace('#', '');
             link.setAttribute(
                 'data-href',
-                link.getAttribute('data-href') + '#' + task.precedingHeader,
+                link.getAttribute('data-href') +
+                    '#' +
+                    task.precedingHeader.replace('#', ''),
             );
         }
 


### PR DESCRIPTION
## Description
Remove tags from backlink's `href` and `data-href` to resolve #654. As discussed in the issue, Obsidian expects links to sections with tags to have `#` symbols removed, this change fixes rendered task's links.

## How has this been tested?
Bug fix tested locally using the Tasks-Demo vault.
Tag added to heading in ACME note and backlink tested for tasks rendered in the Tasks note.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate Unit Test coverage.