### PR TITLE
test: Move custom Jest matchers to separate file

### DIFF
--- a/tests/CustomMatchers/CustomMatchersForFilters.ts
+++ b/tests/CustomMatchers/CustomMatchersForFilters.ts
@@ -1,6 +1,6 @@
-import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
-import { fromLine } from '../../TestHelpers';
-import { TaskBuilder } from '../../TestingTools/TaskBuilder';
+import type { FilterOrErrorMessage } from '../../src/Query/Filter/Filter';
+import { fromLine } from '../TestHelpers';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
 
 /* Example usage (shown for toMatchTaskWithDescription(), but other matchers are available.
 

--- a/tests/Query/Filter/CustomMatchersForFilters.ts
+++ b/tests/Query/Filter/CustomMatchersForFilters.ts
@@ -1,6 +1,16 @@
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
 import { fromLine } from '../../TestHelpers';
 
+/* To use this code, you must add these lines:
+
+import { toMatchTaskWithDescription } from '<relative-path>/CustomMatchersForFilters';
+
+expect.extend({
+    toMatchTaskWithDescription,
+});
+
+ */
+
 declare global {
     namespace jest {
         interface Matchers<R> {

--- a/tests/Query/Filter/CustomMatchersForFilters.ts
+++ b/tests/Query/Filter/CustomMatchersForFilters.ts
@@ -15,15 +15,21 @@ expect.extend({
 declare global {
     namespace jest {
         interface Matchers<R> {
+            toBeValid(): R;
             toMatchTaskWithDescription(description: string): R;
+            toMatchTaskWithPath(path: string): R;
         }
 
         interface Expect {
+            toBeValid(): any;
             toMatchTaskWithDescription(description: string): any;
+            toMatchTaskWithPath(path: string): any;
         }
 
         interface InverseAsymmetricMatchers {
+            toBeValid(): any;
             toMatchTaskWithDescription(description: string): any;
+            toMatchTaskWithPath(path: string): any;
         }
     }
 }
@@ -48,28 +54,6 @@ export function toMatchTaskWithDescription(
         message: () => `filter should not have matched task: ${description}`,
         pass: true,
     };
-}
-
-declare global {
-    namespace jest {
-        interface Matchers<R> {
-            toMatchTaskWithPath(path: string): R;
-
-            toBeValid(): R;
-        }
-
-        interface Expect {
-            toMatchTaskWithPath(path: string): any;
-
-            toBeValid(): any;
-        }
-
-        interface InverseAsymmetricMatchers {
-            toMatchTaskWithPath(path: string): any;
-
-            toBeValid(): any;
-        }
-    }
 }
 
 export function toBeValid(filter: FilterOrErrorMessage) {

--- a/tests/Query/Filter/CustomMatchersForFilters.ts
+++ b/tests/Query/Filter/CustomMatchersForFilters.ts
@@ -1,0 +1,40 @@
+import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
+import { fromLine } from '../../TestHelpers';
+
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toMatchTaskWithDescription(description: string): R;
+        }
+
+        interface Expect {
+            toMatchTaskWithDescription(description: string): any;
+        }
+
+        interface InverseAsymmetricMatchers {
+            toMatchTaskWithDescription(description: string): any;
+        }
+    }
+}
+
+export function toMatchTaskWithDescription(
+    filter: FilterOrErrorMessage,
+    description: string,
+) {
+    const task = fromLine({
+        line: description,
+    });
+
+    const matches = filter.filter!(task);
+    if (!matches) {
+        return {
+            message: () => `unexpected failure to match task: ${description}`,
+            pass: false,
+        };
+    }
+
+    return {
+        message: () => `filter should not have matched task: ${description}`,
+        pass: true,
+    };
+}

--- a/tests/Query/Filter/CustomMatchersForFilters.ts
+++ b/tests/Query/Filter/CustomMatchersForFilters.ts
@@ -34,28 +34,6 @@ declare global {
     }
 }
 
-export function toMatchTaskWithDescription(
-    filter: FilterOrErrorMessage,
-    description: string,
-) {
-    const task = fromLine({
-        line: description,
-    });
-
-    const matches = filter.filter!(task);
-    if (!matches) {
-        return {
-            message: () => `unexpected failure to match task: ${description}`,
-            pass: false,
-        };
-    }
-
-    return {
-        message: () => `filter should not have matched task: ${description}`,
-        pass: true,
-    };
-}
-
 export function toBeValid(filter: FilterOrErrorMessage) {
     if (filter.filter === undefined) {
         return {
@@ -75,6 +53,28 @@ export function toBeValid(filter: FilterOrErrorMessage) {
 
     return {
         message: () => 'filter is unexpectedly valid',
+        pass: true,
+    };
+}
+
+export function toMatchTaskWithDescription(
+    filter: FilterOrErrorMessage,
+    description: string,
+) {
+    const task = fromLine({
+        line: description,
+    });
+
+    const matches = filter.filter!(task);
+    if (!matches) {
+        return {
+            message: () => `unexpected failure to match task: ${description}`,
+            pass: false,
+        };
+    }
+
+    return {
+        message: () => `filter should not have matched task: ${description}`,
         pass: true,
     };
 }

--- a/tests/Query/Filter/CustomMatchersForFilters.ts
+++ b/tests/Query/Filter/CustomMatchersForFilters.ts
@@ -2,7 +2,7 @@ import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
 import { fromLine } from '../../TestHelpers';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 
-/* To use this code, you must add these lines:
+/* Example usage (shown for toMatchTaskWithDescription(), but other matchers are available.
 
 import { toMatchTaskWithDescription } from '<relative-path>/CustomMatchersForFilters';
 

--- a/tests/Query/Filter/CustomMatchersForFilters.ts
+++ b/tests/Query/Filter/CustomMatchersForFilters.ts
@@ -1,5 +1,6 @@
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
 import { fromLine } from '../../TestHelpers';
+import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 
 /* To use this code, you must add these lines:
 
@@ -45,6 +46,72 @@ export function toMatchTaskWithDescription(
 
     return {
         message: () => `filter should not have matched task: ${description}`,
+        pass: true,
+    };
+}
+
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toMatchTaskWithPath(path: string): R;
+
+            toBeValid(): R;
+        }
+
+        interface Expect {
+            toMatchTaskWithPath(path: string): any;
+
+            toBeValid(): any;
+        }
+
+        interface InverseAsymmetricMatchers {
+            toMatchTaskWithPath(path: string): any;
+
+            toBeValid(): any;
+        }
+    }
+}
+
+export function toBeValid(filter: FilterOrErrorMessage) {
+    if (filter.filter === undefined) {
+        return {
+            message: () =>
+                'unexpected null filter: check your instruction matches your filter class',
+            pass: false,
+        };
+    }
+
+    if (filter.error !== undefined) {
+        return {
+            message: () =>
+                'unexpected error message in filter: check your instruction matches your filter class',
+            pass: false,
+        };
+    }
+
+    return {
+        message: () => 'filter is unexpectedly valid',
+        pass: true,
+    };
+}
+
+export function toMatchTaskWithPath(
+    filter: FilterOrErrorMessage,
+    path: string,
+) {
+    const builder = new TaskBuilder();
+    const task = builder.path(path).build();
+
+    const matches = filter.filter!(task);
+    if (!matches) {
+        return {
+            message: () => `unexpected failure to match task: ${path}`,
+            pass: false,
+        };
+    }
+
+    return {
+        message: () => `filter should not have matched task: ${path}`,
         pass: true,
     };
 }

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -3,6 +3,7 @@ import { getSettings, updateSettings } from '../../../src/config/Settings';
 import { testTaskFilter } from '../../TestingTools/FilterTestHelpers';
 import { fromLine } from '../../TestHelpers';
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
+import { toMatchTaskWithDescription } from './CustomMatchersForFilters';
 
 function testDescriptionFilter(
     filter: FilterOrErrorMessage,
@@ -13,44 +14,6 @@ function testDescriptionFilter(
         line,
     });
     testTaskFilter(filter, task, expected);
-}
-
-declare global {
-    namespace jest {
-        interface Matchers<R> {
-            toMatchTaskWithDescription(description: string): R;
-        }
-
-        interface Expect {
-            toMatchTaskWithDescription(description: string): any;
-        }
-
-        interface InverseAsymmetricMatchers {
-            toMatchTaskWithDescription(description: string): any;
-        }
-    }
-}
-
-export function toMatchTaskWithDescription(
-    filter: FilterOrErrorMessage,
-    description: string,
-) {
-    const task = fromLine({
-        line: description,
-    });
-
-    const matches = filter.filter!(task);
-    if (!matches) {
-        return {
-            message: () => `unexpected failure to match task: ${description}`,
-            pass: false,
-        };
-    }
-
-    return {
-        message: () => `filter should not have matched task: ${description}`,
-        pass: true,
-    };
 }
 
 expect.extend({

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -3,7 +3,7 @@ import { getSettings, updateSettings } from '../../../src/config/Settings';
 import { testTaskFilter } from '../../TestingTools/FilterTestHelpers';
 import { fromLine } from '../../TestHelpers';
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
-import { toMatchTaskWithDescription } from './CustomMatchersForFilters';
+import { toMatchTaskWithDescription } from '../../CustomMatchers/CustomMatchersForFilters';
 
 function testDescriptionFilter(
     filter: FilterOrErrorMessage,

--- a/tests/Query/Filter/PathField.test.ts
+++ b/tests/Query/Filter/PathField.test.ts
@@ -2,6 +2,7 @@ import { PathField } from '../../../src/Query/Filter/PathField';
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { testFilter } from '../../TestingTools/FilterTestHelpers';
+import { toBeValid, toMatchTaskWithPath } from './CustomMatchersForFilters';
 
 function testTaskFilterForTaskWithPath(
     filter: FilterOrErrorMessage,
@@ -10,69 +11,6 @@ function testTaskFilterForTaskWithPath(
 ) {
     const builder = new TaskBuilder();
     testFilter(filter, builder.path(path), expected);
-}
-
-declare global {
-    namespace jest {
-        interface Matchers<R> {
-            toMatchTaskWithPath(path: string): R;
-            toBeValid(): R;
-        }
-
-        interface Expect {
-            toMatchTaskWithPath(path: string): any;
-            toBeValid(): any;
-        }
-
-        interface InverseAsymmetricMatchers {
-            toMatchTaskWithPath(path: string): any;
-            toBeValid(): any;
-        }
-    }
-}
-
-export function toBeValid(filter: FilterOrErrorMessage) {
-    if (filter.filter === undefined) {
-        return {
-            message: () =>
-                'unexpected null filter: check your instruction matches your filter class',
-            pass: false,
-        };
-    }
-
-    if (filter.error !== undefined) {
-        return {
-            message: () =>
-                'unexpected error message in filter: check your instruction matches your filter class',
-            pass: false,
-        };
-    }
-
-    return {
-        message: () => 'filter is unexpectedly valid',
-        pass: true,
-    };
-}
-
-export function toMatchTaskWithPath(
-    filter: FilterOrErrorMessage,
-    path: string,
-) {
-    const builder = new TaskBuilder();
-    const task = builder.path(path).build();
-
-    const matches = filter.filter!(task);
-    if (!matches) {
-        return {
-            message: () => `unexpected failure to match task: ${path}`,
-            pass: false,
-        };
-    }
-
-    return {
-        message: () => `filter should not have matched task: ${path}`,
-        pass: true,
-    };
 }
 
 expect.extend({

--- a/tests/Query/Filter/PathField.test.ts
+++ b/tests/Query/Filter/PathField.test.ts
@@ -2,7 +2,10 @@ import { PathField } from '../../../src/Query/Filter/PathField';
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { testFilter } from '../../TestingTools/FilterTestHelpers';
-import { toBeValid, toMatchTaskWithPath } from './CustomMatchersForFilters';
+import {
+    toBeValid,
+    toMatchTaskWithPath,
+} from '../../CustomMatchers/CustomMatchersForFilters';
 
 function testTaskFilterForTaskWithPath(
     filter: FilterOrErrorMessage,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

When the regex searching code was added, @elight showed me how to write custom Jest matches for more expressive tests.

We added the first matcher in the path tests, then more were added in description.

Now I would like to re-use them in other locations, so I've moved them out to a new file:
`tests/CustomMatchers/CustomMatchersForFilters.ts`

I suspect that there may be more idiomatic ways of doing this, like maybe added interface files, but for now I'm happy enough that it's going to be possible to re-use these matches in other places.

## Motivation and Context

To enable me to re-use some valuable testing code.

## How has this been tested?

By re-running the changed tests.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
