### PR TITLE
test: Rename custom matcher and add motivating docs

### DIFF
--- a/tests/CustomMatchers/CustomMatchersForFilters.ts
+++ b/tests/CustomMatchers/CustomMatchersForFilters.ts
@@ -2,13 +2,53 @@ import type { FilterOrErrorMessage } from '../../src/Query/Filter/Filter';
 import { fromLine } from '../TestHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 
-/* Example usage (shown for toMatchTaskFromLine(), but other matchers are available.
+/**
+ @summary
+ This file contains Jest custom matchers, for idiomatic testing of filtering
+ via Field classes.
 
-import { toMatchTaskFromLine } from '<relative-path>/CustomMatchersForFilters';
+ @description
+ These matchers are a more idiomatic way of testing custom objects via
+ the Jest test framework than the helper functions in tests/TestingTools/
+ and various testing helpers in individual x.test.ts files.
+ <br>
 
-expect.extend({
+ When they fail, they show the line number at the call site, rather
+ than some line buried down in the helper function, in other words, a much
+ more useful call stack/traceback.
+ <br>
+
+ They can also generate much more informative error messages describing
+ the failure.
+ <br>
+
+ Example usage (shown for  {@link toMatchTaskFromLine}, but other matchers are available:
+ <br>
+
+ @example
+
+ // Setup:
+ import { toMatchTaskFromLine } from '<relative-path>/CustomMatchersForFilters';
+
+ expect.extend({
     toMatchTaskFromLine,
 });
+
+ // Inside it() and describe() blocks:
+ it('works negating regexes', () => {
+        // Arrange
+        const filter = new DescriptionField().createFilterOrErrorMessage(
+            'description regex does not match /^task/',
+        );
+
+        // Assert
+        expect(filter).toMatchTaskFromLine(
+            '- [ ] this does not start with the pattern',
+        );
+        expect(filter).not.toMatchTaskFromLine(
+            '- [ ] task does start with the pattern',
+        );
+    });
 
  */
 

--- a/tests/CustomMatchers/CustomMatchersForFilters.ts
+++ b/tests/CustomMatchers/CustomMatchersForFilters.ts
@@ -2,12 +2,12 @@ import type { FilterOrErrorMessage } from '../../src/Query/Filter/Filter';
 import { fromLine } from '../TestHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 
-/* Example usage (shown for toMatchTaskWithDescription(), but other matchers are available.
+/* Example usage (shown for toMatchTaskFromLine(), but other matchers are available.
 
-import { toMatchTaskWithDescription } from '<relative-path>/CustomMatchersForFilters';
+import { toMatchTaskFromLine } from '<relative-path>/CustomMatchersForFilters';
 
 expect.extend({
-    toMatchTaskWithDescription,
+    toMatchTaskFromLine,
 });
 
  */
@@ -16,19 +16,19 @@ declare global {
     namespace jest {
         interface Matchers<R> {
             toBeValid(): R;
-            toMatchTaskWithDescription(description: string): R;
+            toMatchTaskFromLine(description: string): R;
             toMatchTaskWithPath(path: string): R;
         }
 
         interface Expect {
             toBeValid(): any;
-            toMatchTaskWithDescription(description: string): any;
+            toMatchTaskFromLine(description: string): any;
             toMatchTaskWithPath(path: string): any;
         }
 
         interface InverseAsymmetricMatchers {
             toBeValid(): any;
-            toMatchTaskWithDescription(description: string): any;
+            toMatchTaskFromLine(description: string): any;
             toMatchTaskWithPath(path: string): any;
         }
     }
@@ -57,7 +57,7 @@ export function toBeValid(filter: FilterOrErrorMessage) {
     };
 }
 
-export function toMatchTaskWithDescription(
+export function toMatchTaskFromLine(
     filter: FilterOrErrorMessage,
     description: string,
 ) {

--- a/tests/CustomMatchers/CustomMatchersForFilters.ts
+++ b/tests/CustomMatchers/CustomMatchersForFilters.ts
@@ -16,19 +16,19 @@ declare global {
     namespace jest {
         interface Matchers<R> {
             toBeValid(): R;
-            toMatchTaskFromLine(description: string): R;
+            toMatchTaskFromLine(line: string): R;
             toMatchTaskWithPath(path: string): R;
         }
 
         interface Expect {
             toBeValid(): any;
-            toMatchTaskFromLine(description: string): any;
+            toMatchTaskFromLine(line: string): any;
             toMatchTaskWithPath(path: string): any;
         }
 
         interface InverseAsymmetricMatchers {
             toBeValid(): any;
-            toMatchTaskFromLine(description: string): any;
+            toMatchTaskFromLine(line: string): any;
             toMatchTaskWithPath(path: string): any;
         }
     }
@@ -59,22 +59,22 @@ export function toBeValid(filter: FilterOrErrorMessage) {
 
 export function toMatchTaskFromLine(
     filter: FilterOrErrorMessage,
-    description: string,
+    line: string,
 ) {
     const task = fromLine({
-        line: description,
+        line: line,
     });
 
     const matches = filter.filter!(task);
     if (!matches) {
         return {
-            message: () => `unexpected failure to match task: ${description}`,
+            message: () => `unexpected failure to match task: ${line}`,
             pass: false,
         };
     }
 
     return {
-        message: () => `filter should not have matched task: ${description}`,
+        message: () => `filter should not have matched task: ${line}`,
         pass: true,
     };
 }

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -3,7 +3,7 @@ import { getSettings, updateSettings } from '../../../src/config/Settings';
 import { testTaskFilter } from '../../TestingTools/FilterTestHelpers';
 import { fromLine } from '../../TestHelpers';
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
-import { toMatchTaskWithDescription } from '../../CustomMatchers/CustomMatchersForFilters';
+import { toMatchTaskFromLine } from '../../CustomMatchers/CustomMatchersForFilters';
 
 function testDescriptionFilter(
     filter: FilterOrErrorMessage,
@@ -17,7 +17,7 @@ function testDescriptionFilter(
 }
 
 expect.extend({
-    toMatchTaskWithDescription,
+    toMatchTaskFromLine,
 });
 
 describe('description', () => {
@@ -76,10 +76,10 @@ describe('description', () => {
         );
 
         // Assert
-        expect(filter).not.toMatchTaskWithDescription(
+        expect(filter).not.toMatchTaskFromLine(
             '- [ ] this does not start with the pattern',
         );
-        expect(filter).toMatchTaskWithDescription(
+        expect(filter).toMatchTaskFromLine(
             '- [ ] task does start with the pattern',
         );
     });
@@ -91,10 +91,10 @@ describe('description', () => {
         );
 
         // Assert
-        expect(filter).toMatchTaskWithDescription(
+        expect(filter).toMatchTaskFromLine(
             '- [ ] this does not start with the pattern',
         );
-        expect(filter).not.toMatchTaskWithDescription(
+        expect(filter).not.toMatchTaskFromLine(
             '- [ ] task does start with the pattern',
         );
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I realised that `toMatchTaskWithDescription()` was actually more general than it sounded, so have renamed it to 
`toMatchTaskFromLine()`, as it not at all specific to descriptions.

## Motivation and Context

More readable tests, and more obvious that a custom matcher can be re-used.

## How has this been tested?

By running existing tests

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
