### PR TITLE
docs: 1.11.1 reads tasks in callouts & blockquotes

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -82,6 +82,8 @@ Warning
 {: .label .label-yellow}
 Tasks can read tasks that are inside blockquotes or [Obsidian's built-in callouts](https://help.obsidian.md/How+to/Use+callouts).
 
+> Reading tasks inside callouts and blockquotes was introduced in Tasks 1.11.1
+
 However, under the following very specific circumstance, Tasks cannot add or remove completion dates or make the next copy of a recurring task:
 
 - Obsidian is in Live Preview editor mode (pencil icon in lower right corner),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Note that version 1.11.1 reads (or will read) tasks in callouts & blockquotes

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)


## Terms


- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
