### PR TITLE
docs: fix notifications, update auto-suggest

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,13 @@ If you can run docker, this is the easiest way.
 
 ### Seeing the docs via Docker
 
-Now every time you want to see the docs locally, run:
+> Note: If using Windows, there are some interoperability issues with Windows, Docker, and Jekyll.
+> Recommend running the command below from a Windows Subsystem for Linux (WSL) shell,
+> where you can likely get to your Windows user directory via `/mnt/c/Users/<your username>`,
+> and using a browser from inside WSL2 if possible. Otherwise, if running the browser from Windows,
+> at every page load you must change "0.0.0.0" to "localhost" in the browser's address bar.
+
+To see the docs locally, run:
 
 ```bash
 cd obsidian-tasks/docs
@@ -108,3 +114,15 @@ bundle exec jekyll serve
 
 In the output, look for the line containing `Server address:` and open that URL in your local browser.
 It will be something like <http://0.0.0.0:4000/obsidian-tasks/>.
+
+## Dependency Management and Updates for the Docs
+
+The dependencies for running the docs locally are stored in the `Gemfile` (short, equivalent to Javascript `package.json`) and `Gemfile.lock` (auto-generated, equivalent to `yarn.lock`) files.
+The package manager (equivalent to "yarn") is "bundle" [docs here](https://bundler.io/guides/using_bundler_in_applications.html#recommended-workflow). The "docker_start" script runs the initial
+`bundle install` when building the Docker image.
+If seeing issues with dependencies or with running the docs locally, check that the versions in the `Gemfile`, especially "github-pages" are up-to-date. If making edits to the `Gemfile`, you
+will need to run `bundle install` or `bundle update` manually. (You may also need to update `bundle` itself!) Before checking in any changes to `Gemfile.lock`, see the paragraph below.
+
+Some dependencies, such as "nokogiri", have platform-specific gems that **should not** be checked into the repo's `Gemfile.lock`.
+For example, Dependabot might add a Linux-specific version of a dependency to the `Gemfile.lock`, which must then be manually edited to remove the Linux-specific version.
+Otherwise, future contributors on non-Linux systems will be unable to build the Docker image or run Jekyll locally.

--- a/docs/advanced/notifications.md
+++ b/docs/advanced/notifications.md
@@ -18,15 +18,35 @@ _Note that this is a screenshot of the reminder plugin's settings and not Tasks.
 
 ## Where to add the reminder date
 
-The order is important when writing the task. You have to put the reminder date between the task name and the other fields :
+The order is important when writing the task. Tasks requires the reminder date after the task description and before any other Tasks fields. Reminders [requires no content between the reminder date and the due date](https://uphy.github.io/obsidian-reminder/guide/interop-tasks.html#distinguish-due-date-and-reminder-date).
 
 ```markdown
-- [ ] #task task name ⏰ YYYY-MM-DD HH:mm ⏫  🔁 every *** 🛫 YYYY-MM-DD ⏳ YYYY-MM-DD 📅 YYYY-MM-DD
+- [ ] #task task name ⏰ YYYY-MM-DD HH:mm 📅 YYYY-MM-DD ⏫ 🔁 every week 🛫 YYYY-MM-DD ⏳ YYYY-MM-DD
 ```
+
+---
+
+Warning
+{: .label .label-yellow}
+The output of the "Create or Edit Tasks" command will not put the due date directly behind the reminder date where Reminders wants it.
+You must fix this manually if you want to use the Reminders "defer" command;
+**otherwise (as of August 2022), using the Reminders "defer" command will overwrite all information between the ⏰ and 📅 emoji!**
+See [this issue in Reminders to check the current status](https://github.com/uphy/obsidian-reminder/issues/100).
+
+---
 
 ## How to complete the reminder
 
-The reminder date doesn't change when completing the task as of yet, the date will change only when you complete it from the reminder popup or from the notification.
+The reminder date doesn't change when completing the task, the date will change only when you complete it from the reminder popup or from the notification.
 
 ![image](https://user-images.githubusercontent.com/38974541/143463881-e4af4b91-426f-48e8-938e-4a1053b06677.png)
 ![image](https://user-images.githubusercontent.com/38974541/143464983-542675ae-a467-41c0-aaca-1075c42f8328.png)
+
+---
+
+Warning
+{: .label .label-yellow}
+Completing recurring tasks does not work correctly with Reminders as of August 2022.
+See [this issue in Reminders to check the current status](https://github.com/uphy/obsidian-reminder/issues/93).
+
+---

--- a/docs/getting-started/auto-suggest.md
+++ b/docs/getting-started/auto-suggest.md
@@ -223,6 +223,17 @@ Similarly, you can type some fraction of the word `start` (of whatever length is
 | next month (2022-08-11) | 2022-08-11                 |
 | next year (2023-07-11)  | 2023-07-11                 |
 
+### How can I use auto-suggest features from other plugins together with the Tasks auto-suggest?
+
+Obsidian plugins such as Tasks cannot tell if you have auto-suggest features from other plugins enabled.
+Therefore it is user responsibility to manage conflicts between auto-suggest features.
+
+The Tasks auto-suggest will only appear on lines that start `- [ ]` and contain the global filter (if one is set).
+If you want to use auto-suggest features from another plugin on such lines, make sure that plugin's settings for auto-suggest
+appearance do not overlap with the keywords listed above,
+then increase the 'Minimum match length for auto-suggest' value in the Tasks settings to more characters than used to activate the other plugin's auto-suggest,
+and re-start Obsidian.
+
 ## Settings
 
 Note that like all Tasks settings, after any changes, Obsidian needs to be restarted for the new settings to take effect.


### PR DESCRIPTION
**Note**: I am putting this as a PR to `main` since GitHub was confused otherwise, but the docs changes can go to `gh-pages` also; they do not need to wait for another Tasks release.

# Description
* docs: Fix "Notifications" page to warn about recent issues - fixes #927 
* docs: Add FAQ entry to "Auto-Suggest" page about combining with auto-suggest features from other plugins - fixes #928 
* docs(internal): Add section to the README in "/docs" about dependency management and a note about running Docker+Jekyll from Windows - fixes #979 

## Motivation and Context
Now that I can finally run the docs locally, working on my backlog of documentation.
Issues: #927 #928 #979

## How has this been tested?
Tested by running docs locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
