### PR TITLE
fix: Correct cursor position after 'Toggle task done' command

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/.obsidian/hotkeys.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/hotkeys.json
@@ -16,5 +16,14 @@
       "key": "/"
     }
   ],
-  "editor:toggle-comments": []
+  "editor:toggle-comments": [],
+  "obsidian-tasks-plugin:toggle-done": [
+    {
+      "modifiers": [
+        "Mod"
+      ],
+      "key": "Enter"
+    }
+  ],
+  "editor:toggle-checklist-status": []
 }

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Toggle Done Cursor Fixes.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Toggle Done Cursor Fixes.md
@@ -1,0 +1,44 @@
+# Testing issues related to cursor movement in for ToggleDone
+
+GitHub issues 449, 460, and perhaps others.
+
+For each line, put the cursor between the `>>` if one is present or anywhere in the line otherwise and run "Task: Toggle Done". Then undo.
+At least once for each subsection do an additional run with the cursor starting at the end of the line.
+
+## Toggle Task Done on `[\s\t>]* wibble` produces `"$1- wibble"` Issue: #460 if the line is blank
+
+%% DO NOT FORGET BLANK LINE %%
+
+>>
+wibble
+>> wibble
+
+## Toggle Task Done on `[\s\t>]*- wibble` produces `"$1- [ ] wibble"`
+
+- w
+
+>> - wibble
+
+## Toggle Task Done on  `[\s\t>]*- [ ] Wibble` with global filter not present produces  `[\s\t>]*- [x] Wibble`
+
+- [ ] w
+
+>> - [ ] wibble
+
+## Toggle Task Done on `[\s\t>]*- [ ] Wibble` with global filter present or disabled produces  `[\s\t>]*- [x] Wibble ✅ YYYY-MM-DD`. Adds 13 chars. Current behavior has cursor move right 13 characters, regardless of start position. Issue #449
+
+- [ ] #task w
+
+>> - [ ] #task wibble
+
+## Toggle Task Done on  `[\s\t>]*- [x] Wibble ✅ YYYY-MM-DD` with global filter present or disabled produces  `[\s\t>]*- [ ] Wibble`. Removes 13 chars
+
+- [x] #task wibble ✅ 2022-09-02
+
+>> - [x] #task wibble ✅ 2022-09-02
+
+## Toggle Task Done on  `[\s\t>]*- [ ] Wibble 🔁 every day` with global filter present or disabled produces  `[\s\t>]*- [ ] Wibble 🔁 every day\n- [ ] Wibble 🔁 every day ✅ YYYY-MM-DD`. Adds a repeated version of the line at the beginning and 13 chars at end
+
+- [ ] #task wibble 🔁 every day
+
+>> - [ ] #task wibble 🔁 every day

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -27,62 +27,35 @@ export const toggleDone = (checking: boolean, editor: Editor, view: View) => {
         return;
     }
 
-    const cursorPosition = editor.getCursor();
-    const lineNumber = cursorPosition.line;
+    const origCursorPos = editor.getCursor();
+    const lineNumber = origCursorPos.line;
     const line = editor.getLine(lineNumber);
 
-    const toggledLine = toggleLine({ line, path });
+    const toggledLine = toggleLine(line, path);
     editor.setLine(lineNumber, toggledLine);
-    const newCursorPosition = editor.getCursor();
 
     /* Cursor positions are 0-based for both "line" and "ch" offsets.
      * If "ch" offset bigger than the line length, will just continue to next line(s).
      * By default "editor.setLine()" appears to either keep the cursor at the end of the line if it is already there,
-     * ...or move it to the beginning if it is anywhere else. Licat explained this (on Discord) as "sticking" to one side or another.
+     * ...or move it to the beginning if it is anywhere else. Licat explained this on Discord as "sticking" to one side or another.
      * Previously, Tasks would reset+move-right the cursor if there was any text in the line, including something inside the checkbox,
-     * moving right by toggledLine.length - line.length (still moves right, but by less if the toggledLine is shorter than the old).
+     * moving right by (toggledLine.length - line.length). (Supposedly, but it still moves right, just by less, if the toggledLine is shorter than the old).
      * This missed the need to move right on the blank line to "- " case (issue #460).
      * This also meant the cursor moved nonsensically if it was before any newly inserted text,
-     * such as a done date at the end of the line, or after the ">" when "> -" -> "> - [ ]".
+     * such as a done date at the end of the line, or after the ">" when "> -" changed to "> - [ ]".
      */
-
-    /* Cases:
-    0) Toggle Task Done on [\s\t>]* produces "$1- " Adds 2 chars. Issue: #460 if the line is blank.
-    1) Toggle Task Done on [\s\t>]*- produces "$1- [ ] ". Adds 4 chars.
-    2) Toggle Task Done on "- Wibble" produces "- [ ] Wibble". Adds 4 chars.
-    3) Toggle Task Done on "- [ ] Wibble" with global filter not present produces "- [x] Wibble". No length change.
-    4) Toggle Task Done on "- [ ] Wibble" with no global filter produces "- [x] Wibble ✅ YYYY-MM-DD". Adds 13 chars.
-        Current behavior has cursor move right 13 characters, regardless of start position. Issue #449
-    5) Toggle Task Done on "- [x] Wibble ✅ YYYY-MM-DD" with global filter present produces "- [] Wibble". Removes 13 chars. Cursor moves left 13 characters sometimes, otherwise behavior is confusing.
-    */
-
-    /* Cases (another way):
-    0) Line got shorter: done date removed from end of task, cursor should reset or be moved to new end if reset position is too long.
-    1) Line stayed the same length: Checking & unchecking textbox that is not a task - cursor should reset.
-    2) Line got longer:
-        a) Dash could have been added. Find it in new text: if cursor was at or right of where it was added, move the cursor right 2.
-        b) Empty checkbox could have been added. If cursor was after the (in old or new), it should move right by 3.
-        c) Done emoji and date could have been added to the end. Cursor should reset if 0, and stay end of line otherwise.
-        d) Recurring task could have been added to the beginning and done emoji and date added to the end. Current behavior adds so much to the offset to make this right.
-
-    So cursor should be reset if 0, which includes being moved to new end if got shorter. Then might need to move right 2 or 3.
-    */
-
-    if (newCursorPosition.ch === 0) {
-        // If setLine moved the cursor to the beginning of the line adjust it
-        editor.setCursor({
-            line: cursorPosition.line,
-            // Works for recurring tasks, done date removal, checking non-task checkboxes, and when the cursor is after any additions
-            ch: cursorPosition.ch + toggledLine.length - line.length,
-        });
-        // Need some additional logic for if the cursor is before additions of dash, checkbox or done date just put it at cursorPosition.ch and not add the line difference
-    }
+    // Reset the cursor. Use the difference in line lengths and original cursor position to determine behavior
+    editor.setCursor({
+        line: origCursorPos.line,
+        ch: calculateCursorOffset(origCursorPos.ch, line, toggledLine),
+    });
 };
 
-const toggleLine = ({ line, path }: { line: string; path: string }): string => {
+const toggleLine = (line: string, path: string) => {
     let toggledLine = line;
 
     const task = Task.fromLine({
+        // Why are we using Task.fromLine instead of the Cache here?
         line,
         path,
         sectionStart: 0, // We don't need this to toggle it here in the editor.
@@ -90,7 +63,7 @@ const toggleLine = ({ line, path }: { line: string; path: string }): string => {
         precedingHeader: null, // We don't need this to toggle it here in the editor.
     });
     if (task !== null) {
-        toggledLine = toggleTask({ task });
+        toggledLine = toggleTask(task);
     } else {
         // If the task is null this means that we have one of:
         // 1. a regular checklist item
@@ -100,27 +73,27 @@ const toggleLine = ({ line, path }: { line: string; path: string }): string => {
         // The task regex will match checklist items.
         const regexMatch = line.match(Task.taskRegex);
         if (regexMatch !== null) {
-            toggledLine = toggleChecklistItem({ regexMatch });
+            // Toggle the status of the checklist item.
+            const statusString = regexMatch[2].toLowerCase(); // Note for future: I do not think this toLowerCase is necessary and there is an issue about how it breaks some theme or snippet.
+            const newStatusString = statusString === ' ' ? 'x' : ' ';
+            toggledLine = line.replace(
+                Task.taskRegex,
+                `$1- [${newStatusString}] $3`,
+            );
+        } else if (Task.listItemRegex.test(line)) {
+            // Convert the list item to a checklist item.
+            toggledLine = line.replace(Task.listItemRegex, '$1$2 [ ]');
         } else {
-            // This is not a checklist item. It is one of:
-            // 1. a list item
-            // 2. a simple text line
-
-            if (Task.listItemRegex.test(line)) {
-                // Let's convert the list item to a checklist item.
-                toggledLine = line.replace(Task.listItemRegex, '$1$2 [ ]');
-            } else {
-                // Let's convert the line to a list item.
-                toggledLine = line.replace(Task.indentationRegex, '$1- ');
-            }
+            // Convert the line to a list item.
+            toggledLine = line.replace(Task.indentationRegex, '$1- ');
         }
     }
 
     return toggledLine;
 };
 
-const toggleTask = ({ task }: { task: Task }): string => {
-    // Toggle a regular task.
+const toggleTask = (task: Task): string => {
+    // Toggling a recurring task will produce two Tasks
     const toggledTasks = task.toggle();
     const serialized = toggledTasks
         .map((task: Task) => task.toFileLineString())
@@ -129,19 +102,49 @@ const toggleTask = ({ task }: { task: Task }): string => {
     return serialized;
 };
 
-const toggleChecklistItem = ({
-    regexMatch,
-}: {
-    regexMatch: RegExpMatchArray;
-}): string => {
-    // It's a checklist item, let's toggle it.
-    const indentation = regexMatch[1];
-    const statusString = regexMatch[2].toLowerCase();
-    const body = regexMatch[3];
+/* Cases (another way):
+0) Line got shorter: done date removed from end of task, cursor should reset or be moved to new end if reset position is too long.
+1) Line stayed the same length: Checking & unchecking textbox that is not a task - cursor should reset.
+2) Line got longer:
+    a) List marker could have been added. Find it in new text: if cursor was at or right of where it was added, move the cursor right.
+    b) Empty checkbox could have been added. If cursor was after the list marker (in old or new), it should move right.
+    c) Done emoji and date could have been added to the end. Cursor should reset if 0, and stay end of line otherwise.
+    d) Recurring task could have been added to the beginning and done emoji and date added to the end. Current behavior adds so much to the offset to make this right.
 
-    const toggledStatusString = statusString === ' ' ? 'x' : ' ';
+So cursor should be reset if 0, which includes being moved to new end if got shorter. Then might need to move right 2 or 3.
+*/
+const calculateCursorOffset = (
+    origCursorCh: number,
+    line: string,
+    toggledLine: string,
+) => {
+    let newLineLen = toggledLine.length;
+    if (newLineLen <= line.length) {
+        // Line got shorter or stayed same length. Reset cursor to original position, capped at end of line.
+        return origCursorCh >= toggledLine.length ? newLineLen : origCursorCh;
+    }
 
-    const toggledLine = `${indentation}- [${toggledStatusString}] ${body}`;
+    // Special-case for done-date append, fixes #449
+    const doneDateLength = ' ✅ YYYY-MM-DD'.length;
+    if (
+        toggledLine.match(Task.doneDateRegex) &&
+        newLineLen - line.length >= doneDateLength
+    ) {
+        newLineLen -= doneDateLength;
+    }
 
-    return toggledLine;
+    // Handle recurring tasks: entire line plus newline prepended. Fix for #449 above means appended done date treated correctly.
+    if (newLineLen >= 2 * line.length && toggledLine.search('.+\n.+') !== -1) {
+        return origCursorCh + newLineLen - line.length;
+    }
+
+    /* Line got longer, not a recurring task. Were the added characters before or after the cursor?
+     * At this point the line is at least a list item. Find the first list marker. */
+    const firstListItemChar = toggledLine.search(/[-*]/);
+    if (origCursorCh < firstListItemChar) {
+        // Cursor was in indentation. Reset to where it was.
+        return origCursorCh;
+    }
+
+    return origCursorCh + newLineLen - line.length;
 };

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -75,6 +75,7 @@ export const toggleDone = (checking: boolean, editor: Editor, view: View) => {
             // Works for recurring tasks, done date removal, checking non-task checkboxes, and when the cursor is after any additions
             ch: cursorPosition.ch + toggledLine.length - line.length,
         });
+        // Need some additional logic for if the cursor is before additions of dash, checkbox or done date just put it at cursorPosition.ch and not add the line difference
     }
 };
 


### PR DESCRIPTION
# Description
Rewrite of the logic in ToggleDone.ts to replacing the cursor correctly. Should fix #449 #460 and maybe others. This took me a really long time to think through and make sure I was testing all corner cases. I am pretty confident of its correctness, but it is not as polished as I might hope and I might always have missed a corner case. Sadly I am out of time to polish. I can try to answer any questions, but I do not have time to fix and test changes, so if additional work is needed, someone else will have to pick it up.

## Motivation and Context
The Tasks: Toggle Done command uses `editor.setLine` which deletes and then replaces a line. This causes the cursor position to get lost and it needs to be explicitly reset. The existing code to do this was based on a no-longer-correct assumption. (Actual behavior explained in long block comment in ToggleDone.)
This incorrect assumption was causing various problems for users:
Fixes #449 
Fixes #460 

## How has this been tested?
Since this heavily uses Obsidian APIs, no automated tests can help. I created a new page of manual tests in the sample vault, and also updated the hotkeys in the sample vault to make testing easier. Code passes all of my new manual tests in the sample vault on Windows.

It probably would be worthwhile to smoke test this on Insider or a non-Windows platform.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
