### PR TITLE
refactor: Tags search now implemented with SubstringMatcher

### DIFF
--- a/src/Query/Filter/TagsField.ts
+++ b/src/Query/Filter/TagsField.ts
@@ -2,6 +2,7 @@ import type { Task } from '../../Task';
 import { SubstringMatcher } from '../Matchers/SubstringMatcher';
 import { Field } from './Field';
 import { FilterOrErrorMessage } from './Filter';
+import { TextField } from './TextField';
 
 /**
  * Support the 'tag' and 'tags' search instructions.
@@ -24,14 +25,21 @@ export class TagsField extends Field {
 
             if (filterMethod === 'include' || filterMethod === 'includes') {
                 const matcher = new SubstringMatcher(search);
-                result.filter = (task: Task) => matcher.matchesAnyOf(task.tags);
+                result.filter = (task: Task) =>
+                    TextField.maybeNegate(
+                        matcher.matchesAnyOf(task.tags),
+                        filterMethod,
+                    );
             } else if (
                 tagMatch[2] === 'do not include' ||
                 tagMatch[2] === 'does not include'
             ) {
                 const matcher = new SubstringMatcher(search);
                 result.filter = (task: Task) =>
-                    !matcher.matchesAnyOf(task.tags);
+                    TextField.maybeNegate(
+                        matcher.matchesAnyOf(task.tags),
+                        filterMethod,
+                    );
             } else {
                 result.error = 'do not understand query filter (tag/tags)';
             }

--- a/src/Query/Filter/TagsField.ts
+++ b/src/Query/Filter/TagsField.ts
@@ -1,4 +1,5 @@
 import type { Task } from '../../Task';
+import { SubstringMatcher } from '../Matchers/SubstringMatcher';
 import { Field } from './Field';
 import { FilterOrErrorMessage } from './Filter';
 import { TextField } from './TextField';
@@ -23,10 +24,8 @@ export class TagsField extends Field {
             const search = tagMatch[3].replace(/^#/, '');
 
             if (filterMethod === 'include' || filterMethod === 'includes') {
-                result.filter = (task: Task) =>
-                    task.tags.find((tag) =>
-                        TextField.stringIncludesCaseInsensitive(tag, search),
-                    ) !== undefined;
+                const matcher = new SubstringMatcher(search);
+                result.filter = (task: Task) => matcher.matchesAnyOf(task.tags);
             } else if (
                 tagMatch[2] === 'do not include' ||
                 tagMatch[2] === 'does not include'

--- a/src/Query/Filter/TagsField.ts
+++ b/src/Query/Filter/TagsField.ts
@@ -23,17 +23,7 @@ export class TagsField extends Field {
             // Search is done sans the hash. If it is provided then strip it off.
             const search = tagMatch[3].replace(/^#/, '');
 
-            if (filterMethod === 'include' || filterMethod === 'includes') {
-                const matcher = new SubstringMatcher(search);
-                result.filter = (task: Task) =>
-                    TextField.maybeNegate(
-                        matcher.matchesAnyOf(task.tags),
-                        filterMethod,
-                    );
-            } else if (
-                tagMatch[2] === 'do not include' ||
-                tagMatch[2] === 'does not include'
-            ) {
+            if (filterMethod.includes('include')) {
                 const matcher = new SubstringMatcher(search);
                 result.filter = (task: Task) =>
                     TextField.maybeNegate(

--- a/src/Query/Filter/TagsField.ts
+++ b/src/Query/Filter/TagsField.ts
@@ -2,7 +2,6 @@ import type { Task } from '../../Task';
 import { SubstringMatcher } from '../Matchers/SubstringMatcher';
 import { Field } from './Field';
 import { FilterOrErrorMessage } from './Filter';
-import { TextField } from './TextField';
 
 /**
  * Support the 'tag' and 'tags' search instructions.
@@ -30,10 +29,9 @@ export class TagsField extends Field {
                 tagMatch[2] === 'do not include' ||
                 tagMatch[2] === 'does not include'
             ) {
+                const matcher = new SubstringMatcher(search);
                 result.filter = (task: Task) =>
-                    task.tags.find((tag) =>
-                        TextField.stringIncludesCaseInsensitive(tag, search),
-                    ) == undefined;
+                    !matcher.matchesAnyOf(task.tags);
             } else {
                 result.error = 'do not understand query filter (tag/tags)';
             }

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -68,7 +68,7 @@ export abstract class TextField extends Field {
      */
     protected abstract value(task: Task): string;
 
-    private static maybeNegate(match: boolean, filterMethod: String) {
+    public static maybeNegate(match: boolean, filterMethod: String) {
         return filterMethod.match(/not/) ? !match : match;
     }
 }

--- a/src/Query/Matchers/IStringMatcher.ts
+++ b/src/Query/Matchers/IStringMatcher.ts
@@ -10,4 +10,12 @@ export abstract class IStringMatcher {
      * @param stringToSearch
      */
     public abstract matches(stringToSearch: string): boolean;
+
+    /**
+     * Return whether any of the given strings matches this condition.
+     * @param stringsToSearch
+     */
+    public matchesAnyOf(stringsToSearch: string[]) {
+        return stringsToSearch.some((s) => this.matches(s));
+    }
 }

--- a/src/Query/Matchers/IStringMatcher.ts
+++ b/src/Query/Matchers/IStringMatcher.ts
@@ -4,10 +4,10 @@
  * This is used to hide away the details of various text searches, such as the
  * simple inclusion of a sub-string, or the more complex regular expression searches.
  */
-export interface IStringMatcher {
+export abstract class IStringMatcher {
     /**
      * Return whether the given string matches this condition.
      * @param stringToSearch
      */
-    matches(stringToSearch: string): boolean;
+    public abstract matches(stringToSearch: string): boolean;
 }

--- a/src/Query/Matchers/RegexMatcher.ts
+++ b/src/Query/Matchers/RegexMatcher.ts
@@ -1,9 +1,9 @@
-import type { IStringMatcher } from './IStringMatcher';
+import { IStringMatcher } from './IStringMatcher';
 
 /**
  * Regular-expression-based implementation of IStringMatcher.
  */
-export class RegexMatcher implements IStringMatcher {
+export class RegexMatcher extends IStringMatcher {
     private readonly regex: RegExp;
 
     /**
@@ -12,6 +12,7 @@ export class RegexMatcher implements IStringMatcher {
      * @param regex {RegExp} - A valid regular expression
      */
     public constructor(regex: RegExp) {
+        super();
         this.regex = regex;
     }
 

--- a/src/Query/Matchers/SubstringMatcher.ts
+++ b/src/Query/Matchers/SubstringMatcher.ts
@@ -1,11 +1,11 @@
-import type { IStringMatcher } from './IStringMatcher';
+import { IStringMatcher } from './IStringMatcher';
 
 /**
  * Substring-based implementation of IStringMatcher.
  *
  * This does a case-insensitive search for the given string.
  */
-export class SubstringMatcher implements IStringMatcher {
+export class SubstringMatcher extends IStringMatcher {
     private readonly stringToFind: string;
 
     /**
@@ -15,6 +15,7 @@ export class SubstringMatcher implements IStringMatcher {
      *                                Searches will be case-insensitive.
      */
     public constructor(stringToFind: string) {
+        super();
         this.stringToFind = stringToFind;
     }
 

--- a/src/Query/Matchers/SubstringMatcher.ts
+++ b/src/Query/Matchers/SubstringMatcher.ts
@@ -26,10 +26,6 @@ export class SubstringMatcher extends IStringMatcher {
         );
     }
 
-    public matchesAnyOf(stringsToSearch: string[]) {
-        return stringsToSearch.some((s) => this.matches(s));
-    }
-
     public static stringIncludesCaseInsensitive(
         haystack: string,
         needle: string,

--- a/src/Query/Matchers/SubstringMatcher.ts
+++ b/src/Query/Matchers/SubstringMatcher.ts
@@ -25,6 +25,10 @@ export class SubstringMatcher implements IStringMatcher {
         );
     }
 
+    public matchesAnyOf(stringsToSearch: string[]) {
+        return stringsToSearch.some((s) => this.matches(s));
+    }
+
     public static stringIncludesCaseInsensitive(
         haystack: string,
         needle: string,

--- a/tests/Query/Matchers/SubstringMatcher.test.ts
+++ b/tests/Query/Matchers/SubstringMatcher.test.ts
@@ -7,4 +7,14 @@ describe('SubstringMatcher', () => {
         expect(matcher.matches('prefix find me suffix')).toStrictEqual(true);
         expect(matcher.matches('FIND ME')).toStrictEqual(true);
     });
+
+    it('should match any values in array of text', () => {
+        const matcher = new SubstringMatcher('find me');
+        expect(
+            matcher.matchesAnyOf(['wibble', 'stuff', 'FIND ME']),
+        ).toStrictEqual(true);
+        expect(
+            matcher.matchesAnyOf(['wibble', 'stuff', 'LOSE ME']),
+        ).not.toStrictEqual(true);
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- `IStringMatcher` is now an abstract class
- Added `IStringMatcher.matchesAnyOf(stringsToSearch: string[])`
- TagsField is now implemented using `SubstringMatcher`

## Motivation and Context

This will make it really easy to add regex searching in a later step

## How has this been tested?

- Running existing tests
- Adding new tests

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
