### PR TITLE
docs: Overhaul the Filters documentation

### DIFF
--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -127,10 +127,11 @@ because the tasks starts before tomorrow. Only one of the dates needs to match.
 
 ## Filters for Other Task Properties
 
-### Status
+### Description
 
-- `done`
-- `not done`
+- `description (includes|does not include) <string>`
+  - Matches case-insensitive (disregards capitalization).
+  - Disregards the global filter when matching.
 
 ### Priority
 
@@ -154,11 +155,10 @@ because the tasks starts before tomorrow. Only one of the dates needs to match.
 - `is recurring`
 - `is not recurring`
 
-### Description
+### Status
 
-- `description (includes|does not include) <string>`
-  - Matches case-insensitive (disregards capitalization).
-  - Disregards the global filter when matching.
+- `done`
+- `not done`
 
 ### Sub-Items
 
@@ -182,15 +182,15 @@ because the tasks starts before tomorrow. Only one of the dates needs to match.
 
 ## Filters for File Properties
 
+### File Path
+
+- `path (includes|does not include) <path>`
+  - Matches case-insensitive (disregards capitalization).
+
 ### Heading
 
 - `heading (includes|does not include) <string>`
   - Whether or not the heading preceding the task includes the given string.
   - Always tries to match the closest heading above the task, regardless of heading level.
   - `does not include` will match a task that does not have a preceding heading in its file.
-  - Matches case-insensitive (disregards capitalization).
-
-### File Path
-
-- `path (includes|does not include) <path>`
   - Matches case-insensitive (disregards capitalization).

--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -41,7 +41,7 @@ When the day changes, relative dates like `due today` are re-evaluated so that t
 
 ---
 
-## Matching
+## Matching - Workaround for Boolean OR
 
 All filters of a query have to match in order for a task to be listed.
 This means you cannot show tasks that have "GitHub in the path and have no due date or are due after 2021-04-04".
@@ -63,7 +63,7 @@ Instead you would have two queries, one for each condition:
 
 ---
 
-## List of Available Filters
+## Filters for Dates in Tasks
 
 ### Done Date
 
@@ -75,22 +75,21 @@ Instead you would have two queries, one for each condition:
 
 > `no done date` and `has done date` were introduced in Tasks 1.7.0.
 
-### Priority
+### Due Date
 
-- `priority is (above|below)? (low|none|medium|high)`
+- `no due date`
+- `has due date`
+- `due (before|after|on) <date>`
 
-#### Examples
+> `has due date` was introduced in Tasks 1.6.0.
 
-{: .no_toc }
+### Scheduled Date
 
-    ```tasks
-    not done
-    priority is above none
-    ```
+- `no scheduled date`
+- `has scheduled date`
+- `scheduled (before|after|on) <date>`
 
-    ```tasks
-    priority is high
-    ```
+> `has scheduled date` was introduced in Tasks 1.6.0.
 
 ### Start Date
 
@@ -110,22 +109,6 @@ Such filter could be:
     starts before tomorrow
     ```
 
-### Scheduled Date
-
-- `no scheduled date`
-- `has scheduled date`
-- `scheduled (before|after|on) <date>`
-
-> `has scheduled date` was introduced in Tasks 1.6.0.
-
-### Due Date
-
-- `no due date`
-- `has due date`
-- `due (before|after|on) <date>`
-
-> `has due date` was introduced in Tasks 1.6.0.
-
 ### Happens
 
 - `happens (before|after|on) <date>`
@@ -142,29 +125,35 @@ because the tasks starts before tomorrow. Only one of the dates needs to match.
 
 > `no happens date` and `has happens date` were introduced in Tasks 1.7.0.
 
+## Filters for Other Task Properties
+
+### Priority
+
+- `priority is (above|below)? (low|none|medium|high)`
+
+#### Examples
+
+{: .no_toc }
+
+    ```tasks
+    not done
+    priority is above none
+    ```
+
+    ```tasks
+    priority is high
+    ```
+
 ### Recurrence
 
 - `is recurring`
 - `is not recurring`
-
-### File Path
-
-- `path (includes|does not include) <path>`
-  - Matches case-insensitive (disregards capitalization).
 
 ### Description
 
 - `description (includes|does not include) <string>`
   - Matches case-insensitive (disregards capitalization).
   - Disregards the global filter when matching.
-
-### Heading
-
-- `heading (includes|does not include) <string>`
-  - Whether or not the heading preceding the task includes the given string.
-  - Always tries to match the closest heading above the task, regardless of heading level.
-  - `does not include` will match a task that does not have a preceding heading in its file.
-  - Matches case-insensitive (disregards capitalization).
 
 ### Sub-Items
 
@@ -185,3 +174,18 @@ because the tasks starts before tomorrow. Only one of the dates needs to match.
 
 - `tags include #todo`
 - `tags do not include #todo`
+
+## Filters for File Properties
+
+### Heading
+
+- `heading (includes|does not include) <string>`
+  - Whether or not the heading preceding the task includes the given string.
+  - Always tries to match the closest heading above the task, regardless of heading level.
+  - `does not include` will match a task that does not have a preceding heading in its file.
+  - Matches case-insensitive (disregards capitalization).
+
+### File Path
+
+- `path (includes|does not include) <path>`
+  - Matches case-insensitive (disregards capitalization).

--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -127,6 +127,11 @@ because the tasks starts before tomorrow. Only one of the dates needs to match.
 
 ## Filters for Other Task Properties
 
+### Status
+
+- `done`
+- `not done`
+
 ### Priority
 
 - `priority is (above|below)? (low|none|medium|high)`

--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -127,6 +127,8 @@ because the tasks starts before tomorrow. Only one of the dates needs to match.
 
 ## Filters for Other Task Properties
 
+As well as the date-related searches above, these filters search other properties in individual tasks.
+
 ### Description
 
 - `description (includes|does not include) <string>`
@@ -181,6 +183,8 @@ because the tasks starts before tomorrow. Only one of the dates needs to match.
 - `tags do not include #todo`
 
 ## Filters for File Properties
+
+These filters allow searching for tasks in particular files and sections of files.
 
 ### File Path
 

--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -25,11 +25,13 @@ parent: Queries
 `<date>` filters can be given in natural language or in formal notation.
 The following are some examples of valid `<date>` filters as inspiration:
 
-- `2021-05-05`
+- `2021-05-25`
+- `yesterday`
 - `today`
 - `tomorrow`
 - `next monday`
 - `last friday`
+- `14 days ago`
 - `in two weeks`
 
 Note that if it is Wednesday and you write `tuesday`, Tasks assumes you mean "yesterday", as that is the closest Tuesday.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes made:

- Add 'days ago' to filter date examples.
    - Based on feedback in #819.
    - Also make yyyy-mm-dd example unambiguous.
    - And add 'yesterday', for completion.
- Divide filters list logically & note OR workaround
    - The list of available filters had become long and a little hard to read and find patterns in.
    - This groups related filters together, for readability and structure.
- Make 'done' and 'not done' more prominent in docs
    - They were previously only listed under 'done date' which was useful, but not entirely accurate.
- Sort sub-headings alphabetically, for readability
- Add brief intros to the new sections

## Motivation and Context

This was prompted by feedback in #819 that `days ago` was not documented.

I had been feeling for some time that the list of all filters had become quite long and unwieldy, as more filters were added.

## How has this been tested?

By viewing the generated docs locally.

## Screenshots (if appropriate):

## Types of changes

- [x] Documentation only

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
