### PR TITLE
fix: Allow multiple spaces after date emojis, when reading task lines

### DIFF
--- a/docs/getting-started/auto-suggest.md
+++ b/docs/getting-started/auto-suggest.md
@@ -104,9 +104,6 @@ Things to be aware of, to make sure your Tasks searches work as you intend:
 
 - You can mix tags in between the emojis (as of Tasks 1.9.0), but you must not mix description text amongst the tags and signifier emojis.
   - See 'What do I need to know about the order of items in a task?' below.
-- Tasks currently **ignores date and recurrence emojis with 2 or more spaces after the emoji** and before its value.
-  - Because the spaces between the emojis and the following text are invisible in most views, this is a serious limitation.
-  - Please be careful to ensure you have only a single space in these locations.
 
 There are some things that might be improved in future releases:
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -96,10 +96,10 @@ export class Task {
     // The following regex's end with `$` because they will be matched and
     // removed from the end until none are left.
     public static readonly priorityRegex = /([⏫🔼🔽])$/u;
-    public static readonly startDateRegex = /🛫 ?(\d{4}-\d{2}-\d{2})$/u;
-    public static readonly scheduledDateRegex = /[⏳⌛] ?(\d{4}-\d{2}-\d{2})$/u;
-    public static readonly dueDateRegex = /[📅📆🗓] ?(\d{4}-\d{2}-\d{2})$/u;
-    public static readonly doneDateRegex = /✅ ?(\d{4}-\d{2}-\d{2})$/u;
+    public static readonly startDateRegex = /🛫 *(\d{4}-\d{2}-\d{2})$/u;
+    public static readonly scheduledDateRegex = /[⏳⌛] *(\d{4}-\d{2}-\d{2})$/u;
+    public static readonly dueDateRegex = /[📅📆🗓] *(\d{4}-\d{2}-\d{2})$/u;
+    public static readonly doneDateRegex = /✅ *(\d{4}-\d{2}-\d{2})$/u;
     public static readonly recurrenceRegex = /🔁 ?([a-zA-Z0-9, !]+)$/iu;
 
     // Regex to match all hash tags, basically hash followed by anything but the characters in the negation.

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -158,6 +158,42 @@ describe('parsing', () => {
             '#tag10',
         ]);
     });
+
+    it('supports parsing of emojis with multiple spaces', () => {
+        // Arrange
+        const lines = [
+            '- [ ] Wobble ✅2022-07-01 📅2022-07-02 ⏳2022-07-03 🛫2022-07-04 🔁every day',
+            '- [ ] Wobble ✅ 2022-07-01 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Wobble ✅  2022-07-01 📅  2022-07-02 ⏳  2022-07-03 🛫  2022-07-04 🔁  every day',
+        ];
+        // Act
+        for (const line of lines) {
+            const task = fromLine({
+                line,
+            });
+
+            // Assert
+            expect({
+                _input: line, // Line is included, so it is shown in any failure output
+                description: task.description,
+                done: task.doneDate?.format('YYYY-MM-DD'),
+                due: task.dueDate?.format('YYYY-MM-DD'),
+                scheduled: task.scheduledDate?.format('YYYY-MM-DD'),
+                start: task.startDate?.format('YYYY-MM-DD'),
+                priority: task.priority,
+                recurrence: task.recurrence?.toText(),
+            }).toMatchObject({
+                _input: line,
+                description: 'Wobble',
+                done: '2022-07-01',
+                due: '2022-07-02',
+                scheduled: '2022-07-03',
+                start: '2022-07-04',
+                priority: '3',
+                recurrence: 'every day',
+            });
+        }
+    });
 });
 
 type TagParsingExpectations = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Allow more than 1 space between date emojis and their dates when parsing task lines

## Motivation and Context

This fixes #898.

## How has this been tested?

- By adding new tests.
- By building the plugin and testing it with the instructions in #898.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
