### PR TITLE
refactor: Preparation for only redrawing tasks blocks if edits change any tasks

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -207,14 +207,14 @@ export class Cache {
             listItems = [];
         }
 
-        const fileContent = await this.vault.cachedRead(file);
-        const fileLines = fileContent.split('\n');
-
         // Remove all tasks from this file from the cache before
         // adding the ones that are currently in the file.
         this.tasks = this.tasks.filter((task: Task) => {
             return task.path !== file.path;
         });
+
+        const fileContent = await this.vault.cachedRead(file);
+        const fileLines = fileContent.split('\n');
 
         // We want to store section information with every task so
         // that we can use that when we post process the markdown

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -230,7 +230,7 @@ export class Cache {
                 ) {
                     // We went past the current section (or this is the first task).
                     // Find the section that is relevant for this task and the following of the same section.
-                    currentSection = this.getSection({
+                    currentSection = Cache.getSection({
                         lineNumberTask: listItem.position.start.line,
                         sections: fileCache.sections,
                     });
@@ -248,7 +248,7 @@ export class Cache {
                     path: file.path,
                     sectionStart: currentSection.position.start.line,
                     sectionIndex,
-                    precedingHeader: this.getPrecedingHeader({
+                    precedingHeader: Cache.getPrecedingHeader({
                         lineNumberTask: listItem.position.start.line,
                         sections: fileCache.sections,
                         fileLines,
@@ -266,7 +266,7 @@ export class Cache {
         this.notifySubscribers();
     }
 
-    private getSection({
+    private static getSection({
         lineNumberTask,
         sections,
     }: {
@@ -290,7 +290,7 @@ export class Cache {
         return null;
     }
 
-    private getPrecedingHeader({
+    private static getPrecedingHeader({
         lineNumberTask,
         sections,
         fileLines,

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -215,7 +215,7 @@ export class Cache {
         });
 
         const fileContent = await this.vault.cachedRead(file);
-        const newTasks = this.getTasksFromFileContent(
+        const newTasks = Cache.getTasksFromFileContent(
             fileContent,
             listItems,
             fileCache,
@@ -227,7 +227,7 @@ export class Cache {
         this.notifySubscribers();
     }
 
-    private getTasksFromFileContent(
+    private static getTasksFromFileContent(
         fileContent: string,
         listItems: ListItemCache[],
         fileCache: CachedMetadata,

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -1,4 +1,5 @@
 import { MetadataCache, TAbstractFile, TFile, Vault } from 'obsidian';
+import type { CachedMetadata, ListItemCache } from 'obsidian';
 import type { EventRef, SectionCache } from 'obsidian';
 import { Mutex } from 'async-mutex';
 
@@ -214,6 +215,18 @@ export class Cache {
         });
 
         const fileContent = await this.vault.cachedRead(file);
+        this.getTasksFromFileContent(fileContent, listItems, fileCache, file);
+
+        // All updated, inform our subscribers.
+        this.notifySubscribers();
+    }
+
+    private getTasksFromFileContent(
+        fileContent: string,
+        listItems: ListItemCache[],
+        fileCache: CachedMetadata,
+        file: TFile,
+    ) {
         const fileLines = fileContent.split('\n');
 
         // We want to store section information with every task so
@@ -261,9 +274,6 @@ export class Cache {
                 }
             }
         }
-
-        // All updated, inform our subscribers.
-        this.notifySubscribers();
     }
 
     private static getSection({

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -215,7 +215,13 @@ export class Cache {
         });
 
         const fileContent = await this.vault.cachedRead(file);
-        this.getTasksFromFileContent(fileContent, listItems, fileCache, file);
+        const newTasks = this.getTasksFromFileContent(
+            fileContent,
+            listItems,
+            fileCache,
+            file,
+        );
+        this.tasks.push(...newTasks);
 
         // All updated, inform our subscribers.
         this.notifySubscribers();
@@ -226,7 +232,8 @@ export class Cache {
         listItems: ListItemCache[],
         fileCache: CachedMetadata,
         file: TFile,
-    ) {
+    ): Task[] {
+        const tasks: Task[] = [];
         const fileLines = fileContent.split('\n');
 
         // We want to store section information with every task so
@@ -270,10 +277,12 @@ export class Cache {
 
                 if (task !== null) {
                     sectionIndex++;
-                    this.tasks.push(task);
+                    tasks.push(task);
                 }
             }
         }
+
+        return tasks;
     }
 
     private static getSection({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a serious of safe refactorings, all but one of which were totally automated in WebStorm.

The core change is to extract the majority of code in `Cache.indexFile()` out in to a separate static method `Cache.getTasksFromFileContent()`.

By making that new method static, I can be confident that it is not changing any state in the Cache, and I can later compare the tasks it read from the edited file, to see if they are different from the tasks last read from the same file.

## Motivation and Context

It is in preparation for fixing #886 - so that the eventual fix will be a smaller commit that is easier to review.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->


By editing some tasks In a test vault. with the new changes, and confirming that tasks blocks are still updated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
