### PR TITLE
docs: Note that Boolean combinations were introduced in Tasks 1.9.0

### DIFF
--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -43,6 +43,8 @@ When the day changes, relative dates like `due today` are re-evaluated so that t
 
 ## Matching multiple filters
 
+> Boolean combinations were introduced in Tasks 1.9.0
+
 Each line of a query has to match in order for a task to be listed.
 In other words, lines are considered to have an 'AND' operator between them.
 Within each line, you can use the boolean operators `NOT`, `AND`, `OR`, `AND NOT`, `OR NOT` and `XOR`, as long as individual filters are wrapped in parentheses or double quotes:


### PR DESCRIPTION
Minor documentation change: I forgot one location to note release version of boolean combinations.