### PR TITLE
refactor: Simplify TextField

### DIFF
--- a/src/Query/Filter/Filter.ts
+++ b/src/Query/Filter/Filter.ts
@@ -22,4 +22,14 @@ export type Filter = (task: Task) => boolean;
 export class FilterOrErrorMessage {
     filter: Filter | undefined;
     error: string | undefined;
+
+    /**
+     * Construct a FilterOrErrorMessage with the given error message.
+     * @param errorMessage
+     */
+    public static fromError(errorMessage: string): FilterOrErrorMessage {
+        const result = new FilterOrErrorMessage();
+        result.error = errorMessage;
+        return result;
+    }
 }

--- a/src/Query/Filter/Filter.ts
+++ b/src/Query/Filter/Filter.ts
@@ -24,6 +24,16 @@ export class FilterOrErrorMessage {
     error: string | undefined;
 
     /**
+     * Construct a FilterOrErrorMessage with the filter.
+     * @param filter
+     */
+    public static fromFilter(filter: Filter): FilterOrErrorMessage {
+        const result = new FilterOrErrorMessage();
+        result.filter = filter;
+        return result;
+    }
+
+    /**
      * Construct a FilterOrErrorMessage with the given error message.
      * @param errorMessage
      */

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -14,10 +14,15 @@ export abstract class TextField extends Field {
     public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         const match = Field.getMatch(this.filterRegexp(), line);
         if (match === null) {
+            // If Field.canCreateFilterForLine() has been checked, we should never get
+            // in to this block.
             return FilterOrErrorMessage.fromError(
                 `do not understand query filter (${this.fieldName()})`,
             );
         }
+
+        // Construct an IStringMatcher for this filter, or return
+        // if the inputs are invalid.
         const filterMethod = match[1];
         const searchString = match[2];
         let matcher: IStringMatcher | null = null;
@@ -42,6 +47,9 @@ export abstract class TextField extends Field {
             );
         }
 
+        // Finally, we can create the Filter, that takes a task
+        // and tests if it matches the string filtering rule
+        // represented by this object.
         return FilterOrErrorMessage.fromFilter((task: Task) => {
             return TextField.maybeNegate(
                 matcher!.matches(this.value(task)),

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -36,16 +36,15 @@ export abstract class TextField extends Field {
                 return FilterOrErrorMessage.fromError(
                     `cannot parse regex (${this.fieldName()}); check your leading and trailing slashes for your query`,
                 );
-            } else {
-                const result = new FilterOrErrorMessage();
-                result.filter = (task: Task) => {
-                    return TextField.maybeNegate(
-                        matcher.matches(this.value(task)),
-                        filterMethod,
-                    );
-                };
-                return result;
             }
+            const result = new FilterOrErrorMessage();
+            result.filter = (task: Task) => {
+                return TextField.maybeNegate(
+                    matcher.matches(this.value(task)),
+                    filterMethod,
+                );
+            };
+            return result;
         } else {
             return FilterOrErrorMessage.fromError(
                 `do not understand query filter (${this.fieldName()})`,

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -19,13 +19,14 @@ export abstract class TextField extends Field {
             );
         }
         const filterMethod = match[1];
+        const searchString = match[2];
         let matcher: IStringMatcher | null = null;
         if (['includes', 'does not include'].includes(filterMethod)) {
-            matcher = new SubstringMatcher(match[2]);
+            matcher = new SubstringMatcher(searchString);
         } else if (
             ['regex matches', 'regex does not match'].includes(filterMethod)
         ) {
-            matcher = RegexMatcher.validateAndConstruct(match[2]);
+            matcher = RegexMatcher.validateAndConstruct(searchString);
             if (matcher === null) {
                 return FilterOrErrorMessage.fromError(
                     `cannot parse regex (${this.fieldName()}); check your leading and trailing slashes for your query`,

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -12,7 +12,11 @@ import { FilterOrErrorMessage } from './Filter';
 export abstract class TextField extends Field {
     public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         const match = Field.getMatch(this.filterRegexp(), line);
-        if (match !== null) {
+        if (match === null) {
+            return FilterOrErrorMessage.fromError(
+                `do not understand query filter (${this.fieldName()})`,
+            );
+        } else {
             const filterMethod = match[1];
             if (['includes', 'does not include'].includes(filterMethod)) {
                 const matcher = new SubstringMatcher(match[2]);
@@ -47,10 +51,6 @@ export abstract class TextField extends Field {
                     `do not understand query filter (${this.fieldName()})`,
                 );
             }
-        } else {
-            return FilterOrErrorMessage.fromError(
-                `do not understand query filter (${this.fieldName()})`,
-            );
         }
     }
 

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -11,29 +11,32 @@ import { FilterOrErrorMessage } from './Filter';
  */
 export abstract class TextField extends Field {
     public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
-        const result = new FilterOrErrorMessage();
         const match = Field.getMatch(this.filterRegexp(), line);
         if (match !== null) {
             const filterMethod = match[1];
             if (['includes', 'does not include'].includes(filterMethod)) {
                 const matcher = new SubstringMatcher(match[2]);
+                const result = new FilterOrErrorMessage();
                 result.filter = (task: Task) => {
                     return TextField.maybeNegate(
                         matcher.matches(this.value(task)),
                         filterMethod,
                     );
                 };
+                return result;
             } else if (
                 ['regex matches', 'regex does not match'].includes(filterMethod)
             ) {
                 const matcher = RegexMatcher.validateAndConstruct(match[2]);
                 if (matcher !== null) {
+                    const result = new FilterOrErrorMessage();
                     result.filter = (task: Task) => {
                         return TextField.maybeNegate(
                             matcher.matches(this.value(task)),
                             filterMethod,
                         );
                     };
+                    return result;
                 } else {
                     return FilterOrErrorMessage.fromError(
                         `cannot parse regex (${this.fieldName()}); check your leading and trailing slashes for your query`,
@@ -49,7 +52,6 @@ export abstract class TextField extends Field {
                 `do not understand query filter (${this.fieldName()})`,
             );
         }
-        return result;
     }
 
     public static stringIncludesCaseInsensitive(

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -32,7 +32,11 @@ export abstract class TextField extends Field {
             ['regex matches', 'regex does not match'].includes(filterMethod)
         ) {
             const matcher = RegexMatcher.validateAndConstruct(match[2]);
-            if (matcher !== null) {
+            if (matcher === null) {
+                return FilterOrErrorMessage.fromError(
+                    `cannot parse regex (${this.fieldName()}); check your leading and trailing slashes for your query`,
+                );
+            } else {
                 const result = new FilterOrErrorMessage();
                 result.filter = (task: Task) => {
                     return TextField.maybeNegate(
@@ -41,10 +45,6 @@ export abstract class TextField extends Field {
                     );
                 };
                 return result;
-            } else {
-                return FilterOrErrorMessage.fromError(
-                    `cannot parse regex (${this.fieldName()}); check your leading and trailing slashes for your query`,
-                );
             }
         } else {
             return FilterOrErrorMessage.fromError(

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -16,10 +16,23 @@ export abstract class TextField extends Field {
             return FilterOrErrorMessage.fromError(
                 `do not understand query filter (${this.fieldName()})`,
             );
-        } else {
-            const filterMethod = match[1];
-            if (['includes', 'does not include'].includes(filterMethod)) {
-                const matcher = new SubstringMatcher(match[2]);
+        }
+        const filterMethod = match[1];
+        if (['includes', 'does not include'].includes(filterMethod)) {
+            const matcher = new SubstringMatcher(match[2]);
+            const result = new FilterOrErrorMessage();
+            result.filter = (task: Task) => {
+                return TextField.maybeNegate(
+                    matcher.matches(this.value(task)),
+                    filterMethod,
+                );
+            };
+            return result;
+        } else if (
+            ['regex matches', 'regex does not match'].includes(filterMethod)
+        ) {
+            const matcher = RegexMatcher.validateAndConstruct(match[2]);
+            if (matcher !== null) {
                 const result = new FilterOrErrorMessage();
                 result.filter = (task: Task) => {
                     return TextField.maybeNegate(
@@ -28,29 +41,15 @@ export abstract class TextField extends Field {
                     );
                 };
                 return result;
-            } else if (
-                ['regex matches', 'regex does not match'].includes(filterMethod)
-            ) {
-                const matcher = RegexMatcher.validateAndConstruct(match[2]);
-                if (matcher !== null) {
-                    const result = new FilterOrErrorMessage();
-                    result.filter = (task: Task) => {
-                        return TextField.maybeNegate(
-                            matcher.matches(this.value(task)),
-                            filterMethod,
-                        );
-                    };
-                    return result;
-                } else {
-                    return FilterOrErrorMessage.fromError(
-                        `cannot parse regex (${this.fieldName()}); check your leading and trailing slashes for your query`,
-                    );
-                }
             } else {
                 return FilterOrErrorMessage.fromError(
-                    `do not understand query filter (${this.fieldName()})`,
+                    `cannot parse regex (${this.fieldName()}); check your leading and trailing slashes for your query`,
                 );
             }
+        } else {
+            return FilterOrErrorMessage.fromError(
+                `do not understand query filter (${this.fieldName()})`,
+            );
         }
     }
 

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -35,13 +35,19 @@ export abstract class TextField extends Field {
                         );
                     };
                 } else {
-                    result.error = `cannot parse regex (${this.fieldName()}); check your leading and trailing slashes for your query`;
+                    return FilterOrErrorMessage.fromError(
+                        `cannot parse regex (${this.fieldName()}); check your leading and trailing slashes for your query`,
+                    );
                 }
             } else {
-                result.error = `do not understand query filter (${this.fieldName()})`;
+                return FilterOrErrorMessage.fromError(
+                    `do not understand query filter (${this.fieldName()})`,
+                );
             }
         } else {
-            result.error = `do not understand query filter (${this.fieldName()})`;
+            return FilterOrErrorMessage.fromError(
+                `do not understand query filter (${this.fieldName()})`,
+            );
         }
         return result;
     }

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -45,11 +45,10 @@ export abstract class TextField extends Field {
                 );
             };
             return result;
-        } else {
-            return FilterOrErrorMessage.fromError(
-                `do not understand query filter (${this.fieldName()})`,
-            );
         }
+        return FilterOrErrorMessage.fromError(
+            `do not understand query filter (${this.fieldName()})`,
+        );
     }
 
     public static stringIncludesCaseInsensitive(

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -41,14 +41,12 @@ export abstract class TextField extends Field {
             );
         }
 
-        const result = new FilterOrErrorMessage();
-        result.filter = (task: Task) => {
+        return FilterOrErrorMessage.fromFilter((task: Task) => {
             return TextField.maybeNegate(
                 matcher!.matches(this.value(task)),
                 filterMethod,
             );
-        };
-        return result;
+        });
     }
 
     public static stringIncludesCaseInsensitive(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

## Background

This looks like a rather scary refactoring, that has changed large amounts of code in `TextField.createFilterOrErrorMessage()`.

In fact, it's a series of almost entirely automated refactorings, done with WebStorm.

I tried multiple times to find a way to make the diff clear in the GitHub API, but because it doesn't have a way to temporarily ignore differences in indentation only in diffs, it was never going to be very clear in this view.

## Goals

The two goals were:

1. Replace 3 levels of nested if/else blocks with early return statements.
2. Elimate the duplicate code for creating `result.filter`

## Mechanics

For details of the refactorings, see the commits.

But basically, the bulk of it was a series of:

- Flip if/else - so that the error-check comes before the implementation
- Unwrap 'else' - so that because I made all the error-checking code return immediately after the error was recorded, the corresponding `else` is not needed. Eliminating removes a lot of nesting.

---

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Working towards greatly simplifying this code, and adding regex search for tags.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

By running all the existing tests.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
