### PR TITLE
docs: Refine explanation of callouts in Live Preview

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -81,8 +81,15 @@ The following _does not work:_
 Warning
 {: .label .label-yellow}
 Tasks can read tasks that are inside blockquotes or [Obsidian's built-in callouts](https://help.obsidian.md/How+to/Use+callouts).
-However, in the Live Preview editor mode (pencil icon in lower right corner), tasks written inside callouts cannot be completed by clicking the checkbox.
-You will see a warning; use the command `Tasks: Toggle Done`, or switch to Reading View (book icon in lower right corner) to click the checkbox.
+
+However, under the following very specific circumstance, Tasks cannot add or remove completion dates or make the next copy of a recurring task:
+
+- Obsidian is in Live Preview editor mode (pencil icon in lower right corner),
+- AND the task's markdown is in a callout,
+- AND the user clicked on the task's checkbox to complete or re-open the task.
+
+If you toggle a task's status in this situation, you will see a warning. Use the command `Tasks: Toggle Done`, or switch to Reading View (book icon in lower right corner) to click the checkbox.
+
 Completing a task by clicking its checkbox from a `tasks` query block _will_ work in any editor mode, even if the query is inside a callout.
 
 ---


### PR DESCRIPTION
# Description

This essentially copies in @AnnaKornfeldSimpson's text from the popup warning about issues with completing tasks that are in callouts when in Live Preview mode.

It also breaks up a long-ish paragraph a bit.

## Motivation and Context

Just to make it a little easier to see what the issue is with tasks in callouts in Live Preview.

## How has this been tested?

By viewing the rendered docs locally in docker.

## Screenshots (if appropriate)

This is what the changed docs look like now:

![image](https://user-images.githubusercontent.com/4840096/183420910-87eefa17-9c00-4f75-88db-b17d7e77b3af.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
