### PR TITLE
docs: Improve readability of columns in Quick Reference

### DIFF
--- a/docs/quick-reference/index.md
+++ b/docs/quick-reference/index.md
@@ -14,26 +14,26 @@ has_toc: false
 
 This table summarizes the filters and other options available inside a `tasks` block.
 
-| [Filter][1]                                                                        | Presence<br>Absence                          | [Sort][2]<br>[Group][3]                     | [Display][4]           |
-| ---------------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------- | ---------------------- |
-| `done`<br>`not done`                                                               |                                              | `sort by status`<br>`group by status`       |                        |
-| `done (before, after, on) <date>`                                                  | `has done date`<br>`no  done date`           | `sort by done`<br>`group by done`           | `hide done date`       |
-| `starts (before, after, on) <date>`                                                | `has start date`<br>`no  start date`         | `sort by start`<br>`group by start`         | `hide start date`      |
-| `scheduled (before, after, on) <date>`                                             | `has scheduled date`<br>`no  scheduled date` | `sort by scheduled`<br>`group by scheduled` | `hide scheduled date`  |
-| `due (before, after, on) <date>`                                                   | `has due date`<br>`no  due date`             | `sort by due`<br>`group by due`             | `hide due date`        |
-| `happens (before, after, on) <date>`                                               | `has happens date`<br>`no  happens date`     |                                             |                        |
-| `is recurring`<br>`is not recurring`                                               |                                              |                                             | `hide recurrence rule` |
-| `priority is (above, below)? (low, none, medium, high)`                            |                                              | `sort by priority`                          | `hide priority`        |
-|                                                                                    |                                              | `sort by urgency`                           |                        |
-| `path (includes, does not include) <path>`                                         |                                              | `sort by path`<br>`group by path`           |                        |
-|                                                                                    |                                              | `group by folder`                           |                        |
-|                                                                                    |                                              | `group by filename`                         |                        |
-| `heading (includes, does not include) <string>`                                    |                                              | `group by heading`                          |                        |
-|                                                                                    |                                              | `group by backlink`                         | `hide backlink`        |
-| `description (includes, does not include) <string>`                                |                                              | `sort by description`                       |                        |
-| `tag (includes, does not include) <tag>`<br>`tags (include, do not include) <tag>` |                                              | `sort by tag`<br>`sort by tag <tag_number>` |                        |
-| `exclude sub-items`                                                                |                                              |                                             |                        |
-| `limit to <number> tasks`<br>`limit <number>`                                      |                                              |                                             |                        |
+| [Filters][1]                                                                           | [Sort][2]                                   |  [Group][3]         | [Display][4]           |
+| ---------------------------------------------------------------------------------------| ------------------------------------------- | --------------------| -----------------------|
+| `done`<br>`not done`                                                                   | `sort by status`                            | `group by status`   |                        |
+| `done (before, after, on) <date>`<br>`has done date`<br>`no  done date`                | `sort by done`                              | `group by done`     | `hide done date`       |
+| `starts (before, after, on) <date>`<br>`has start date`<br>`no  start date`            | `sort by start`                             | `group by start`    | `hide start date`      |
+| `scheduled (before, after, on) <date>`<br>`has scheduled date`<br>`no  scheduled date` | `sort by scheduled`                         | `group by scheduled`| `hide scheduled date`  |
+| `due (before, after, on) <date>`<br>`has due date`<br>`no  due date`                   | `sort by due`                               | `group by due`      | `hide due date`        |
+| `happens (before, after, on) <date>`<br>`has happens date`<br>`no  happens date`       |                                             |                     |                        |
+| `is recurring`<br>`is not recurring`                                                   |                                             |                     | `hide recurrence rule` |
+| `priority is (above, below)? (low, none, medium, high)`                                | `sort by priority`                          |                     | `hide priority`        |
+|                                                                                        | `sort by urgency`                           |                     |                        |
+| `path (includes, does not include) <path>`                                             | `sort by path`                              | `group by path`     |                        |
+|                                                                                        |                                             | `group by folder`   |                        |
+|                                                                                        |                                             | `group by filename` |                        |
+| `heading (includes, does not include) <string>`                                        |                                             | `group by heading`  |                        |
+|                                                                                        |                                             | `group by backlink` | `hide backlink`        |
+| `description (includes, does not include) <string>`                                    | `sort by description`                       |                     |                        |
+| `tag (includes, does not include) <tag>`<br>`tags (include, do not include) <tag>`     | `sort by tag`<br>`sort by tag <tag_number>` |                     |                        |
+| `exclude sub-items`                                                                    |                                             |                     |                        |
+| `limit to <number> tasks`<br>`limit <number>`                                          |                                             |                     |                        |
 
 Other layout options:
 


### PR DESCRIPTION
## Description

I found that by separating Sort and Group in to different columns, it is easier to spot the gaps in functionality Filter, Sort and Group functionality.

This required combing the Filter and Presence/Absence columns instead in to a single Filters column.

## Motivation and Context

I want to be able to see the gaps in features, so I can fill some of them in.

## How has this been tested?

By generating and viewing the docs locally.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/4840096/175762570-db603d2d-a6c3-4c3b-b187-a4efdb726f89.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation only

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
