### PR TITLE
fix: find tasks in blockquotes and Obsidian callouts

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -80,6 +80,22 @@ The following _does not work:_
 
 Warning
 {: .label .label-yellow}
+Tasks can read tasks that are inside blockquotes or [Obsidian's built-in callouts](https://help.obsidian.md/How+to/Use+callouts).
+However, in the Live Preview editor mode (pencil icon in lower right corner), tasks written inside callouts cannot be completed by clicking the checkbox.
+You will see a warning; use the command `Tasks: Toggle Done`, or switch to Reading View (book icon in lower right corner) to click the checkbox.
+Completing a task by clicking its checkbox from a `tasks` query block _will_ work in any editor mode, even if the query is inside a callout.
+
+---
+
+Warning
+{: .label .label-yellow}
+
+Tasks cannot read tasks that are inside code blocks, such as the ones used by the Admonitions plugin. Use Obsidian's built-in callouts instead.
+
+---
+
+Warning
+{: .label .label-yellow}
 Tasks can only render inline footnotes. Regular footnotes are not supported.
 
 ```markdown

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
@@ -63,7 +63,7 @@ Work through all the tasks below, until zero tasks remain in this query:
 
 ### Recurring Tasks
 
-Confirm that when a recurring task is completed, a new task is created, all the date fields are incremented, and the indentation is correct.
+Confirm that when a recurring task is completed, a new task is created, all the date fields are incremented, and the indentation is unchanged.
 
 > [!Todo]
 >

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
@@ -63,12 +63,17 @@ Work through all the tasks below, until zero tasks remain in this query:
 
 ### Recurring Tasks
 
-Confirm that when a recurring task is completed, a new task is created and all the date fields are incremented.
+Confirm that when a recurring task is completed, a new task is created, all the date fields are incremented, and the indentation is correct.
 
-- [ ] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19
-- [ ] #task Complete this recurring task in **Reading view**🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19
+> [!Todo]
+>
+> - [ ] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19
+>
+> > - [ ] #task Complete this recurring task in **Reading view**🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19
+
 - [ ] #task Complete this recurring task in **Live Preview**🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19
-- [ ] #task **check**: Checked all above steps for **recurring tasks** worked
+
+> - [ ] #task **check**: Checked all above steps for **recurring tasks** worked
 
 ### Rendering of Task Blocks
 

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -1,6 +1,6 @@
 import { MetadataCache, TAbstractFile, TFile, Vault } from 'obsidian';
 import type { CachedMetadata, EventRef } from 'obsidian';
-import type { HeadingCache, ListItemCache, SectionCache } from 'obsidian';
+import type { ListItemCache, SectionCache } from 'obsidian';
 import { Mutex } from 'async-mutex';
 
 import { Task } from './Task';
@@ -290,10 +290,11 @@ export class Cache {
                     path: file.path,
                     sectionStart: currentSection.position.start.line,
                     sectionIndex,
-                    precedingHeader: Cache.getPrecedingHeader(
-                        listItem.position.start.line,
-                        fileCache.headings,
-                    ),
+                    precedingHeader: Cache.getPrecedingHeader({
+                        lineNumberTask: listItem.position.start.line,
+                        sections: fileCache.sections,
+                        fileLines,
+                    }),
                 });
 
                 if (task !== null) {
@@ -329,22 +330,44 @@ export class Cache {
         return null;
     }
 
-    private static getPrecedingHeader(
-        lineNumberTask: number,
-        headings: HeadingCache[] | undefined,
-    ): string | null {
-        if (headings === undefined) {
+    private static getPrecedingHeader({
+        lineNumberTask,
+        sections,
+        fileLines,
+    }: {
+        lineNumberTask: number;
+        sections: SectionCache[] | undefined;
+        fileLines: string[];
+    }): string | null {
+        if (sections === undefined) {
             return null;
         }
 
-        let precedingHeading: string | null = null;
-
-        for (const heading of headings) {
-            if (heading.position.start.line > lineNumberTask) {
-                return precedingHeading;
+        let precedingHeaderSection: SectionCache | undefined;
+        for (const section of sections) {
+            if (section.type === 'heading') {
+                if (section.position.start.line > lineNumberTask) {
+                    // Break out of the loop as the last header was the preceding one.
+                    break;
+                }
+                precedingHeaderSection = section;
             }
-            precedingHeading = heading.heading;
         }
-        return precedingHeading;
+        if (precedingHeaderSection === undefined) {
+            return null;
+        }
+
+        const lineNumberPrecedingHeader =
+            precedingHeaderSection.position.start.line;
+
+        const linePrecedingHeader = fileLines[lineNumberPrecedingHeader];
+
+        const headerRegex = /^#+ +(.*)/u;
+        const headerMatch = linePrecedingHeader.match(headerRegex);
+        if (headerMatch === null) {
+            return null;
+        } else {
+            return headerMatch[1];
+        }
     }
 }

--- a/src/Commands/CreateOrEdit.ts
+++ b/src/Commands/CreateOrEdit.ts
@@ -58,7 +58,7 @@ const taskFromLine = ({ line, path }: { line: string; path: string }): Task => {
 
     // If we are not on a line of a task, we take what we have.
     // The non-task line can still be a checklist, for example if it is lacking the global filter.
-    const nonTaskRegex: RegExp = /^([\s\t]*)[-*]? *(\[(.)\])? *(.*)/u;
+    const nonTaskRegex: RegExp = /^([\s\t>]*)[-*]? *(\[(.)\])? *(.*)/u;
     const nonTaskMatch = line.match(nonTaskRegex);
     if (nonTaskMatch === null) {
         // Should never happen; everything in the regex is optional.

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -72,13 +72,13 @@ const toggleLine = ({ line, path }: { line: string; path: string }): string => {
             // 1. a list item
             // 2. a simple text line
 
-            const listItemRegex = /^([\s\t]*)([-*])/;
+            const listItemRegex = /^([\s\t>]*)([-*])/;
             if (listItemRegex.test(line)) {
                 // Let's convert the list item to a checklist item.
                 toggledLine = line.replace(listItemRegex, '$1$2 [ ]');
             } else {
                 // Let's convert the line to a list item.
-                toggledLine = line.replace(/^([\s\t]*)/, '$1- ');
+                toggledLine = line.replace(/^([\s\t>]*)/, '$1- ');
             }
         }
     }

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -16,8 +16,8 @@ interface CacheUpdateData {
 export class Events {
     private obsidianEvents: ObsidianEvents;
 
-    constructor({ obsidianEents }: { obsidianEents: ObsidianEvents }) {
-        this.obsidianEvents = obsidianEents;
+    constructor({ obsidianEvents }: { obsidianEvents: ObsidianEvents }) {
+        this.obsidianEvents = obsidianEvents;
     }
 
     public onCacheUpdate(

--- a/src/LivePreviewExtension.ts
+++ b/src/LivePreviewExtension.ts
@@ -49,10 +49,10 @@ class LivePreviewExtension implements PluginValue {
             if (ancestor.matches('div.callout-content')) {
                 // Error message for now.
                 const msg =
-                    'obsidian-tasks-plugin warning: Clicking a checkbox inside a callout in Live Preview not supported. \n' +
-                    'Undo your change, then either click the line of the task and use the "Toggle Task Done" command, or switch to Reading View to click the checkbox.';
+                    'obsidian-tasks-plugin warning: Tasks cannot add or remove completion dates or make the next copy of a recurring task for tasks written inside a callout when you click their checkboxes in Live Preview. \n' +
+                    'If you wanted Tasks to do these things, please undo your change, then either click the line of the task and use the "Toggle Task Done" command, or switch to Reading View to click the checkbox.';
                 console.warn(msg);
-                new Notice(msg, 30000);
+                new Notice(msg, 45000);
             }
             return false;
         }

--- a/src/LivePreviewExtension.ts
+++ b/src/LivePreviewExtension.ts
@@ -52,7 +52,7 @@ class LivePreviewExtension implements PluginValue {
                     'obsidian-tasks-plugin warning: Clicking a checkbox inside a callout in Live Preview not supported. \n' +
                     'Undo your change, then either click the line of the task and use the "Toggle Task Done" command, or switch to Reading View to click the checkbox.';
                 console.warn(msg);
-                new Notice(msg, 3000);
+                new Notice(msg, 30000);
             }
             return false;
         }

--- a/src/LivePreviewExtension.ts
+++ b/src/LivePreviewExtension.ts
@@ -34,8 +34,14 @@ class LivePreviewExtension implements PluginValue {
             return false;
         }
 
-        // Right now Obsidian API does not give us a way to handle checkbox clicks inside rendered-widgets-in-LP such as callouts.
-        // However, tasks from "task" query codeblocks handle themselves, so be specific about error messaging.
+        /* Right now Obsidian API does not give us a way to handle checkbox clicks inside rendered-widgets-in-LP such as
+         * callouts, tables, and transclusions because `this.view.posAtDOM` will return the beginning of the widget
+         * as the position for any click inside the widget.
+         * For callouts, this means that the task will never be found, since the `lineAt` will be the beginning of the callout.
+         * Therefore, produce an error message pop-up using Obsidian's "Notice" feature, log a console warning, then return.
+         */
+
+        // Tasks from "task" query codeblocks handle themselves thanks to `toLi`, so be specific about error messaging, but still return.
         const ancestor = target.closest(
             'ul.plugin-tasks-query-result, div.callout-content',
         );
@@ -44,7 +50,7 @@ class LivePreviewExtension implements PluginValue {
                 // Error message for now.
                 const msg =
                     'obsidian-tasks-plugin warning: Clicking a checkbox inside a callout in Live Preview not supported. \n' +
-                    'Click the line of the task and use "Toggle Task Done" command, or switch to Reading View to click the checkbox.';
+                    'Undo your change, then either click the line of the task and use the "Toggle Task Done" command, or switch to Reading View to click the checkbox.';
                 console.warn(msg);
                 new Notice(msg, 3000);
             }

--- a/src/Query/Filter/ExcludeSubItemsField.ts
+++ b/src/Query/Filter/ExcludeSubItemsField.ts
@@ -7,10 +7,15 @@ export class ExcludeSubItemsField extends FilterInstructionsBasedField {
     constructor() {
         super();
 
-        this._filters.add(
-            'exclude sub-items',
-            (task) => task.indentation === '',
-        );
+        this._filters.add('exclude sub-items', (task) => {
+            if (task.indentation === '') return true; // no indentation, not a subitem
+
+            const lastBlockquoteMark = task.indentation.lastIndexOf('>');
+            if (lastBlockquoteMark === -1) return false; // indentation present, not in a blockquote, subitem
+
+            // Up to one space allowed after last > in blockquote/callout, otherwise subitem
+            return /^ ?$/.test(task.indentation.slice(lastBlockquoteMark + 1));
+        });
     }
 
     protected fieldName(): string {

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -85,7 +85,7 @@ export class Task {
     public static readonly dateFormat = 'YYYY-MM-DD';
 
     // Main regex for parsing a line. It matches the following:
-    // - Indentation
+    // - Indentation (including > for potentially nested blockquotes or Obsidian callouts)
     // - Status character
     // - Rest of task after checkbox markdown
     public static readonly taskRegex = /^([\s\t>]*)[-*] +\[(.)\] *(.*)/u;

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -88,7 +88,7 @@ export class Task {
     // - Indentation
     // - Status character
     // - Rest of task after checkbox markdown
-    public static readonly taskRegex = /^([\s\t]*)[-*] +\[(.)\] *(.*)/u;
+    public static readonly taskRegex = /^([\s\t>]*)[-*] +\[(.)\] *(.*)/u;
 
     // Match on block link at end.
     public static readonly blockLinkRegex = / \^[a-zA-Z0-9-]+$/u;

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ export default class TasksPlugin extends Plugin {
             vault: this.app.vault,
         });
 
-        const events = new Events({ obsidianEents: this.app.workspace });
+        const events = new Events({ obsidianEvents: this.app.workspace });
         this.cache = new Cache({
             metadataCache: this.app.metadataCache,
             vault: this.app.vault,

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -840,12 +840,12 @@ describe('Query', () => {
             const query = new Query({ source: input });
 
             const tasksAsMarkdown = `
-> > - [x] Task 1 - should not appear in output
-> > - [x] Task 2 - should not appear in output
-> > - [ ] Task 3 - will be sorted to 1st place, so should pass limit
-> > - [ ] Task 4 - will be sorted to 2nd place, so should pass limit
-> > - [ ] Task 5 - should not appear in output
-> > - [ ] Task 6 - should not appear in output
+- [x] Task 1 - should not appear in output
+- [x] Task 2 - should not appear in output
+- [ ] Task 3 - will be sorted to 1st place, so should pass limit
+- [ ] Task 4 - will be sorted to 2nd place, so should pass limit
+- [ ] Task 5 - should not appear in output
+- [ ] Task 6 - should not appear in output
             `;
 
             const tasks = createTasksFromMarkdown(
@@ -861,8 +861,8 @@ describe('Query', () => {
             expect(groups.groups.length).toEqual(1);
             const soleTaskGroup = groups.groups[0];
             const expectedTasks = `
-> > - [ ] Task 3 - will be sorted to 1st place, so should pass limit
-> > - [ ] Task 4 - will be sorted to 2nd place, so should pass limit
+- [ ] Task 3 - will be sorted to 1st place, so should pass limit
+- [ ] Task 4 - will be sorted to 2nd place, so should pass limit
 `;
             expect('\n' + soleTaskGroup.tasksAsStringOfLines()).toStrictEqual(
                 expectedTasks,

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -840,12 +840,12 @@ describe('Query', () => {
             const query = new Query({ source: input });
 
             const tasksAsMarkdown = `
-- [x] Task 1 - should not appear in output
-- [x] Task 2 - should not appear in output
-- [ ] Task 3 - will be sorted to 1st place, so should pass limit
-- [ ] Task 4 - will be sorted to 2nd place, so should pass limit
-- [ ] Task 5 - should not appear in output
-- [ ] Task 6 - should not appear in output
+> > - [x] Task 1 - should not appear in output
+> > - [x] Task 2 - should not appear in output
+> > - [ ] Task 3 - will be sorted to 1st place, so should pass limit
+> > - [ ] Task 4 - will be sorted to 2nd place, so should pass limit
+> > - [ ] Task 5 - should not appear in output
+> > - [ ] Task 6 - should not appear in output
             `;
 
             const tasks = createTasksFromMarkdown(
@@ -861,8 +861,8 @@ describe('Query', () => {
             expect(groups.groups.length).toEqual(1);
             const soleTaskGroup = groups.groups[0];
             const expectedTasks = `
-- [ ] Task 3 - will be sorted to 1st place, so should pass limit
-- [ ] Task 4 - will be sorted to 2nd place, so should pass limit
+> > - [ ] Task 3 - will be sorted to 1st place, so should pass limit
+> > - [ ] Task 4 - will be sorted to 2nd place, so should pass limit
 `;
             expect('\n' + soleTaskGroup.tasksAsStringOfLines()).toStrictEqual(
                 expectedTasks,

--- a/tests/Query/Filter/ExcludeSubItemsField.test.ts
+++ b/tests/Query/Filter/ExcludeSubItemsField.test.ts
@@ -14,4 +14,20 @@ describe('sub-items', () => {
         testTaskFilter(filter, fromLine({ line: '  - [ ] Subtask1' }), false);
         testTaskFilter(filter, fromLine({ line: '    - [ ] Subtask2' }), false);
     });
+    it('subitem has more than one space after last > of blockquotes or callouts', () => {
+        // Arrange
+        const filter = new ExcludeSubItemsField().createFilterOrErrorMessage(
+            'exclude sub-items',
+        );
+
+        // Assert
+        testTaskFilter(filter, fromLine({ line: '> - [ ] Task' }), true);
+        testTaskFilter(filter, fromLine({ line: '> > - [ ] Task' }), true);
+        testTaskFilter(filter, fromLine({ line: '>>  - [ ] Subtask1' }), false);
+        testTaskFilter(
+            filter,
+            fromLine({ line: '> >  - [ ] Subtask2' }),
+            false,
+        );
+    });
 });

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -214,10 +214,12 @@ describe('parsing', () => {
                 _input: line, // Line is included, so it is shown in any failure output
                 description: task.description,
                 due: task.dueDate?.format('YYYY-MM-DD'),
+                indentation: task.indentation,
             }).toMatchObject({
                 _input: line,
                 description: 'Task inside a blockquote or callout',
                 due: '2022-07-29',
+                indentation: line.split('-')[0],
             });
         }
     });

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -200,7 +200,7 @@ describe('parsing', () => {
         const lines = [
             '> - [ ] Task inside a blockquote or callout 📅2022-07-29',
             '>>> - [ ] Task inside a blockquote or callout 📅2022-07-29',
-            '> > > - [ ] Task inside a blockquote or callout 📅2022-07-29',
+            '> > > * [ ] Task inside a blockquote or callout 📅2022-07-29',
         ];
 
         // Act
@@ -219,7 +219,7 @@ describe('parsing', () => {
                 _input: line,
                 description: 'Task inside a blockquote or callout',
                 due: '2022-07-29',
-                indentation: line.split('-')[0],
+                indentation: line.split(/[-*]/)[0],
             });
         }
     });
@@ -324,7 +324,7 @@ describe('parsing tags', () => {
         },
         {
             markdownTask:
-                '- [ ] Export [Cloud Feedly feeds](https://cloud.feedly.com/#opml) #context/pc_clare 🔁 every 4 weeks on Sunday ⏳ 2022-05-15 #context/more_context',
+                '* [ ] Export [Cloud Feedly feeds](https://cloud.feedly.com/#opml) #context/pc_clare 🔁 every 4 weeks on Sunday ⏳ 2022-05-15 #context/more_context',
             expectedDescription:
                 'Export [Cloud Feedly feeds](https://cloud.feedly.com/#opml) #context/pc_clare #context/more_context',
             extractedTags: ['#context/pc_clare', '#context/more_context'],
@@ -354,7 +354,7 @@ describe('parsing tags', () => {
         },
         {
             markdownTask:
-                '>>> - [ ] Task inside a nested blockquote or callout #tagone',
+                '>>> * [ ] Task inside a nested blockquote or callout #tagone',
             expectedDescription:
                 'Task inside a nested blockquote or callout #tagone',
             extractedTags: ['#tagone'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Now that I am familiar with the dataview codebase, I found their regex for parsing list items, which works with Obsidian callouts, and it turns out the fix is super easy to add to Tasks! Blockquote/callout indicators are now stored along with spaces and tabs in the `indentation` field of the Task, so they are preserved when the task is rendered out to string.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #656 including nested blockquotes/callouts

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Added unit tests for parsing the task, parsing tags out of the task, and toString. Something mentioned in the issue thread is testing specifically that the `indentation` is preserved when a new instance of a recurring task is generated - I could not figure out where in the tests to put that, if you still think it is needed, could you give me a pointer please to where in the tests it should go?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage. (mostly, see note above!)

By creating a Pull Request I agree to the [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).