### PR TITLE
docs: Add 'How to get tasks in current file'

### DIFF
--- a/docs/how-to/get-tasks-in-current-file.md
+++ b/docs/how-to/get-tasks-in-current-file.md
@@ -114,7 +114,9 @@ Changing the last line to create a `text` block instead of a `tasks` one will sh
 
     dv.paragraph('```text\n' + query + '\n```');
 
-### Putting it in to a callout, for pretter output
+### Putting it in to a callout, for prettier output
+
+If you would like a more pleasing appearance for your Tasks results, you can put them in a [callout](https://help.obsidian.md/How+to/Use+callouts). In the example below, the results are displayed in a callout of type `todo`:
 
     ## Summary of Tasks within this note
 

--- a/docs/how-to/get-tasks-in-current-file.md
+++ b/docs/how-to/get-tasks-in-current-file.md
@@ -1,0 +1,136 @@
+---
+layout: default
+title: How to get tasks in current file
+nav_order: 2
+parent: How Tos
+---
+
+# How to get all tasks in the current file
+
+{: .no_toc }
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Motivation and assumptions
+
+When working on a note with lots of tasks, it can be useful to see a list of all the remaining tasks in the file,
+for example to make sure no task gets accidentally missed.
+
+This page documents ways of setting this up.
+
+Assumptions:
+
+- We assume that you know how to install and enable the [Dataview](https://github.com/blacksmithgu/obsidian-dataview) plugin.
+
+## Using pure Tasks blocks - fragile and error-prone
+
+Tasks does not provide an automated way to include the location of the `tasks` block in a query.
+
+It is possible to use the `path` instruction, but unfortunately you have to insert the path to the file yourself:
+
+    ## Summary of Tasks within this note
+
+    ```tasks
+    not done
+    path includes [insert current note's name or full path]
+    ```
+
+For example:
+
+    ## Summary of Tasks within this note
+
+    ```tasks
+    not done
+    path includes Obsidian/tasks/tasks user support/03 Done - tasks user support/1.11.0 release
+    ```
+
+<div class="code-example" markdown="1">
+
+Warning
+{: .label .label-yellow}
+
+Using `path includes` to search for a particular file name or folder is error-prone, as if you rename the file,
+you have to remember to manually update the location in the tasks block, and this is very error-prone.
+</div>
+
+## Using Dataview to generate Tasks blocks - safe and convenient
+
+There is a nice property that the [Dataview](https://github.com/blacksmithgu/obsidian-dataview) plugin can write out code blocks that are then processed by other plugins.
+
+This means that we can use Dataview to generate a standard Tasks code block, so that features like recurrence all work fine,
+and we make Dataview fill in the file name for us automatically.
+
+### Sample code - and how to use it
+
+1. Ensure that Dataview is installed in your Obsidian vault, and is enabled.
+1. Copy the entire following sample code block to your clipboard.
+1. Open an obsidian note that has some incomplete tasks.
+1. Paste the text in to Obsidian **without formatting** (`Shift+Ctrl+V` or `Shift+Command+V`).
+1. Switch to either Live Preview or Reading modes, to see the remaining tasks.
+
+Sample code block:
+
+    ## Summary of Tasks within this note
+
+    ```dataviewjs
+    const query = `
+    not done
+    path includes ${dv.current().file.path}
+    # you can add any number of extra Tasks instructions, for example:
+    group by heading
+    `;
+
+    dv.paragraph('```tasks\n' + query + '\n```');
+    ```
+
+### Using the example
+
+- There are a lot of punctuation and special characters in that code, which are easy to get wrong if you re-type the code.
+- Therefore, we strongly recommend that you copy-and-paste-without-formatting the code sample in to your note, and then modify the query instructions to suit your needs.
+
+### How the code works
+
+- The sample code block above  is a `dataviewjs` code block, which generates a Tasks code block!
+- By putting a backtick character (``` ` ```) at both ends of the `query` value, we can create a multi-line string, and we can embed values inside that string using `${...}`.
+  - To find out more about this JavaScript technique, see [Template literals (Template strings)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).
+- The Dataview magic bit is the use of `dv.current().file.path`, which gives the path of the file containing code block.
+- The line `dv.paragraph('```tasks\n' + query + '\n```');`:
+  - turns our query in to a tasks block, by adding the first and last lines (each with 3 backticks)
+  - and then writes out the full tasks block as a paragraph.
+- When viewed in either Live Preview or Reading mode, Tasks just works!
+
+### Viewing the generated tasks instructions
+
+Changing the last line to create a `text` block instead of a `tasks` one will show the raw tasks instructions generated, which can be useful if you want to see what Dataview has generated:
+
+    dv.paragraph('```text\n' + query + '\n```');
+
+### Putting it in to a callout, for pretter output
+
+    ## Summary of Tasks within this note
+
+    ```dataviewjs
+    function callout(text, type) {
+        const allText = `> [!${type}]\n` + text;
+        const lines = allText.split('\n');
+        return lines.join('\n> ') + '\n'
+    }
+
+    const query = `
+    not done
+    path includes ${dv.current().file.path}
+    # you can add any number of extra Tasks instructions, for example:
+    group by heading
+    `;
+
+    dv.paragraph(callout('```tasks\n' + query + '\n```', 'todo'));
+    ```

--- a/docs/how-to/get-tasks-in-current-file.md
+++ b/docs/how-to/get-tasks-in-current-file.md
@@ -134,3 +134,7 @@ Changing the last line to create a `text` block instead of a `tasks` one will sh
 
     dv.paragraph(callout('```tasks\n' + query + '\n```', 'todo'));
     ```
+
+## Related pages
+
+- [Dataview]({{ site.baseurl }}{% link other-plugins/dataview.md %})

--- a/docs/other-plugins/dataview.md
+++ b/docs/other-plugins/dataview.md
@@ -37,3 +37,7 @@ To get the correct behavior for recurring tasks from Dataview TASK query results
 and then use the "Tasks: Toggle Done" command or click the checkbox from there.
 
 ---
+
+## Related pages
+
+- [How to get all tasks in the current file]({{ site.baseurl }}{% link how-to/get-tasks-in-current-file.md %}) - an example of using the Dataview plugin to generate Tasks code blocks, to do things that Tasks alone cannot do.

--- a/docs/other-plugins/dataview.md
+++ b/docs/other-plugins/dataview.md
@@ -8,6 +8,19 @@ has_toc: false
 
 # Combining Dataview and Tasks
 
+{: .no_toc }
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
 The [Dataview](https://github.com/blacksmithgu/dataview) plugin provides many data analysis features for Obsidian vaults, including queries about tasks.
 This page only describes settings to maximize compatibility between Dataview and Tasks; for all other information on Dataview, including Dataview's names for the task emoji fields,
 please see its [documentation](https://blacksmithgu.github.io/obsidian-dataview/data-annotation/#tasks).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I have finally written up how to use dataview to create a list of tasks in the current file that does not get broken when the file is renamed.

Commits made:

- docs: Add 'How to get tasks in current file'  
- docs: Add links between dataview-related pages  
- docs: Add table of contents to dataview page

## Motivation and Context

This and related searches are a common request, e.g. the discussion in #444

## How has this been tested?

By generating the docs locally.

## Screenshots (if appropriate)

## Types of changes

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
