### PR TITLE
docs: Add 'group by tags' to Quick Ref docs

### DIFF
--- a/docs/queries/grouping.md
+++ b/docs/queries/grouping.md
@@ -61,6 +61,8 @@ Task properties:
     * The tags of the tasks or `(No tags)`. If the task has multiple tags, it will show up under every tag.
 
 > `start`, `scheduled`, `due` and `done` grouping options were introduced in Tasks 1.7.0.
+>
+> `tags` grouping option was introduced in Tasks 1.10.0.
 
 ### Multiple groups
 

--- a/docs/quick-reference/index.md
+++ b/docs/quick-reference/index.md
@@ -31,7 +31,7 @@ This table summarizes the filters and other options available inside a `tasks` b
 | `heading (includes, does not include) <string>`                                        |                                             | `group by heading`  |                        |
 |                                                                                        |                                             | `group by backlink` | `hide backlink`        |
 | `description (includes, does not include) <string>`                                    | `sort by description`                       |                     |                        |
-| `tag (includes, does not include) <tag>`<br>`tags (include, do not include) <tag>`     | `sort by tag`<br>`sort by tag <tag_number>` |                     |                        |
+| `tag (includes, does not include) <tag>`<br>`tags (include, do not include) <tag>`     | `sort by tag`<br>`sort by tag <tag_number>` | `group by tags`     |                        |
 | `(filter 1) AND (filter 2)`                                                            |                                             |                     |                        |
 | `(filter 1) OR (filter 2)`                                                             |                                             |                     |                        |
 | `NOT (filter 1)`                                                                       |                                             |                     |                        |


### PR DESCRIPTION
Also, note that 'group by tags' was added in 1.10.0
