### PR TITLE
docs: Make it easier to find and install this plugin

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -9,7 +9,7 @@ has_toc: false
 
 Follow the steps below to install Tasks.
 
-1. Search for "Tasks" in Obsidian's community plugins browser
+1. Search for "[Tasks](https://obsidian.md/plugins?id=obsidian-tasks-plugin)" in Obsidian's community plugins browser
 2. Enable the plugin in your Obsidian settings (find "Tasks" under "Community plugins").
 3. Check the settings. It makes sense to set the global filter early on (if you want one).
 4. Replace the "Toggle Checkbox Status" hotkey with "Tasks: Toggle Done".


### PR DESCRIPTION
When you enter "tasks" on [plugins page](https://obsidian.md/plugins?search=tasks) this plugin is actually at the bottom making it hard to find...

With this link it will be easier to find and install this plugin.