### PR TITLE
test: Simplify some tests in Task.test.ts

### DIFF
--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -13,18 +13,10 @@ describe('parsing', () => {
     it('parses a task from a line', () => {
         // Arrange
         const line = '- [x] this is a done task 🗓 2021-09-12 ✅ 2021-06-20';
-        const path = 'this/is a path/to a/file.md';
-        const sectionStart = 1337;
-        const sectionIndex = 1209;
-        const precedingHeader = 'Eloquent Section';
 
         // Act
-        const task = Task.fromLine({
+        const task = fromLine({
             line,
-            path,
-            sectionStart,
-            sectionIndex,
-            precedingHeader,
         });
 
         // Assert
@@ -46,18 +38,10 @@ describe('parsing', () => {
         const originalSettings = getSettings();
         updateSettings({ globalFilter: '#task' });
         const line = '- [x] this is a done task 🗓 2021-09-12 ✅ 2021-06-20';
-        const path = 'this/is a path/to a/file.md';
-        const sectionStart = 1337;
-        const sectionIndex = 1209;
-        const precedingHeader = 'Eloquent Section';
 
         // Act
-        const task = Task.fromLine({
+        const task = fromLine({
             line,
-            path,
-            sectionStart,
-            sectionIndex,
-            precedingHeader,
         });
 
         // Assert
@@ -70,18 +54,10 @@ describe('parsing', () => {
     it('allows signifier emojis as part of the description', () => {
         // Arrange
         const line = '- [x] this is a ✅ done task 🗓 2021-09-12 ✅ 2021-06-20';
-        const path = 'this/is a path/to a/file.md';
-        const sectionStart = 1337;
-        const sectionIndex = 1209;
-        const precedingHeader = 'Eloquent Section';
 
         // Act
-        const task = Task.fromLine({
+        const task = fromLine({
             line,
-            path,
-            sectionStart,
-            sectionIndex,
-            precedingHeader,
         });
 
         // Assert
@@ -102,18 +78,10 @@ describe('parsing', () => {
         // Arrange
         const line =
             '- [x] this is a ✅ done task 🗓 2021-09-12 ✅ 2021-06-20 ^my-precious  ';
-        const path = 'this/is a path/to a/file.md';
-        const sectionStart = 1337;
-        const sectionIndex = 1209;
-        const precedingHeader = 'Eloquent Section';
 
         // Act
-        const task = Task.fromLine({
+        const task = fromLine({
             line,
-            path,
-            sectionStart,
-            sectionIndex,
-            precedingHeader,
         });
 
         // Assert
@@ -314,12 +282,8 @@ describe('to string', () => {
         const line = '- [ ] this is a task 📅 2021-09-12 ^my-precious';
 
         // Act
-        const task: Task = Task.fromLine({
+        const task: Task = fromLine({
             line,
-            path: '',
-            sectionStart: 0,
-            sectionIndex: 0,
-            precedingHeader: '',
         }) as Task;
 
         // Assert
@@ -333,12 +297,8 @@ describe('to string', () => {
             '- [x] this is a done task #tagone 📅 2021-09-12 ✅ 2021-06-20 #journal/daily';
 
         // Act
-        const task: Task = Task.fromLine({
+        const task: Task = fromLine({
             line,
-            path: '',
-            sectionStart: 0,
-            sectionIndex: 0,
-            precedingHeader: '',
         }) as Task;
 
         // Assert
@@ -354,12 +314,8 @@ describe('toggle done', () => {
         const line = '- [ ] this is a task 📅 2021-09-12 ^my-precious';
 
         // Act
-        const task: Task = Task.fromLine({
+        const task: Task = fromLine({
             line,
-            path: '',
-            sectionStart: 0,
-            sectionIndex: 0,
-            precedingHeader: '',
         }) as Task;
         const toggled: Task = task.toggle()[0];
 
@@ -614,12 +570,8 @@ describe('toggle done', () => {
                 .filter(Boolean)
                 .join(' ');
 
-            const task = Task.fromLine({
+            const task = fromLine({
                 line,
-                path: '',
-                precedingHeader: '',
-                sectionStart: 0,
-                sectionIndex: 0,
             });
 
             const nextTask: Task = task!.toggle()[0];
@@ -643,18 +595,10 @@ describe('toggle done', () => {
     it('supports recurrence rule after a due date', () => {
         // Arrange
         const line = '- [ ] this is a task 🗓 2021-09-12 🔁 every day';
-        const path = 'this/is a path/to a/file.md';
-        const sectionStart = 1337;
-        const sectionIndex = 1209;
-        const precedingHeader = 'Eloquent Section';
 
         // Act
-        const task = Task.fromLine({
+        const task = fromLine({
             line,
-            path,
-            sectionStart,
-            sectionIndex,
-            precedingHeader,
         });
 
         // Assert


### PR DESCRIPTION

## Description

Simplify some tests in `Task.test.ts` By using `fromLine()` in `TestHelpers`, instead of `Task.fromLine()` as the former is simpler to call, when we don't care about file and section names.

## Motivation and Context

To try to steer future Pull Requests towards simpler code when writing tests of the parsing of task lines,

## How has this been tested?

By running the existing tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tests only

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
