### PR TITLE
test: Test heading with regex, add 2 custom matchers

### DIFF
--- a/tests/CustomMatchers/CustomMatchersForFilters.ts
+++ b/tests/CustomMatchers/CustomMatchersForFilters.ts
@@ -1,3 +1,4 @@
+import type { Task } from '../../src/Task';
 import type { FilterOrErrorMessage } from '../../src/Query/Filter/Filter';
 import { fromLine } from '../TestHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
@@ -100,14 +101,7 @@ export function toBeValid(filter: FilterOrErrorMessage) {
     };
 }
 
-export function toMatchTaskFromLine(
-    filter: FilterOrErrorMessage,
-    line: string,
-) {
-    const task = fromLine({
-        line: line,
-    });
-
+function toMatchTask(filter: FilterOrErrorMessage, task: Task, line: string) {
     const matches = filter.filter!(task);
     if (!matches) {
         return {
@@ -120,6 +114,16 @@ export function toMatchTaskFromLine(
         message: () => `filter should not have matched task: ${line}`,
         pass: true,
     };
+}
+
+export function toMatchTaskFromLine(
+    filter: FilterOrErrorMessage,
+    line: string,
+) {
+    const task = fromLine({
+        line: line,
+    });
+    return toMatchTask(filter, task, line);
 }
 
 export function toMatchTaskWithHeading(

--- a/tests/CustomMatchers/CustomMatchersForFilters.ts
+++ b/tests/CustomMatchers/CustomMatchersForFilters.ts
@@ -134,19 +134,7 @@ export function toMatchTaskWithHeading(
 ) {
     const builder = new TaskBuilder();
     const task = builder.precedingHeader(heading).build();
-
-    const matches = filter.filter!(task);
-    if (!matches) {
-        return {
-            message: () => `unexpected failure to match task: ${heading}`,
-            pass: false,
-        };
-    }
-
-    return {
-        message: () => `filter should not have matched task: ${heading}`,
-        pass: true,
-    };
+    return toMatchTask(filter, task);
 }
 
 export function toMatchTaskWithPath(
@@ -155,17 +143,5 @@ export function toMatchTaskWithPath(
 ) {
     const builder = new TaskBuilder();
     const task = builder.path(path).build();
-
-    const matches = filter.filter!(task);
-    if (!matches) {
-        return {
-            message: () => `unexpected failure to match task: ${path}`,
-            pass: false,
-        };
-    }
-
-    return {
-        message: () => `filter should not have matched task: ${path}`,
-        pass: true,
-    };
+    return toMatchTask(filter, task);
 }

--- a/tests/CustomMatchers/CustomMatchersForFilters.ts
+++ b/tests/CustomMatchers/CustomMatchersForFilters.ts
@@ -101,17 +101,19 @@ export function toBeValid(filter: FilterOrErrorMessage) {
     };
 }
 
-function toMatchTask(filter: FilterOrErrorMessage, task: Task, line: string) {
+function toMatchTask(filter: FilterOrErrorMessage, task: Task) {
     const matches = filter.filter!(task);
     if (!matches) {
         return {
-            message: () => `unexpected failure to match task: ${line}`,
+            message: () =>
+                `unexpected failure to match task: ${task.toFileLineString()}`,
             pass: false,
         };
     }
 
     return {
-        message: () => `filter should not have matched task: ${line}`,
+        message: () =>
+            `filter should not have matched task: ${task.toFileLineString()}`,
         pass: true,
     };
 }
@@ -123,7 +125,7 @@ export function toMatchTaskFromLine(
     const task = fromLine({
         line: line,
     });
-    return toMatchTask(filter, task, line);
+    return toMatchTask(filter, task);
 }
 
 export function toMatchTaskWithHeading(

--- a/tests/CustomMatchers/CustomMatchersForFilters.ts
+++ b/tests/CustomMatchers/CustomMatchersForFilters.ts
@@ -57,6 +57,7 @@ declare global {
     namespace jest {
         interface Matchers<R> {
             toBeValid(): R;
+            toMatchTask(task: Task): R;
             toMatchTaskFromLine(line: string): R;
             toMatchTaskWithHeading(heading: string | null): R;
             toMatchTaskWithPath(path: string): R;
@@ -64,6 +65,7 @@ declare global {
 
         interface Expect {
             toBeValid(): any;
+            toMatchTask(task: Task): any;
             toMatchTaskFromLine(line: string): any;
             toMatchTaskWithHeading(heading: string | null): any;
             toMatchTaskWithPath(path: string): any;
@@ -71,6 +73,7 @@ declare global {
 
         interface InverseAsymmetricMatchers {
             toBeValid(): any;
+            toMatchTask(task: Task): any;
             toMatchTaskFromLine(line: string): any;
             toMatchTaskWithHeading(heading: string | null): any;
             toMatchTaskWithPath(path: string): any;
@@ -101,7 +104,7 @@ export function toBeValid(filter: FilterOrErrorMessage) {
     };
 }
 
-function toMatchTask(filter: FilterOrErrorMessage, task: Task) {
+export function toMatchTask(filter: FilterOrErrorMessage, task: Task) {
     const matches = filter.filter!(task);
     if (!matches) {
         return {

--- a/tests/CustomMatchers/CustomMatchersForFilters.ts
+++ b/tests/CustomMatchers/CustomMatchersForFilters.ts
@@ -57,18 +57,21 @@ declare global {
         interface Matchers<R> {
             toBeValid(): R;
             toMatchTaskFromLine(line: string): R;
+            toMatchTaskWithHeading(heading: string | null): R;
             toMatchTaskWithPath(path: string): R;
         }
 
         interface Expect {
             toBeValid(): any;
             toMatchTaskFromLine(line: string): any;
+            toMatchTaskWithHeading(heading: string | null): any;
             toMatchTaskWithPath(path: string): any;
         }
 
         interface InverseAsymmetricMatchers {
             toBeValid(): any;
             toMatchTaskFromLine(line: string): any;
+            toMatchTaskWithHeading(heading: string | null): any;
             toMatchTaskWithPath(path: string): any;
         }
     }
@@ -115,6 +118,27 @@ export function toMatchTaskFromLine(
 
     return {
         message: () => `filter should not have matched task: ${line}`,
+        pass: true,
+    };
+}
+
+export function toMatchTaskWithHeading(
+    filter: FilterOrErrorMessage,
+    heading: string,
+) {
+    const builder = new TaskBuilder();
+    const task = builder.precedingHeader(heading).build();
+
+    const matches = filter.filter!(task);
+    if (!matches) {
+        return {
+            message: () => `unexpected failure to match task: ${heading}`,
+            pass: false,
+        };
+    }
+
+    return {
+        message: () => `filter should not have matched task: ${heading}`,
         pass: true,
     };
 }

--- a/tests/Query/Filter/HeadingField.test.ts
+++ b/tests/Query/Filter/HeadingField.test.ts
@@ -2,6 +2,10 @@ import { HeadingField } from '../../../src/Query/Filter/HeadingField';
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { testFilter } from '../../TestingTools/FilterTestHelpers';
+import {
+    toBeValid,
+    toMatchTaskWithHeading,
+} from '../../CustomMatchers/CustomMatchersForFilters';
 
 function testTaskFilterForHeading(
     filter: FilterOrErrorMessage,
@@ -11,6 +15,14 @@ function testTaskFilterForHeading(
     const builder = new TaskBuilder();
     testFilter(filter, builder.precedingHeader(precedingHeader), expected);
 }
+
+expect.extend({
+    toBeValid,
+});
+
+expect.extend({
+    toMatchTaskWithHeading,
+});
 
 describe('heading', () => {
     it('by heading (includes)', () => {
@@ -35,5 +47,31 @@ describe('heading', () => {
         testTaskFilterForHeading(filter, null, true);
         testTaskFilterForHeading(filter, 'SoMe InteResting HeaDing', false);
         testTaskFilterForHeading(filter, 'Other Heading', true);
+    });
+
+    it('by heading (regex matches - case sensitive)', () => {
+        // Arrange
+        const filter = new HeadingField().createFilterOrErrorMessage(
+            'heading regex matches /[Ii]nteresting Head.ng/',
+        );
+
+        // Act, Assert
+        expect(filter).toBeValid();
+        expect(filter).toMatchTaskWithHeading('Interesting Heading');
+        expect(filter).not.toMatchTaskWithHeading(null);
+        expect(filter).not.toMatchTaskWithHeading('SoMe InteResting HeaDing');
+    });
+
+    it('by heading (regex does not match - case in-sensitive)', () => {
+        // Arrange
+        const filter = new HeadingField().createFilterOrErrorMessage(
+            'heading regex does not match /[Ii]nteresting Head.ng/i',
+        );
+
+        // Act, Assert
+        expect(filter).toBeValid();
+        expect(filter).toMatchTaskWithHeading(null);
+        expect(filter).not.toMatchTaskWithHeading('Interesting Heading');
+        expect(filter).not.toMatchTaskWithHeading('SoMe InteResting HeaDing');
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Add missing tests for filtering headings with regex
- Add Jest custom  matcher `toMatchTaskWithHeading()`
- Refactor out duplicated code in the custom matchers by adding `toMatchTask()`

## Motivation and Context

Fill gap in test coverage for regex searches
Simplify the jest custom matcher implementations.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Running all existing tests, and adding new ones

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
