### PR TITLE
refactor: Move TextField.maybeNegate() to end and make static

### DIFF
--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -8,9 +8,6 @@ import { FilterOrErrorMessage } from './Filter';
  * value, such as the description or file path.
  */
 export abstract class TextField extends Field {
-    private maybeNegate(match: boolean, filterMethod: String) {
-        return filterMethod.match(/not/) ? !match : match;
-    }
     public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         const result = new FilterOrErrorMessage();
         const match = Field.getMatch(this.filterRegexp(), line);
@@ -76,4 +73,8 @@ export abstract class TextField extends Field {
      * @protected
      */
     protected abstract value(task: Task): string;
+
+    private maybeNegate(match: boolean, filterMethod: String) {
+        return filterMethod.match(/not/) ? !match : match;
+    }
 }

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -15,7 +15,7 @@ export abstract class TextField extends Field {
             const filterMethod = match[1];
             if (['includes', 'does not include'].includes(filterMethod)) {
                 result.filter = (task: Task) =>
-                    this.maybeNegate(
+                    TextField.maybeNegate(
                         TextField.stringIncludesCaseInsensitive(
                             this.value(task),
                             match[2],
@@ -32,7 +32,7 @@ export abstract class TextField extends Field {
 
                 if (query !== null) {
                     result.filter = (task: Task) =>
-                        this.maybeNegate(
+                        TextField.maybeNegate(
                             this.value(task).match(
                                 new RegExp(query[1], query[2]),
                             ) !== null,
@@ -74,7 +74,7 @@ export abstract class TextField extends Field {
      */
     protected abstract value(task: Task): string;
 
-    private maybeNegate(match: boolean, filterMethod: String) {
+    private static maybeNegate(match: boolean, filterMethod: String) {
         return filterMethod.match(/not/) ? !match : match;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This was code review feedback from #790.

## Motivation and Context

To resolve a conversation from review of #790, and prevent WebStorm from warning that `maybeNegate()` may be static on every commit.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

By running exiting tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
