### PR TITLE
chore: Make git happy with the resources/sample_vaults/Tasks-Demo/ sample vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ yarn-error.log
 
 # files in sample vaults
 /resources/sample_vaults/Tasks-Demo/.obsidian/workspace
+.hotreload
 
 # Backup files.
 *.bak

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/core-plugins.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/core-plugins.json
@@ -10,6 +10,5 @@
   "editor-status",
   "markdown-importer",
   "word-count",
-  "open-with-default-app",
   "file-recovery"
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Obsidian has removed the core plugin "open-with-default-app", so commit the updated `core-plugins.json` in the Tasks-Demo sample vault.
2. Tell git to ignore `.hotreload`, to enable use of the hot reload plugin when testing new versions of Tasks in the Tasks-Demo sample vault.

## Motivation and Context

Just minor house-keeping, to streamline testing the Tasks plugin manually.

## How has this been tested?

By editing the sample vault in Obsidian 0.15.2.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Changes for the sample vault

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
