### PR TITLE
refactor: Moved the logic of removing the global filter in Task and covered it with tests

### DIFF
--- a/src/Task.ts
+++ b/src/Task.ts
@@ -861,4 +861,12 @@ export class Task {
             window.moment().startOf('day'),
         )})`;
     }
+
+    public getDescriptionWithoutGlobalFilter() {
+        const { globalFilter } = getSettings();
+        return this.description
+            .replace(globalFilter, '')
+            .replace('  ', ' ')
+            .trim();
+    }
 }

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -107,12 +107,7 @@
     }
 
     onMount(() => {
-        const { globalFilter } = getSettings();
-        const description = task.description
-            .replace(globalFilter, '')
-            .replace('  ', ' ')
-            .trim();
-
+        const description = task.getDescriptionWithoutGlobalFilter();
         let priority: 'none' | 'low' | 'medium' | 'high' = 'none';
         if (task.priority === Priority.Low) {
             priority = 'low';

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -318,7 +318,7 @@ describe('parsing tags', () => {
             globalFilter: '',
         },
     ])(
-        'should parse $markdownTask and extract $extractedTags',
+        'should parse "$markdownTask" and extract "$extractedTags"',
         ({
             markdownTask,
             expectedDescription,
@@ -960,11 +960,10 @@ describe('check removal of the global filter', () => {
         {
             globalFilter: '#t',
             markdownTask: '- [ ] task with #t multiple global filters #t',
-            // This is not the behavior we eventually want, but this is the existing situation
             expectedDescription: 'task with multiple global filters #t',
         },
     ])(
-        'should parse $markdownTask and extract $expectedDescription',
+        'should parse "$markdownTask" and extract "$expectedDescription"',
         ({ globalFilter, markdownTask, expectedDescription }) => {
             // Arrange
             const originalSettings = getSettings();

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -902,3 +902,89 @@ describe('checking if task lists are identical', () => {
         expect(Task.tasksListsIdentical(list1, list2)).toBe(false);
     });
 });
+
+describe('check removal of the global filter', () => {
+    type GlobalFilterRemovalExpectation = {
+        globalFilter: string;
+        markdownTask: string;
+        expectedDescription: string;
+    };
+
+    test.each<GlobalFilterRemovalExpectation>([
+        {
+            globalFilter: '#task',
+            markdownTask: '- [ ] #task this is a very simple task',
+            expectedDescription: 'this is a very simple task',
+        },
+        {
+            globalFilter: '',
+            markdownTask: '- [ ] #task this is a very simple task',
+            expectedDescription: '#task this is a very simple task',
+        },
+        {
+            globalFilter: '🞋',
+            markdownTask: '- [ ] task with emoji 🞋 global filter',
+            expectedDescription: 'task with emoji global filter',
+        },
+        {
+            globalFilter: '#t',
+            markdownTask: '- [ ] task with #t global filter in the middle',
+            expectedDescription: 'task with global filter in the middle',
+        },
+        {
+            globalFilter: '#t',
+            markdownTask: '- [ ] task with global filter in the end #t',
+            expectedDescription: 'task with global filter in the end',
+        },
+        {
+            globalFilter: '#t',
+            markdownTask:
+                '- [ ] task with global filter in the end and some spaces  #t  ',
+            expectedDescription:
+                'task with global filter in the end and some spaces',
+        },
+        {
+            globalFilter: '#complex/global/filter',
+            markdownTask:
+                '- [ ] task with #complex/global/filter in the middle',
+            expectedDescription: 'task with in the middle',
+        },
+        {
+            globalFilter: '#task',
+            markdownTask:
+                '- [ ] task with an extension of the global filter #task/with/extension',
+            // This is not the behavior we eventually want, but this is the existing situation
+            expectedDescription:
+                'task with an extension of the global filter /with/extension',
+        },
+        {
+            globalFilter: '#t',
+            markdownTask: '- [ ] task with #t multiple global filters #t',
+            // This is not the behavior we eventually want, but this is the existing situation
+            expectedDescription: 'task with multiple global filters #t',
+        },
+    ])(
+        'should parse $markdownTask and extract $expectedDescription',
+        ({ globalFilter, markdownTask, expectedDescription }) => {
+            // Arrange
+            const originalSettings = getSettings();
+            if (globalFilter != '') {
+                updateSettings({ globalFilter: globalFilter });
+            }
+
+            // Act
+            const task = constructTaskFromLine(markdownTask);
+
+            // Assert
+            expect(task).not.toBeNull();
+            expect(task!.getDescriptionWithoutGlobalFilter()).toEqual(
+                expectedDescription,
+            );
+
+            // Cleanup
+            if (globalFilter != '') {
+                updateSettings(originalSettings);
+            }
+        },
+    );
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR is a pure refactor (no change in functionality) of the simple logic in `EditTask.svelte` that removes a task's global filter before it is displayed in the edit window.
It just moves those 5 lines into a new method `Task.getDescriptionWithoutGlobalFilter` and covers this with multiple new tests.

## Motivation and Context

This is a result of the discussion in [this](https://github.com/obsidian-tasks-group/obsidian-tasks/pull/869) bug fix.
Wanting to do a more comprehensive fix for this logic, which is a source for multiple bugs, we wanted to cover it with tests first.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Multiple automated tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
