### PR TITLE
test: Simplify the resetting of settings in tests

### DIFF
--- a/src/config/Settings.ts
+++ b/src/config/Settings.ts
@@ -27,3 +27,7 @@ export const updateSettings = (newSettings: Partial<Settings>): Settings => {
 
     return getSettings();
 };
+
+export const resetSettings = (): Settings => {
+    return updateSettings(defaultSettings);
+};

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -3,7 +3,7 @@
  */
 import moment from 'moment';
 import { DescriptionField } from '../../../src/Query/Filter/DescriptionField';
-import { getSettings, updateSettings } from '../../../src/config/Settings';
+import { resetSettings, updateSettings } from '../../../src/config/Settings';
 import { testTaskFilter } from '../../TestingTools/FilterTestHelpers';
 import { fromLine } from '../../TestHelpers';
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
@@ -47,7 +47,6 @@ describe('description should strip signifiers, some duplicate spaces and trailin
 
     it('with tag as global filter - all tags included', () => {
         // Arrange
-        const originalSettings = getSettings();
         updateSettings({ globalFilter: '#task' });
 
         const task = fromLine({
@@ -61,12 +60,11 @@ describe('description should strip signifiers, some duplicate spaces and trailin
         );
 
         // Cleanup
-        updateSettings(originalSettings);
+        resetSettings();
     });
 
     it('with non-tag as global filter - all tags included', () => {
         // Arrange
-        const originalSettings = getSettings();
         updateSettings({ globalFilter: 'global-filter' });
 
         const task = fromLine({
@@ -80,14 +78,13 @@ describe('description should strip signifiers, some duplicate spaces and trailin
         );
 
         // Cleanup
-        updateSettings(originalSettings);
+        resetSettings();
     });
 });
 
 describe('description', () => {
     it('ignores the global filter when filtering', () => {
         // Arrange
-        const originalSettings = getSettings();
         updateSettings({ globalFilter: '#task' });
         const filter = new DescriptionField().createFilterOrErrorMessage(
             'description includes task',
@@ -103,12 +100,11 @@ describe('description', () => {
         testDescriptionFilter(filter, '- [ ] #task this does: task', true);
 
         // Cleanup
-        updateSettings(originalSettings);
+        resetSettings();
     });
 
     it('works without a global filter', () => {
         // Arrange
-        const originalSettings = getSettings();
         updateSettings({ globalFilter: '' });
         const filter = new DescriptionField().createFilterOrErrorMessage(
             'description includes task',
@@ -130,7 +126,7 @@ describe('description', () => {
         testDescriptionFilter(filter, '- [ ] #task this does: task', true);
 
         // Cleanup
-        updateSettings(originalSettings);
+        resetSettings();
     });
 
     it('works with regex', () => {

--- a/tests/Query/Filter/TagsField.test.ts
+++ b/tests/Query/Filter/TagsField.test.ts
@@ -1,4 +1,4 @@
-import { getSettings, updateSettings } from '../../../src/config/Settings';
+import { resetSettings, updateSettings } from '../../../src/config/Settings';
 import type { FilteringCase } from '../../TestingTools/FilterTestHelpers';
 import { shouldSupportFiltering } from '../../TestingTools/FilterTestHelpers';
 
@@ -141,7 +141,6 @@ describe('tag/tags', () => {
             'should filter tag with globalFilter %s',
             (_, { tasks: allTaskLines, filters, expectedResult }) => {
                 // Arrange
-                const originalSettings = getSettings();
                 updateSettings({ globalFilter: '#task' });
 
                 // Run on the plural version of the filter first.
@@ -162,7 +161,7 @@ describe('tag/tags', () => {
                 shouldSupportFiltering(filters, allTaskLines, expectedResult);
 
                 // Cleanup
-                updateSettings(originalSettings);
+                resetSettings();
             },
         );
 
@@ -190,25 +189,17 @@ describe('tag/tags', () => {
             },
         );
 
-        it('should filter tags without globalFilter by tag presence when it is the global tag', () => {
-            // Arrange
-            const originalSettings = getSettings();
-            updateSettings({ globalFilter: '' });
-
+        it('should filter tags without globalFilter by tag presence when there is no global filter', () => {
             // Act, Assert
             shouldSupportFiltering(
                 ['tags include task'],
                 defaultTasksWithTags,
                 defaultTasksWithTags,
             );
-
-            // Cleanup
-            updateSettings(originalSettings);
         });
 
-        it('should filter tag with globalFilter by tag presence when it is the global tag', () => {
+        it('should ignore the tag which is the global filter', () => {
             // Arrange
-            const originalSettings = getSettings();
             updateSettings({ globalFilter: '#task' });
             const filters: Array<string> = ['tags include task'];
 
@@ -216,7 +207,7 @@ describe('tag/tags', () => {
             shouldSupportFiltering(filters, defaultTasksWithTags, []);
 
             // Cleanup
-            updateSettings(originalSettings);
+            resetSettings();
         });
     });
 });

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -6,7 +6,7 @@ import moment from 'moment';
 window.moment = moment;
 
 import { Sort } from '../src/Sort';
-import { getSettings, updateSettings } from '../src/config/Settings';
+import { resetSettings, updateSettings } from '../src/config/Settings';
 import { fromLine } from './TestHelpers';
 
 describe('Sort', () => {
@@ -410,7 +410,6 @@ describe('Sort by tags', () => {
 
     it('should sort correctly by tag defaulting to first with global filter', () => {
         // Arrange
-        const originalSettings = getSettings();
         updateSettings({ globalFilter: '#task' });
 
         const t1 = fromLine({ line: '- [ ] #task a #aaa #jjj' });
@@ -460,12 +459,11 @@ describe('Sort by tags', () => {
         ).toEqual(expectedOrder);
 
         // Cleanup
-        updateSettings(originalSettings);
+        resetSettings();
     });
 
     it('should sort correctly reversed by tag defaulting to first with global filter', () => {
         // Arrange
-        const originalSettings = getSettings();
         updateSettings({ globalFilter: '#task' });
 
         const t1 = fromLine({ line: '- [ ] #task a #aaa #jjj' });
@@ -515,12 +513,11 @@ describe('Sort by tags', () => {
         ).toEqual(expectedOrder);
 
         // Cleanup
-        updateSettings(originalSettings);
+        resetSettings();
     });
 
     it('should sort correctly by second tag with global filter', () => {
         // Arrange
-        const originalSettings = getSettings();
         updateSettings({ globalFilter: '#task' });
 
         const t1 = fromLine({ line: '- [ ] #task a #fff #aaa' });
@@ -551,12 +548,11 @@ describe('Sort by tags', () => {
         expect(result).toEqual(expectedOrder);
 
         // Cleanup
-        updateSettings(originalSettings);
+        resetSettings();
     });
 
     it('should sort correctly reversed by second tag with global filter', () => {
         // Arrange
-        const originalSettings = getSettings();
         updateSettings({ globalFilter: '#task' });
 
         const t1 = fromLine({ line: '- [ ] #task a #fff #aaa' });
@@ -587,6 +583,6 @@ describe('Sort by tags', () => {
         expect(result).toEqual(expectedOrder);
 
         // Cleanup
-        updateSettings(originalSettings);
+        resetSettings();
     });
 });

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -3,7 +3,7 @@
  */
 import moment from 'moment';
 import { Priority, Status, Task } from '../src/Task';
-import { getSettings, updateSettings } from '../src/config/Settings';
+import { resetSettings, updateSettings } from '../src/config/Settings';
 import { fromLine } from './TestHelpers';
 import { TaskBuilder } from './TestingTools/TaskBuilder';
 import { RecurrenceBuilder } from './TestingTools/RecurrenceBuilder';
@@ -37,7 +37,6 @@ describe('parsing', () => {
 
     it('returns null when task does not have global filter', () => {
         // Arrange
-        const originalSettings = getSettings();
         updateSettings({ globalFilter: '#task' });
         const line = '- [x] this is a done task 🗓 2021-09-12 ✅ 2021-06-20';
 
@@ -50,7 +49,7 @@ describe('parsing', () => {
         expect(task).toBeNull();
 
         // Cleanup
-        updateSettings(originalSettings);
+        resetSettings();
     });
 
     it('allows signifier emojis as part of the description', () => {
@@ -369,7 +368,6 @@ describe('parsing tags', () => {
             globalFilter,
         }) => {
             // Arrange
-            const originalSettings = getSettings();
             if (globalFilter != '') {
                 updateSettings({ globalFilter: globalFilter });
             }
@@ -384,7 +382,7 @@ describe('parsing tags', () => {
 
             // Cleanup
             if (globalFilter != '') {
-                updateSettings(originalSettings);
+                resetSettings();
             }
         },
     );
@@ -1043,7 +1041,6 @@ describe('check removal of the global filter', () => {
         'should parse "$markdownTask" and extract "$expectedDescription"',
         ({ globalFilter, markdownTask, expectedDescription }) => {
             // Arrange
-            const originalSettings = getSettings();
             if (globalFilter != '') {
                 updateSettings({ globalFilter: globalFilter });
             }
@@ -1059,7 +1056,7 @@ describe('check removal of the global filter', () => {
 
             // Cleanup
             if (globalFilter != '') {
-                updateSettings(originalSettings);
+                resetSettings();
             }
         },
     );
@@ -1159,7 +1156,6 @@ describe('check removal of the global filter exhaustively', () => {
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {
             // Arrange
-            const originalSettings = getSettings();
             if (globalFilter != '') {
                 updateSettings({ globalFilter: globalFilter });
             }
@@ -1184,7 +1180,7 @@ describe('check removal of the global filter exhaustively', () => {
 
             // Cleanup
             if (globalFilter != '') {
-                updateSettings(originalSettings);
+                resetSettings();
             }
         },
     );


### PR DESCRIPTION
# Description

This adds a new function resetSettings() and updates all existing tests that used to save originalSettings, so that they now just call resetSettings() on completion.

This ensures that **passing** tests that fiddle with global settings definitely return them to the default state on completion.

Unlike the fix proposed in #1046, this does not reset the global settings after any failing tests.

<!--- Describe your changes in detail -->

## Motivation and Context

This is related to #1046.

## How has this been tested?

By running the existing tests.

## Screenshots (if appropriate)

## Types of changes

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
