### PR TITLE
chore: lefthook was renamed

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "author": "Martin Schenck and Clare Macrae",
   "license": "MIT",
   "devDependencies": {
-    "@arkweid/lefthook": "^0.7.6",
     "@codemirror/view": "^6.2.0",
+    "@evilmartians/lefthook": "^1.1.1",
     "@tsconfig/svelte": "^3.0.0",
     "@types/jest": "^28.1.8",
     "@typescript-eslint/eslint-plugin": "^5.34.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,11 +10,6 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@arkweid/lefthook@^0.7.6":
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/@arkweid/lefthook/-/lefthook-0.7.7.tgz#12951b09b955d8054885ffe929aa07a49f39027c"
-  integrity sha512-Eq30OXKmjxIAIsTtbX2fcF3SNZIXS8yry1u8yty7PQFYRctx04rVlhOJCEB2UmfTh8T2vrOMC9IHHUvvo5zbaQ==
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -551,6 +546,11 @@
     js-yaml "^4.1.0"
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
+
+"@evilmartians/lefthook@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@evilmartians/lefthook/-/lefthook-1.1.1.tgz#26e0de9ca3df1c8d2d97840f187a52cd95bb5f59"
+  integrity sha512-5C/AD937A6jz4mdBLAKXIeYVkxvLmPWxlv1YWfuHcIwZ2wp4W3z1Htjjtp+7gtO41CoCycIJcaxLfwaAsbS6qA==
 
 "@humanwhocodes/config-array@^0.10.4":
   version "0.10.4"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
* rename lefthook as instructed by warning from yarn

## Motivation and Context
When installing packages from scratch, yarn gives a warning that `lefthook` has been renamed. This PR does the rename and gets rid of the warning.
Also the lefthook output on Windows is now clearer!

## How has this been tested?
Hooks run for commit and push locally and via GitHub Actions.

## Types of changes

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.

## Terms

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
