### PR TITLE
refactor: The date fields do their own presence/absence searches

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -58,15 +58,6 @@ export class Query implements IQuery {
     private _sorting: Sorting[] = [];
     private _grouping: Grouping[] = [];
 
-    private readonly noStartString = 'no start date';
-    private readonly hasStartString = 'has start date';
-
-    private readonly noScheduledString = 'no scheduled date';
-    private readonly hasScheduledString = 'has scheduled date';
-
-    private readonly noDueString = 'no due date';
-    private readonly hasDueString = 'has due date';
-
     private readonly doneString = 'done';
     private readonly notDoneString = 'not done';
 
@@ -117,28 +108,6 @@ export class Query implements IQuery {
                         break;
                     case line === this.excludeSubItemsString:
                         this._filters.push((task) => task.indentation === '');
-                        break;
-                    case line === this.noStartString:
-                        this._filters.push((task) => task.startDate === null);
-                        break;
-                    case line === this.noScheduledString:
-                        this._filters.push(
-                            (task) => task.scheduledDate === null,
-                        );
-                        break;
-                    case line === this.noDueString:
-                        this._filters.push((task) => task.dueDate === null);
-                        break;
-                    case line === this.hasStartString:
-                        this._filters.push((task) => task.startDate !== null);
-                        break;
-                    case line === this.hasScheduledString:
-                        this._filters.push(
-                            (task) => task.scheduledDate !== null,
-                        );
-                        break;
-                    case line === this.hasDueString:
-                        this._filters.push((task) => task.dueDate !== null);
                         break;
                     case this.shortModeRegexp.test(line):
                         this._layoutOptions.shortMode = true;

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -10,8 +10,34 @@ import { FilterOrErrorMessage } from './Filter';
  * value, such as the done date.
  */
 export abstract class DateField extends Field {
+    private readonly instructionForFieldPresence = `has ${this.fieldName()} date`;
+    private readonly instructionForFieldAbsence = `no ${this.fieldName()} date`;
+
+    public canCreateFilterForLine(line: string): boolean {
+        if (line === this.instructionForFieldPresence) {
+            return true;
+        }
+        if (line === this.instructionForFieldAbsence) {
+            return true;
+        }
+        return super.canCreateFilterForLine(line);
+    }
+
     public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         const result = new FilterOrErrorMessage();
+
+        if (line === this.instructionForFieldPresence) {
+            const result = new FilterOrErrorMessage();
+            result.filter = (task: Task) => this.date(task) !== null;
+            return result;
+        }
+
+        if (line === this.instructionForFieldAbsence) {
+            const result = new FilterOrErrorMessage();
+            result.filter = (task: Task) => this.date(task) === null;
+            return result;
+        }
+
         const match = line.match(this.filterRegexp());
         if (match !== null) {
             const filterDate = DateParser.parseDate(match[2]);

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -27,13 +27,11 @@ export abstract class DateField extends Field {
         const result = new FilterOrErrorMessage();
 
         if (line === this.instructionForFieldPresence) {
-            const result = new FilterOrErrorMessage();
             result.filter = (task: Task) => this.date(task) !== null;
             return result;
         }
 
         if (line === this.instructionForFieldAbsence) {
-            const result = new FilterOrErrorMessage();
             result.filter = (task: Task) => this.date(task) === null;
             return result;
         }

--- a/src/Query/Filter/DoneDateField.ts
+++ b/src/Query/Filter/DoneDateField.ts
@@ -1,41 +1,12 @@
 import type { Moment } from 'moment';
 import type { Task } from '../../Task';
 import { DateField } from './DateField';
-import { FilterOrErrorMessage } from './Filter';
 
 /**
  * Support the 'done' search instruction.
  */
 export class DoneDateField extends DateField {
     private static readonly doneRegexp = /^done (before|after|on)? ?(.*)/;
-    private static readonly instructionForFieldPresence = 'has done date';
-    private static readonly instructionForFieldAbsence = 'no done date';
-
-    public canCreateFilterForLine(line: string): boolean {
-        if (line === DoneDateField.instructionForFieldPresence) {
-            return true;
-        }
-        if (line === DoneDateField.instructionForFieldAbsence) {
-            return true;
-        }
-        return super.canCreateFilterForLine(line);
-    }
-
-    public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
-        if (line === DoneDateField.instructionForFieldPresence) {
-            const result = new FilterOrErrorMessage();
-            result.filter = (task: Task) => this.date(task) !== null;
-            return result;
-        }
-
-        if (line === DoneDateField.instructionForFieldAbsence) {
-            const result = new FilterOrErrorMessage();
-            result.filter = (task: Task) => this.date(task) === null;
-            return result;
-        }
-
-        return super.createFilterOrErrorMessage(line);
-    }
 
     protected filterRegexp(): RegExp {
         return DoneDateField.doneRegexp;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Teach `DateField` to do these searches:

-  `has [due|start|scheduled|done] date`
-  `no [due|start|scheduled|done] date`

This removes the need for some text from Query that implemented the presence/absence tests for Due, Start and Scheduled dates.

Note: There was error in one commit message. I'll fix it during the merge.

<!--- Describe your changes in detail -->

## Motivation and Context

This moves more responsibility to the `DateField` class, and will make it easier to add filtering for any new date types in future.

## How has this been tested?

Via the pre-existing tests.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
