### PR TITLE
perf: Stop many non-task edits triggering a redraw of all active tasks blocks

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -208,12 +208,6 @@ export class Cache {
             listItems = [];
         }
 
-        // Remove all tasks from this file from the cache before
-        // adding the ones that are currently in the file.
-        this.tasks = this.tasks.filter((task: Task) => {
-            return task.path !== file.path;
-        });
-
         const fileContent = await this.vault.cachedRead(file);
         const newTasks = Cache.getTasksFromFileContent(
             fileContent,
@@ -221,6 +215,13 @@ export class Cache {
             fileCache,
             file,
         );
+
+        // Remove all tasks from this file from the cache before
+        // adding the ones that are currently in the file.
+        this.tasks = this.tasks.filter((task: Task) => {
+            return task.path !== file.path;
+        });
+
         this.tasks.push(...newTasks);
 
         // All updated, inform our subscribers.

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -231,7 +231,7 @@ export class Cache {
 
         if (this.getState() == State.Warm) {
             console.debug(
-                `At least one task or its heading has changed in ${file.path}: triggering a refresh of all active Tasks blocks in Live Preview and Reading mode views.`,
+                `At least one task, its line number or its heading has changed in ${file.path}: triggering a refresh of all active Tasks blocks in Live Preview and Reading mode views.`,
             );
         }
 

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -37,6 +37,7 @@ export class QueryRenderer {
                 events: this.events,
                 container: element,
                 source,
+                sourcePath: context.sourcePath,
             }),
         );
     }
@@ -46,6 +47,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     private readonly app: App;
     private readonly events: Events;
     private readonly source: string;
+    private readonly sourcePath: string;
     private query: IQuery;
     private queryType: string;
 
@@ -57,17 +59,20 @@ class QueryRenderChild extends MarkdownRenderChild {
         events,
         container,
         source,
+        sourcePath,
     }: {
         app: App;
         events: Events;
         container: HTMLElement;
         source: string;
+        sourcePath: string;
     }) {
         super(container);
 
         this.app = app;
         this.events = events;
         this.source = source;
+        this.sourcePath = sourcePath;
 
         // The engine is chosen on the basis of the code block language. Currently
         // there is only the main engine for the plugin, this allows others to be
@@ -129,7 +134,7 @@ class QueryRenderChild extends MarkdownRenderChild {
 
     private async render({ tasks, state }: { tasks: Task[]; state: State }) {
         console.debug(
-            `Render ${this.queryType} called for ${tasks.length} tasks, state: ${state}`,
+            `Render ${this.queryType} called for a block in active file "${this.sourcePath}", to select from ${tasks.length} tasks: plugin state: ${state}`,
         );
 
         const content = this.containerEl.createEl('div');
@@ -148,6 +153,9 @@ class QueryRenderChild extends MarkdownRenderChild {
                 content.appendChild(taskList);
             }
             const totalTasksCount = tasksSortedLimitedGrouped.totalTasksCount();
+            console.debug(
+                `${totalTasksCount} of ${tasks.length} tasks displayed in a block in "${this.sourcePath}"`,
+            );
             this.addTaskCount(content, totalTasksCount);
         } else if (this.query.error !== undefined) {
             content.setText(`Tasks query: ${this.query.error}`);

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -47,7 +47,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     private readonly app: App;
     private readonly events: Events;
     private readonly source: string;
-    private readonly sourcePath: string;
+    private readonly filePath: string;
     private query: IQuery;
     private queryType: string;
 
@@ -72,7 +72,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         this.app = app;
         this.events = events;
         this.source = source;
-        this.sourcePath = sourcePath;
+        this.filePath = sourcePath;
 
         // The engine is chosen on the basis of the code block language. Currently
         // there is only the main engine for the plugin, this allows others to be
@@ -134,7 +134,7 @@ class QueryRenderChild extends MarkdownRenderChild {
 
     private async render({ tasks, state }: { tasks: Task[]; state: State }) {
         console.debug(
-            `Render ${this.queryType} called for a block in active file "${this.sourcePath}", to select from ${tasks.length} tasks: plugin state: ${state}`,
+            `Render ${this.queryType} called for a block in active file "${this.filePath}", to select from ${tasks.length} tasks: plugin state: ${state}`,
         );
 
         const content = this.containerEl.createEl('div');
@@ -154,7 +154,7 @@ class QueryRenderChild extends MarkdownRenderChild {
             }
             const totalTasksCount = tasksSortedLimitedGrouped.totalTasksCount();
             console.debug(
-                `${totalTasksCount} of ${tasks.length} tasks displayed in a block in "${this.sourcePath}"`,
+                `${totalTasksCount} of ${tasks.length} tasks displayed in a block in "${this.filePath}"`,
             );
             this.addTaskCount(content, totalTasksCount);
         } else if (this.query.error !== undefined) {

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -37,7 +37,7 @@ export class QueryRenderer {
                 events: this.events,
                 container: element,
                 source,
-                sourcePath: context.sourcePath,
+                filePath: context.sourcePath,
             }),
         );
     }
@@ -59,20 +59,20 @@ class QueryRenderChild extends MarkdownRenderChild {
         events,
         container,
         source,
-        sourcePath,
+        filePath,
     }: {
         app: App;
         events: Events;
         container: HTMLElement;
         source: string;
-        sourcePath: string;
+        filePath: string;
     }) {
         super(container);
 
         this.app = app;
         this.events = events;
         this.source = source;
-        this.filePath = sourcePath;
+        this.filePath = filePath;
 
         // The engine is chosen on the basis of the code block language. Currently
         // there is only the main engine for the plugin, this allows others to be

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -46,8 +46,8 @@ export class QueryRenderer {
 class QueryRenderChild extends MarkdownRenderChild {
     private readonly app: App;
     private readonly events: Events;
-    private readonly source: string;
-    private readonly filePath: string;
+    private readonly source: string; // The complete text in the instruction block, such as 'not done\nshort mode'
+    private readonly filePath: string; // The path of the file that contains the instruction block
     private query: IQuery;
     private queryType: string;
 

--- a/src/Recurrence.ts
+++ b/src/Recurrence.ts
@@ -219,4 +219,14 @@ export class Recurrence {
 
         return null;
     }
+
+    public identicalTo(other: Recurrence) {
+        if (this.toText() !== other.toText()) {
+            return false;
+        }
+        if (this.baseOnToday !== other.baseOnToday) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/Recurrence.ts
+++ b/src/Recurrence.ts
@@ -233,6 +233,9 @@ export class Recurrence {
         if (Sort.compareByDate(this.startDate, other.startDate) !== 0) {
             return false;
         }
+        if (Sort.compareByDate(this.scheduledDate, other.scheduledDate) !== 0) {
+            return false;
+        }
         return true;
     }
 }

--- a/src/Recurrence.ts
+++ b/src/Recurrence.ts
@@ -222,9 +222,6 @@ export class Recurrence {
     }
 
     public identicalTo(other: Recurrence) {
-        if (this.toText() !== other.toText()) {
-            return false;
-        }
         if (this.baseOnToday !== other.baseOnToday) {
             return false;
         }
@@ -239,6 +236,7 @@ export class Recurrence {
         if (Sort.compareByDate(this.dueDate, other.dueDate) !== 0) {
             return false;
         }
-        return true;
+
+        return this.toText() === other.toText(); // this also checks baseOnToday
     }
 }

--- a/src/Recurrence.ts
+++ b/src/Recurrence.ts
@@ -236,6 +236,9 @@ export class Recurrence {
         if (Sort.compareByDate(this.scheduledDate, other.scheduledDate) !== 0) {
             return false;
         }
+        if (Sort.compareByDate(this.dueDate, other.dueDate) !== 0) {
+            return false;
+        }
         return true;
     }
 }

--- a/src/Recurrence.ts
+++ b/src/Recurrence.ts
@@ -1,5 +1,6 @@
 import type { Moment } from 'moment';
 import { RRule } from 'rrule';
+import { Sort } from './Sort';
 
 export class Recurrence {
     private readonly rrule: RRule;
@@ -225,6 +226,11 @@ export class Recurrence {
             return false;
         }
         if (this.baseOnToday !== other.baseOnToday) {
+            return false;
+        }
+
+        // Compare Date fields
+        if (Sort.compareByDate(this.startDate, other.startDate) !== 0) {
             return false;
         }
         return true;

--- a/src/Sort.ts
+++ b/src/Sort.ts
@@ -145,7 +145,7 @@ export class Sort {
         }
     }
 
-    private static compareByDate(
+    public static compareByDate(
         a: moment.Moment | null,
         b: moment.Moment | null,
     ): -1 | 0 | 1 {

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -688,7 +688,12 @@ export class Task {
         // Based on ideas from koala. AquaCat and javalent in Discord:
         // https://discord.com/channels/686053708261228577/840286264964022302/996735200388186182
         // and later.
-        const args: Array<keyof Task> = ['status', 'description', 'path'];
+        const args: Array<keyof Task> = [
+            'status',
+            'description',
+            'path',
+            'indentation',
+        ];
         for (const el of args) {
             if (this[el] !== other[el]) return false;
         }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -685,15 +685,12 @@ export class Task {
     }
 
     identicalTo(other: Task) {
-        // Based on ideas from koala and AquaCat in Discord:
+        // Based on ideas from koala. AquaCat and javalent in Discord:
         // https://discord.com/channels/686053708261228577/840286264964022302/996735200388186182
         // and later.
-        const args = ['status', 'description'];
+        const args: Array<keyof Task> = ['status', 'description'];
         for (const el of args) {
-            // 'as any' suppresses TS7053
-            if ((this as any)[el] !== (other as any)[el]) {
-                return false;
-            }
+            if (this[el] !== other[el]) return false;
         }
         return true;
     }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -702,7 +702,7 @@ export class Task {
         }
 
         // Compare Date fields
-        args = ['startDate', 'scheduledDate', 'dueDate'];
+        args = ['startDate', 'scheduledDate', 'dueDate', 'doneDate'];
         for (const el of args) {
             const date1 = this[el] as Moment | null;
             const date2 = other[el] as Moment | null;

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -702,7 +702,7 @@ export class Task {
         }
 
         // Compare Date fields
-        args = ['startDate'];
+        args = ['startDate', 'scheduledDate'];
         for (const el of args) {
             const date1 = this[el] as Moment | null;
             const date2 = other[el] as Moment | null;

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -684,7 +684,7 @@ export class Task {
         return linkText;
     }
 
-    identicalTo(other: Task) {
+    public identicalTo(other: Task) {
         // Based on ideas from koala. AquaCat and javalent in Discord:
         // https://discord.com/channels/686053708261228577/840286264964022302/996735200388186182
         // and later.

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -768,7 +768,7 @@ export class Task {
         } else if (
             recurrence1 &&
             recurrence2 &&
-            !recurrence1!.identicalTo(recurrence2!)
+            !recurrence1.identicalTo(recurrence2)
         ) {
             return false;
         }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -728,6 +728,21 @@ export class Task {
                 return false;
             }
         }
+
+        const recurrence1 = this.recurrence;
+        const recurrence2 = other.recurrence;
+        if (recurrence1 === null && recurrence2 !== null) {
+            return false;
+        } else if (recurrence1 !== null && recurrence2 === null) {
+            return false;
+        } else if (
+            recurrence1 &&
+            recurrence2 &&
+            !recurrence1!.identicalTo(recurrence2!)
+        ) {
+            return false;
+        }
+
         return true;
     }
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -720,6 +720,10 @@ export class Task {
         // Based on ideas from koala. AquaCat and javalent in Discord:
         // https://discord.com/channels/686053708261228577/840286264964022302/996735200388186182
         // and later.
+        //
+        // Note: sectionStart changes every time a line is added or deleted before
+        //       any of the tasks in a file. This does mean that redrawing of tasks blocks
+        //       happens more often than is ideal.
         let args: Array<keyof Task> = [
             'status',
             'description',

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -691,6 +691,7 @@ export class Task {
             'description',
             'path',
             'indentation',
+            'sectionStart',
         ];
         for (const el of args) {
             if (this[el] !== other[el]) return false;

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -684,6 +684,16 @@ export class Task {
         return linkText;
     }
 
+    identicalTo(other: Task) {
+        if (this.status !== other.status) {
+            return false;
+        }
+        if (this.description !== other.description) {
+            return false;
+        }
+        return true;
+    }
+
     private addTooltip({
         element,
         isFilenameUnique,

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -692,6 +692,7 @@ export class Task {
             'path',
             'indentation',
             'sectionStart',
+            'sectionIndex',
         ];
         for (const el of args) {
             if (this[el] !== other[el]) return false;

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -688,7 +688,7 @@ export class Task {
         // Based on ideas from koala. AquaCat and javalent in Discord:
         // https://discord.com/channels/686053708261228577/840286264964022302/996735200388186182
         // and later.
-        const args: Array<keyof Task> = ['status', 'description'];
+        const args: Array<keyof Task> = ['status', 'description', 'path'];
         for (const el of args) {
             if (this[el] !== other[el]) return false;
         }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -683,6 +683,28 @@ export class Task {
         return linkText;
     }
 
+    /**
+     * Compare two lists of Task objects, and report whether their
+     * tasks are identical in the same order.
+     *
+     * This can be useful for optimising code if it is guaranteed that
+     * there are no possible differences in the tasks in a file
+     * after an edit, for example.
+     *
+     * If any field is different in any task, it will return false.
+     *
+     * @param oldTasks
+     * @param newTasks
+     */
+    static tasksListsIdentical(oldTasks: Task[], newTasks: Task[]): boolean {
+        if (oldTasks.length !== newTasks.length) {
+            return false;
+        }
+        return oldTasks.every((oldTask, index) =>
+            oldTask.identicalTo(newTasks[index]),
+        );
+    }
+
     public identicalTo(other: Task) {
         // Based on ideas from koala. AquaCat and javalent in Discord:
         // https://discord.com/channels/686053708261228577/840286264964022302/996735200388186182

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -702,6 +702,19 @@ export class Task {
             if (this[el] !== other[el]) return false;
         }
 
+        // Compare tags
+        if (this.tags.length !== other.tags.length) {
+            return false;
+        }
+        // Tags are the same only if the values are in the same order
+        if (
+            !this.tags.every(function (element, index) {
+                return element === other.tags[index];
+            })
+        ) {
+            return false;
+        }
+
         // Compare Date fields
         args = ['startDate', 'scheduledDate', 'dueDate', 'doneDate'];
         for (const el of args) {

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -705,6 +705,17 @@ export class Task {
         );
     }
 
+    /**
+     * Compare all the fields in another Task, to detect any differences from this one.
+     *
+     * If any field is different in any way, it will return false.
+     *
+     * This is used in some optimisations, to avoid work if an edit to file
+     * does not change any tasks, so it is vital that its definition
+     * of identical is very strict.
+     *
+     * @param other
+     */
     public identicalTo(other: Task) {
         // Based on ideas from koala. AquaCat and javalent in Discord:
         // https://discord.com/channels/686053708261228577/840286264964022302/996735200388186182

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -5,6 +5,7 @@ import { LayoutOptions } from './LayoutOptions';
 import { Recurrence } from './Recurrence';
 import { getSettings } from './config/Settings';
 import { Urgency } from './Urgency';
+import { Sort } from './Sort';
 
 /**
  * Collection of status types supported by the plugin.
@@ -720,11 +721,7 @@ export class Task {
         for (const el of args) {
             const date1 = this[el] as Moment | null;
             const date2 = other[el] as Moment | null;
-            if (date1 === null && date2 !== null) {
-                return false;
-            } else if (date1 !== null && date2 === null) {
-                return false;
-            } else if (date1 && date2 && !date1!.isSame(date2!)) {
+            if (!(Sort.compareByDate(date1, date2) == 0)) {
                 return false;
             }
         }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -695,6 +695,7 @@ export class Task {
             'sectionIndex',
             'originalStatusCharacter',
             'precedingHeader',
+            'priority',
         ];
         for (const el of args) {
             if (this[el] !== other[el]) return false;

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -721,7 +721,7 @@ export class Task {
         for (const el of args) {
             const date1 = this[el] as Moment | null;
             const date2 = other[el] as Moment | null;
-            if (!(Sort.compareByDate(date1, date2) == 0)) {
+            if (Sort.compareByDate(date1, date2) !== 0) {
                 return false;
             }
         }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -696,6 +696,7 @@ export class Task {
             'originalStatusCharacter',
             'precedingHeader',
             'priority',
+            'blockLink',
         ];
         for (const el of args) {
             if (this[el] !== other[el]) return false;

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -685,11 +685,15 @@ export class Task {
     }
 
     identicalTo(other: Task) {
-        if (this.status !== other.status) {
-            return false;
-        }
-        if (this.description !== other.description) {
-            return false;
+        // Based on ideas from koala and AquaCat in Discord:
+        // https://discord.com/channels/686053708261228577/840286264964022302/996735200388186182
+        // and later.
+        const args = ['status', 'description'];
+        for (const el of args) {
+            // 'as any' suppresses TS7053
+            if ((this as any)[el] !== (other as any)[el]) {
+                return false;
+            }
         }
         return true;
     }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -375,7 +375,7 @@ export class Task {
                 .map((tag) => tag.trim());
         }
 
-        const task = new Task({
+        return new Task({
             status,
             description,
             path,
@@ -393,8 +393,6 @@ export class Task {
             blockLink,
             tags,
         });
-
-        return task;
     }
 
     public async toLi({

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -694,6 +694,7 @@ export class Task {
             'sectionStart',
             'sectionIndex',
             'originalStatusCharacter',
+            'precedingHeader',
         ];
         for (const el of args) {
             if (this[el] !== other[el]) return false;

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -686,7 +686,7 @@ export class Task {
         // Based on ideas from koala. AquaCat and javalent in Discord:
         // https://discord.com/channels/686053708261228577/840286264964022302/996735200388186182
         // and later.
-        const args: Array<keyof Task> = [
+        let args: Array<keyof Task> = [
             'status',
             'description',
             'path',
@@ -699,6 +699,20 @@ export class Task {
         ];
         for (const el of args) {
             if (this[el] !== other[el]) return false;
+        }
+
+        // Compare Date fields
+        args = ['startDate'];
+        for (const el of args) {
+            const date1 = this[el] as Moment | null;
+            const date2 = other[el] as Moment | null;
+            if (date1 === null && date2 !== null) {
+                return false;
+            } else if (date1 !== null && date2 === null) {
+                return false;
+            } else if (date1 && date2 && !date1!.isSame(date2!)) {
+                return false;
+            }
         }
         return true;
     }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -702,7 +702,7 @@ export class Task {
         }
 
         // Compare Date fields
-        args = ['startDate', 'scheduledDate'];
+        args = ['startDate', 'scheduledDate', 'dueDate'];
         for (const el of args) {
             const date1 = this[el] as Moment | null;
             const date2 = other[el] as Moment | null;

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -693,6 +693,7 @@ export class Task {
             'indentation',
             'sectionStart',
             'sectionIndex',
+            'originalStatusCharacter',
         ];
         for (const el of args) {
             if (this[el] !== other[el]) return false;

--- a/tests/Recurrence.test.ts
+++ b/tests/Recurrence.test.ts
@@ -28,3 +28,41 @@ describe('Recurrence', () => {
         });
     });
 });
+
+describe('Recurrence equality', () => {
+    it('differing only in rule text', () => {
+        const weekly = Recurrence.fromText({
+            recurrenceRuleText: 'every week',
+            startDate: null,
+            scheduledDate: null,
+            dueDate: null,
+        }) as Recurrence;
+        const daily = Recurrence.fromText({
+            recurrenceRuleText: 'every day',
+            startDate: null,
+            scheduledDate: null,
+            dueDate: null,
+        }) as Recurrence;
+        expect(weekly.identicalTo(daily)).toBe(false);
+    });
+
+    it('differing only in "when done"', () => {
+        const weekly = Recurrence.fromText({
+            recurrenceRuleText: 'every week',
+            startDate: null,
+            scheduledDate: null,
+            dueDate: null,
+        }) as Recurrence;
+        const weeklyWhenDone = Recurrence.fromText({
+            recurrenceRuleText: 'every week when done',
+            startDate: null,
+            scheduledDate: null,
+            dueDate: null,
+        }) as Recurrence;
+        expect(weekly?.identicalTo(weeklyWhenDone)).toBe(false);
+    });
+
+    // startDate: Moment | null;
+    // scheduledDate: Moment | null;
+    // dueDate: Moment | null;
+});

--- a/tests/Recurrence.test.ts
+++ b/tests/Recurrence.test.ts
@@ -30,7 +30,7 @@ describe('Recurrence', () => {
     });
 });
 
-describe('Recurrence equality', () => {
+describe('identicalTo', () => {
     it('differing only in rule text', () => {
         const weekly = new RecurrenceBuilder().rule('every week').build();
         const daily = new RecurrenceBuilder().rule('every day').build();

--- a/tests/Recurrence.test.ts
+++ b/tests/Recurrence.test.ts
@@ -78,6 +78,18 @@ describe('Recurrence equality', () => {
         expect(date1Recurrence?.identicalTo(date2Recurrence)).toBe(false);
     });
 
-    // scheduledDate: Moment | null;
-    // dueDate: Moment | null;
+    it('differing only in dueDate', () => {
+        // Two different dates
+        // No need to replicate the null checks in startDate
+        const date1Recurrence = new RecurrenceBuilder()
+            .dueDate('2021-10-21')
+            .build();
+
+        const date2Recurrence = new RecurrenceBuilder()
+            .dueDate('1998-03-13')
+            .build();
+
+        expect(date1Recurrence?.identicalTo(date1Recurrence)).toBe(true);
+        expect(date1Recurrence?.identicalTo(date2Recurrence)).toBe(false);
+    });
 });

--- a/tests/Recurrence.test.ts
+++ b/tests/Recurrence.test.ts
@@ -48,24 +48,34 @@ describe('Recurrence equality', () => {
     it('differing only in startDate', () => {
         // Two different dates
         const date1Recurrence = new RecurrenceBuilder()
-            .rule('every week')
             .startDate('2021-10-21')
             .build();
 
         const date2Recurrence = new RecurrenceBuilder()
-            .rule('every week')
             .startDate('1998-03-13')
             .build();
 
-        const nullRecurrence = new RecurrenceBuilder()
-            .rule('every week')
-            .startDate(null)
-            .build();
+        const nullRecurrence = new RecurrenceBuilder().startDate(null).build();
 
         expect(date1Recurrence?.identicalTo(date1Recurrence)).toBe(true);
         expect(date1Recurrence?.identicalTo(date2Recurrence)).toBe(false);
         expect(date1Recurrence?.identicalTo(nullRecurrence)).toBe(false);
         expect(nullRecurrence?.identicalTo(date1Recurrence)).toBe(false);
+    });
+
+    it('differing only in scheduledDate', () => {
+        // Two different dates
+        // No need to replicate the null checks in startDate
+        const date1Recurrence = new RecurrenceBuilder()
+            .scheduledDate('2021-10-21')
+            .build();
+
+        const date2Recurrence = new RecurrenceBuilder()
+            .scheduledDate('1998-03-13')
+            .build();
+
+        expect(date1Recurrence?.identicalTo(date1Recurrence)).toBe(true);
+        expect(date1Recurrence?.identicalTo(date2Recurrence)).toBe(false);
     });
 
     // scheduledDate: Moment | null;

--- a/tests/Recurrence.test.ts
+++ b/tests/Recurrence.test.ts
@@ -4,6 +4,7 @@
 import moment from 'moment';
 import { Recurrence } from '../src/Recurrence';
 import { DateParser } from '../src/Query/DateParser';
+import { RecurrenceBuilder } from './TestingTools/RecurrenceBuilder';
 
 jest.mock('obsidian');
 window.moment = moment;
@@ -48,18 +49,10 @@ describe('Recurrence equality', () => {
     });
 
     it('differing only in "when done"', () => {
-        const weekly = Recurrence.fromText({
-            recurrenceRuleText: 'every week',
-            startDate: null,
-            scheduledDate: null,
-            dueDate: null,
-        }) as Recurrence;
-        const weeklyWhenDone = Recurrence.fromText({
-            recurrenceRuleText: 'every week when done',
-            startDate: null,
-            scheduledDate: null,
-            dueDate: null,
-        }) as Recurrence;
+        const weekly = new RecurrenceBuilder().rule('every week').build();
+        const weeklyWhenDone = new RecurrenceBuilder()
+            .rule('every week when done')
+            .build();
         expect(weekly?.identicalTo(weeklyWhenDone)).toBe(false);
     });
 

--- a/tests/Recurrence.test.ts
+++ b/tests/Recurrence.test.ts
@@ -3,6 +3,7 @@
  */
 import moment from 'moment';
 import { Recurrence } from '../src/Recurrence';
+import { DateParser } from '../src/Query/DateParser';
 
 jest.mock('obsidian');
 window.moment = moment;
@@ -62,7 +63,38 @@ describe('Recurrence equality', () => {
         expect(weekly?.identicalTo(weeklyWhenDone)).toBe(false);
     });
 
-    // startDate: Moment | null;
+    it('differing only in startDate', () => {
+        const date1 = DateParser.parseDate('2021-10-21');
+        const date2 = DateParser.parseDate('1998-03-13');
+
+        // Two different dates
+        const date1Recurrence = Recurrence.fromText({
+            recurrenceRuleText: 'every week',
+            startDate: date1,
+            scheduledDate: null,
+            dueDate: null,
+        }) as Recurrence;
+
+        const date2Recurrence = Recurrence.fromText({
+            recurrenceRuleText: 'every week',
+            startDate: date2,
+            scheduledDate: null,
+            dueDate: null,
+        }) as Recurrence;
+
+        const nullRecurrence = Recurrence.fromText({
+            recurrenceRuleText: 'every week',
+            startDate: null,
+            scheduledDate: null,
+            dueDate: null,
+        }) as Recurrence;
+
+        expect(date1Recurrence?.identicalTo(date1Recurrence)).toBe(true);
+        expect(date1Recurrence?.identicalTo(date2Recurrence)).toBe(false);
+        expect(date1Recurrence?.identicalTo(nullRecurrence)).toBe(false);
+        expect(nullRecurrence?.identicalTo(date1Recurrence)).toBe(false);
+    });
+
     // scheduledDate: Moment | null;
     // dueDate: Moment | null;
 });

--- a/tests/Recurrence.test.ts
+++ b/tests/Recurrence.test.ts
@@ -3,7 +3,6 @@
  */
 import moment from 'moment';
 import { Recurrence } from '../src/Recurrence';
-import { DateParser } from '../src/Query/DateParser';
 import { RecurrenceBuilder } from './TestingTools/RecurrenceBuilder';
 
 jest.mock('obsidian');
@@ -33,18 +32,8 @@ describe('Recurrence', () => {
 
 describe('Recurrence equality', () => {
     it('differing only in rule text', () => {
-        const weekly = Recurrence.fromText({
-            recurrenceRuleText: 'every week',
-            startDate: null,
-            scheduledDate: null,
-            dueDate: null,
-        }) as Recurrence;
-        const daily = Recurrence.fromText({
-            recurrenceRuleText: 'every day',
-            startDate: null,
-            scheduledDate: null,
-            dueDate: null,
-        }) as Recurrence;
+        const weekly = new RecurrenceBuilder().rule('every week').build();
+        const daily = new RecurrenceBuilder().rule('every day').build();
         expect(weekly.identicalTo(daily)).toBe(false);
     });
 
@@ -57,30 +46,21 @@ describe('Recurrence equality', () => {
     });
 
     it('differing only in startDate', () => {
-        const date1 = DateParser.parseDate('2021-10-21');
-        const date2 = DateParser.parseDate('1998-03-13');
-
         // Two different dates
-        const date1Recurrence = Recurrence.fromText({
-            recurrenceRuleText: 'every week',
-            startDate: date1,
-            scheduledDate: null,
-            dueDate: null,
-        }) as Recurrence;
+        const date1Recurrence = new RecurrenceBuilder()
+            .rule('every week')
+            .startDate('2021-10-21')
+            .build();
 
-        const date2Recurrence = Recurrence.fromText({
-            recurrenceRuleText: 'every week',
-            startDate: date2,
-            scheduledDate: null,
-            dueDate: null,
-        }) as Recurrence;
+        const date2Recurrence = new RecurrenceBuilder()
+            .rule('every week')
+            .startDate('1998-03-13')
+            .build();
 
-        const nullRecurrence = Recurrence.fromText({
-            recurrenceRuleText: 'every week',
-            startDate: null,
-            scheduledDate: null,
-            dueDate: null,
-        }) as Recurrence;
+        const nullRecurrence = new RecurrenceBuilder()
+            .rule('every week')
+            .startDate(null)
+            .build();
 
         expect(date1Recurrence?.identicalTo(date1Recurrence)).toBe(true);
         expect(date1Recurrence?.identicalTo(date2Recurrence)).toBe(false);

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -726,7 +726,12 @@ describe('equality', () => {
         );
     });
 
-    // indentation: string;
+    it('should check indentation', () => {
+        const lhs = new TaskBuilder().indentation('');
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().indentation(''));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().indentation('    '));
+    });
+
     // sectionStart: number;
     // sectionIndex: number;
     // originalStatusCharacter: string;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -816,6 +816,12 @@ describe('equality', () => {
     });
 
     // recurrence: Recurrence | null;
-    // blockLink: string;
+
+    it('should check blockLink', () => {
+        const lhs = new TaskBuilder().blockLink('');
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().blockLink(''));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().blockLink('dcf64c'));
+    });
+
     // tags: string[] | [];
 });

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -695,12 +695,9 @@ expect.extend({
 
 describe('equality', () => {
     it('should check status', () => {
-        expect(new TaskBuilder().status(Status.Todo)).toBeIdenticalTo(
-            new TaskBuilder().status(Status.Todo),
-        );
-        expect(new TaskBuilder().status(Status.Todo)).not.toBeIdenticalTo(
-            new TaskBuilder().status(Status.Done),
-        );
+        const lhs = new TaskBuilder().status(Status.Todo);
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().status(Status.Todo));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().status(Status.Done));
     });
 
     it('should check description', () => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -767,7 +767,16 @@ describe('equality', () => {
         );
     });
 
-    // priority: Priority;
+    it('should check priority', () => {
+        const lhs = new TaskBuilder().priority(Priority.Medium);
+        expect(lhs).toBeIdenticalTo(
+            new TaskBuilder().priority(Priority.Medium),
+        );
+        expect(lhs).not.toBeIdenticalTo(
+            new TaskBuilder().priority(Priority.None),
+        );
+    });
+
     // startDate: moment.Moment | null;
     // scheduledDate: moment.Moment | null;
     // dueDate: moment.Moment | null;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -823,5 +823,9 @@ describe('equality', () => {
         expect(lhs).not.toBeIdenticalTo(new TaskBuilder().blockLink('dcf64c'));
     });
 
-    // tags: string[] | [];
+    it('should check tags', () => {
+        const lhs = new TaskBuilder().tags([]);
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().tags([]));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().tags(['#stuff']));
+    });
 });

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -840,3 +840,29 @@ describe('identicalTo', () => {
         expect(lhs).not.toBeIdenticalTo(new TaskBuilder().tags(['#stuff']));
     });
 });
+
+describe('checking if task lists are identical', () => {
+    it('should treat empty lists as identical', () => {
+        const list1: Task[] = [];
+        const list2: Task[] = [];
+        expect(Task.tasksListsIdentical(list1, list2)).toBe(true);
+    });
+
+    it('should treat different sized lists as different', () => {
+        const list1: Task[] = [];
+        const list2: Task[] = [new TaskBuilder().build()];
+        expect(Task.tasksListsIdentical(list1, list2)).toBe(false);
+    });
+
+    it('should detect matching tasks as same', () => {
+        const list1: Task[] = [new TaskBuilder().description('1').build()];
+        const list2: Task[] = [new TaskBuilder().description('1').build()];
+        expect(Task.tasksListsIdentical(list1, list2)).toBe(true);
+    });
+
+    it('should detect non-matching tasks as different', () => {
+        const list1: Task[] = [new TaskBuilder().description('1').build()];
+        const list2: Task[] = [new TaskBuilder().description('2').build()];
+        expect(Task.tasksListsIdentical(list1, list2)).toBe(false);
+    });
+});

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -732,7 +732,12 @@ describe('equality', () => {
         expect(lhs).not.toBeIdenticalTo(new TaskBuilder().indentation('    '));
     });
 
-    // sectionStart: number;
+    it('should check sectionStart', () => {
+        const lhs = new TaskBuilder().sectionStart(0);
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().sectionStart(0));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().sectionStart(2));
+    });
+
     // sectionIndex: number;
     // originalStatusCharacter: string;
     // precedingHeader: string | null;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -820,45 +820,21 @@ describe('equality', () => {
         const lhs = new TaskBuilder().recurrence(null);
         expect(lhs).toBeIdenticalTo(new TaskBuilder().recurrence(null));
 
-        it('differing only in rule text', () => {
-            const weekly = Recurrence.fromText({
-                recurrenceRuleText: 'every week',
-                startDate: null,
-                scheduledDate: null,
-                dueDate: null,
-            });
-            const daily = Recurrence.fromText({
-                recurrenceRuleText: 'every day',
-                startDate: null,
-                scheduledDate: null,
-                dueDate: null,
-            });
-            expect(new TaskBuilder().recurrence(weekly)).not.toBeIdenticalTo(
-                new TaskBuilder().recurrence(daily),
-            );
+        const weekly = Recurrence.fromText({
+            recurrenceRuleText: 'every week',
+            startDate: null,
+            scheduledDate: null,
+            dueDate: null,
         });
-
-        it('differing only in "when done"', () => {
-            const weekly = Recurrence.fromText({
-                recurrenceRuleText: 'every week',
-                startDate: null,
-                scheduledDate: null,
-                dueDate: null,
-            });
-            const weeklyWhenDone = Recurrence.fromText({
-                recurrenceRuleText: 'every week when done',
-                startDate: null,
-                scheduledDate: null,
-                dueDate: null,
-            });
-            expect(new TaskBuilder().recurrence(weekly)).not.toBeIdenticalTo(
-                new TaskBuilder().recurrence(weeklyWhenDone),
-            );
+        const daily = Recurrence.fromText({
+            recurrenceRuleText: 'every day',
+            startDate: null,
+            scheduledDate: null,
+            dueDate: null,
         });
-
-        // startDate: Moment | null;
-        // scheduledDate: Moment | null;
-        // dueDate: Moment | null;
+        expect(new TaskBuilder().recurrence(weekly)).not.toBeIdenticalTo(
+            new TaskBuilder().recurrence(daily),
+        );
     });
 
     it('should check blockLink', () => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -738,7 +738,12 @@ describe('equality', () => {
         expect(lhs).not.toBeIdenticalTo(new TaskBuilder().sectionStart(2));
     });
 
-    // sectionIndex: number;
+    it('should check sectionIndex', () => {
+        const lhs = new TaskBuilder().sectionIndex(0);
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().sectionIndex(0));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().sectionIndex(2));
+    });
+
     // originalStatusCharacter: string;
     // precedingHeader: string | null;
     // priority: Priority;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -777,7 +777,15 @@ describe('equality', () => {
         );
     });
 
-    // startDate: moment.Moment | null;
+    it('should check startDate', () => {
+        const lhs = new TaskBuilder().startDate('2012-12-27');
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().startDate('2012-12-27'));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().startDate(null));
+        expect(lhs).not.toBeIdenticalTo(
+            new TaskBuilder().startDate('2012-12-26'),
+        );
+    });
+
     // scheduledDate: moment.Moment | null;
     // dueDate: moment.Moment | null;
     // doneDate: moment.Moment | null;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -696,7 +696,7 @@ expect.extend({
     toBeIdenticalTo,
 });
 
-describe('equality', () => {
+describe('identicalTo', () => {
     it('should check status', () => {
         const lhs = new TaskBuilder().status(Status.Todo);
         expect(lhs).toBeIdenticalTo(new TaskBuilder().status(Status.Todo));

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -744,7 +744,16 @@ describe('equality', () => {
         expect(lhs).not.toBeIdenticalTo(new TaskBuilder().sectionIndex(2));
     });
 
-    // originalStatusCharacter: string;
+    it('should check originalStatusCharacter', () => {
+        const lhs = new TaskBuilder().originalStatusCharacter(' ');
+        expect(lhs).toBeIdenticalTo(
+            new TaskBuilder().originalStatusCharacter(' '),
+        );
+        expect(lhs).not.toBeIdenticalTo(
+            new TaskBuilder().originalStatusCharacter('x'),
+        );
+    });
+
     // precedingHeader: string | null;
     // priority: Priority;
     // startDate: moment.Moment | null;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -701,16 +701,13 @@ describe('equality', () => {
     });
 
     it('should check description', () => {
-        const builder = new TaskBuilder();
-        const task1 = builder.description('same text').build();
-
-        expect(
-            task1.identicalTo(builder.description('same text').build()),
-        ).toEqual(true);
-
-        expect(
-            task1.identicalTo(builder.description('different text').build()),
-        ).toEqual(false);
+        const lhs = new TaskBuilder().description('same long initial text');
+        expect(lhs).toBeIdenticalTo(
+            new TaskBuilder().description('same long initial text'),
+        );
+        expect(lhs).not.toBeIdenticalTo(
+            new TaskBuilder().description('different text'),
+        );
     });
 
     it('should check path', () => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -786,7 +786,17 @@ describe('equality', () => {
         );
     });
 
-    // scheduledDate: moment.Moment | null;
+    it('should check scheduledDate', () => {
+        const lhs = new TaskBuilder().scheduledDate('2012-12-27');
+        expect(lhs).toBeIdenticalTo(
+            new TaskBuilder().scheduledDate('2012-12-27'),
+        );
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().scheduledDate(null));
+        expect(lhs).not.toBeIdenticalTo(
+            new TaskBuilder().scheduledDate('2012-12-26'),
+        );
+    });
+
     // dueDate: moment.Moment | null;
     // doneDate: moment.Moment | null;
     // recurrence: Recurrence | null;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -684,7 +684,9 @@ export function toBeIdenticalTo(builder1: TaskBuilder, builder2: TaskBuilder) {
         };
     }
     return {
-        message: () => 'Tasks are identical, but are treated as different',
+        message: () => {
+            return 'Tasks should be identical, but are treated as different';
+        },
         pass: false,
     };
 }
@@ -711,21 +713,17 @@ describe('equality', () => {
     });
 
     it('should check path', () => {
-        const builder = new TaskBuilder();
-        const task1 = builder.path('same file.md').build();
-
-        expect(task1.identicalTo(builder.path('same file.md').build())).toEqual(
-            true,
+        const lhs = new TaskBuilder().path('same test file.md');
+        expect(lhs).toBeIdenticalTo(
+            new TaskBuilder().path('same test file.md'),
         );
-
         // Check it is case-sensitive
-        expect(task1.identicalTo(builder.path('Same File.md').build())).toEqual(
-            false,
+        expect(lhs).not.toBeIdenticalTo(
+            new TaskBuilder().path('Same Test File.md'),
         );
-
-        expect(
-            task1.identicalTo(builder.path('different file.md').build()),
-        ).toEqual(false);
+        expect(lhs).not.toBeIdenticalTo(
+            new TaskBuilder().path('different text.md'),
+        );
     });
 
     // indentation: string;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -806,8 +806,15 @@ describe('equality', () => {
         );
     });
 
-    // dueDate: moment.Moment | null;
-    // doneDate: moment.Moment | null;
+    it('should check doneDate', () => {
+        const lhs = new TaskBuilder().doneDate('2012-12-27');
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().doneDate('2012-12-27'));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().doneDate(null));
+        expect(lhs).not.toBeIdenticalTo(
+            new TaskBuilder().doneDate('2012-12-26'),
+        );
+    });
+
     // recurrence: Recurrence | null;
     // blockLink: string;
     // tags: string[] | [];

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -4,9 +4,9 @@
 import moment from 'moment';
 import { Priority, Status, Task } from '../src/Task';
 import { getSettings, updateSettings } from '../src/config/Settings';
-import { Recurrence } from '../src/Recurrence';
 import { fromLine } from './TestHelpers';
 import { TaskBuilder } from './TestingTools/TaskBuilder';
+import { RecurrenceBuilder } from './TestingTools/RecurrenceBuilder';
 
 jest.mock('obsidian');
 window.moment = moment;
@@ -820,21 +820,12 @@ describe('identicalTo', () => {
         const lhs = new TaskBuilder().recurrence(null);
         expect(lhs).toBeIdenticalTo(new TaskBuilder().recurrence(null));
 
-        const weekly = Recurrence.fromText({
-            recurrenceRuleText: 'every week',
-            startDate: null,
-            scheduledDate: null,
-            dueDate: null,
-        });
-        const daily = Recurrence.fromText({
-            recurrenceRuleText: 'every day',
-            startDate: null,
-            scheduledDate: null,
-            dueDate: null,
-        });
+        const weekly = new RecurrenceBuilder().rule('every week').build();
+        const daily = new RecurrenceBuilder().rule('every day').build();
         expect(new TaskBuilder().recurrence(weekly)).not.toBeIdenticalTo(
             new TaskBuilder().recurrence(daily),
         );
+        // Note: There are more thorough tests of Recurrence.identicalTo() in Recurrence.test.ts.
     });
 
     it('should check blockLink', () => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -5,6 +5,7 @@ import moment from 'moment';
 import { Priority, Status, Task } from '../src/Task';
 import { getSettings, updateSettings } from '../src/config/Settings';
 import { fromLine } from './TestHelpers';
+import { TaskBuilder } from './TestingTools/TaskBuilder';
 
 jest.mock('obsidian');
 window.moment = moment;
@@ -652,4 +653,46 @@ describe('toggle done', () => {
             nextStart: undefined,
         });
     });
+});
+
+describe('equality', () => {
+    it('should check status', () => {
+        const builder = new TaskBuilder();
+        const task1 = builder.status(Status.Todo).build();
+
+        expect(task1.identicalTo(builder.status(Status.Todo).build())).toEqual(
+            true,
+        );
+        expect(task1.identicalTo(builder.status(Status.Done).build())).toEqual(
+            false,
+        );
+    });
+
+    it('should check description', () => {
+        const builder = new TaskBuilder();
+        const task1 = builder.description('same text').build();
+
+        expect(
+            task1.identicalTo(builder.description('same text').build()),
+        ).toEqual(true);
+
+        expect(
+            task1.identicalTo(builder.description('different text').build()),
+        ).toEqual(false);
+    });
+
+    // path: string;
+    // indentation: string;
+    // sectionStart: number;
+    // sectionIndex: number;
+    // originalStatusCharacter: string;
+    // precedingHeader: string | null;
+    // priority: Priority;
+    // startDate: moment.Moment | null;
+    // scheduledDate: moment.Moment | null;
+    // dueDate: moment.Moment | null;
+    // doneDate: moment.Moment | null;
+    // recurrence: Recurrence | null;
+    // blockLink: string;
+    // tags: string[] | [];
 });

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -754,7 +754,19 @@ describe('equality', () => {
         );
     });
 
-    // precedingHeader: string | null;
+    it('should check precedingHeader', () => {
+        const lhs = new TaskBuilder().precedingHeader('Heading 1');
+        expect(lhs).toBeIdenticalTo(
+            new TaskBuilder().precedingHeader('Heading 1'),
+        );
+        expect(lhs).not.toBeIdenticalTo(
+            new TaskBuilder().precedingHeader('Different Heading'),
+        );
+        expect(lhs).not.toBeIdenticalTo(
+            new TaskBuilder().precedingHeader(null),
+        );
+    });
+
     // priority: Priority;
     // startDate: moment.Moment | null;
     // scheduledDate: moment.Moment | null;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -797,6 +797,15 @@ describe('equality', () => {
         );
     });
 
+    it('should check dueDate', () => {
+        const lhs = new TaskBuilder().dueDate('2012-12-27');
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().dueDate('2012-12-27'));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().dueDate(null));
+        expect(lhs).not.toBeIdenticalTo(
+            new TaskBuilder().dueDate('2012-12-26'),
+        );
+    });
+
     // dueDate: moment.Moment | null;
     // doneDate: moment.Moment | null;
     // recurrence: Recurrence | null;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -681,7 +681,24 @@ describe('equality', () => {
         ).toEqual(false);
     });
 
-    // path: string;
+    it('should check path', () => {
+        const builder = new TaskBuilder();
+        const task1 = builder.path('same file.md').build();
+
+        expect(task1.identicalTo(builder.path('same file.md').build())).toEqual(
+            true,
+        );
+
+        // Check it is case-sensitive
+        expect(task1.identicalTo(builder.path('Same File.md').build())).toEqual(
+            false,
+        );
+
+        expect(
+            task1.identicalTo(builder.path('different file.md').build()),
+        ).toEqual(false);
+    });
+
     // indentation: string;
     // sectionStart: number;
     // sectionIndex: number;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -4,6 +4,7 @@
 import moment from 'moment';
 import { Priority, Status, Task } from '../src/Task';
 import { getSettings, updateSettings } from '../src/config/Settings';
+import { Recurrence } from '../src/Recurrence';
 import { fromLine } from './TestHelpers';
 import { TaskBuilder } from './TestingTools/TaskBuilder';
 
@@ -815,7 +816,50 @@ describe('equality', () => {
         );
     });
 
-    // recurrence: Recurrence | null;
+    describe('should check recurrence', () => {
+        const lhs = new TaskBuilder().recurrence(null);
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().recurrence(null));
+
+        it('differing only in rule text', () => {
+            const weekly = Recurrence.fromText({
+                recurrenceRuleText: 'every week',
+                startDate: null,
+                scheduledDate: null,
+                dueDate: null,
+            });
+            const daily = Recurrence.fromText({
+                recurrenceRuleText: 'every day',
+                startDate: null,
+                scheduledDate: null,
+                dueDate: null,
+            });
+            expect(new TaskBuilder().recurrence(weekly)).not.toBeIdenticalTo(
+                new TaskBuilder().recurrence(daily),
+            );
+        });
+
+        it('differing only in "when done"', () => {
+            const weekly = Recurrence.fromText({
+                recurrenceRuleText: 'every week',
+                startDate: null,
+                scheduledDate: null,
+                dueDate: null,
+            });
+            const weeklyWhenDone = Recurrence.fromText({
+                recurrenceRuleText: 'every week when done',
+                startDate: null,
+                scheduledDate: null,
+                dueDate: null,
+            });
+            expect(new TaskBuilder().recurrence(weekly)).not.toBeIdenticalTo(
+                new TaskBuilder().recurrence(weeklyWhenDone),
+            );
+        });
+
+        // startDate: Moment | null;
+        // scheduledDate: Moment | null;
+        // dueDate: Moment | null;
+    });
 
     it('should check blockLink', () => {
         const lhs = new TaskBuilder().blockLink('');

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -655,16 +655,51 @@ describe('toggle done', () => {
     });
 });
 
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toBeIdenticalTo(builder2: TaskBuilder): R;
+        }
+
+        interface Expect {
+            toBeIdenticalTo(builder2: TaskBuilder): any;
+        }
+
+        interface InverseAsymmetricMatchers {
+            toBeIdenticalTo(builder2: TaskBuilder): any;
+        }
+    }
+}
+
+export function toBeIdenticalTo(builder1: TaskBuilder, builder2: TaskBuilder) {
+    const task1 = builder1.build();
+    const task2 = builder2.build();
+    const pass = task1.identicalTo(task2);
+
+    if (pass) {
+        return {
+            message: () =>
+                'Tasks treated as identical, but should be different',
+            pass: true,
+        };
+    }
+    return {
+        message: () => 'Tasks are identical, but are treated as different',
+        pass: false,
+    };
+}
+
+expect.extend({
+    toBeIdenticalTo,
+});
+
 describe('equality', () => {
     it('should check status', () => {
-        const builder = new TaskBuilder();
-        const task1 = builder.status(Status.Todo).build();
-
-        expect(task1.identicalTo(builder.status(Status.Todo).build())).toEqual(
-            true,
+        expect(new TaskBuilder().status(Status.Todo)).toBeIdenticalTo(
+            new TaskBuilder().status(Status.Todo),
         );
-        expect(task1.identicalTo(builder.status(Status.Done).build())).toEqual(
-            false,
+        expect(new TaskBuilder().status(Status.Todo)).not.toBeIdenticalTo(
+            new TaskBuilder().status(Status.Done),
         );
     });
 

--- a/tests/TestingTools/RecurrenceBuilder.test.ts
+++ b/tests/TestingTools/RecurrenceBuilder.test.ts
@@ -11,10 +11,10 @@ describe('RecurrenceBuilder', () => {
     it('should build a Recurrence object', () => {
         const builder = new RecurrenceBuilder();
         const recurrence = builder
-            .rule('every week')
+            .rule('every week when done')
             .startDate('2022-07-14')
             .build();
         expect(recurrence).not.toEqual(null);
-        expect(recurrence.toText())!.toBe('every week');
+        expect(recurrence.toText())!.toBe('every week when done');
     });
 });

--- a/tests/TestingTools/RecurrenceBuilder.test.ts
+++ b/tests/TestingTools/RecurrenceBuilder.test.ts
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+import moment from 'moment';
+
+import { RecurrenceBuilder } from './RecurrenceBuilder';
+
+window.moment = moment;
+
+describe('RecurrenceBuilder', () => {
+    it('should build a Recurrence object', () => {
+        const builder = new RecurrenceBuilder();
+        const recurrence = builder
+            .rule('every week')
+            .startDate('2022-07-14')
+            .build();
+        expect(recurrence).not.toEqual(null);
+        expect(recurrence.toText())!.toBe('every week');
+    });
+});

--- a/tests/TestingTools/RecurrenceBuilder.ts
+++ b/tests/TestingTools/RecurrenceBuilder.ts
@@ -28,7 +28,7 @@ export class RecurrenceBuilder {
      *
      *  const builder = new RecurrenceBuilder();
      *  const recurrence = builder
-     *      .rule('every week')
+     *      .rule('every week when done')
      *      .startDate('2022-07-14')
      *      .build();
      */

--- a/tests/TestingTools/RecurrenceBuilder.ts
+++ b/tests/TestingTools/RecurrenceBuilder.ts
@@ -1,0 +1,71 @@
+// Builder
+import type { Moment } from 'moment';
+import { Recurrence } from '../../src/Recurrence';
+import { DateParser } from '../../src/Query/DateParser';
+
+/**
+ * A fluent class for creating Recurrence objects for tests.
+ *
+ * This uses the Builder Pattern.
+ *
+ * See RecurrenceBuilder.build() for an example of use.
+ *
+ * IMPORTANT: Changed values are retained after calls to .build()
+ *            There is no way to reset a RecurrenceBuilder to its default
+ *            start currently.
+ *            Create a new RecurrenceBuilder object to start from a clean state,
+ */
+export class RecurrenceBuilder {
+    private _recurrenceRuleText: string = 'every day';
+    private _startDate: Moment | null = null;
+    private _scheduledDate: Moment | null = null;
+    private _dueDate: Moment | null = null;
+
+    /**
+     * Build a Recurrence
+     *
+     * Example of use:
+     *
+     *  const builder = new RecurrenceBuilder();
+     *  const recurrence = builder
+     *      .rule('every week')
+     *      .startDate('2022-07-14')
+     *      .build();
+     */
+    public build(): Recurrence {
+        return Recurrence.fromText({
+            recurrenceRuleText: this._recurrenceRuleText,
+            startDate: this._startDate,
+            scheduledDate: this._scheduledDate,
+            dueDate: this._dueDate,
+        }) as Recurrence;
+    }
+
+    public rule(recurrenceRuleText: string): RecurrenceBuilder {
+        this._recurrenceRuleText = recurrenceRuleText;
+        return this;
+    }
+
+    public startDate(startDate: string | null): RecurrenceBuilder {
+        this._startDate = RecurrenceBuilder.parseDate(startDate);
+        return this;
+    }
+
+    public scheduledDate(scheduledDate: string | null): RecurrenceBuilder {
+        this._scheduledDate = RecurrenceBuilder.parseDate(scheduledDate);
+        return this;
+    }
+
+    public dueDate(dueDate: string | null): RecurrenceBuilder {
+        this._dueDate = RecurrenceBuilder.parseDate(dueDate);
+        return this;
+    }
+
+    private static parseDate(date: string | null): Moment | null {
+        if (date) {
+            return DateParser.parseDate(date);
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- `Cache` changed to only trigger a refresh of active tasks blocks if the edit made changed any tasks, or their parent headings
    - Intended benefit: When editing, there will be far fewer refreshes
    - Unintended benefit: When starting up tasks, and every file is read to find tasks, only the files with tasks in trigger the refreshing of tasks blocks, not every file. (I will look at making that more efficient in future)
    - Debug logging added to help users understand what is triggering refresh
- `QueryRenderer` now prints out console information, including file name, so users can see which files are taking most time to render. 

Behind the scenes:

- Very thorough mechanism added to detect changes between tasks and their recurrences. Lots of tests added for that.
- Added `Recurrence.identicalTo()`
- Added `Task.identicalTo()`, `Task.tasksListsIdentical()`
- Added `RecurrenceBuilder` and tests of it - to make writing of tests easier


## Motivation and Context

This implements the behaviour described in #886: When notified that a file has changed:

1. Process the file
2. Compare the result to what's currently in the cache
3. Only if it differs, send all tasks to all subscribers

It is a first step towards improving #697.

## How has this been tested?

Loads of unit tests, and testing pretty thoroughly with editing files in test vaults with 1500 tasks.

Testing still required:

- [ ] Behaviour when renaming files
- [ ] Behaviour when deleting files
- [ ] Behaviour when creating files that contain tasks (e.g. copying file in to vault externally to Obsidian)
- [ ] Test what happens when sections are inserted before a task - make sure that it refreshes as section index will have changed)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Here is an example shot of the new console output as I was making edits:

![image](https://user-images.githubusercontent.com/4840096/179197904-e64faa10-de01-453b-b24f-c8f26058d1d9.png)

It's clear that one of the `tasks` blocks in `Tasks.md` is showing a large number of tasks (1236).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
