### PR TITLE
Add support for grouping by tags

### DIFF
--- a/docs/queries/grouping.md
+++ b/docs/queries/grouping.md
@@ -57,6 +57,8 @@ Task properties:
     * The due date of the task, including the week-day, or `No due date`.
 1. `done`
     * The done date of the task, including the week-day, or `No done date`.
+1. `tags`
+    * The tags of the tasks or `(No tags)`. If the task has multiple tags, it will show up under every tag.
 
 > `start`, `scheduled`, `due` and `done` grouping options were introduced in Tasks 1.7.0.
 

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -34,7 +34,8 @@ export type GroupingProperty =
     | 'path'
     | 'scheduled'
     | 'start'
-    | 'status';
+    | 'status'
+    | 'tags';
 export type Grouping = { property: GroupingProperty };
 
 export class Query implements IQuery {
@@ -53,7 +54,7 @@ export class Query implements IQuery {
         /^sort by (urgency|status|priority|start|scheduled|due|done|path|description|tag)( reverse)?[\s]*(\d+)?/;
 
     private readonly groupByRegexp =
-        /^group by (backlink|done|due|filename|folder|heading|path|scheduled|start|status)/;
+        /^group by (backlink|done|due|filename|folder|heading|path|scheduled|start|status|tags)/;
 
     private readonly hideOptionsRegexp =
         /^hide (task count|backlink|priority|start date|scheduled date|done date|due date|recurrence rule|edit button)/;

--- a/src/Query/Group.ts
+++ b/src/Query/Group.ts
@@ -5,7 +5,7 @@ import { TaskGroups } from './TaskGroups';
 /**
  * A naming function, that takes a Task object and returns the corresponding group property name
  */
-type Grouper = (task: Task) => string;
+type Grouper = (task: Task) => string[];
 
 /**
  * Implementation of the 'group by' instruction.
@@ -23,42 +23,14 @@ export class Group {
     }
 
     /**
-     * Return the Grouper functions matching the 'group by' lines
-     * @param grouping 0 or more Grouping values, one per 'group by' line
-     */
-    public static getGroupersForAllQueryGroupings(grouping: Grouping[]) {
-        const groupers: Grouper[] = [];
-        for (const { property } of grouping) {
-            const comparator = Group.groupers[property];
-            groupers.push(comparator);
-        }
-        return groupers;
-    }
-
-    /**
-     * Return the group names for a single task
-     * @param groupers The Grouper functions indicating the requested types of group
-     * @param task
-     */
-    public static getGroupNamesForTask(groupers: Grouper[], task: Task) {
-        const groupNames = [];
-        for (const grouper of groupers) {
-            const groupName = grouper(task);
-            groupNames.push(groupName);
-        }
-        return groupNames;
-    }
-
-    /**
-     * Return a single property name for a single task.
-     * A convenience method for unit tests.
+     * Return the properties of a single task for the passed grouping property
      * @param property
      * @param task
      */
-    public static getGroupNameForTask(
+    public static getGroupNamesForTask(
         property: GroupingProperty,
         task: Task,
-    ): string {
+    ): string[] {
         const grouper = Group.groupers[property];
         return grouper(task);
     }
@@ -76,36 +48,39 @@ export class Group {
         status: Group.groupByStatus,
     };
 
-    private static groupByStartDate(task: Task): string {
-        return Group.groupByDate(task.startDate, 'start');
+    private static groupByStartDate(task: Task): string[] {
+        return [Group.stringFromDate(task.startDate, 'start')];
     }
 
-    private static groupByScheduledDate(task: Task): string {
-        return Group.groupByDate(task.scheduledDate, 'scheduled');
+    private static groupByScheduledDate(task: Task): string[] {
+        return [Group.stringFromDate(task.scheduledDate, 'scheduled')];
     }
 
-    private static groupByDueDate(task: Task): string {
-        return Group.groupByDate(task.dueDate, 'due');
+    private static groupByDueDate(task: Task): string[] {
+        return [Group.stringFromDate(task.dueDate, 'due')];
     }
 
-    private static groupByDoneDate(task: Task): string {
-        return Group.groupByDate(task.doneDate, 'done');
+    private static groupByDoneDate(task: Task): string[] {
+        return [Group.stringFromDate(task.doneDate, 'done')];
     }
 
-    private static groupByDate(date: moment.Moment | null, field: string) {
+    private static stringFromDate(
+        date: moment.Moment | null,
+        field: string,
+    ): string {
         if (date === null) {
             return 'No ' + field + ' date';
         }
         return date.format(Group.groupDateFormat);
     }
 
-    private static groupByPath(task: Task): string {
+    private static groupByPath(task: Task): string[] {
         // Does this need to be made stricter?
         // Is there a better way of getting the file name?
-        return task.path.replace('.md', '');
+        return [task.path.replace('.md', '')];
     }
 
-    private static groupByFolder(task: Task): string {
+    private static groupByFolder(task: Task): string[] {
         const path = task.path;
         const fileNameWithExtension = task.filename + '.md';
         const folder = path.substring(
@@ -113,41 +88,41 @@ export class Group {
             path.lastIndexOf(fileNameWithExtension),
         );
         if (folder === '') {
-            return '/';
+            return ['/'];
         }
-        return folder;
+        return [folder];
     }
 
-    private static groupByFileName(task: Task): string {
+    private static groupByFileName(task: Task): string[] {
         // Note current limitation: Tasks from different notes with the
         // same name will be grouped together, even though they are in
         // different files and their links will look different.
         const filename = task.filename;
         if (filename === null) {
-            return 'Unknown Location';
+            return ['Unknown Location'];
         }
-        return filename;
+        return [filename];
     }
 
-    private static groupByBacklink(task: Task): string {
+    private static groupByBacklink(task: Task): string[] {
         const linkText = task.getLinkText({ isFilenameUnique: true });
         if (linkText === null) {
-            return 'Unknown Location';
+            return ['Unknown Location'];
         }
-        return linkText;
+        return [linkText];
     }
 
-    private static groupByStatus(task: Task): string {
-        return task.status;
+    private static groupByStatus(task: Task): string[] {
+        return [task.status];
     }
 
-    private static groupByHeading(task: Task): string {
+    private static groupByHeading(task: Task): string[] {
         if (
             task.precedingHeader === null ||
             task.precedingHeader.length === 0
         ) {
-            return '(No heading)';
+            return ['(No heading)'];
         }
-        return task.precedingHeader;
+        return [task.precedingHeader];
     }
 }

--- a/src/Query/Group.ts
+++ b/src/Query/Group.ts
@@ -46,6 +46,7 @@ export class Group {
         scheduled: Group.groupByScheduledDate,
         start: Group.groupByStartDate,
         status: Group.groupByStatus,
+        tags: Group.groupByTags,
     };
 
     private static groupByStartDate(task: Task): string[] {
@@ -124,5 +125,12 @@ export class Group {
             return ['(No heading)'];
         }
         return [task.precedingHeader];
+    }
+
+    private static groupByTags(task: Task): string[] {
+        if (task.tags.length == 0) {
+            return ['(No tags)'];
+        }
+        return task.tags;
     }
 }

--- a/src/Query/GroupingTreeNode.ts
+++ b/src/Query/GroupingTreeNode.ts
@@ -1,0 +1,38 @@
+/**
+ * A node in the grouping tree. The node contains the
+ * list of values matching the path from the root so far, and its children
+ * are the further grouping of those values.
+ *
+ */
+export class GroupingTreeNode<T> {
+    children: Map<string, GroupingTreeNode<T>> = new Map();
+    values: T[] = [];
+
+    constructor(values: T[]) {
+        this.values = values;
+    }
+
+    /**
+     * Recursively traverse the tree to generate all the paths to the leaves.
+     * This function returns a map from every leaf path, to the list of values
+     * matching this path.
+     * NOTE: The node itself doesn't get included in the generated paths.
+     */
+    generateAllPaths(pathSoFar: string[] = []): Map<string[], T[]> {
+        const resultMap = new Map();
+        if (this.children.size == 0) {
+            // Base case: Leaf node. Populate the results map with the path to
+            // this node, and the values that match this path.
+            resultMap.set([...pathSoFar], this.values);
+            return resultMap;
+        }
+
+        for (const [property, child] of this.children) {
+            pathSoFar.push(property);
+            const childResult = child.generateAllPaths(pathSoFar);
+            childResult.forEach((value, key) => resultMap.set(key, value));
+            pathSoFar.pop();
+        }
+        return resultMap;
+    }
+}

--- a/src/Query/IntermediateTaskGroups.ts
+++ b/src/Query/IntermediateTaskGroups.ts
@@ -1,6 +1,7 @@
 import type { Grouping } from '../Query';
 import type { Task } from '../Task';
 import { Group } from './Group';
+import { GroupingTreeNode } from './GroupingTreeNode';
 
 /**
  * Storage used for the initial grouping together of tasks.
@@ -11,43 +12,7 @@ import { Group } from './Group';
  */
 export class IntermediateTaskGroupsStorage extends Map<string[], Task[]> {}
 
-/**
- * A node in the grouping tree. The node contains the
- * list of tasks matching the path from the root so far, and its children
- * are the further grouping of those tasks.
- *
- * Check the docs of @GroupingTree for more details.
- *
- */
-class GroupingTreeNode {
-    children: Map<string, GroupingTreeNode> = new Map();
-    tasks: Task[] = [];
-
-    /**
-     * Recursively traverse the tree to generate all the paths to the leaves.
-     * This function returns a map from every leaf path, to the list of tasks
-     * matching this path.
-     */
-    generateAllPaths(pathSoFar: string[] = []): IntermediateTaskGroupsStorage {
-        const resultMap = new IntermediateTaskGroupsStorage();
-        if (this.children.size == 0) {
-            // Base case: Leaf node. Populate the results map with the path to
-            // this node, and the tasks that match this path.
-            resultMap.set([...pathSoFar], this.tasks);
-            return resultMap;
-        }
-
-        for (const [property, child] of this.children) {
-            pathSoFar.push(property);
-            const childResult = child.generateAllPaths(pathSoFar);
-            childResult.forEach((value, key) => resultMap.set(key, value));
-            pathSoFar.pop();
-        }
-        return resultMap;
-    }
-}
-
-/**
+/*
  * A tree of tasks where every level in the tree corresponds to a grouping property.
  *
  * For example, if we have:
@@ -70,7 +35,7 @@ class GroupingTreeNode {
  *
  * NOTE: The same task can appear in multiple leaf nodes, if it matches multiple paths.
  */
-type GroupingTree = GroupingTreeNode;
+class TaskGroupingTreeNode extends GroupingTreeNode<Task> {}
 
 /**
  * IntermediateTaskGroups does the initial grouping together of tasks,
@@ -103,20 +68,19 @@ export class IntermediateTaskGroups {
     private buildGroupingTree(
         groupings: Grouping[],
         tasks: Task[],
-    ): GroupingTree {
+    ): TaskGroupingTreeNode {
         // The tree is build layer by layer, starting from the root.
         // At every level, we iterate on the nodes of that level to generate
         // the next one using the next grouping.
 
         // The root of the tree contains all the tasks.
-        const root = new GroupingTreeNode();
-        root.tasks = tasks;
+        const root = new TaskGroupingTreeNode(tasks);
 
         let currentTreeLevel = [root];
         for (const grouping of groupings) {
             const nextTreeLevel = [];
             for (const currentTreeNode of currentTreeLevel) {
-                for (const task of currentTreeNode.tasks) {
+                for (const task of currentTreeNode.values) {
                     const groupNames = Group.getGroupNamesForTask(
                         grouping.property,
                         task,
@@ -124,11 +88,11 @@ export class IntermediateTaskGroups {
                     for (const groupName of groupNames) {
                         let child = currentTreeNode.children.get(groupName);
                         if (child === undefined) {
-                            child = new GroupingTreeNode();
+                            child = new TaskGroupingTreeNode([]);
                             currentTreeNode.children.set(groupName, child);
                             nextTreeLevel.push(child);
                         }
-                        child.tasks.push(task);
+                        child.values.push(task);
                     }
                 }
             }

--- a/src/Query/IntermediateTaskGroups.ts
+++ b/src/Query/IntermediateTaskGroups.ts
@@ -12,6 +12,67 @@ import { Group } from './Group';
 export class IntermediateTaskGroupsStorage extends Map<string[], Task[]> {}
 
 /**
+ * A node in the grouping tree. The node contains the
+ * list of tasks matching the path from the root so far, and its children
+ * are the further grouping of those tasks.
+ *
+ * Check the docs of @GroupingTree for more details.
+ *
+ */
+class GroupingTreeNode {
+    children: Map<string, GroupingTreeNode> = new Map();
+    tasks: Task[] = [];
+
+    /**
+     * Recursively traverse the tree to generate all the paths to the leaves.
+     * This function returns a map from every leaf path, to the list of tasks
+     * matching this path.
+     */
+    generateAllPaths(pathSoFar: string[] = []): IntermediateTaskGroupsStorage {
+        const resultMap = new IntermediateTaskGroupsStorage();
+        if (this.children.size == 0) {
+            // Base case: Leaf node. Populate the results map with the path to
+            // this node, and the tasks that match this path.
+            resultMap.set([...pathSoFar], this.tasks);
+            return resultMap;
+        }
+
+        for (const [property, child] of this.children) {
+            pathSoFar.push(property);
+            const childResult = child.generateAllPaths(pathSoFar);
+            childResult.forEach((value, key) => resultMap.set(key, value));
+            pathSoFar.pop();
+        }
+        return resultMap;
+    }
+}
+
+/**
+ * A tree of tasks where every level in the tree corresponds to a grouping property.
+ *
+ * For example, if we have:
+ * # Heading 1
+ * - [ ] Task 1
+ * # Heading 2
+ * - [ ] Task 2
+ * - [X] Task 3
+ *
+ * And we group by heading then status, the tree will look like:
+ *
+ *                   Root [T1, T2, T3]
+ *                     /              \
+ *              Heading 1 [T1]     Heading [T2, T3]
+ *                   |               /        \
+ *               TODO [T1]     TODO [T2]    Done [T3]
+ *
+ * The nice property of this tree is that every path from the root to a leaf, maps
+ * to how the tasks will be rendered.
+ *
+ * NOTE: The same task can appear in multiple leaf nodes, if it matches multiple paths.
+ */
+type GroupingTree = GroupingTreeNode;
+
+/**
  * IntermediateTaskGroups does the initial grouping together of tasks,
  * in alphabetical order by group names.
  *
@@ -27,53 +88,54 @@ export class IntermediateTaskGroups {
 
     /**
      * Group a list of tasks, according to one or more task properties
-     * @param grouping 0 or more Grouping values, one per 'group by' line
+     * @param groupings 0 or more Grouping values, one per 'group by' line
      * @param tasks The tasks that match the task block's Query
      */
-    constructor(grouping: Grouping[], tasks: Task[]) {
-        if (grouping.length === 0 || tasks.length === 0) {
-            // There are no groups or no tasks: treat this as a single group,
-            // with an empty group name.
-            this.groups.set([], tasks);
-        } else {
-            const groupers = Group.getGroupersForAllQueryGroupings(grouping);
-
-            for (const task of tasks) {
-                const groupNames = Group.getGroupNamesForTask(groupers, task);
-                this.addTask(groupNames, task);
-            }
-            this.groups = this.getSortedGroups();
-        }
-    }
-
-    private addTask(groupNames: string[], task: Task) {
-        const groupForNames = this.getOrCreateGroupForGroupNames(groupNames);
-        groupForNames?.push(task);
+    constructor(groupings: Grouping[], tasks: Task[]) {
+        const tree = this.buildGroupingTree(groupings, tasks);
+        this.groups = tree.generateAllPaths();
+        this.groups = this.getSortedGroups();
     }
 
     /**
-     * If a task has been seen before with this exact combination of group names,
-     * return the container that the previous task(s) were added to.
-     *
-     * Otherwise, create and return a new container.
-     * @param newGroupNames
-     * @private
+     * Returns a grouping tree that groups the passed @tasks by the passed @groupings.
      */
-    private getOrCreateGroupForGroupNames(newGroupNames: string[]) {
-        for (const [groupNames, taskGroup] of this.groups) {
-            // Is there a better way to check if the contents of two string arrays
-            // are identical?
-            // Use of JSON feels inefficient, and is O(n-squared) on the number
-            // of unique group-name combinations, so may scale badly if
-            // very large numbers of tasks are displayed.
-            // Related: https://stackoverflow.com/questions/7837456/how-to-compare-arrays-in-javascript
-            if (JSON.stringify(groupNames) === JSON.stringify(newGroupNames)) {
-                return taskGroup;
+    private buildGroupingTree(
+        groupings: Grouping[],
+        tasks: Task[],
+    ): GroupingTree {
+        // The tree is build layer by layer, starting from the root.
+        // At every level, we iterate on the nodes of that level to generate
+        // the next one using the next grouping.
+
+        // The root of the tree contains all the tasks.
+        const root = new GroupingTreeNode();
+        root.tasks = tasks;
+
+        let currentTreeLevel = [root];
+        for (const grouping of groupings) {
+            const nextTreeLevel = [];
+            for (const currentTreeNode of currentTreeLevel) {
+                for (const task of currentTreeNode.tasks) {
+                    const groupNames = Group.getGroupNamesForTask(
+                        grouping.property,
+                        task,
+                    );
+                    for (const groupName of groupNames) {
+                        let child = currentTreeNode.children.get(groupName);
+                        if (child === undefined) {
+                            child = new GroupingTreeNode();
+                            currentTreeNode.children.set(groupName, child);
+                            nextTreeLevel.push(child);
+                        }
+                        child.tasks.push(task);
+                    }
+                }
             }
+            currentTreeLevel = nextTreeLevel;
         }
-        const taskGroup: Task[] = [];
-        this.groups.set(newGroupNames, taskGroup);
-        return taskGroup;
+
+        return root;
     }
 
     private getSortedGroups() {

--- a/src/Query/TaskGroups.ts
+++ b/src/Query/TaskGroups.ts
@@ -10,6 +10,7 @@ import { TaskGroup } from './TaskGroup';
  */
 export class TaskGroups {
     private _groups: TaskGroup[] = new Array<TaskGroup>();
+    private _totalTaskCount = 0;
 
     /**
      * Constructor for TaskGroups
@@ -20,6 +21,10 @@ export class TaskGroups {
      */
     constructor(groups: Grouping[], tasks: Task[]) {
         const initialGroups = new IntermediateTaskGroups(groups, tasks);
+
+        // Grouping doesn't change the number of tasks, and all the tasks
+        // will be shown in at least one group.
+        this._totalTaskCount = tasks.length;
         this.addTasks(initialGroups);
     }
 
@@ -35,11 +40,7 @@ export class TaskGroups {
      * The total number of tasks matching the query.
      */
     public totalTasksCount() {
-        let totalTasksCount = 0;
-        for (const group of this.groups) {
-            totalTasksCount += group.tasks.length;
-        }
-        return totalTasksCount;
+        return this._totalTaskCount;
     }
 
     /**

--- a/src/Query/TaskGroups.ts
+++ b/src/Query/TaskGroups.ts
@@ -20,11 +20,11 @@ export class TaskGroups {
      *                         matching the query, already in sort order
      */
     constructor(groups: Grouping[], tasks: Task[]) {
-        const initialGroups = new IntermediateTaskGroups(groups, tasks);
-
         // Grouping doesn't change the number of tasks, and all the tasks
         // will be shown in at least one group.
         this._totalTaskCount = tasks.length;
+
+        const initialGroups = new IntermediateTaskGroups(groups, tasks);
         this.addTasks(initialGroups);
     }
 

--- a/tests/Group.test.ts
+++ b/tests/Group.test.ts
@@ -9,13 +9,13 @@ import { fromLine } from './TestHelpers';
 
 window.moment = moment;
 
-function checkGroupNameOfTask(
+function checkGroupNamesOfTask(
     task: Task,
     property: GroupingProperty,
-    expectedGroupName: string,
+    expectedGroupNames: string[],
 ) {
-    const group = Group.getGroupNameForTask(property, task);
-    expect(group).toEqual(expectedGroupName);
+    const group = Group.getGroupNamesForTask(property, task);
+    expect(group).toEqual(expectedGroupNames);
 }
 
 describe('Grouping tasks', () => {
@@ -194,7 +194,7 @@ describe('Group names', () => {
     type GroupNameCase = {
         groupBy: GroupingProperty;
         taskLine: string;
-        expectedGroupName: string;
+        expectedGroupNames: string[];
         path?: string;
         precedingHeading?: string | null;
     };
@@ -207,7 +207,7 @@ describe('Group names', () => {
         {
             groupBy: 'backlink',
             taskLine: '- [ ] xxx',
-            expectedGroupName: 'c > heading',
+            expectedGroupNames: ['c > heading'],
             path: 'a/b/c.md',
             precedingHeading: 'heading',
         },
@@ -217,12 +217,12 @@ describe('Group names', () => {
         {
             groupBy: 'done',
             taskLine: '- [ ] a ✅ 1970-01-01',
-            expectedGroupName: '1970-01-01 Thursday',
+            expectedGroupNames: ['1970-01-01 Thursday'],
         },
         {
             groupBy: 'done',
             taskLine: '- [ ] a',
-            expectedGroupName: 'No done date',
+            expectedGroupNames: ['No done date'],
         },
 
         // -----------------------------------------------------------
@@ -230,12 +230,12 @@ describe('Group names', () => {
         {
             groupBy: 'due',
             taskLine: '- [ ] a 📅 1970-01-01',
-            expectedGroupName: '1970-01-01 Thursday',
+            expectedGroupNames: ['1970-01-01 Thursday'],
         },
         {
             groupBy: 'due',
             taskLine: '- [ ] a',
-            expectedGroupName: 'No due date',
+            expectedGroupNames: ['No due date'],
         },
 
         // -----------------------------------------------------------
@@ -243,7 +243,7 @@ describe('Group names', () => {
         {
             groupBy: 'filename',
             taskLine: '- [ ] a',
-            expectedGroupName: 'c',
+            expectedGroupNames: ['c'],
             path: 'a/b/c.md',
         },
 
@@ -252,14 +252,14 @@ describe('Group names', () => {
         {
             groupBy: 'folder',
             taskLine: '- [ ] a',
-            expectedGroupName: 'a/b/',
+            expectedGroupNames: ['a/b/'],
             path: 'a/b/c.md',
         },
         {
             // file in root of vault:
             groupBy: 'folder',
             taskLine: '- [ ] a',
-            expectedGroupName: '/',
+            expectedGroupNames: ['/'],
             path: 'a.md',
         },
 
@@ -268,19 +268,19 @@ describe('Group names', () => {
         {
             groupBy: 'heading',
             taskLine: '- [ ] xxx',
-            expectedGroupName: '(No heading)',
+            expectedGroupNames: ['(No heading)'],
             precedingHeading: null,
         },
         {
             groupBy: 'heading',
             taskLine: '- [ ] xxx',
-            expectedGroupName: '(No heading)',
+            expectedGroupNames: ['(No heading)'],
             precedingHeading: '',
         },
         {
             groupBy: 'heading',
             taskLine: '- [ ] xxx',
-            expectedGroupName: 'heading',
+            expectedGroupNames: ['heading'],
             precedingHeading: 'heading',
         },
 
@@ -290,7 +290,7 @@ describe('Group names', () => {
             groupBy: 'path',
             taskLine: '- [ ] a',
             path: 'a/b/c.md',
-            expectedGroupName: 'a/b/c',
+            expectedGroupNames: ['a/b/c'],
         },
 
         // -----------------------------------------------------------
@@ -298,12 +298,12 @@ describe('Group names', () => {
         {
             groupBy: 'scheduled',
             taskLine: '- [ ] a ⏳ 1970-01-01',
-            expectedGroupName: '1970-01-01 Thursday',
+            expectedGroupNames: ['1970-01-01 Thursday'],
         },
         {
             groupBy: 'scheduled',
             taskLine: '- [ ] a',
-            expectedGroupName: 'No scheduled date',
+            expectedGroupNames: ['No scheduled date'],
         },
 
         // -----------------------------------------------------------
@@ -311,12 +311,12 @@ describe('Group names', () => {
         {
             groupBy: 'start',
             taskLine: '- [ ] a 🛫 1970-01-01',
-            expectedGroupName: '1970-01-01 Thursday',
+            expectedGroupNames: ['1970-01-01 Thursday'],
         },
         {
             groupBy: 'start',
             taskLine: '- [ ] a',
-            expectedGroupName: 'No start date',
+            expectedGroupNames: ['No start date'],
         },
 
         // -----------------------------------------------------------
@@ -324,12 +324,12 @@ describe('Group names', () => {
         {
             groupBy: 'status',
             taskLine: '- [ ] a',
-            expectedGroupName: 'Todo',
+            expectedGroupNames: ['Todo'],
         },
         {
             groupBy: 'status',
             taskLine: '- [x] a',
-            expectedGroupName: 'Done',
+            expectedGroupNames: ['Done'],
         },
 
         // -----------------------------------------------------------
@@ -337,13 +337,13 @@ describe('Group names', () => {
 
     test.concurrent.each<GroupNameCase>(groupNameCases)(
         'assigns correct group name (%j)',
-        ({ groupBy, taskLine, path, expectedGroupName, precedingHeading }) => {
+        ({ groupBy, taskLine, path, expectedGroupNames, precedingHeading }) => {
             const task = fromLine({
                 line: taskLine,
                 path: path ? path : '',
                 precedingHeader: precedingHeading,
             });
-            checkGroupNameOfTask(task, groupBy, expectedGroupName);
+            checkGroupNamesOfTask(task, groupBy, expectedGroupNames);
         },
     );
 });

--- a/tests/Group.test.ts
+++ b/tests/Group.test.ts
@@ -333,6 +333,24 @@ describe('Group names', () => {
         },
 
         // -----------------------------------------------------------
+        // group by tags
+        {
+            groupBy: 'tags',
+            taskLine: '- [ ] a #tag1',
+            expectedGroupNames: ['#tag1'],
+        },
+        {
+            groupBy: 'tags',
+            taskLine: '- [ ] a #tag1 #tag2',
+            expectedGroupNames: ['#tag1', '#tag2'],
+        },
+        {
+            groupBy: 'tags',
+            taskLine: '- [x] a',
+            expectedGroupNames: ['(No tags)'],
+        },
+
+        // -----------------------------------------------------------
     ];
 
     test.concurrent.each<GroupNameCase>(groupNameCases)(

--- a/tests/Group.test.ts
+++ b/tests/Group.test.ts
@@ -137,6 +137,42 @@ describe('Grouping tasks', () => {
         `);
     });
 
+    it('handles tasks matching multiple groups correctly', () => {
+        const a = fromLine({
+            line: '- [ ] Task 1 #group1',
+        });
+        const b = fromLine({
+            line: '- [ ] Task 2 #group2 #group1',
+        });
+        const c = fromLine({
+            line: '- [ ] Task 3 #group2',
+        });
+        const inputs = [a, b, c];
+
+        const group_by: GroupingProperty = 'tags';
+        const grouping = [{ property: group_by }];
+        const groups = Group.by(grouping, inputs);
+        expect(groups.toString()).toMatchInlineSnapshot(`
+            "
+            Group names: [#group1]
+            #### #group1
+            - [ ] Task 1 #group1
+            - [ ] Task 2 #group2 #group1
+
+            ---
+
+            Group names: [#group2]
+            #### #group2
+            - [ ] Task 2 #group2 #group1
+            - [ ] Task 3 #group2
+
+            ---
+
+            3 tasks
+            "
+        `);
+    });
+
     it('should create nested headings if multiple groups used', () => {
         // Arrange
         const t1 = fromLine({

--- a/tests/GroupingTreeNode.test.ts
+++ b/tests/GroupingTreeNode.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+import { GroupingTreeNode } from '../src/Query/GroupingTreeNode';
+
+describe('Grouping Tree', () => {
+    it('correctly generates all paths', () => {
+        // Arrange
+        // Build the following tree
+        //              Root[1, 2, 3, 4, 5, 6]
+        //             /                 \
+        //        B[1, 5, 6]              C[3, 4, 5, 6]
+        //          |                      /        \
+        //        D[1]                  E[3, 4]       F[4, 5, 6]
+        //                                            /        \
+        //                                          G[4]       H[5, 6]
+
+        // Let's start building the tree
+        const tree = new GroupingTreeNode<number>([1, 2, 3, 4, 5, 6]);
+        const b = new GroupingTreeNode<number>([1, 5, 6]);
+        const c = new GroupingTreeNode<number>([3, 4, 5, 6]);
+        const d = new GroupingTreeNode<number>([1]);
+        const e = new GroupingTreeNode<number>([3, 4]);
+        const f = new GroupingTreeNode<number>([4, 5, 6]);
+        const g = new GroupingTreeNode<number>([4]);
+        const h = new GroupingTreeNode<number>([5, 6]);
+        tree.children.set('B', b);
+        tree.children.set('C', c);
+        b.children.set('D', d);
+        c.children.set('E', e);
+        c.children.set('F', f);
+        f.children.set('G', g);
+        f.children.set('H', h);
+
+        // Validation
+        const allLeafs = tree.generateAllPaths();
+        const expected = new Map<string[], number[]>();
+        expected.set(['B', 'D'], [1]);
+        expected.set(['C', 'E'], [3, 4]);
+        expected.set(['C', 'F', 'G'], [4]);
+        expected.set(['C', 'F', 'H'], [5, 6]);
+
+        // Assert
+        expect(allLeafs).toEqual(expected);
+    });
+
+    it("generates correct map when the node doesn't have children", () => {
+        const tree = new GroupingTreeNode<number>([1, 2, 3, 4, 5, 6]);
+        const allLeafs = tree.generateAllPaths();
+
+        const expected = new Map<string[], number[]>();
+        expected.set([], [1, 2, 3, 4, 5, 6]);
+
+        expect(allLeafs).toEqual(expected);
+    });
+});

--- a/tests/GroupingTreeNode.test.ts
+++ b/tests/GroupingTreeNode.test.ts
@@ -6,6 +6,7 @@ import { GroupingTreeNode } from '../src/Query/GroupingTreeNode';
 describe('Grouping Tree', () => {
     it('correctly generates all paths', () => {
         // Arrange
+
         // Build the following tree
         //              Root[1, 2, 3, 4, 5, 6]
         //             /                 \
@@ -14,8 +15,6 @@ describe('Grouping Tree', () => {
         //        D[1]                  E[3, 4]       F[4, 5, 6]
         //                                            /        \
         //                                          G[4]       H[5, 6]
-
-        // Let's start building the tree
         const tree = new GroupingTreeNode<number>([1, 2, 3, 4, 5, 6]);
         const b = new GroupingTreeNode<number>([1, 5, 6]);
         const c = new GroupingTreeNode<number>([3, 4, 5, 6]);
@@ -32,25 +31,28 @@ describe('Grouping Tree', () => {
         f.children.set('G', g);
         f.children.set('H', h);
 
-        // Validation
+        // Act
         const allLeafs = tree.generateAllPaths();
+
+        // Assert
         const expected = new Map<string[], number[]>();
         expected.set(['B', 'D'], [1]);
         expected.set(['C', 'E'], [3, 4]);
         expected.set(['C', 'F', 'G'], [4]);
         expected.set(['C', 'F', 'H'], [5, 6]);
-
-        // Assert
         expect(allLeafs).toEqual(expected);
     });
 
     it("generates correct map when the node doesn't have children", () => {
+        // Arrange
         const tree = new GroupingTreeNode<number>([1, 2, 3, 4, 5, 6]);
+
+        // Act
         const allLeafs = tree.generateAllPaths();
 
+        // Assert
         const expected = new Map<string[], number[]>();
         expected.set([], [1, 2, 3, 4, 5, 6]);
-
         expect(allLeafs).toEqual(expected);
     });
 });

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -169,6 +169,7 @@ describe('Query parsing', () => {
             'group by scheduled',
             'group by start',
             'group by status',
+            'group by tags',
         ];
         test.concurrent.each<string>(filters)('recognises %j', (filter) => {
             // Arrange


### PR DESCRIPTION
## Description
This PR adds support for grouping tasks by tags. Given that a single task can have multiple tags, this PR also refactors the grouping logic to be more generic and support having the same task under multiple groups.

The approach I went with is building a tree of each grouping layer, and at the end traversing this tree to get the final task groups to render. The logic is documented in code with examples.

> Side Note: I'm very impressed with the code/documentation quality of the plugin. Reading and contributing to the codebase was extremely smooth.

## Motivation and Context
I personally categorize my tasks with tags, and I'd like to have a single dashboard with all my tasks grouped by the specified tag.

Seems like a popular request as well:
https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/620
https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/873
https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/892

## How has this been tested?

- All tests were still passing after the commit that does the refactoring. It should be a no-op commit.
- The commit that adds support for grouping by tags, adds unit tests.
- I tested it manually (by symlinking my fork into a test obsidian vault and seeing how it behaves). Examples in the next section.

## Screenshots (if appropriate):

Initial task list:

<img width="309" alt="Screen Shot 2022-07-15 at 1 53 23 AM" src="https://user-images.githubusercontent.com/2418637/179119957-878ae09b-9b75-40f5-bcf1-8cb2e4a13ea6.png">


```tasks
group by tags
group by headings
```
<img width="730" alt="Screen Shot 2022-07-15 at 1 54 09 AM" src="https://user-images.githubusercontent.com/2418637/179120009-d74c3f3c-b135-46cc-a508-3f61c2aca4d6.png">

No grouping still works as expected:
<img width="499" alt="Screen Shot 2022-07-15 at 1 54 38 AM" src="https://user-images.githubusercontent.com/2418637/179120058-1401dcf6-c735-4bc2-91d9-c524e2239f07.png">

I also validated that if there's a global filter set, it doesn't get added to the groups.

<img width="543" alt="Screen Shot 2022-07-15 at 2 04 49 AM" src="https://user-images.githubusercontent.com/2418637/179120972-a7cf41aa-eb7f-4e50-9d1e-369fe9d33bc6.png">

Multiple tags per task:

<img width="512" alt="Screen Shot 2022-07-15 at 10 19 00 AM" src="https://user-images.githubusercontent.com/2418637/179183228-efe8a085-0648-427e-9995-e4789deb1ec1.png">


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project and passes `yarn run lint`.
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] My change has adequate Unit Test coverage.

I'll do the documentation change once I get an initial approval regarding the approach.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
