### PR TITLE
chore: Remove markdown from issue descriptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Suggest a new feature
     url: https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/new?category=ideas
-    about: Request a new feature or improvement in the Tasks plugin.<br>Please [search existing ideas](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/categories/ideas) first, and up-vote, to avoid duplicates.
+    about: Request a new feature or improvement in the Tasks plugin. Please search existing Discussion Ideas first, and up-vote, to avoid duplicates.
   - name: Ask a question
     url: https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/new?category=q-a
-    about: Ask for help with using the Tasks plugin.<br>In case your question has been asked before, for quicker results you can [search existing questions](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/categories/q-a).
+    about: Ask for help with using the Tasks plugin. In case your question has been asked before, for quicker results you can search existing Discussion Q&As.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

It turns out that Markdown is not rendered in 'about' descriptions, so remove it

## Motivation and Context

Still trying to help users find existing discussions.

## How has this been tested?

Can't be tested until merged.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
