### PR TITLE
refactor: Reformat code to match the format used by tasks-x plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,9 +31,12 @@ module.exports = {
         'prettier/prettier': [
             'error',
             {
-                singleQuote: true,
-                tabWidth: 4,
                 trailingComma: 'all',
+                printWidth: 120,
+                tabWidth: 4,
+                useTabs: false,
+                singleQuote: true,
+                bracketSpacing: true,
             },
         ],
         semi: ['error', 'always'],

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,8 @@
 module.exports = {
   trailingComma: 'all',
-  singleQuote: true,
+  printWidth: 120,
   tabWidth: 4,
+  useTabs: false,
+  singleQuote: true,
+  bracketSpacing: true
 };

--- a/src/Commands/CreateOrEdit.ts
+++ b/src/Commands/CreateOrEdit.ts
@@ -2,12 +2,7 @@ import { App, Editor, MarkdownView, View } from 'obsidian';
 import { TaskModal } from '../TaskModal';
 import { Priority, Status, Task } from '../Task';
 
-export const createOrEdit = (
-    checking: boolean,
-    editor: Editor,
-    view: View,
-    app: App,
-) => {
+export const createOrEdit = (checking: boolean, editor: Editor, view: View, app: App) => {
     if (checking) {
         return view instanceof MarkdownView;
     }
@@ -28,9 +23,7 @@ export const createOrEdit = (
     const task = taskFromLine({ line, path });
 
     const onSubmit = (updatedTasks: Task[]): void => {
-        const serialized = updatedTasks
-            .map((task: Task) => task.toFileLineString())
-            .join('\n');
+        const serialized = updatedTasks.map((task: Task) => task.toFileLineString()).join('\n');
         editor.setLine(lineNumber, serialized);
     };
 

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -76,10 +76,7 @@ export const toggleLine = (line: string, path: string) => {
             // Toggle the status of the checklist item.
             const statusString = regexMatch[2].toLowerCase(); // Note for future: I do not think this toLowerCase is necessary and there is an issue about how it breaks some theme or snippet.
             const newStatusString = statusString === ' ' ? 'x' : ' ';
-            toggledLine = line.replace(
-                Task.taskRegex,
-                `$1- [${newStatusString}] $3`,
-            );
+            toggledLine = line.replace(Task.taskRegex, `$1- [${newStatusString}] $3`);
         } else if (Task.listItemRegex.test(line)) {
             // Convert the list item to a checklist item.
             toggledLine = line.replace(Task.listItemRegex, '$1$2 [ ]');
@@ -95,9 +92,7 @@ export const toggleLine = (line: string, path: string) => {
 const toggleTask = (task: Task): string => {
     // Toggling a recurring task will produce two Tasks
     const toggledTasks = task.toggle();
-    const serialized = toggledTasks
-        .map((task: Task) => task.toFileLineString())
-        .join('\n');
+    const serialized = toggledTasks.map((task: Task) => task.toFileLineString()).join('\n');
 
     return serialized;
 };
@@ -113,11 +108,7 @@ const toggleTask = (task: Task): string => {
 
 So cursor should be reset if 0, which includes being moved to new end if got shorter. Then might need to move right 2 or 3.
 */
-export const calculateCursorOffset = (
-    origCursorCh: number,
-    line: string,
-    toggledLine: string,
-) => {
+export const calculateCursorOffset = (origCursorCh: number, line: string, toggledLine: string) => {
     let newLineLen = toggledLine.length;
     if (newLineLen <= line.length) {
         // Line got shorter or stayed same length. Reset cursor to original position, capped at end of line.
@@ -126,10 +117,7 @@ export const calculateCursorOffset = (
 
     // Special-case for done-date append, fixes #449
     const doneDateLength = ' ✅ YYYY-MM-DD'.length;
-    if (
-        toggledLine.match(Task.doneDateRegex) &&
-        newLineLen - line.length >= doneDateLength
-    ) {
+    if (toggledLine.match(Task.doneDateRegex) && newLineLen - line.length >= doneDateLength) {
         newLineLen -= doneDateLength;
     }
 

--- a/src/Commands/index.ts
+++ b/src/Commands/index.ts
@@ -17,11 +17,7 @@ export class Commands {
             id: 'edit-task',
             name: 'Create or edit task',
             icon: 'pencil',
-            editorCheckCallback: (
-                checking: boolean,
-                editor: Editor,
-                view: View,
-            ) => {
+            editorCheckCallback: (checking: boolean, editor: Editor, view: View) => {
                 return createOrEdit(checking, editor, view, this.app);
             },
         });

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -73,10 +73,7 @@ export const isFeatureEnabled = (internalName: string): boolean => {
  * @param enabled the expected state of the feature.
  * @returns the features with the specified feature toggled.
  */
-export const toggleFeature = (
-    internalName: string,
-    enabled: boolean,
-): FeatureFlag => {
+export const toggleFeature = (internalName: string, enabled: boolean): FeatureFlag => {
     settings.features[internalName] = enabled;
     return settings.features;
 };

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -23,9 +23,7 @@ export class SettingsTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Global task filter')
-            .setDesc(
-                'The global filter will be applied to all checklist items.',
-            )
+            .setDesc('The global filter will be applied to all checklist items.')
             .addText((text) => {
                 const settings = getSettings();
 
@@ -55,43 +53,33 @@ export class SettingsTab extends PluginSettingTab {
             .addToggle((toggle) => {
                 const settings = getSettings();
 
-                toggle
-                    .setValue(settings.removeGlobalFilter)
-                    .onChange(async (value) => {
-                        updateSettings({ removeGlobalFilter: value });
+                toggle.setValue(settings.removeGlobalFilter).onChange(async (value) => {
+                    updateSettings({ removeGlobalFilter: value });
 
-                        await this.plugin.saveSettings();
-                    });
+                    await this.plugin.saveSettings();
+                });
             });
 
         new Setting(containerEl)
             .setName('Set done date on every completed task')
-            .setDesc(
-                'Enabling this will add a timestamp ✅ YYYY-MM-DD at the end when a task is toggled to done',
-            )
+            .setDesc('Enabling this will add a timestamp ✅ YYYY-MM-DD at the end when a task is toggled to done')
             .addToggle((toogle) => {
                 const settings = getSettings();
-                toogle
-                    .setValue(settings.setDoneDate)
-                    .onChange(async (value) => {
-                        updateSettings({ setDoneDate: value });
-                        await this.plugin.saveSettings();
-                    });
+                toogle.setValue(settings.setDoneDate).onChange(async (value) => {
+                    updateSettings({ setDoneDate: value });
+                    await this.plugin.saveSettings();
+                });
             });
 
         new Setting(containerEl)
             .setName('Auto-suggest task content')
-            .setDesc(
-                'Enabling this will open an intelligent suggest menu while typing inside a recognized task line.',
-            )
+            .setDesc('Enabling this will open an intelligent suggest menu while typing inside a recognized task line.')
             .addToggle((toggle) => {
                 const settings = getSettings();
-                toggle
-                    .setValue(settings.autoSuggestInEditor)
-                    .onChange(async (value) => {
-                        updateSettings({ autoSuggestInEditor: value });
-                        await this.plugin.saveSettings();
-                    });
+                toggle.setValue(settings.autoSuggestInEditor).onChange(async (value) => {
+                    updateSettings({ autoSuggestInEditor: value });
+                    await this.plugin.saveSettings();
+                });
             });
 
         new Setting(containerEl)

--- a/src/File.ts
+++ b/src/File.ts
@@ -70,9 +70,7 @@ const tryRepetitive = async ({
 }): Promise<void> => {
     const retry = () => {
         if (previousTries > 10) {
-            console.error(
-                'Tasks: Too many retries. File update not possible ...',
-            );
+            console.error('Tasks: Too many retries. File update not possible ...');
             return;
         }
 
@@ -90,32 +88,24 @@ const tryRepetitive = async ({
 
     const file = vault.getAbstractFileByPath(originalTask.path);
     if (!(file instanceof TFile)) {
-        console.warn(
-            `Tasks: No file found for task ${originalTask.description}. Retrying ...`,
-        );
+        console.warn(`Tasks: No file found for task ${originalTask.description}. Retrying ...`);
         return retry();
     }
 
     if (file.extension !== 'md') {
-        console.error(
-            'Tasks: Only supporting files with the .md file extension.',
-        );
+        console.error('Tasks: Only supporting files with the .md file extension.');
         return;
     }
 
     const fileCache = metadataCache.getFileCache(file);
     if (fileCache == undefined || fileCache === null) {
-        console.warn(
-            `Tasks: No file cache found for file ${file.path}. Retrying ...`,
-        );
+        console.warn(`Tasks: No file cache found for file ${file.path}. Retrying ...`);
         return retry();
     }
 
     const listItemsCache = fileCache.listItems;
     if (listItemsCache === undefined || listItemsCache.length === 0) {
-        console.warn(
-            `Tasks: No list items found in file cache of ${file.path}. Retrying ...`,
-        );
+        console.warn(`Tasks: No list items found in file cache of ${file.path}. Retrying ...`);
         return retry();
     }
 

--- a/src/LivePreviewExtension.ts
+++ b/src/LivePreviewExtension.ts
@@ -26,11 +26,7 @@ class LivePreviewExtension implements PluginValue {
         const { target } = event;
 
         // Only handle checkbox clicks.
-        if (
-            !target ||
-            !(target instanceof HTMLInputElement) ||
-            target.type !== 'checkbox'
-        ) {
+        if (!target || !(target instanceof HTMLInputElement) || target.type !== 'checkbox') {
             return false;
         }
 
@@ -42,9 +38,7 @@ class LivePreviewExtension implements PluginValue {
          */
 
         // Tasks from "task" query codeblocks handle themselves thanks to `toLi`, so be specific about error messaging, but still return.
-        const ancestor = target.closest(
-            'ul.plugin-tasks-query-result, div.callout-content',
-        );
+        const ancestor = target.closest('ul.plugin-tasks-query-result, div.callout-content');
         if (ancestor) {
             if (ancestor.matches('div.callout-content')) {
                 // Error message for now.
@@ -71,9 +65,7 @@ class LivePreviewExtension implements PluginValue {
             precedingHeader: null,
         });
 
-        console.debug(
-            `Live Preview Extension: toggle called. Position: ${position} Line: ${line.text}`,
-        );
+        console.debug(`Live Preview Extension: toggle called. Position: ${position} Line: ${line.text}`);
 
         // Only handle checkboxes of tasks.
         if (task === null) {
@@ -85,9 +77,7 @@ class LivePreviewExtension implements PluginValue {
 
         // Clicked on a task's checkbox. Toggle the task and set it.
         const toggled = task.toggle();
-        const toggledString = toggled
-            .map((t) => t.toFileLineString())
-            .join(state.lineBreak);
+        const toggledString = toggled.map((t) => t.toFileLineString()).join(state.lineBreak);
 
         // Creates a CodeMirror transaction in order to update the document.
         const transaction = state.update({

--- a/src/Query/DateParser.ts
+++ b/src/Query/DateParser.ts
@@ -1,10 +1,7 @@
 import * as chrono from 'chrono-node';
 
 export class DateParser {
-    public static parseDate(
-        input: string,
-        forwardDate: boolean = false,
-    ): moment.Moment {
+    public static parseDate(input: string, forwardDate: boolean = false): moment.Moment {
         // Using start of day to correctly match on comparison with other dates (like equality).
         return window
             .moment(

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -96,8 +96,7 @@ export class BooleanField extends Field {
             };
             return result;
         } catch (error) {
-            const message =
-                error instanceof Error ? error.message : 'unknown error type';
+            const message = error instanceof Error ? error.message : 'unknown error type';
             result.error = `malformed boolean query -- ${message} (check the documentation for guidelines)`;
             return result;
         }
@@ -118,10 +117,7 @@ export class BooleanField extends Field {
      * See here how it works: http://www.btechsmartclass.com/data_structures/postfix-evaluation.html
      * Another reference: https://www.tutorialspoint.com/Evaluate-Postfix-Expression
      */
-    private filterTaskWithParsedQuery(
-        task: Task,
-        postfixExpression: PostfixExpression,
-    ): boolean {
+    private filterTaskWithParsedQuery(task: Task, postfixExpression: PostfixExpression): boolean {
         const toBool = (s: string | undefined) => {
             return s === 'true';
         };
@@ -155,9 +151,7 @@ export class BooleanField extends Field {
                 } else if (token.value === 'XOR') {
                     const arg1 = toBool(booleanStack.pop());
                     const arg2 = toBool(booleanStack.pop());
-                    booleanStack.push(
-                        toString((arg1 && !arg2) || (!arg1 && arg2)),
-                    );
+                    booleanStack.push(toString((arg1 && !arg2) || (!arg1 && arg2)));
                 } else {
                     throw Error('Unsupported operator: ' + token.value);
                 }

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -40,37 +40,27 @@ export abstract class DateField extends Field {
         if (match !== null) {
             const filterDate = DateParser.parseDate(match[2]);
             if (!filterDate.isValid()) {
-                result.error =
-                    'do not understand ' + this.fieldName() + ' date';
+                result.error = 'do not understand ' + this.fieldName() + ' date';
             } else {
                 if (match[1] === 'before') {
                     result.filter = (task: Task) => {
                         const date = this.date(task);
-                        return date
-                            ? date.isBefore(filterDate)
-                            : this.filterResultIfFieldMissing();
+                        return date ? date.isBefore(filterDate) : this.filterResultIfFieldMissing();
                     };
                 } else if (match[1] === 'after') {
                     result.filter = (task: Task) => {
                         const date = this.date(task);
-                        return date
-                            ? date.isAfter(filterDate)
-                            : this.filterResultIfFieldMissing();
+                        return date ? date.isAfter(filterDate) : this.filterResultIfFieldMissing();
                     };
                 } else {
                     result.filter = (task: Task) => {
                         const date = this.date(task);
-                        return date
-                            ? date.isSame(filterDate)
-                            : this.filterResultIfFieldMissing();
+                        return date ? date.isSame(filterDate) : this.filterResultIfFieldMissing();
                     };
                 }
             }
         } else {
-            result.error =
-                'do not understand query filter (' +
-                this.fieldName() +
-                ' date)';
+            result.error = 'do not understand query filter (' + this.fieldName() + ' date)';
         }
         return result;
     }

--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -30,9 +30,7 @@ export abstract class Field {
      * which are both wrapped in a FilterOrErrorMessage object.
      * @param line - A line from a ```tasks``` block.
      */
-    public abstract createFilterOrErrorMessage(
-        line: string,
-    ): FilterOrErrorMessage;
+    public abstract createFilterOrErrorMessage(line: string): FilterOrErrorMessage;
 
     /**
      * Does the given line match the given filter?
@@ -41,10 +39,7 @@ export abstract class Field {
      * @param line - A line from a tasks code block query.
      * @protected
      */
-    protected static lineMatchesFilter(
-        filter: RegExp | null,
-        line: string,
-    ): boolean {
+    protected static lineMatchesFilter(filter: RegExp | null, line: string): boolean {
         if (filter) {
             return filter.test(line);
         } else {
@@ -59,10 +54,7 @@ export abstract class Field {
      * @param line - A line from a tasks code block query.
      * @protected
      */
-    protected static getMatch(
-        filterRegexp: RegExp | null,
-        line: string,
-    ): RegExpMatchArray | null {
+    protected static getMatch(filterRegexp: RegExp | null, line: string): RegExpMatchArray | null {
         if (filterRegexp) {
             return line.match(filterRegexp);
         } else {

--- a/src/Query/Filter/HappensDateField.ts
+++ b/src/Query/Filter/HappensDateField.ts
@@ -29,15 +29,13 @@ export class HappensDateField extends Field {
 
         if (line === HappensDateField.instructionForFieldPresence) {
             const result = new FilterOrErrorMessage();
-            result.filter = (task: Task) =>
-                this.dates(task).some((date) => date !== null);
+            result.filter = (task: Task) => this.dates(task).some((date) => date !== null);
             return result;
         }
 
         if (line === HappensDateField.instructionForFieldAbsence) {
             const result = new FilterOrErrorMessage();
-            result.filter = (task: Task) =>
-                !this.dates(task).some((date) => date !== null);
+            result.filter = (task: Task) => !this.dates(task).some((date) => date !== null);
             return result;
         }
 
@@ -49,21 +47,15 @@ export class HappensDateField extends Field {
             } else {
                 if (happensMatch[1] === 'before') {
                     result.filter = (task: Task) => {
-                        return this.dates(task).some(
-                            (date) => date && date.isBefore(filterDate),
-                        );
+                        return this.dates(task).some((date) => date && date.isBefore(filterDate));
                     };
                 } else if (happensMatch[1] === 'after') {
                     result.filter = (task: Task) => {
-                        return this.dates(task).some(
-                            (date) => date && date.isAfter(filterDate),
-                        );
+                        return this.dates(task).some((date) => date && date.isAfter(filterDate));
                     };
                 } else {
                     result.filter = (task: Task) => {
-                        return this.dates(task).some(
-                            (date) => date && date.isSame(filterDate),
-                        );
+                        return this.dates(task).some((date) => date && date.isSame(filterDate));
                     };
                 }
             }

--- a/src/Query/Filter/PriorityField.ts
+++ b/src/Query/Filter/PriorityField.ts
@@ -3,8 +3,7 @@ import { Field } from './Field';
 import { FilterOrErrorMessage } from './Filter';
 
 export class PriorityField extends Field {
-    private static readonly priorityRegexp =
-        /^priority (is )?(above|below)? ?(low|none|medium|high)/;
+    private static readonly priorityRegexp = /^priority (is )?(above|below)? ?(low|none|medium|high)/;
 
     createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         const result = new FilterOrErrorMessage();
@@ -35,18 +34,11 @@ export class PriorityField extends Field {
 
             let filter;
             if (priorityMatch[2] === 'above') {
-                filter = (task: Task) =>
-                    task.priority
-                        ? task.priority.localeCompare(filterPriority!) < 0
-                        : false;
+                filter = (task: Task) => (task.priority ? task.priority.localeCompare(filterPriority!) < 0 : false);
             } else if (priorityMatch[2] === 'below') {
-                filter = (task: Task) =>
-                    task.priority
-                        ? task.priority.localeCompare(filterPriority!) > 0
-                        : false;
+                filter = (task: Task) => (task.priority ? task.priority.localeCompare(filterPriority!) > 0 : false);
             } else {
-                filter = (task: Task) =>
-                    task.priority ? task.priority === filterPriority : false;
+                filter = (task: Task) => (task.priority ? task.priority === filterPriority : false);
             }
 
             result.filter = filter;

--- a/src/Query/Filter/RecurringField.ts
+++ b/src/Query/Filter/RecurringField.ts
@@ -4,10 +4,7 @@ export class RecurringField extends FilterInstructionsBasedField {
     constructor() {
         super();
         this._filters.add('is recurring', (task) => task.recurrence !== null);
-        this._filters.add(
-            'is not recurring',
-            (task) => task.recurrence === null,
-        );
+        this._filters.add('is not recurring', (task) => task.recurrence === null);
     }
 
     public fieldName(): string {

--- a/src/Query/Filter/ScheduledDateField.ts
+++ b/src/Query/Filter/ScheduledDateField.ts
@@ -6,8 +6,7 @@ import { DateField } from './DateField';
  * Support the 'scheduled' search instruction.
  */
 export class ScheduledDateField extends DateField {
-    private static readonly scheduledRegexp =
-        /^scheduled (before|after|on)? ?(.*)/;
+    private static readonly scheduledRegexp = /^scheduled (before|after|on)? ?(.*)/;
 
     protected filterRegexp(): RegExp {
         return ScheduledDateField.scheduledRegexp;

--- a/src/Query/Filter/StatusField.ts
+++ b/src/Query/Filter/StatusField.ts
@@ -6,10 +6,7 @@ export class StatusField extends FilterInstructionsBasedField {
         super();
 
         this._filters.add('done', (task: Task) => task.status === Status.Done);
-        this._filters.add(
-            'not done',
-            (task: Task) => task.status !== Status.Done,
-        );
+        this._filters.add('not done', (task: Task) => task.status !== Status.Done);
     }
 
     public fieldName(): string {

--- a/src/Query/Filter/TagsField.ts
+++ b/src/Query/Filter/TagsField.ts
@@ -19,9 +19,7 @@ export class TagsField extends Field {
     public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         const match = Field.getMatch(this.filterRegexp(), line);
         if (match === null) {
-            return FilterOrErrorMessage.fromError(
-                `do not understand query filter (${this.fieldName()})`,
-            );
+            return FilterOrErrorMessage.fromError(`do not understand query filter (${this.fieldName()})`);
         }
         const filterMethod = match[2];
         const search = match[3];
@@ -40,16 +38,11 @@ export class TagsField extends Field {
         if (matcher === null) {
             // It's likely this can now never be reached.
             // Retained for safety, for now.
-            return FilterOrErrorMessage.fromError(
-                `do not understand query filter (${this.fieldName()})`,
-            );
+            return FilterOrErrorMessage.fromError(`do not understand query filter (${this.fieldName()})`);
         }
 
         return FilterOrErrorMessage.fromFilter((task: Task) => {
-            return TextField.maybeNegate(
-                matcher!.matchesAnyOf(task.tags),
-                filterMethod,
-            );
+            return TextField.maybeNegate(matcher!.matchesAnyOf(task.tags), filterMethod);
         });
     }
 

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -16,9 +16,7 @@ export abstract class TextField extends Field {
         if (match === null) {
             // If Field.canCreateFilterForLine() has been checked, we should never get
             // in to this block.
-            return FilterOrErrorMessage.fromError(
-                `do not understand query filter (${this.fieldName()})`,
-            );
+            return FilterOrErrorMessage.fromError(`do not understand query filter (${this.fieldName()})`);
         }
 
         // Construct an IStringMatcher for this filter, or return
@@ -28,9 +26,7 @@ export abstract class TextField extends Field {
         let matcher: IStringMatcher | null = null;
         if (['includes', 'does not include'].includes(filterMethod)) {
             matcher = new SubstringMatcher(searchString);
-        } else if (
-            ['regex matches', 'regex does not match'].includes(filterMethod)
-        ) {
+        } else if (['regex matches', 'regex does not match'].includes(filterMethod)) {
             matcher = RegexMatcher.validateAndConstruct(searchString);
             if (matcher === null) {
                 return FilterOrErrorMessage.fromError(
@@ -42,33 +38,23 @@ export abstract class TextField extends Field {
         if (matcher === null) {
             // It's likely this can now never be reached.
             // Retained for safety, for now.
-            return FilterOrErrorMessage.fromError(
-                `do not understand query filter (${this.fieldName()})`,
-            );
+            return FilterOrErrorMessage.fromError(`do not understand query filter (${this.fieldName()})`);
         }
 
         // Finally, we can create the Filter, that takes a task
         // and tests if it matches the string filtering rule
         // represented by this object.
         return FilterOrErrorMessage.fromFilter((task: Task) => {
-            return TextField.maybeNegate(
-                matcher!.matches(this.value(task)),
-                filterMethod,
-            );
+            return TextField.maybeNegate(matcher!.matches(this.value(task)), filterMethod);
         });
     }
 
-    public static stringIncludesCaseInsensitive(
-        haystack: string,
-        needle: string,
-    ): boolean {
+    public static stringIncludesCaseInsensitive(haystack: string, needle: string): boolean {
         return SubstringMatcher.stringIncludesCaseInsensitive(haystack, needle);
     }
 
     protected filterRegexp(): RegExp {
-        return new RegExp(
-            `^${this.fieldName()} (includes|does not include|regex matches|regex does not match) (.*)`,
-        );
+        return new RegExp(`^${this.fieldName()} (includes|does not include|regex matches|regex does not match) (.*)`);
     }
 
     public abstract fieldName(): string;

--- a/src/Query/FilterParser.ts
+++ b/src/Query/FilterParser.ts
@@ -37,8 +37,7 @@ const fieldCreators = [
 export function parseFilter(filterString: string): FilterOrErrorMessage | null {
     for (const creator of fieldCreators) {
         const field = creator();
-        if (field.canCreateFilterForLine(filterString))
-            return field.createFilterOrErrorMessage(filterString);
+        if (field.canCreateFilterForLine(filterString)) return field.createFilterOrErrorMessage(filterString);
     }
     return null;
 }

--- a/src/Query/Group.ts
+++ b/src/Query/Group.ts
@@ -32,10 +32,7 @@ export class Group {
      * @param property
      * @param task
      */
-    public static getGroupNamesForTask(
-        property: GroupingProperty,
-        task: Task,
-    ): string[] {
+    public static getGroupNamesForTask(property: GroupingProperty, task: Task): string[] {
         const grouper = Group.groupers[property];
         return grouper(task);
     }
@@ -120,10 +117,7 @@ export class Group {
         return [Group.stringFromDate(earliestDateIfAny, 'happens')];
     }
 
-    private static stringFromDate(
-        date: moment.Moment | null,
-        field: string,
-    ): string {
+    private static stringFromDate(date: moment.Moment | null, field: string): string {
         if (date === null) {
             return 'No ' + field + ' date';
         }
@@ -139,10 +133,7 @@ export class Group {
     private static groupByFolder(task: Task): string[] {
         const path = task.path;
         const fileNameWithExtension = task.filename + '.md';
-        const folder = path.substring(
-            0,
-            path.lastIndexOf(fileNameWithExtension),
-        );
+        const folder = path.substring(0, path.lastIndexOf(fileNameWithExtension));
         if (folder === '') {
             return ['/'];
         }
@@ -166,11 +157,7 @@ export class Group {
         if (separatorIndex == -1) {
             return ['/'];
         }
-        return [
-            Group.escapeMarkdownCharacters(
-                path.substring(0, separatorIndex + 1),
-            ),
-        ];
+        return [Group.escapeMarkdownCharacters(path.substring(0, separatorIndex + 1))];
     }
 
     private static groupByBacklink(task: Task): string[] {
@@ -182,10 +169,7 @@ export class Group {
         // Markdown characters in the file name must be escaped.
         // Markdown characters in the heading must NOT be escaped.
         const filenameComponent = Group.groupByFileName(task)[0];
-        if (
-            task.precedingHeader === null ||
-            task.precedingHeader.length === 0
-        ) {
+        if (task.precedingHeader === null || task.precedingHeader.length === 0) {
             return [filenameComponent];
         }
         const headingComponent = Group.groupByHeading(task)[0];
@@ -202,10 +186,7 @@ export class Group {
     }
 
     private static groupByHeading(task: Task): string[] {
-        if (
-            task.precedingHeader === null ||
-            task.precedingHeader.length === 0
-        ) {
+        if (task.precedingHeader === null || task.precedingHeader.length === 0) {
             return ['(No heading)'];
         }
         return [task.precedingHeader];

--- a/src/Query/IntermediateTaskGroups.ts
+++ b/src/Query/IntermediateTaskGroups.ts
@@ -65,10 +65,7 @@ export class IntermediateTaskGroups {
     /**
      * Returns a grouping tree that groups the passed @tasks by the passed @groupings.
      */
-    private buildGroupingTree(
-        groupings: Grouping[],
-        tasks: Task[],
-    ): TaskGroupingTreeNode {
+    private buildGroupingTree(groupings: Grouping[], tasks: Task[]): TaskGroupingTreeNode {
         // The tree is build layer by layer, starting from the root.
         // At every level, we iterate on the nodes of that level to generate
         // the next one using the next grouping.
@@ -81,10 +78,7 @@ export class IntermediateTaskGroups {
             const nextTreeLevel = [];
             for (const currentTreeNode of currentTreeLevel) {
                 for (const task of currentTreeNode.values) {
-                    const groupNames = Group.getGroupNamesForTask(
-                        grouping.property,
-                        task,
-                    );
+                    const groupNames = Group.getGroupNamesForTask(grouping.property, task);
                     for (const groupName of groupNames) {
                         let child = currentTreeNode.children.get(groupName);
                         if (child === undefined) {
@@ -106,8 +100,6 @@ export class IntermediateTaskGroups {
         // groups.keys() will initially be in the order the entries were added,
         // so effectively random.
         // Return a duplicate map, with the keys (that is, group names) sorted in alphabetical order:
-        return new IntermediateTaskGroupsStorage(
-            [...this.groups.entries()].sort(),
-        );
+        return new IntermediateTaskGroupsStorage([...this.groups.entries()].sort());
     }
 }

--- a/src/Query/Matchers/RegexMatcher.ts
+++ b/src/Query/Matchers/RegexMatcher.ts
@@ -24,9 +24,7 @@ export class RegexMatcher extends IStringMatcher {
      *                              It must begin with a /, and end either with / and optionally any
      *                              valid flags.
      */
-    public static validateAndConstruct(
-        regexInput: string,
-    ): RegexMatcher | null {
+    public static validateAndConstruct(regexInput: string): RegexMatcher | null {
         // Courtesy of https://stackoverflow.com/questions/17843691/javascript-regex-to-match-a-regex
         const regexPattern =
             /\/((?![*+?])(?:[^\r\n[/\\]|\\.|\[(?:[^\r\n\]\\]|\\.)*])+)\/((?:g(?:im?|mi?)?|i(?:gm?|mg?)?|m(?:gi?|ig?)?)?)/;

--- a/src/Query/Matchers/SubstringMatcher.ts
+++ b/src/Query/Matchers/SubstringMatcher.ts
@@ -20,18 +20,10 @@ export class SubstringMatcher extends IStringMatcher {
     }
 
     public matches(stringToSearch: string): boolean {
-        return SubstringMatcher.stringIncludesCaseInsensitive(
-            stringToSearch,
-            this.stringToFind,
-        );
+        return SubstringMatcher.stringIncludesCaseInsensitive(stringToSearch, this.stringToFind);
     }
 
-    public static stringIncludesCaseInsensitive(
-        haystack: string,
-        needle: string,
-    ): boolean {
-        return haystack
-            .toLocaleLowerCase()
-            .includes(needle.toLocaleLowerCase());
+    public static stringIncludesCaseInsensitive(haystack: string, needle: string): boolean {
+        return haystack.toLocaleLowerCase().includes(needle.toLocaleLowerCase());
     }
 }

--- a/src/Query/Sort.ts
+++ b/src/Query/Sort.ts
@@ -21,20 +21,13 @@ export class Sort {
 
         for (const { property, reverse, propertyInstance } of query.sorting) {
             const comparator = Sort.comparators[property];
-            userComparators.push(
-                reverse ? Sort.makeReversedComparator(comparator) : comparator,
-            );
+            userComparators.push(reverse ? Sort.makeReversedComparator(comparator) : comparator);
             if (property === 'tag') {
                 Sort.tagPropertyInstance = propertyInstance;
             }
         }
 
-        return tasks.sort(
-            Sort.makeCompositeComparator([
-                ...userComparators,
-                ...defaultComparators,
-            ]),
-        );
+        return tasks.sort(Sort.makeCompositeComparator([...userComparators, ...defaultComparators]));
     }
 
     private static comparators: Record<SortingProperty, Comparator> = {
@@ -54,9 +47,7 @@ export class Sort {
         return (a, b) => (comparator(a, b) * -1) as -1 | 0 | 1;
     }
 
-    private static makeCompositeComparator(
-        comparators: Comparator[],
-    ): Comparator {
+    private static makeCompositeComparator(comparators: Comparator[]): Comparator {
         return (a, b) => {
             for (const comparator of comparators) {
                 const result = comparator(a, b);
@@ -118,20 +109,11 @@ export class Sort {
         // Arrays start at 0 but the users specify a tag starting at 1.
         const tagInstanceToSortBy = Sort.tagPropertyInstance - 1;
 
-        if (
-            a.tags.length < Sort.tagPropertyInstance &&
-            b.tags.length >= Sort.tagPropertyInstance
-        ) {
+        if (a.tags.length < Sort.tagPropertyInstance && b.tags.length >= Sort.tagPropertyInstance) {
             return 1;
-        } else if (
-            b.tags.length < Sort.tagPropertyInstance &&
-            a.tags.length >= Sort.tagPropertyInstance
-        ) {
+        } else if (b.tags.length < Sort.tagPropertyInstance && a.tags.length >= Sort.tagPropertyInstance) {
             return -1;
-        } else if (
-            a.tags.length < Sort.tagPropertyInstance &&
-            b.tags.length < Sort.tagPropertyInstance
-        ) {
+        } else if (a.tags.length < Sort.tagPropertyInstance && b.tags.length < Sort.tagPropertyInstance) {
             return 0;
         }
 
@@ -144,10 +126,7 @@ export class Sort {
         }
     }
 
-    public static compareByDate(
-        a: moment.Moment | null,
-        b: moment.Moment | null,
-    ): -1 | 0 | 1 {
+    public static compareByDate(a: moment.Moment | null, b: moment.Moment | null): -1 | 0 | 1 {
         if (a !== null && b === null) {
             return -1;
         } else if (a === null && b !== null) {
@@ -182,9 +161,7 @@ export class Sort {
      * in order to be simpler, faster, and not async.
      */
     private static compareByDescription(a: Task, b: Task) {
-        return Sort.cleanDescription(a.description).localeCompare(
-            Sort.cleanDescription(b.description),
-        );
+        return Sort.cleanDescription(a.description).localeCompare(Sort.cleanDescription(b.description));
     }
 
     /**
@@ -204,28 +181,21 @@ export class Sort {
             // For a link, we have to check whether it has another visible name set.
             // For example `[[this is the link|but this is actually shown]]`.
             description =
-                innerLinkText.substring(innerLinkText.indexOf('|') + 1) +
-                description.replace(startsWithLinkRegex, '');
+                innerLinkText.substring(innerLinkText.indexOf('|') + 1) + description.replace(startsWithLinkRegex, '');
         }
 
         const startsWithItalicOrBoldRegex = /^\*\*?([^*]*)\*/;
-        const italicBoldRegexMatch = description.match(
-            startsWithItalicOrBoldRegex,
-        );
+        const italicBoldRegexMatch = description.match(startsWithItalicOrBoldRegex);
         if (italicBoldRegexMatch !== null) {
             const innerItalicBoldText = italicBoldRegexMatch[1];
-            description =
-                innerItalicBoldText +
-                description.replace(startsWithLinkRegex, '');
+            description = innerItalicBoldText + description.replace(startsWithLinkRegex, '');
         }
 
         const startsWithHighlightRegex = /^==?([^=]*)==/;
         const highlightRegexMatch = description.match(startsWithHighlightRegex);
         if (highlightRegexMatch !== null) {
             const innerHighlightsText = highlightRegexMatch[1];
-            description =
-                innerHighlightsText +
-                description.replace(startsWithHighlightRegex, '');
+            description = innerHighlightsText + description.replace(startsWithHighlightRegex, '');
         }
 
         return description;

--- a/src/Query/TaskGroup.ts
+++ b/src/Query/TaskGroup.ts
@@ -47,11 +47,7 @@ export class TaskGroup {
      * @param {GroupHeading[]} groupHeadings - See this.groupHeadings for details
      * @param tasks {Task[]} - See this.tasks for details
      */
-    constructor(
-        groups: string[],
-        groupHeadings: GroupHeading[],
-        tasks: Task[],
-    ) {
+    constructor(groups: string[], groupHeadings: GroupHeading[], tasks: Task[]) {
         this.groups = groups;
         this.groupHeadings = groupHeadings;
         this.tasks = tasks;

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -1,10 +1,4 @@
-import {
-    App,
-    MarkdownRenderChild,
-    MarkdownRenderer,
-    Plugin,
-    TFile,
-} from 'obsidian';
+import { App, MarkdownRenderChild, MarkdownRenderer, Plugin, TFile } from 'obsidian';
 import type { EventRef, MarkdownPostProcessorContext } from 'obsidian';
 
 import type { IQuery } from './IQuery';
@@ -24,19 +18,12 @@ export class QueryRenderer {
         this.app = plugin.app;
         this.events = events;
 
-        plugin.registerMarkdownCodeBlockProcessor(
-            'tasks',
-            this._addQueryRenderChild.bind(this),
-        );
+        plugin.registerMarkdownCodeBlockProcessor('tasks', this._addQueryRenderChild.bind(this));
     }
 
     public addQueryRenderChild = this._addQueryRenderChild.bind(this);
 
-    private async _addQueryRenderChild(
-        source: string,
-        element: HTMLElement,
-        context: MarkdownPostProcessorContext,
-    ) {
+    private async _addQueryRenderChild(source: string, element: HTMLElement, context: MarkdownPostProcessorContext) {
         context.addChild(
             new QueryRenderChild({
                 app: this.app,
@@ -149,8 +136,7 @@ class QueryRenderChild extends MarkdownRenderChild {
                 `Render ${this.queryType} called for a block in active file "${this.filePath}", to select from ${tasks.length} tasks: plugin state: ${state}`,
             );
 
-            const tasksSortedLimitedGrouped =
-                this.query.applyQueryToTasks(tasks);
+            const tasksSortedLimitedGrouped = this.query.applyQueryToTasks(tasks);
             for (const group of tasksSortedLimitedGrouped.groups) {
                 // If there were no 'group by' instructions, group.groupHeadings
                 // will be empty, and no headings will be added.
@@ -163,9 +149,7 @@ class QueryRenderChild extends MarkdownRenderChild {
                 content.appendChild(taskList);
             }
             const totalTasksCount = tasksSortedLimitedGrouped.totalTasksCount();
-            console.debug(
-                `${totalTasksCount} of ${tasks.length} tasks displayed in a block in "${this.filePath}"`,
-            );
+            console.debug(`${totalTasksCount} of ${tasks.length} tasks displayed in a block in "${this.filePath}"`);
             this.addTaskCount(content, totalTasksCount);
         } else if (this.query.error !== undefined) {
             content.setText(`Tasks query: ${this.query.error}`);
@@ -186,10 +170,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         const tasksCount = tasks.length;
 
         const taskList = content.createEl('ul');
-        taskList.addClasses([
-            'contains-task-list',
-            'plugin-tasks-query-result',
-        ]);
+        taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);
         for (let i = 0; i < tasksCount; i++) {
             const task = tasks[i];
             const isFilenameUnique = this.isFilenameUnique({ task });
@@ -253,19 +234,13 @@ class QueryRenderChild extends MarkdownRenderChild {
      *                        in which case no headings will be added.
      * @private
      */
-    private addGroupHeadings(
-        content: HTMLDivElement,
-        groupHeadings: GroupHeading[],
-    ) {
+    private addGroupHeadings(content: HTMLDivElement, groupHeadings: GroupHeading[]) {
         for (const heading of groupHeadings) {
             this.addGroupHeading(content, heading);
         }
     }
 
-    private async addGroupHeading(
-        content: HTMLDivElement,
-        group: GroupHeading,
-    ) {
+    private async addGroupHeading(content: HTMLDivElement, group: GroupHeading) {
         let header: any;
         // Is it possible to remove the repetition here?
         // Ideally, by creating a variable that contains h4, h5 or h6
@@ -284,12 +259,7 @@ class QueryRenderChild extends MarkdownRenderChild {
                 cls: 'tasks-group-heading',
             });
         }
-        await MarkdownRenderer.renderMarkdown(
-            group.name,
-            header,
-            this.filePath,
-            this,
-        );
+        await MarkdownRenderer.renderMarkdown(group.name, header, this.filePath, this);
     }
 
     private addBacklinks(
@@ -316,10 +286,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         if (task.precedingHeader !== null) {
             const sanitisedHeading = task.precedingHeader.replace(/#/g, '');
             link.href = link.href + '#' + sanitisedHeading;
-            link.setAttribute(
-                'data-href',
-                link.getAttribute('data-href') + '#' + sanitisedHeading,
-            );
+            link.setAttribute('data-href', link.getAttribute('data-href') + '#' + sanitisedHeading);
         }
 
         let linkText: string;
@@ -352,14 +319,12 @@ class QueryRenderChild extends MarkdownRenderChild {
         }
 
         const filename = filenameMatch[1];
-        const allFilesWithSameName = this.app.vault
-            .getMarkdownFiles()
-            .filter((file: TFile) => {
-                if (file.basename === filename) {
-                    // Found a file with the same name (it might actually be the same file, but we'll take that into account later.)
-                    return true;
-                }
-            });
+        const allFilesWithSameName = this.app.vault.getMarkdownFiles().filter((file: TFile) => {
+            if (file.basename === filename) {
+                // Found a file with the same name (it might actually be the same file, but we'll take that into account later.)
+                return true;
+            }
+        });
 
         return allFilesWithSameName.length < 2;
     }

--- a/src/Recurrence.ts
+++ b/src/Recurrence.ts
@@ -59,9 +59,7 @@ export class Recurrence {
         dueDate: Moment | null;
     }): Recurrence | null {
         try {
-            const match = recurrenceRuleText.match(
-                /^([a-zA-Z0-9, !]+?)( when done)?$/i,
-            );
+            const match = recurrenceRuleText.match(/^([a-zA-Z0-9, !]+?)( when done)?$/i);
             if (match == null) {
                 return null;
             }
@@ -84,17 +82,9 @@ export class Recurrence {
                 }
 
                 if (!baseOnToday && referenceDate !== null) {
-                    options.dtstart = window
-                        .moment(referenceDate)
-                        .startOf('day')
-                        .utc(true)
-                        .toDate();
+                    options.dtstart = window.moment(referenceDate).startOf('day').utc(true).toDate();
                 } else {
-                    options.dtstart = window
-                        .moment()
-                        .startOf('day')
-                        .utc(true)
-                        .toDate();
+                    options.dtstart = window.moment().startOf('day').utc(true).toDate();
                 }
 
                 const rrule = new RRule(options);
@@ -139,9 +129,7 @@ export class Recurrence {
                 ...this.rrule.origOptions,
                 dtstart: today.startOf('day').utc(true).toDate(),
             });
-            next = ruleBasedOnToday.after(
-                today.endOf('day').utc(true).toDate(),
-            );
+            next = ruleBasedOnToday.after(today.endOf('day').utc(true).toDate());
         } else {
             // The next occurrence should happen based on the original reference
             // date if possible. Otherwise, base it on today if we do not have a
@@ -171,43 +159,28 @@ export class Recurrence {
             // least one of the other dates is set.
             if (this.referenceDate) {
                 if (this.startDate) {
-                    const originalDifference = window.moment.duration(
-                        this.startDate.diff(this.referenceDate),
-                    );
+                    const originalDifference = window.moment.duration(this.startDate.diff(this.referenceDate));
 
                     // Cloning so that original won't be manipulated:
                     startDate = window.moment(nextOccurrence);
                     // Rounding days to handle cross daylight-savings-time recurrences.
-                    startDate.add(
-                        Math.round(originalDifference.asDays()),
-                        'days',
-                    );
+                    startDate.add(Math.round(originalDifference.asDays()), 'days');
                 }
                 if (this.scheduledDate) {
-                    const originalDifference = window.moment.duration(
-                        this.scheduledDate.diff(this.referenceDate),
-                    );
+                    const originalDifference = window.moment.duration(this.scheduledDate.diff(this.referenceDate));
 
                     // Cloning so that original won't be manipulated:
                     scheduledDate = window.moment(nextOccurrence);
                     // Rounding days to handle cross daylight-savings-time recurrences.
-                    scheduledDate.add(
-                        Math.round(originalDifference.asDays()),
-                        'days',
-                    );
+                    scheduledDate.add(Math.round(originalDifference.asDays()), 'days');
                 }
                 if (this.dueDate) {
-                    const originalDifference = window.moment.duration(
-                        this.dueDate.diff(this.referenceDate),
-                    );
+                    const originalDifference = window.moment.duration(this.dueDate.diff(this.referenceDate));
 
                     // Cloning so that original won't be manipulated:
                     dueDate = window.moment(nextOccurrence);
                     // Rounding days to handle cross daylight-savings-time recurrences.
-                    dueDate.add(
-                        Math.round(originalDifference.asDays()),
-                        'days',
-                    );
+                    dueDate.add(Math.round(originalDifference.asDays()), 'days');
                 }
             }
 

--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -1,9 +1,5 @@
 import { App, Editor, EditorSuggest, TFile } from 'obsidian';
-import type {
-    EditorPosition,
-    EditorSuggestContext,
-    EditorSuggestTriggerInfo,
-} from 'obsidian';
+import type { EditorPosition, EditorSuggestContext, EditorSuggestTriggerInfo } from 'obsidian';
 
 import type { Settings } from '../Config/Settings';
 import * as task from '../Task';
@@ -22,17 +18,10 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
         this.settings = settings;
     }
 
-    onTrigger(
-        cursor: EditorPosition,
-        editor: Editor,
-        _file: TFile,
-    ): EditorSuggestTriggerInfo | null {
+    onTrigger(cursor: EditorPosition, editor: Editor, _file: TFile): EditorSuggestTriggerInfo | null {
         if (!this.settings.autoSuggestInEditor) return null;
         const line = editor.getLine(cursor.line);
-        if (
-            line.contains(this.settings.globalFilter) &&
-            line.match(task.Task.taskRegex)
-        ) {
+        if (line.contains(this.settings.globalFilter) && line.match(task.Task.taskRegex)) {
             return {
                 start: { line: cursor.line, ch: 0 },
                 end: {
@@ -49,16 +38,11 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
         const line = context.query;
         const currentCursor = context.editor.getCursor();
 
-        const suggestions: SuggestInfo[] = buildSuggestions(
-            line,
-            currentCursor.ch,
-            this.settings,
-        );
+        const suggestions: SuggestInfo[] = buildSuggestions(line, currentCursor.ch, this.settings);
 
         // Add the editor context to all the suggestions
         const suggestionsWithContext: SuggestInfoWithContext[] = [];
-        for (const suggestion of suggestions)
-            suggestionsWithContext.push({ ...suggestion, context: context });
+        for (const suggestion of suggestions) suggestionsWithContext.push({ ...suggestion, context: context });
 
         return suggestionsWithContext;
     }
@@ -67,10 +51,7 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
         el.setText(value.displayText);
     }
 
-    selectSuggestion(
-        value: SuggestInfoWithContext,
-        _evt: MouseEvent | KeyboardEvent,
-    ) {
+    selectSuggestion(value: SuggestInfoWithContext, _evt: MouseEvent | KeyboardEvent) {
         const editor = value.context.editor;
         if (value.suggestionType === 'empty') {
             // Close the suggestion dialog and simulate an Enter press to the editor
@@ -93,11 +74,7 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
                   ch: replaceFrom.ch + value.insertSkip,
               }
             : undefined;
-        value.context.editor.replaceRange(
-            value.appendText,
-            replaceFrom,
-            replaceTo,
-        );
+        value.context.editor.replaceRange(value.appendText, replaceFrom, replaceTo);
         value.context.editor.setCursor({
             line: currentCursor.line,
             ch: replaceFrom.ch + value.appendText.length,

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -25,28 +25,17 @@ export type SuggestInfo = {
 /*
  * Return a list of suggestions, either generic or more fine-grained to the words at the cursor.
  */
-export function buildSuggestions(
-    line: string,
-    cursorPos: number,
-    settings: Settings,
-): SuggestInfo[] {
+export function buildSuggestions(line: string, cursorPos: number, settings: Settings): SuggestInfo[] {
     let suggestions: SuggestInfo[] = [];
 
     // Step 1: add date suggestions if relevant
-    suggestions = suggestions.concat(
-        addDatesSuggestions(line, cursorPos, settings),
-    );
+    suggestions = suggestions.concat(addDatesSuggestions(line, cursorPos, settings));
 
     // Step 2: add recurrence suggestions if relevant
-    suggestions = suggestions.concat(
-        addRecurrenceSuggestions(line, cursorPos, settings),
-    );
+    suggestions = suggestions.concat(addRecurrenceSuggestions(line, cursorPos, settings));
 
     // Step 3: add more general suggestions ('due', 'recurrence' etc)
-    const morePossibleSuggestions = getPossibleComponentSuggestions(
-        line,
-        settings,
-    );
+    const morePossibleSuggestions = getPossibleComponentSuggestions(line, settings);
     // We now filter the general suggestions according to the word at the cursor. If there's
     // something to match, we filter the suggestions accordingly, so the user can get more specific
     // results according to what she's typing.
@@ -55,14 +44,9 @@ export function buildSuggestions(
     let addedSuggestions = false;
     if (wordMatch && wordMatch.length > 0) {
         const wordUnderCursor = wordMatch[0];
-        if (
-            wordUnderCursor.length >= Math.max(1, settings.autoSuggestMinMatch)
-        ) {
-            const filteredSuggestions = morePossibleSuggestions.filter(
-                (suggestInfo) =>
-                    suggestInfo.displayText
-                        .toLowerCase()
-                        .includes(wordUnderCursor.toLowerCase()),
+        if (wordUnderCursor.length >= Math.max(1, settings.autoSuggestMinMatch)) {
+            const filteredSuggestions = morePossibleSuggestions.filter((suggestInfo) =>
+                suggestInfo.displayText.toLowerCase().includes(wordUnderCursor.toLowerCase()),
             );
             for (const filtered of filteredSuggestions) {
                 suggestions.push({
@@ -84,10 +68,7 @@ export function buildSuggestions(
     // Unless we have a suggestion that is a match for something the user is currently typing, add
     // an 'Enter' entry in the beginning of the menu, so an Enter press will move to the next line
     // rather than insert a suggestion
-    if (
-        suggestions.length > 0 &&
-        !suggestions.some((value) => value.suggestionType === 'match')
-    ) {
+    if (suggestions.length > 0 && !suggestions.some((value) => value.suggestionType === 'match')) {
         // No actual match, only default ones
         suggestions.unshift({
             suggestionType: 'empty',
@@ -103,21 +84,13 @@ export function buildSuggestions(
 }
 
 function hasPriority(line: string) {
-    if (
-        Object.values(task.prioritySymbols).some(
-            (value) => value.length > 0 && line.includes(value),
-        )
-    )
-        return true;
+    if (Object.values(task.prioritySymbols).some((value) => value.length > 0 && line.includes(value))) return true;
 }
 
 /*
  * Get suggestions for generic task components, e.g. a priority or a 'due' symbol
  */
-function getPossibleComponentSuggestions(
-    line: string,
-    _settings: Settings,
-): SuggestInfo[] {
+function getPossibleComponentSuggestions(line: string, _settings: Settings): SuggestInfo[] {
     const suggestions: SuggestInfo[] = [];
 
     if (!line.includes(task.dueDateSymbol))
@@ -166,11 +139,7 @@ function getPossibleComponentSuggestions(
  * Generic predefined suggestions, in turn, also have two options: either filtered (if the user started typing
  * something where a date is expected) or unfiltered
  */
-function addDatesSuggestions(
-    line: string,
-    cursorPos: number,
-    settings: Settings,
-): SuggestInfo[] {
+function addDatesSuggestions(line: string, cursorPos: number, settings: Settings): SuggestInfo[] {
     const genericSuggestions = [
         'today',
         'tomorrow',
@@ -187,10 +156,7 @@ function addDatesSuggestions(
     ];
 
     const results: SuggestInfo[] = [];
-    const dateRegex = new RegExp(
-        `([${datePrefixCharacters}])\\s*([0-9a-zA-Z ]*)`,
-        'ug',
-    );
+    const dateRegex = new RegExp(`([${datePrefixCharacters}])\\s*([0-9a-zA-Z ]*)`, 'ug');
     const dateMatch = matchByPosition(line, dateRegex, cursorPos);
     if (dateMatch && dateMatch.length >= 2) {
         const datePrefix = dateMatch[1];
@@ -203,17 +169,13 @@ function addDatesSuggestions(
         // be in the future, i.e. if today is Sunday and the user typed "due <Enter> Saturday", she
         // most likely means Saturday *in the future* and not yesterday.
         const possibleDate =
-            dateString && dateString.length > 1
-                ? DateParser.parseDate(doAutocomplete(dateString), true)
-                : null;
+            dateString && dateString.length > 1 ? DateParser.parseDate(doAutocomplete(dateString), true) : null;
         if (possibleDate && possibleDate.isValid()) {
             // Seems like the text that the user typed can be parsed as a valid date.
             // Present its completed form as a 1st suggestion
             results.push({
                 displayText: `${possibleDate.format(task.Task.dateFormat)}`,
-                appendText: `${datePrefix} ${possibleDate.format(
-                    task.Task.dateFormat,
-                )} `,
+                appendText: `${datePrefix} ${possibleDate.format(task.Task.dateFormat)} `,
                 insertAt: dateMatch.index,
                 insertSkip: dateMatch[0].length,
             });
@@ -262,11 +224,7 @@ function addDatesSuggestions(
  * Generic predefined suggestions, in turn, also have two options: either filtered (if the user started typing
  * something where a recurrence is expected) or unfiltered
  */
-function addRecurrenceSuggestions(
-    line: string,
-    cursorPos: number,
-    settings: Settings,
-) {
+function addRecurrenceSuggestions(line: string, cursorPos: number, settings: Settings) {
     const genericSuggestions = [
         'every',
         'every day',
@@ -284,10 +242,7 @@ function addRecurrenceSuggestions(
     ];
 
     const results: SuggestInfo[] = [];
-    const recurrenceRegex = new RegExp(
-        `(${task.recurrenceSymbol})\\s*([0-9a-zA-Z ]*)`,
-        'ug',
-    );
+    const recurrenceRegex = new RegExp(`(${task.recurrenceSymbol})\\s*([0-9a-zA-Z ]*)`, 'ug');
     const recurrenceMatch = matchByPosition(line, recurrenceRegex, cursorPos);
     if (recurrenceMatch && recurrenceMatch.length >= 2) {
         const recurrencePrefix = recurrenceMatch[1];
@@ -333,21 +288,13 @@ function addRecurrenceSuggestions(
                 (value) =>
                     recurrenceString &&
                     recurrenceString.length >= minMatch &&
-                    value
-                        .toLowerCase()
-                        .includes(recurrenceString.toLowerCase()),
+                    value.toLowerCase().includes(recurrenceString.toLowerCase()),
             )
             .slice(0, maxGenericDateSuggestions);
-        if (
-            genericMatches.length === 0 &&
-            recurrenceString.trim().length === 0
-        ) {
+        if (genericMatches.length === 0 && recurrenceString.trim().length === 0) {
             // We have no actual match so do completely generic recurrence suggestions, but not if
             // there *was* a text to match (because it means the user is actually typing something else)
-            genericMatches = genericSuggestions.slice(
-                0,
-                maxGenericDateSuggestions,
-            );
+            genericMatches = genericSuggestions.slice(0, maxGenericDateSuggestions);
         }
         for (const match of genericMatches) {
             results.push({
@@ -367,19 +314,10 @@ function addRecurrenceSuggestions(
  * Matches a string with a regex according to a position (typically of a cursor).
  * Will return a result only if a match exists and the given position is part of it.
  */
-export function matchByPosition(
-    s: string,
-    r: RegExp,
-    position: number,
-): RegExpMatchArray {
+export function matchByPosition(s: string, r: RegExp, position: number): RegExpMatchArray {
     const matches = s.matchAll(r);
     for (const match of matches) {
-        if (
-            match?.index &&
-            match.index <= position &&
-            position <= match.index + match[0].length
-        )
-            return match;
+        if (match?.index && match.index <= position && position <= match.index + match[0].length) return match;
     }
     return [];
 }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -145,9 +145,7 @@ export class Task {
     // description: '#dog #car http://www/ddd#ere #house'
     // matches: #dog, #car, #house
     public static readonly hashTags = /(^|\s)#[^ !@#$%^&*(),.?":{}|<>]*/g;
-    public static readonly hashTagsFromEnd = new RegExp(
-        this.hashTags.source + '$',
-    );
+    public static readonly hashTagsFromEnd = new RegExp(this.hashTags.source + '$');
 
     private _urgency: number | null = null;
 
@@ -308,18 +306,14 @@ export class Task {
                         break;
                 }
 
-                description = description
-                    .replace(Task.priorityRegex, '')
-                    .trim();
+                description = description.replace(Task.priorityRegex, '').trim();
                 matched = true;
             }
 
             const doneDateMatch = description.match(Task.doneDateRegex);
             if (doneDateMatch !== null) {
                 doneDate = window.moment(doneDateMatch[1], Task.dateFormat);
-                description = description
-                    .replace(Task.doneDateRegex, '')
-                    .trim();
+                description = description.replace(Task.doneDateRegex, '').trim();
                 matched = true;
             }
 
@@ -330,26 +324,17 @@ export class Task {
                 matched = true;
             }
 
-            const scheduledDateMatch = description.match(
-                Task.scheduledDateRegex,
-            );
+            const scheduledDateMatch = description.match(Task.scheduledDateRegex);
             if (scheduledDateMatch !== null) {
-                scheduledDate = window.moment(
-                    scheduledDateMatch[1],
-                    Task.dateFormat,
-                );
-                description = description
-                    .replace(Task.scheduledDateRegex, '')
-                    .trim();
+                scheduledDate = window.moment(scheduledDateMatch[1], Task.dateFormat);
+                description = description.replace(Task.scheduledDateRegex, '').trim();
                 matched = true;
             }
 
             const startDateMatch = description.match(Task.startDateRegex);
             if (startDateMatch !== null) {
                 startDate = window.moment(startDateMatch[1], Task.dateFormat);
-                description = description
-                    .replace(Task.startDateRegex, '')
-                    .trim();
+                description = description.replace(Task.startDateRegex, '').trim();
                 matched = true;
             }
 
@@ -359,9 +344,7 @@ export class Task {
                 // Creating the Recurrence object requires a reference date (e.g. a due date),
                 // and it might appear in the next (earlier in the line) tokens to parse
                 recurrenceRule = recurrenceMatch[1].trim();
-                description = description
-                    .replace(Task.recurrenceRegex, '')
-                    .trim();
+                description = description.replace(Task.recurrenceRegex, '').trim();
                 matched = true;
             }
 
@@ -369,16 +352,11 @@ export class Task {
             // tags. These tags will be added back to the description below
             const tagsMatch = description.match(Task.hashTagsFromEnd);
             if (tagsMatch != null) {
-                description = description
-                    .replace(Task.hashTagsFromEnd, '')
-                    .trim();
+                description = description.replace(Task.hashTagsFromEnd, '').trim();
                 matched = true;
                 const tagName = tagsMatch[0].trim();
                 // Adding to the left because the matching is done right-to-left
-                trailingTags =
-                    trailingTags.length > 0
-                        ? [tagName, trailingTags].join(' ')
-                        : tagName;
+                trailingTags = trailingTags.length > 0 ? [tagName, trailingTags].join(' ') : tagName;
             }
 
             runs++;
@@ -406,9 +384,7 @@ export class Task {
         // The global filter will be removed from the collection.
         const hashTagMatch = description.match(this.hashTags);
         if (hashTagMatch !== null) {
-            tags = hashTagMatch
-                .filter((tag) => tag !== globalFilter)
-                .map((tag) => tag.trim());
+            tags = hashTagMatch.filter((tag) => tag !== globalFilter).map((tag) => tag.trim());
         }
 
         return new Task({
@@ -455,12 +431,7 @@ export class Task {
         const textSpan = li.createSpan();
         textSpan.addClass('tasks-list-text');
 
-        await MarkdownRenderer.renderMarkdown(
-            taskAsString,
-            textSpan,
-            this.path,
-            null as unknown as Component,
-        );
+        await MarkdownRenderer.renderMarkdown(taskAsString, textSpan, this.path, null as unknown as Component);
 
         // If the task is a block quote, the block quote wraps the p-tag that contains the content.
         // In that case, we need to unwrap the p-tag *inside* the surrounding block quote.
@@ -560,18 +531,14 @@ export class Task {
         if (!layoutOptions.hideStartDate && this.startDate) {
             const startDate: string = layoutOptions.shortMode
                 ? ' ' + startDateSymbol
-                : ` ${startDateSymbol} ${this.startDate.format(
-                      Task.dateFormat,
-                  )}`;
+                : ` ${startDateSymbol} ${this.startDate.format(Task.dateFormat)}`;
             taskString += startDate;
         }
 
         if (!layoutOptions.hideScheduledDate && this.scheduledDate) {
             const scheduledDate: string = layoutOptions.shortMode
                 ? ' ' + scheduledDateSymbol
-                : ` ${scheduledDateSymbol} ${this.scheduledDate.format(
-                      Task.dateFormat,
-                  )}`;
+                : ` ${scheduledDateSymbol} ${this.scheduledDate.format(Task.dateFormat)}`;
             taskString += scheduledDate;
         }
 
@@ -602,9 +569,7 @@ export class Task {
      * @memberof Task
      */
     public toFileLineString(): string {
-        return `${this.indentation}- [${
-            this.originalStatusCharacter
-        }] ${this.toString()}`;
+        return `${this.indentation}- [${this.originalStatusCharacter}] ${this.toString()}`;
     }
 
     /**
@@ -616,8 +581,7 @@ export class Task {
      * task is not recurring, it will return `[toggled]`.
      */
     public toggle(): Task[] {
-        const newStatus: Status =
-            this.status === Status.Todo ? Status.Done : Status.Todo;
+        const newStatus: Status = this.status === Status.Todo ? Status.Done : Status.Todo;
 
         let newDoneDate = null;
 
@@ -693,11 +657,7 @@ export class Task {
      *                                        If it is undefined, the outcome will be the same as with a unique file name: the file name only.
      *                                        If set to `true`, the full path will be returned.
      */
-    public getLinkText({
-        isFilenameUnique,
-    }: {
-        isFilenameUnique: boolean | undefined;
-    }): string | null {
+    public getLinkText({ isFilenameUnique }: { isFilenameUnique: boolean | undefined }): string | null {
         let linkText: string | null;
         if (isFilenameUnique) {
             linkText = this.filename;
@@ -711,10 +671,7 @@ export class Task {
         }
 
         // Otherwise, this wouldn't provide additional information and only take up space.
-        if (
-            this.precedingHeader !== null &&
-            this.precedingHeader !== linkText
-        ) {
+        if (this.precedingHeader !== null && this.precedingHeader !== linkText) {
             linkText = linkText + ' > ' + this.precedingHeader;
         }
 
@@ -738,9 +695,7 @@ export class Task {
         if (oldTasks.length !== newTasks.length) {
             return false;
         }
-        return oldTasks.every((oldTask, index) =>
-            oldTask.identicalTo(newTasks[index]),
-        );
+        return oldTasks.every((oldTask, index) => oldTask.identicalTo(newTasks[index]));
     }
 
     /**
@@ -807,11 +762,7 @@ export class Task {
             return false;
         } else if (recurrence1 !== null && recurrence2 === null) {
             return false;
-        } else if (
-            recurrence1 &&
-            recurrence2 &&
-            !recurrence1.identicalTo(recurrence2)
-        ) {
+        } else if (recurrence1 && recurrence2 && !recurrence1.identicalTo(recurrence2)) {
             return false;
         }
 
@@ -831,9 +782,7 @@ export class Task {
 
             if (this.recurrence) {
                 const recurrenceDiv = tooltip.createDiv();
-                recurrenceDiv.setText(
-                    `${recurrenceSymbol} ${this.recurrence.toText()}`,
-                );
+                recurrenceDiv.setText(`${recurrenceSymbol} ${this.recurrence.toText()}`);
             }
 
             if (this.startDate) {
@@ -888,16 +837,8 @@ export class Task {
         });
     }
 
-    private static toTooltipDate({
-        signifier,
-        date,
-    }: {
-        signifier: string;
-        date: Moment;
-    }): string {
-        return `${signifier} ${date.format(Task.dateFormat)} (${date.from(
-            window.moment().startOf('day'),
-        )})`;
+    private static toTooltipDate({ signifier, date }: { signifier: string; date: Moment }): string {
+        return `${signifier} ${date.format(Task.dateFormat)} (${date.from(window.moment().startOf('day'))})`;
     }
 
     /**
@@ -932,15 +873,9 @@ export class Task {
         let description = this.description;
         if (globalFilter.length === 0) return description;
         // This matches the global filter (after escaping it) only when it's a complete word
-        const globalFilterRegex = RegExp(
-            '(^|\\s)' + this.escapeRegExp(globalFilter) + '($|\\s)',
-            'ug',
-        );
+        const globalFilterRegex = RegExp('(^|\\s)' + this.escapeRegExp(globalFilter) + '($|\\s)', 'ug');
         if (this.description.search(globalFilterRegex) > -1) {
-            description = description
-                .replace(globalFilterRegex, '$1$2')
-                .replace('  ', ' ')
-                .trim();
+            description = description.replace(globalFilterRegex, '$1$2').replace('  ', ' ').trim();
         }
         return description;
     }

--- a/src/TaskModal.ts
+++ b/src/TaskModal.ts
@@ -6,15 +6,7 @@ export class TaskModal extends Modal {
     public readonly task: Task;
     public readonly onSubmit: (updatedTasks: Task[]) => void;
 
-    constructor({
-        app,
-        task,
-        onSubmit,
-    }: {
-        app: App;
-        task: Task;
-        onSubmit: (updatedTasks: Task[]) => void;
-    }) {
+    constructor({ app, task, onSubmit }: { app: App; task: Task; onSubmit: (updatedTasks: Task[]) => void }) {
         super(app);
 
         this.task = task;

--- a/src/TasksEvents.ts
+++ b/src/TasksEvents.ts
@@ -20,9 +20,7 @@ export class TasksEvents {
         this.obsidianEvents = obsidianEvents;
     }
 
-    public onCacheUpdate(
-        handler: (cacheData: CacheUpdateData) => void,
-    ): EventRef {
+    public onCacheUpdate(handler: (cacheData: CacheUpdateData) => void): EventRef {
         return this.obsidianEvents.on(Event.CacheUpdate, handler);
     }
 
@@ -30,15 +28,11 @@ export class TasksEvents {
         this.obsidianEvents.trigger(Event.CacheUpdate, cacheData);
     }
 
-    public onRequestCacheUpdate(
-        handler: (fn: (cacheData: CacheUpdateData) => void) => void,
-    ): EventRef {
+    public onRequestCacheUpdate(handler: (fn: (cacheData: CacheUpdateData) => void) => void): EventRef {
         return this.obsidianEvents.on(Event.RequestCacheUpdate, handler);
     }
 
-    public triggerRequestCacheUpdate(
-        fn: (cacheData: CacheUpdateData) => void,
-    ): void {
+    public triggerRequestCacheUpdate(fn: (cacheData: CacheUpdateData) => void): void {
         this.obsidianEvents.trigger(Event.RequestCacheUpdate, fn);
     }
 

--- a/src/Urgency.ts
+++ b/src/Urgency.ts
@@ -13,9 +13,7 @@ export class Urgency {
 
         if (task.dueDate !== null) {
             // Map a range of 21 days to the value 0.2 - 1.0
-            const daysOverdue = Math.round(
-                window.moment().diff(task.dueDate) / Urgency.milliSecondsPerDay,
-            );
+            const daysOverdue = Math.round(window.moment().diff(task.dueDate) / Urgency.milliSecondsPerDay);
 
             let dueMultiplier: number;
             if (daysOverdue >= 7.0) {

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -135,9 +135,7 @@ export class LogManager extends EventEmitter2 {
         if (this.consoleLoggerRegistered) return this;
 
         this.onLogEntry((logEntry) => {
-            let msg = `[${moment().format('YYYYMMDDHHmmss')}][${
-                logEntry.level
-            }][${logEntry.module}]`;
+            let msg = `[${moment().format('YYYYMMDDHHmmss')}][${logEntry.level}][${logEntry.module}]`;
 
             if (logEntry.traceId) {
                 msg += `[${logEntry.traceId}]`;
@@ -214,8 +212,7 @@ export class Logger {
      * @param minLevel
      */
     private levelToInt(minLevel: string): number {
-        if (minLevel.toLowerCase() in this.levels)
-            return this.levels[minLevel.toLowerCase()];
+        if (minLevel.toLowerCase() in this.levels) return this.levels[minLevel.toLowerCase()];
         else return 99;
     }
 
@@ -273,12 +270,7 @@ export class Logger {
      * @param logLevel
      * @param message
      */
-    public logWithId(
-        logLevel: string,
-        traceId: string,
-        message: string,
-        objects?: any,
-    ): void {
+    public logWithId(logLevel: string, traceId: string, message: string, objects?: any): void {
         const level = this.levelToInt(logLevel);
         if (level < this.minLevel) return;
 
@@ -324,11 +316,7 @@ const timingMap: TimingMap = {};
  * @export
  * @return {*}
  */
-export const logCall = (
-    target: Object,
-    propertyKey: string,
-    descriptor: PropertyDescriptor,
-) => {
+export const logCall = (target: Object, propertyKey: string, descriptor: PropertyDescriptor) => {
     const originalMethod = descriptor.value;
     //const logger = logging.getLogger('taskssql.perf');
     descriptor.value = function (...args: any[]) {
@@ -363,11 +351,7 @@ export const logCall = (
 };
 
 export function logCallDetails() {
-    return function (
-        target: any,
-        propertyKey: string,
-        descriptor: PropertyDescriptor,
-    ) {
+    return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
         const originalMethod = descriptor.value;
         const logger = logging.getLogger('taskssql');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,9 +37,7 @@ export default class TasksPlugin extends Plugin {
         this.queryRenderer = new QueryRenderer({ plugin: this, events });
 
         this.registerEditorExtension(newLivePreviewExtension());
-        this.registerEditorSuggest(
-            new EditorSuggestor(this.app, getSettings()),
-        );
+        this.registerEditorSuggest(new EditorSuggestor(this.app, getSettings()));
         new Commands({ plugin: this });
     }
 

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -3,10 +3,7 @@
  */
 
 import moment from 'moment';
-import {
-    calculateCursorOffset,
-    toggleLine,
-} from '../../src/Commands/ToggleDone';
+import { calculateCursorOffset, toggleLine } from '../../src/Commands/ToggleDone';
 
 window.moment = moment;
 
@@ -20,10 +17,7 @@ window.moment = moment;
  * @param inputWithCursorMark
  * @param expectedWithCursorMark
  */
-function testToggleLine(
-    inputWithCursorMark: string,
-    expectedWithCursorMark: string,
-) {
+function testToggleLine(inputWithCursorMark: string, expectedWithCursorMark: string) {
     const cursorMarker = '|';
     const cursorMarkerRegex = /\|/g;
 
@@ -64,18 +58,12 @@ function testToggleLineForOutOfRangeCursorPositions(
 ) {
     const result = toggleLine(input, 'x.md');
     expect(result).toStrictEqual(expected);
-    const actualCursorOffset = calculateCursorOffset(
-        initialCursorOffset,
-        input,
-        result,
-    );
+    const actualCursorOffset = calculateCursorOffset(initialCursorOffset, input, result);
     expect(actualCursorOffset).toEqual(expectedCursorOffset);
 }
 
 describe('ToggleDone', () => {
-    const todaySpy = jest
-        .spyOn(Date, 'now')
-        .mockReturnValue(moment('2022-09-04').valueOf());
+    const todaySpy = jest.spyOn(Date, 'now').mockReturnValue(moment('2022-09-04').valueOf());
 
     // The | (pipe) indicates the calculated position where the cursor should be displayed.
     // Note that prior to the #1103 fix, this position was sometimes ignored.
@@ -94,10 +82,7 @@ describe('ToggleDone', () => {
         testToggleLine('- [ ] |', '- [x] | ✅ 2022-09-04');
 
         // Issue #449 - cursor jumped 13 characters to the right on completion
-        testToggleLine(
-            '- [ ] I have a |proper description',
-            '- [x] I have a |proper description ✅ 2022-09-04',
-        );
+        testToggleLine('- [ ] I have a |proper description', '- [x] I have a |proper description ✅ 2022-09-04');
     });
 
     it('should un-complete a completed task', () => {
@@ -105,10 +90,7 @@ describe('ToggleDone', () => {
         testToggleLine('- [x]  ✅ 2022-09-04|', '- [ ] |');
 
         // Issue #449 - cursor jumped 13 characters to the left on un-completion
-        testToggleLine(
-            '- [x] I have a proper description| ✅ 2022-09-04',
-            '- [ ] I have a proper description|',
-        );
+        testToggleLine('- [x] I have a proper description| ✅ 2022-09-04', '- [ ] I have a proper description|');
     });
 
     it('should complete a recurring task', () => {

--- a/tests/Config/Feature.test.ts
+++ b/tests/Config/Feature.test.ts
@@ -30,9 +30,7 @@ describe('feature-usage', () => {
         expect(feature.internalName).toBe(name);
         expect(feature.index).toBe(9999);
         expect(feature.description).toBe('Description');
-        expect(feature.displayName).toBe(
-            'Test Item. Used to validate the Feature Framework.',
-        );
+        expect(feature.displayName).toBe('Test Item. Used to validate the Feature Framework.');
         expect(feature.enabledByDefault).toBe(true);
         expect(feature.stable).toBe(false);
     });

--- a/tests/Config/Settings.test.ts
+++ b/tests/Config/Settings.test.ts
@@ -1,44 +1,27 @@
 /**
  * @jest-environment jsdom
  */
-import {
-    getSettings,
-    isFeatureEnabled,
-    toggleFeature,
-} from '../../src/Config/Settings';
+import { getSettings, isFeatureEnabled, toggleFeature } from '../../src/Config/Settings';
 
 describe('settings-usage', () => {
     it('load default settings and validate features', () => {
         const currentSettings = getSettings();
 
-        expect(Object.entries(currentSettings.features).length).toBeGreaterThan(
-            0,
-        );
-        expect(
-            currentSettings.features['INTERNAL_TESTING_ENABLED_BY_DEFAULT'],
-        ).toBe(true);
+        expect(Object.entries(currentSettings.features).length).toBeGreaterThan(0);
+        expect(currentSettings.features['INTERNAL_TESTING_ENABLED_BY_DEFAULT']).toBe(true);
     });
 
     it('returns true if feature enabled', () => {
-        const currentSettings = isFeatureEnabled(
-            'INTERNAL_TESTING_ENABLED_BY_DEFAULT',
-        );
+        const currentSettings = isFeatureEnabled('INTERNAL_TESTING_ENABLED_BY_DEFAULT');
 
         expect(currentSettings).toBe(true);
     });
 
     it('toggles a feature', () => {
-        const updatedFeatures = toggleFeature(
-            'INTERNAL_TESTING_ENABLED_BY_DEFAULT',
-            false,
-        );
-        expect(updatedFeatures['INTERNAL_TESTING_ENABLED_BY_DEFAULT']).toBe(
-            false,
-        );
+        const updatedFeatures = toggleFeature('INTERNAL_TESTING_ENABLED_BY_DEFAULT', false);
+        expect(updatedFeatures['INTERNAL_TESTING_ENABLED_BY_DEFAULT']).toBe(false);
 
         const currentSettings = getSettings();
-        expect(
-            currentSettings.features['INTERNAL_TESTING_ENABLED_BY_DEFAULT'],
-        ).toBe(false);
+        expect(currentSettings.features['INTERNAL_TESTING_ENABLED_BY_DEFAULT']).toBe(false);
     });
 });

--- a/tests/CustomMatchers/CustomMatchersForFilters.ts
+++ b/tests/CustomMatchers/CustomMatchersForFilters.ts
@@ -84,16 +84,14 @@ declare global {
 export function toBeValid(filter: FilterOrErrorMessage) {
     if (filter.filter === undefined) {
         return {
-            message: () =>
-                'unexpected null filter: check your instruction matches your filter class',
+            message: () => 'unexpected null filter: check your instruction matches your filter class',
             pass: false,
         };
     }
 
     if (filter.error !== undefined) {
         return {
-            message: () =>
-                'unexpected error message in filter: check your instruction matches your filter class',
+            message: () => 'unexpected error message in filter: check your instruction matches your filter class',
             pass: false,
         };
     }
@@ -108,42 +106,31 @@ export function toMatchTask(filter: FilterOrErrorMessage, task: Task) {
     const matches = filter.filter!(task);
     if (!matches) {
         return {
-            message: () =>
-                `unexpected failure to match task: ${task.toFileLineString()}`,
+            message: () => `unexpected failure to match task: ${task.toFileLineString()}`,
             pass: false,
         };
     }
 
     return {
-        message: () =>
-            `filter should not have matched task: ${task.toFileLineString()}`,
+        message: () => `filter should not have matched task: ${task.toFileLineString()}`,
         pass: true,
     };
 }
 
-export function toMatchTaskFromLine(
-    filter: FilterOrErrorMessage,
-    line: string,
-) {
+export function toMatchTaskFromLine(filter: FilterOrErrorMessage, line: string) {
     const task = fromLine({
         line: line,
     });
     return toMatchTask(filter, task);
 }
 
-export function toMatchTaskWithHeading(
-    filter: FilterOrErrorMessage,
-    heading: string,
-) {
+export function toMatchTaskWithHeading(filter: FilterOrErrorMessage, heading: string) {
     const builder = new TaskBuilder();
     const task = builder.precedingHeader(heading).build();
     return toMatchTask(filter, task);
 }
 
-export function toMatchTaskWithPath(
-    filter: FilterOrErrorMessage,
-    path: string,
-) {
+export function toMatchTaskWithPath(filter: FilterOrErrorMessage, path: string) {
     const builder = new TaskBuilder();
     const task = builder.path(path).build();
     return toMatchTask(filter, task);

--- a/tests/EditorSuggest.test.ts
+++ b/tests/EditorSuggest.test.ts
@@ -15,11 +15,7 @@ describe('auto-complete', () => {
         // Arrange
         const originalSettings = getSettings();
         const line = '- [ ] ';
-        const suggestions: SuggestInfo[] = buildSuggestions(
-            line,
-            5,
-            originalSettings,
-        );
+        const suggestions: SuggestInfo[] = buildSuggestions(line, 5, originalSettings);
         expect(suggestions).toEqual([
             { suggestionType: 'empty', displayText: '⏎', appendText: '\n' },
             { displayText: '📅 due date', appendText: '📅 ' },
@@ -34,11 +30,7 @@ describe('auto-complete', () => {
         // Arrange
         const originalSettings = getSettings();
         const line = '- [ ] some task 📅';
-        const suggestions: SuggestInfo[] = buildSuggestions(
-            line,
-            17,
-            originalSettings,
-        );
+        const suggestions: SuggestInfo[] = buildSuggestions(line, 17, originalSettings);
         expect(suggestions[0].displayText).toContain('today');
         expect(suggestions[1].displayText).toContain('tomorrow');
         expect(suggestions.length).toEqual(6);
@@ -48,11 +40,7 @@ describe('auto-complete', () => {
         // Arrange
         const originalSettings = getSettings();
         const line = '- [ ] some task 📅 to';
-        const suggestions: SuggestInfo[] = buildSuggestions(
-            line,
-            20,
-            originalSettings,
-        );
+        const suggestions: SuggestInfo[] = buildSuggestions(line, 20, originalSettings);
         expect(suggestions[0].displayText).toContain('today');
         expect(suggestions[1].displayText).toContain('tomorrow');
     });
@@ -61,11 +49,7 @@ describe('auto-complete', () => {
         // Arrange
         const originalSettings = getSettings();
         const line = '- [ ] some task 🔁';
-        const suggestions: SuggestInfo[] = buildSuggestions(
-            line,
-            17,
-            originalSettings,
-        );
+        const suggestions: SuggestInfo[] = buildSuggestions(line, 17, originalSettings);
         expect(suggestions[0].displayText).toEqual('every');
         expect(suggestions[1].displayText).toEqual('every day');
         expect(suggestions[2].displayText).toEqual('every week');
@@ -75,11 +59,7 @@ describe('auto-complete', () => {
         // Arrange
         const originalSettings = getSettings();
         const line = '- [ ] some task 🔁 every w';
-        const suggestions: SuggestInfo[] = buildSuggestions(
-            line,
-            25,
-            originalSettings,
-        );
+        const suggestions: SuggestInfo[] = buildSuggestions(line, 25, originalSettings);
         expect(suggestions[0].displayText).toEqual('every week');
         expect(suggestions[1].displayText).toEqual('every week on Sunday');
         expect(suggestions[2].displayText).toEqual('every week on Monday');
@@ -90,11 +70,7 @@ describe('auto-complete', () => {
         const originalSettings = getSettings();
         originalSettings.autoSuggestMinMatch = 2;
         let line = '- [ ] some task 🔁 e';
-        let suggestions: SuggestInfo[] = buildSuggestions(
-            line,
-            19,
-            originalSettings,
-        );
+        let suggestions: SuggestInfo[] = buildSuggestions(line, 19, originalSettings);
         expect(suggestions.length).toEqual(0);
         line = '- [ ] some task 🔁 ev';
         suggestions = buildSuggestions(line, 20, originalSettings);
@@ -127,11 +103,7 @@ describe('auto-complete', () => {
         const allSuggestions: string[] = [];
         for (const line of lines) {
             // allSuggestions.push(`| ${line} | |`);
-            const suggestions: SuggestInfo[] = buildSuggestions(
-                line,
-                line.length - 1,
-                originalSettings,
-            );
+            const suggestions: SuggestInfo[] = buildSuggestions(line, line.length - 1, originalSettings);
             for (const suggestion of suggestions) {
                 // The 'new line' replacement adds a trailing space at the end of a line,
                 // which causes auto-formatting to then make the test fail.

--- a/tests/Group.test.ts
+++ b/tests/Group.test.ts
@@ -9,11 +9,7 @@ import { fromLine } from './TestHelpers';
 
 window.moment = moment;
 
-function checkGroupNamesOfTask(
-    task: Task,
-    property: GroupingProperty,
-    expectedGroupNames: string[],
-) {
+function checkGroupNamesOfTask(task: Task, property: GroupingProperty, expectedGroupNames: string[]) {
     const group = Group.getGroupNamesForTask(property, task);
     expect(group).toEqual(expectedGroupNames);
 }
@@ -189,10 +185,7 @@ describe('Grouping tasks', () => {
         });
         const tasks = [t1, t2, t3];
 
-        const grouping: Grouping[] = [
-            { property: 'folder' },
-            { property: 'filename' },
-        ];
+        const grouping: Grouping[] = [{ property: 'folder' }, { property: 'filename' }];
 
         // Act
         const groups = Group.by(grouping, tasks);
@@ -364,22 +357,19 @@ describe('Group names', () => {
         {
             // Check that earliest date is prioritised: due
             groupBy: 'happens',
-            taskLine:
-                '- [ ] due is earliest date 🛫 1970-01-03 ⏳ 1970-01-02 📅 1970-01-01',
+            taskLine: '- [ ] due is earliest date 🛫 1970-01-03 ⏳ 1970-01-02 📅 1970-01-01',
             expectedGroupNames: ['1970-01-01 Thursday'],
         },
         {
             // Check that earliest date is prioritised: scheduled
             groupBy: 'happens',
-            taskLine:
-                '- [ ] scheduled is earliest date 🛫 1970-01-03 ⏳ 1970-01-01 📅 1970-01-02',
+            taskLine: '- [ ] scheduled is earliest date 🛫 1970-01-03 ⏳ 1970-01-01 📅 1970-01-02',
             expectedGroupNames: ['1970-01-01 Thursday'],
         },
         {
             // Check that earliest date is prioritised: start
             groupBy: 'happens',
-            taskLine:
-                '- [ ] start is earliest date 🛫 1970-01-01 ⏳ 1970-01-02 📅 1970-01-03',
+            taskLine: '- [ ] start is earliest date 🛫 1970-01-01 ⏳ 1970-01-02 📅 1970-01-03',
             expectedGroupNames: ['1970-01-01 Thursday'],
         },
 

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -95,29 +95,25 @@ describe('Query parsing', () => {
     });
 
     describe('should not confuse a boolean query for any other single field', () => {
-        test.concurrent.each<string>(filters)(
-            'sub-query %j is recognized inside a boolean query',
-            (filter) => {
-                // Arrange
-                // For every sub-query from the filters list above, compose a boolean query that is always
-                // true, in the format (expression) OR NOT (expression)
-                const queryString = `(${filter}) OR NOT (${filter})`;
-                const query = new Query({ source: queryString });
+        test.concurrent.each<string>(filters)('sub-query %j is recognized inside a boolean query', (filter) => {
+            // Arrange
+            // For every sub-query from the filters list above, compose a boolean query that is always
+            // true, in the format (expression) OR NOT (expression)
+            const queryString = `(${filter}) OR NOT (${filter})`;
+            const query = new Query({ source: queryString });
 
-                const taskLine =
-                    '- [ ] this is a task due 📅 2021-09-12 #inside_tag ⏫ #some/tags_with_underscore';
-                const task = fromLine({
-                    line: taskLine,
-                });
+            const taskLine = '- [ ] this is a task due 📅 2021-09-12 #inside_tag ⏫ #some/tags_with_underscore';
+            const task = fromLine({
+                line: taskLine,
+            });
 
-                // Assert
-                expect(query.error).toBeUndefined();
-                expect(query.filters.length).toEqual(1);
-                expect(query.filters[0]).toBeDefined();
-                // If the boolean query and its sub-query are parsed correctly, the expression should always be true
-                expect(query.filters[0](task)).toBeTruthy();
-            },
-        );
+            // Assert
+            expect(query.error).toBeUndefined();
+            expect(query.filters.length).toEqual(1);
+            expect(query.filters[0]).toBeDefined();
+            // If the boolean query and its sub-query are parsed correctly, the expression should always be true
+            expect(query.filters[0](task)).toBeTruthy();
+        });
     });
 
     describe('should recognise every sort instruction', () => {
@@ -407,17 +403,12 @@ describe('Query', () => {
                         '- [ ] I am done before filter, and should pass ✅ 2022-12-01',
                         '- [ ] I have no done date, so should fail',
                     ],
-                    expectedResult: [
-                        '- [ ] I am done before filter, and should pass ✅ 2022-12-01',
-                    ],
+                    expectedResult: ['- [ ] I am done before filter, and should pass ✅ 2022-12-01'],
                 },
             ],
-        ])(
-            'should support filtering %s',
-            (_, { tasks: allTaskLines, filters, expectedResult }) => {
-                shouldSupportFiltering(filters, allTaskLines, expectedResult);
-            },
-        );
+        ])('should support filtering %s', (_, { tasks: allTaskLines, filters, expectedResult }) => {
+            shouldSupportFiltering(filters, allTaskLines, expectedResult);
+        });
     });
 
     describe('filtering with "happens"', () => {
@@ -476,22 +467,19 @@ describe('Query', () => {
             // ----------------------------------------------------------------
             // 'before'
             {
-                description:
-                    'before: should match if a date is before specified date',
+                description: 'before: should match if a date is before specified date',
                 happensFilter: 'happens before 2012-03-04',
                 start: '2012-03-02',
                 taskShouldMatch: true,
             },
             {
-                description:
-                    'before: should not match if a date is on specified date',
+                description: 'before: should not match if a date is on specified date',
                 happensFilter: 'happens before 2012-03-04',
                 start: '2012-03-04',
                 taskShouldMatch: false,
             },
             {
-                description:
-                    'before: should not match if a date is after specified date',
+                description: 'before: should not match if a date is after specified date',
                 happensFilter: 'happens before 2012-03-04',
                 start: '2012-03-05',
                 taskShouldMatch: false,
@@ -500,22 +488,19 @@ describe('Query', () => {
             // ----------------------------------------------------------------
             // 'after'
             {
-                description:
-                    'after: should match if a date is after specified date',
+                description: 'after: should match if a date is after specified date',
                 happensFilter: 'happens after 2012-03-04',
                 start: '2012-03-05',
                 taskShouldMatch: true,
             },
             {
-                description:
-                    'after: should not match if a date is on specified date',
+                description: 'after: should not match if a date is on specified date',
                 happensFilter: 'happens after 2012-03-04',
                 start: '2012-03-04',
                 taskShouldMatch: false,
             },
             {
-                description:
-                    'after: should not match if a date is before specified date',
+                description: 'after: should not match if a date is before specified date',
                 happensFilter: 'happens after 2012-03-04',
                 start: '2012-03-03',
                 taskShouldMatch: false,
@@ -524,8 +509,7 @@ describe('Query', () => {
             // ----------------------------------------------------------------
             // multiple date values
             {
-                description:
-                    'multiple dates in task: should match if any date matches',
+                description: 'multiple dates in task: should match if any date matches',
                 happensFilter: 'happens on 2012-03-04',
                 due: '2012-03-04',
                 scheduled: '2012-03-05',
@@ -536,14 +520,7 @@ describe('Query', () => {
 
         test.concurrent.each<HappensCase>(HappensCases)(
             'filters via "happens" correctly (%j)',
-            ({
-                happensFilter,
-                due,
-                scheduled,
-                start,
-                done,
-                taskShouldMatch,
-            }) => {
+            ({ happensFilter, due, scheduled, start, done, taskShouldMatch }) => {
                 // Arrange
                 const line = [
                     '- [ ] this is a task',
@@ -571,9 +548,7 @@ describe('Query', () => {
             [
                 'simple OR',
                 {
-                    filters: [
-                        '"has due date" OR (description includes special)',
-                    ],
+                    filters: ['"has due date" OR (description includes special)'],
                     tasks: [
                         '- [ ] task 1',
                         '- [ ] task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
@@ -590,26 +565,20 @@ describe('Query', () => {
             [
                 'simple AND',
                 {
-                    filters: [
-                        '(has start date) AND "description includes some"',
-                    ],
+                    filters: ['(has start date) AND "description includes some"'],
                     tasks: [
                         '- [ ] task 1',
                         '- [ ] some task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
                         '- [ ] any task 3 🛫 2022-04-20',
                         '- [ ] special task 4',
                     ],
-                    expectedResult: [
-                        '- [ ] some task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
-                    ],
+                    expectedResult: ['- [ ] some task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20'],
                 },
             ],
             [
                 'simple AND NOT',
                 {
-                    filters: [
-                        '(has start date) AND NOT (description includes some)',
-                    ],
+                    filters: ['(has start date) AND NOT (description includes some)'],
                     tasks: [
                         '- [ ] task 1',
                         '- [ ] some task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
@@ -622,9 +591,7 @@ describe('Query', () => {
             [
                 'simple OR NOT',
                 {
-                    filters: [
-                        '(has start date) OR NOT (description includes special)',
-                    ],
+                    filters: ['(has start date) OR NOT (description includes special)'],
                     tasks: [
                         '- [ ] task 1',
                         '- [ ] some task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
@@ -641,19 +608,14 @@ describe('Query', () => {
             [
                 'simple XOR',
                 {
-                    filters: [
-                        '(has start date) XOR (description includes special)',
-                    ],
+                    filters: ['(has start date) XOR (description includes special)'],
                     tasks: [
                         '- [ ] task 1',
                         '- [ ] special task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
                         '- [ ] any task 3 🛫 2022-04-20',
                         '- [ ] special task 4',
                     ],
-                    expectedResult: [
-                        '- [ ] any task 3 🛫 2022-04-20',
-                        '- [ ] special task 4',
-                    ],
+                    expectedResult: ['- [ ] any task 3 🛫 2022-04-20', '- [ ] special task 4'],
                 },
             ],
             [
@@ -672,9 +634,7 @@ describe('Query', () => {
             [
                 'AND-first composition',
                 {
-                    filters: [
-                        '(has start date) AND ((description includes some) OR (has due date))',
-                    ],
+                    filters: ['(has start date) AND ((description includes some) OR (has due date))'],
                     tasks: [
                         '- [ ] task 1',
                         '- [ ] some task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
@@ -691,9 +651,7 @@ describe('Query', () => {
             [
                 'OR-first composition',
                 {
-                    filters: [
-                        '(has start date) OR ((description includes special) AND (has due date))',
-                    ],
+                    filters: ['(has start date) OR ((description includes special) AND (has due date))'],
                     tasks: [
                         '- [ ] special task 1',
                         '- [ ] some task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
@@ -712,9 +670,7 @@ describe('Query', () => {
             [
                 'NOT-first composition',
                 {
-                    filters: [
-                        'NOT ((has start date) OR (description includes special))',
-                    ],
+                    filters: ['NOT ((has start date) OR (description includes special))'],
                     tasks: [
                         '- [ ] regular task 1',
                         '- [ ] some task 2 🛫 2022-04-20 ⏳ 2022-04-20 📅 2022-04-20',
@@ -725,12 +681,9 @@ describe('Query', () => {
                     expectedResult: ['- [ ] regular task 1'],
                 },
             ],
-        ])(
-            'should support boolean filtering %s',
-            (_, { tasks: allTaskLines, filters, expectedResult }) => {
-                shouldSupportFiltering(filters, allTaskLines, expectedResult);
-            },
-        );
+        ])('should support boolean filtering %s', (_, { tasks: allTaskLines, filters, expectedResult }) => {
+            shouldSupportFiltering(filters, allTaskLines, expectedResult);
+        });
     });
 
     describe('sorting instructions', () => {
@@ -765,15 +718,11 @@ describe('Query', () => {
             },
             {
                 input: 'sort by tag',
-                output: [
-                    { property: 'tag', reverse: false, propertyInstance: 1 },
-                ],
+                output: [{ property: 'tag', reverse: false, propertyInstance: 1 }],
             },
             {
                 input: 'sort by tag 2',
-                output: [
-                    { property: 'tag', reverse: false, propertyInstance: 2 },
-                ],
+                output: [{ property: 'tag', reverse: false, propertyInstance: 2 }],
             },
         ];
         it.concurrent.each(cases)('sorting as %j', ({ input, output }) => {
@@ -849,11 +798,7 @@ describe('Query', () => {
 - [ ] Task 6 - should not appear in output
             `;
 
-            const tasks = createTasksFromMarkdown(
-                tasksAsMarkdown,
-                'some_markdown_file',
-                'Some Heading',
-            );
+            const tasks = createTasksFromMarkdown(tasksAsMarkdown, 'some_markdown_file', 'Some Heading');
 
             // Act
             const groups = query.applyQueryToTasks(tasks);
@@ -865,9 +810,7 @@ describe('Query', () => {
 - [ ] Task 3 - will be sorted to 1st place, so should pass limit
 - [ ] Task 4 - will be sorted to 2nd place, so should pass limit
 `;
-            expect('\n' + soleTaskGroup.tasksAsStringOfLines()).toStrictEqual(
-                expectedTasks,
-            );
+            expect('\n' + soleTaskGroup.tasksAsStringOfLines()).toStrictEqual(expectedTasks);
         });
     });
 });

--- a/tests/Query/Filter/BooleanField.test.ts
+++ b/tests/Query/Filter/BooleanField.test.ts
@@ -9,11 +9,7 @@ import { testFilter } from '../../TestingTools/FilterTestHelpers';
 
 window.moment = moment;
 
-function testWithDescription(
-    filter: FilterOrErrorMessage,
-    description: string,
-    expected: boolean,
-) {
+function testWithDescription(filter: FilterOrErrorMessage, description: string, expected: boolean) {
     const builder = new TaskBuilder();
     testFilter(filter, builder.description(description), expected);
 }
@@ -62,9 +58,7 @@ describe('boolean query', () => {
 
         it('NOT', () => {
             // Arrange
-            const filter = new BooleanField().createFilterOrErrorMessage(
-                'NOT (description includes d1)',
-            );
+            const filter = new BooleanField().createFilterOrErrorMessage('NOT (description includes d1)');
 
             // Act, Assert
             testWithDescription(filter, 'nothing', true);
@@ -117,36 +111,26 @@ describe('boolean query', () => {
         });
 
         it('Invalid AND', () => {
-            const filter = new BooleanField().createFilterOrErrorMessage(
-                'AND (description includes d1)',
-            );
+            const filter = new BooleanField().createFilterOrErrorMessage('AND (description includes d1)');
             expect(filter.error).toStrictEqual(
                 'malformed boolean query -- Invalid token (check the documentation for guidelines)',
             );
         });
 
         it('Invalid OR', () => {
-            const filter = new BooleanField().createFilterOrErrorMessage(
-                'OR (description includes d1)',
-            );
+            const filter = new BooleanField().createFilterOrErrorMessage('OR (description includes d1)');
             expect(filter.error).toStrictEqual(
                 'malformed boolean query -- Invalid token (check the documentation for guidelines)',
             );
         });
 
         it('Invalid sub-expression', () => {
-            const filter = new BooleanField().createFilterOrErrorMessage(
-                'NOT (description blahblah d1)',
-            );
-            expect(filter.error).toStrictEqual(
-                "couldn't parse sub-expression 'description blahblah d1'",
-            );
+            const filter = new BooleanField().createFilterOrErrorMessage('NOT (description blahblah d1)');
+            expect(filter.error).toStrictEqual("couldn't parse sub-expression 'description blahblah d1'");
         });
 
         it('Invalid sub-expression - gives error', () => {
-            const filter = new BooleanField().createFilterOrErrorMessage(
-                'NOT (happens before blahblahblah)',
-            );
+            const filter = new BooleanField().createFilterOrErrorMessage('NOT (happens before blahblahblah)');
             expect(filter.error).toStrictEqual(
                 "couldn't parse sub-expression 'happens before blahblahblah': do not understand happens date",
             );

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -12,11 +12,7 @@ import { toMatchTaskFromLine } from '../../CustomMatchers/CustomMatchersForFilte
 
 window.moment = moment;
 
-function testDescriptionFilter(
-    filter: FilterOrErrorMessage,
-    line: string,
-    expected: boolean,
-) {
+function testDescriptionFilter(filter: FilterOrErrorMessage, line: string, expected: boolean) {
     const task = fromLine({
         line,
     });
@@ -40,9 +36,7 @@ describe('description should strip signifiers, some duplicate spaces and trailin
         // Multiple spaces in middle of tags and signifiers are removed.
         // Signifiers are removed (priority, due date etc)
         // Trailing spaces are removed.
-        expect(field.value(task)).toStrictEqual(
-            'Initial  description #tag1 #tag2/sub-tag',
-        );
+        expect(field.value(task)).toStrictEqual('Initial  description #tag1 #tag2/sub-tag');
     });
 
     it('with tag as global filter - all tags included', () => {
@@ -55,9 +49,7 @@ describe('description should strip signifiers, some duplicate spaces and trailin
 
         // Act, Assert
         // Global filter tag is removed:
-        expect(field.value(task)).toStrictEqual(
-            'Initial  description #tag1 #tag2/sub-tag',
-        );
+        expect(field.value(task)).toStrictEqual('Initial  description #tag1 #tag2/sub-tag');
 
         // Cleanup
         resetSettings();
@@ -73,9 +65,7 @@ describe('description should strip signifiers, some duplicate spaces and trailin
 
         // Act, Assert
         // Global filter tag is removed:
-        expect(field.value(task)).toStrictEqual(
-            'Initial  description #tag1 #tag2/sub-tag',
-        );
+        expect(field.value(task)).toStrictEqual('Initial  description #tag1 #tag2/sub-tag');
 
         // Cleanup
         resetSettings();
@@ -86,9 +76,7 @@ describe('description', () => {
     it('ignores the global filter when filtering', () => {
         // Arrange
         updateSettings({ globalFilter: '#task' });
-        const filter = new DescriptionField().createFilterOrErrorMessage(
-            'description includes task',
-        );
+        const filter = new DescriptionField().createFilterOrErrorMessage('description includes task');
 
         // Act, Assert
         testDescriptionFilter(
@@ -106,22 +94,12 @@ describe('description', () => {
     it('works without a global filter', () => {
         // Arrange
         updateSettings({ globalFilter: '' });
-        const filter = new DescriptionField().createFilterOrErrorMessage(
-            'description includes task',
-        );
+        const filter = new DescriptionField().createFilterOrErrorMessage('description includes task');
 
         // Act, Assert
-        testDescriptionFilter(
-            filter,
-            '- [ ] this does not include the word at all',
-            false,
-        );
+        testDescriptionFilter(filter, '- [ ] this does not include the word at all', false);
 
-        testDescriptionFilter(
-            filter,
-            '- [ ] #task this includes the word as a tag',
-            true,
-        );
+        testDescriptionFilter(filter, '- [ ] #task this includes the word as a tag', true);
 
         testDescriptionFilter(filter, '- [ ] #task this does: task', true);
 
@@ -131,32 +109,20 @@ describe('description', () => {
 
     it('works with regex', () => {
         // Arrange
-        const filter = new DescriptionField().createFilterOrErrorMessage(
-            'description regex matches /^task/',
-        );
+        const filter = new DescriptionField().createFilterOrErrorMessage('description regex matches /^task/');
 
         // Assert
-        expect(filter).not.toMatchTaskFromLine(
-            '- [ ] this does not start with the pattern',
-        );
-        expect(filter).toMatchTaskFromLine(
-            '- [ ] task does start with the pattern',
-        );
+        expect(filter).not.toMatchTaskFromLine('- [ ] this does not start with the pattern');
+        expect(filter).toMatchTaskFromLine('- [ ] task does start with the pattern');
     });
 
     it('works negating regexes', () => {
         // Arrange
-        const filter = new DescriptionField().createFilterOrErrorMessage(
-            'description regex does not match /^task/',
-        );
+        const filter = new DescriptionField().createFilterOrErrorMessage('description regex does not match /^task/');
 
         // Assert
-        expect(filter).toMatchTaskFromLine(
-            '- [ ] this does not start with the pattern',
-        );
-        expect(filter).not.toMatchTaskFromLine(
-            '- [ ] task does start with the pattern',
-        );
+        expect(filter).toMatchTaskFromLine('- [ ] this does not start with the pattern');
+        expect(filter).not.toMatchTaskFromLine('- [ ] task does start with the pattern');
     });
 });
 
@@ -197,9 +163,7 @@ describe('search description for short tags, excluding sub-tags', () => {
         // text at the end of lines.
         // However, task descriptions do not have end-of-line characters,
         // so it does not match a tag at the end of the line.
-        const filter = new DescriptionField().createFilterOrErrorMessage(
-            String.raw`description regex matches /#t\s/i`,
-        );
+        const filter = new DescriptionField().createFilterOrErrorMessage(String.raw`description regex matches /#t\s/i`);
 
         // Assert
         expect(filter).toMatchTaskFromLine('- [ ] #t Do stuff');
@@ -218,9 +182,7 @@ describe('search description for short tags, excluding sub-tags', () => {
         // Arrange
         // $ is an end-of-input character.
         // So this search will find the given tag at the end of any task description
-        const filter = new DescriptionField().createFilterOrErrorMessage(
-            'description regex matches /#t$/i',
-        );
+        const filter = new DescriptionField().createFilterOrErrorMessage('description regex matches /#t$/i');
 
         // Assert
         expect(filter).toMatchTaskFromLine('- [ ] Do stuff #t');
@@ -260,9 +222,7 @@ describe('search description for sub-tags', () => {
         );
 
         // Assert
-        expect(filter).toMatchTaskFromLine(
-            '- [ ] Do stuff #tag/subtag3/subsubtag5',
-        );
+        expect(filter).toMatchTaskFromLine('- [ ] Do stuff #tag/subtag3/subsubtag5');
         expect(filter).not.toMatchTaskFromLine('- [ ] Do stuff #tag');
     });
 });

--- a/tests/Query/Filter/DoneDateField.test.ts
+++ b/tests/Query/Filter/DoneDateField.test.ts
@@ -9,11 +9,7 @@ import { testFilter } from '../../TestingTools/FilterTestHelpers';
 
 window.moment = moment;
 
-function testTaskFilterForTaskWithDoneDate(
-    filter: FilterOrErrorMessage,
-    doneDate: string | null,
-    expected: boolean,
-) {
+function testTaskFilterForTaskWithDoneDate(filter: FilterOrErrorMessage, doneDate: string | null, expected: boolean) {
     const builder = new TaskBuilder();
     testFilter(filter, builder.doneDate(doneDate), expected);
 }
@@ -21,9 +17,7 @@ function testTaskFilterForTaskWithDoneDate(
 describe('done date', () => {
     it('by done date presence', () => {
         // Arrange
-        const filter = new DoneDateField().createFilterOrErrorMessage(
-            'has done date',
-        );
+        const filter = new DoneDateField().createFilterOrErrorMessage('has done date');
 
         // Act, Assert
         testTaskFilterForTaskWithDoneDate(filter, null, false);
@@ -32,9 +26,7 @@ describe('done date', () => {
 
     it('by done date absence', () => {
         // Arrange
-        const filter = new DoneDateField().createFilterOrErrorMessage(
-            'no done date',
-        );
+        const filter = new DoneDateField().createFilterOrErrorMessage('no done date');
 
         // Act, Assert
         testTaskFilterForTaskWithDoneDate(filter, null, true);

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -9,11 +9,7 @@ import { testFilter } from '../../TestingTools/FilterTestHelpers';
 
 window.moment = moment;
 
-function testTaskFilterForTaskWithDueDate(
-    filter: FilterOrErrorMessage,
-    dueDate: string | null,
-    expected: boolean,
-) {
+function testTaskFilterForTaskWithDueDate(filter: FilterOrErrorMessage, dueDate: string | null, expected: boolean) {
     const builder = new TaskBuilder();
     testFilter(filter, builder.dueDate(dueDate), expected);
 }
@@ -21,9 +17,7 @@ function testTaskFilterForTaskWithDueDate(
 describe('due date', () => {
     it('by due date (before)', () => {
         // Arrange
-        const filter = new DueDateField().createFilterOrErrorMessage(
-            'due before 2022-04-20',
-        );
+        const filter = new DueDateField().createFilterOrErrorMessage('due before 2022-04-20');
 
         // Act, Assert
         testTaskFilterForTaskWithDueDate(filter, null, false);

--- a/tests/Query/Filter/ExcludeSubItemsField.test.ts
+++ b/tests/Query/Filter/ExcludeSubItemsField.test.ts
@@ -5,9 +5,7 @@ import { ExcludeSubItemsField } from '../../../src/Query/Filter/ExcludeSubItemsF
 describe('sub-items', () => {
     it('exclude sub-items', () => {
         // Arrange
-        const filter = new ExcludeSubItemsField().createFilterOrErrorMessage(
-            'exclude sub-items',
-        );
+        const filter = new ExcludeSubItemsField().createFilterOrErrorMessage('exclude sub-items');
 
         // Assert
         testTaskFilter(filter, fromLine({ line: '- [ ] Task' }), true);
@@ -16,18 +14,12 @@ describe('sub-items', () => {
     });
     it('subitem has more than one space after last > of blockquotes or callouts', () => {
         // Arrange
-        const filter = new ExcludeSubItemsField().createFilterOrErrorMessage(
-            'exclude sub-items',
-        );
+        const filter = new ExcludeSubItemsField().createFilterOrErrorMessage('exclude sub-items');
 
         // Assert
         testTaskFilter(filter, fromLine({ line: '> - [ ] Task' }), true);
         testTaskFilter(filter, fromLine({ line: '> > - [ ] Task' }), true);
         testTaskFilter(filter, fromLine({ line: '>>  - [ ] Subtask1' }), false);
-        testTaskFilter(
-            filter,
-            fromLine({ line: '> >  - [ ] Subtask2' }),
-            false,
-        );
+        testTaskFilter(filter, fromLine({ line: '> >  - [ ] Subtask2' }), false);
     });
 });

--- a/tests/Query/Filter/FilenameField.test.ts
+++ b/tests/Query/Filter/FilenameField.test.ts
@@ -1,9 +1,6 @@
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { FilenameField } from '../../../src/Query/Filter/FilenameField';
-import {
-    toBeValid,
-    toMatchTaskWithPath,
-} from '../../CustomMatchers/CustomMatchersForFilters';
+import { toBeValid, toMatchTaskWithPath } from '../../CustomMatchers/CustomMatchersForFilters';
 
 expect.extend({
     toMatchTaskWithPath,
@@ -21,15 +18,11 @@ describe('filename', () => {
 
         expect(pathField.value(builder.path('').build())).toStrictEqual('');
 
-        expect(
-            pathField.value(builder.path('file in root.md').build()),
-        ).toStrictEqual('file in root.md');
+        expect(pathField.value(builder.path('file in root.md').build())).toStrictEqual('file in root.md');
 
-        expect(
-            pathField.value(
-                builder.path('directory name/file in sub-directory.md').build(),
-            ),
-        ).toStrictEqual('file in sub-directory.md');
+        expect(pathField.value(builder.path('directory name/file in sub-directory.md').build())).toStrictEqual(
+            'file in sub-directory.md',
+        );
     });
 });
 
@@ -40,9 +33,7 @@ describe('filename', () => {
 
     it('by filename (includes)', () => {
         // Arrange
-        const filter = new FilenameField().createFilterOrErrorMessage(
-            'filename includes search_text',
-        );
+        const filter = new FilenameField().createFilterOrErrorMessage('filename includes search_text');
 
         // Assert
         expect(filter).toBeValid();
@@ -53,9 +44,7 @@ describe('filename', () => {
 
     it('by filename (does not include)', () => {
         // Arrange
-        const filter = new FilenameField().createFilterOrErrorMessage(
-            'filename does not include search_text',
-        );
+        const filter = new FilenameField().createFilterOrErrorMessage('filename does not include search_text');
 
         // Assert
         expect(filter).toBeValid();
@@ -66,9 +55,7 @@ describe('filename', () => {
 
     it('by filename (regex matches)', () => {
         // Arrange
-        const filter = new FilenameField().createFilterOrErrorMessage(
-            String.raw`filename regex matches /w.bble/`,
-        );
+        const filter = new FilenameField().createFilterOrErrorMessage(String.raw`filename regex matches /w.bble/`);
 
         // Assert
         expect(filter).toBeValid();

--- a/tests/Query/Filter/HappensDateField.test.ts
+++ b/tests/Query/Filter/HappensDateField.test.ts
@@ -11,9 +11,7 @@ window.moment = moment;
 describe('happens date', () => {
     it('by happens date presence', () => {
         // Arrange
-        const filter = new HappensDateField().createFilterOrErrorMessage(
-            'has happens date',
-        );
+        const filter = new HappensDateField().createFilterOrErrorMessage('has happens date');
 
         // Act, Assert
         testFilter(filter, new TaskBuilder().dueDate(null), false);
@@ -29,19 +27,13 @@ describe('happens date', () => {
 
     it('by happens date absence', () => {
         // Arrange
-        const filter = new HappensDateField().createFilterOrErrorMessage(
-            'no happens date',
-        );
+        const filter = new HappensDateField().createFilterOrErrorMessage('no happens date');
 
         // Act, Assert
         testFilter(filter, new TaskBuilder().dueDate(null), true);
 
         // scheduled, start and due all contribute to happens:
-        testFilter(
-            filter,
-            new TaskBuilder().scheduledDate('2022-04-15'),
-            false,
-        );
+        testFilter(filter, new TaskBuilder().scheduledDate('2022-04-15'), false);
         testFilter(filter, new TaskBuilder().startDate('2022-04-15'), false);
         testFilter(filter, new TaskBuilder().dueDate('2022-04-15'), false);
 
@@ -52,18 +44,11 @@ describe('happens date', () => {
 
 describe('accessing earliest happens date', () => {
     it('should return null if no dates set', () => {
-        expect(
-            new HappensDateField().earliestDate(new TaskBuilder().build()),
-        ).toBeNull();
+        expect(new HappensDateField().earliestDate(new TaskBuilder().build())).toBeNull();
     });
 
-    function checkEarliestHappensDate(
-        taskBuilder: TaskBuilder,
-        expectedEarliestHappensDate: string,
-    ) {
-        const earliest = new HappensDateField().earliestDate(
-            taskBuilder.build(),
-        );
+    function checkEarliestHappensDate(taskBuilder: TaskBuilder, expectedEarliestHappensDate: string) {
+        const earliest = new HappensDateField().earliestDate(taskBuilder.build());
         expect({
             earliest: earliest?.format('YYYY-MM-DD'),
         }).toMatchObject({
@@ -72,32 +57,20 @@ describe('accessing earliest happens date', () => {
     }
 
     it('should return due if only date set', () => {
-        checkEarliestHappensDate(
-            new TaskBuilder().dueDate('1989-12-17'),
-            '1989-12-17',
-        );
+        checkEarliestHappensDate(new TaskBuilder().dueDate('1989-12-17'), '1989-12-17');
     });
 
     it('should return start if only date set', () => {
-        checkEarliestHappensDate(
-            new TaskBuilder().startDate('1989-12-17'),
-            '1989-12-17',
-        );
+        checkEarliestHappensDate(new TaskBuilder().startDate('1989-12-17'), '1989-12-17');
     });
 
     it('should return scheduled if only date set', () => {
-        checkEarliestHappensDate(
-            new TaskBuilder().scheduledDate('1989-12-17'),
-            '1989-12-17',
-        );
+        checkEarliestHappensDate(new TaskBuilder().scheduledDate('1989-12-17'), '1989-12-17');
     });
 
     it('should return earliest if all dates set', () => {
         checkEarliestHappensDate(
-            new TaskBuilder()
-                .dueDate('1989-12-17')
-                .startDate('1999-12-17')
-                .scheduledDate('2009-12-17'),
+            new TaskBuilder().dueDate('1989-12-17').startDate('1999-12-17').scheduledDate('2009-12-17'),
             '1989-12-17',
         );
     });

--- a/tests/Query/Filter/HeadingField.test.ts
+++ b/tests/Query/Filter/HeadingField.test.ts
@@ -2,16 +2,9 @@ import { HeadingField } from '../../../src/Query/Filter/HeadingField';
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { testFilter } from '../../TestingTools/FilterTestHelpers';
-import {
-    toBeValid,
-    toMatchTaskWithHeading,
-} from '../../CustomMatchers/CustomMatchersForFilters';
+import { toBeValid, toMatchTaskWithHeading } from '../../CustomMatchers/CustomMatchersForFilters';
 
-function testTaskFilterForHeading(
-    filter: FilterOrErrorMessage,
-    precedingHeader: string | null,
-    expected: boolean,
-) {
+function testTaskFilterForHeading(filter: FilterOrErrorMessage, precedingHeader: string | null, expected: boolean) {
     const builder = new TaskBuilder();
     testFilter(filter, builder.precedingHeader(precedingHeader), expected);
 }
@@ -27,9 +20,7 @@ expect.extend({
 describe('heading', () => {
     it('by heading (includes)', () => {
         // Arrange
-        const filter = new HeadingField().createFilterOrErrorMessage(
-            'heading includes Interesting Heading',
-        );
+        const filter = new HeadingField().createFilterOrErrorMessage('heading includes Interesting Heading');
 
         // Act, Assert
         testTaskFilterForHeading(filter, null, false);
@@ -39,9 +30,7 @@ describe('heading', () => {
 
     it('by heading (does not include)', () => {
         // Arrange
-        const filter = new HeadingField().createFilterOrErrorMessage(
-            'heading does not include Interesting Heading',
-        );
+        const filter = new HeadingField().createFilterOrErrorMessage('heading does not include Interesting Heading');
 
         // Act, Assert
         testTaskFilterForHeading(filter, null, true);

--- a/tests/Query/Filter/PathField.test.ts
+++ b/tests/Query/Filter/PathField.test.ts
@@ -2,16 +2,9 @@ import { PathField } from '../../../src/Query/Filter/PathField';
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { testFilter } from '../../TestingTools/FilterTestHelpers';
-import {
-    toBeValid,
-    toMatchTaskWithPath,
-} from '../../CustomMatchers/CustomMatchersForFilters';
+import { toBeValid, toMatchTaskWithPath } from '../../CustomMatchers/CustomMatchersForFilters';
 
-function testTaskFilterForTaskWithPath(
-    filter: FilterOrErrorMessage,
-    path: string,
-    expected: boolean,
-) {
+function testTaskFilterForTaskWithPath(filter: FilterOrErrorMessage, path: string, expected: boolean) {
     const builder = new TaskBuilder();
     testFilter(filter, builder.path(path), expected);
 }
@@ -27,9 +20,7 @@ expect.extend({
 describe('path', () => {
     it('by path (includes)', () => {
         // Arrange
-        const filter = new PathField().createFilterOrErrorMessage(
-            'path includes some/path',
-        );
+        const filter = new PathField().createFilterOrErrorMessage('path includes some/path');
 
         // Assert
         testTaskFilterForTaskWithPath(filter, '', false);
@@ -40,9 +31,7 @@ describe('path', () => {
 
     it('by path (does not include)', () => {
         // Arrange
-        const filter = new PathField().createFilterOrErrorMessage(
-            'path does not include some/path',
-        );
+        const filter = new PathField().createFilterOrErrorMessage('path does not include some/path');
 
         // Assert
         testTaskFilterForTaskWithPath(filter, '', true);
@@ -52,9 +41,7 @@ describe('path', () => {
 
     it('by path (regex matches)', () => {
         // Arrange
-        const filter = new PathField().createFilterOrErrorMessage(
-            String.raw`path regex matches /w.bble/`,
-        );
+        const filter = new PathField().createFilterOrErrorMessage(String.raw`path regex matches /w.bble/`);
 
         // Assert
         expect(filter).toBeValid();
@@ -67,9 +54,7 @@ describe('path', () => {
 
     it('by path (regex matches) with flags', () => {
         // Arrange
-        const filter = new PathField().createFilterOrErrorMessage(
-            String.raw`path regex matches /w.bble/i`,
-        );
+        const filter = new PathField().createFilterOrErrorMessage(String.raw`path regex matches /w.bble/i`);
 
         // Assert
         expect(filter).toBeValid();
@@ -82,9 +67,7 @@ describe('path', () => {
 
     it('by path (regex does not match)', () => {
         // Arrange
-        const filter = new PathField().createFilterOrErrorMessage(
-            String.raw`path regex does not match /w.bble/`,
-        );
+        const filter = new PathField().createFilterOrErrorMessage(String.raw`path regex does not match /w.bble/`);
 
         // Assert
         expect(filter).toBeValid();
@@ -97,10 +80,9 @@ describe('path', () => {
 });
 
 describe('invalid unescaped slash should give helpful error text and not search', () => {
-    const filterWithUnescapedSlashes =
-        new PathField().createFilterOrErrorMessage(
-            String.raw`path regex matches /a/b/c/d/`,
-        );
+    const filterWithUnescapedSlashes = new PathField().createFilterOrErrorMessage(
+        String.raw`path regex matches /a/b/c/d/`,
+    );
 
     // This test demonstrates the issue logged in
     // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1037

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -3,15 +3,9 @@ import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { testFilter } from '../../TestingTools/FilterTestHelpers';
 import { PriorityField } from '../../../src/Query/Filter/PriorityField';
 
-function testTaskFilterForTaskWithPriority(
-    filter: string,
-    priority: Priority,
-    expected: boolean,
-) {
+function testTaskFilterForTaskWithPriority(filter: string, priority: Priority, expected: boolean) {
     const builder = new TaskBuilder();
-    const filterOrError = new PriorityField().createFilterOrErrorMessage(
-        filter,
-    );
+    const filterOrError = new PriorityField().createFilterOrErrorMessage(filter);
     testFilter(filterOrError, builder.priority(priority), expected);
 }
 
@@ -70,9 +64,7 @@ describe('priority below', () => {
 describe('priority error cases', () => {
     it('priority is something', () => {
         const field = new PriorityField();
-        const filter = field.createFilterOrErrorMessage(
-            'priority is no-such-priority',
-        );
+        const filter = field.createFilterOrErrorMessage('priority is no-such-priority');
         expect(filter.filter).toBeUndefined();
         expect(filter.error).toBe('do not understand query filter (priority)');
     });

--- a/tests/Query/Filter/RecurringField.test.ts
+++ b/tests/Query/Filter/RecurringField.test.ts
@@ -9,11 +9,7 @@ import { fromLine } from '../../TestHelpers';
 
 window.moment = moment;
 
-function testRecurringFilter(
-    filter: FilterOrErrorMessage,
-    line: string,
-    expected: boolean,
-) {
+function testRecurringFilter(filter: FilterOrErrorMessage, line: string, expected: boolean) {
     const task = fromLine({ line });
     testTaskFilter(filter, task, expected);
 }
@@ -26,9 +22,7 @@ describe('recurring', () => {
 
     it('is recurring', () => {
         // Arrange
-        const filter = new RecurringField().createFilterOrErrorMessage(
-            'is recurring',
-        );
+        const filter = new RecurringField().createFilterOrErrorMessage('is recurring');
 
         // Assert
         testRecurringFilter(filter, non_recurring, false);
@@ -38,9 +32,7 @@ describe('recurring', () => {
 
     it('is not recurring', () => {
         // Arrange
-        const filter = new RecurringField().createFilterOrErrorMessage(
-            'is not recurring',
-        );
+        const filter = new RecurringField().createFilterOrErrorMessage('is not recurring');
 
         // Assert
         testRecurringFilter(filter, non_recurring, true);

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -4,11 +4,7 @@ import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { testFilter } from '../../TestingTools/FilterTestHelpers';
 import { Status } from '../../../src/Task';
 
-function testStatusFilter(
-    filter: FilterOrErrorMessage,
-    status: Status,
-    expected: boolean,
-) {
+function testStatusFilter(filter: FilterOrErrorMessage, status: Status, expected: boolean) {
     const builder = new TaskBuilder();
     testFilter(filter, builder.status(status), expected);
 }

--- a/tests/Query/Filter/TagsField.test.ts
+++ b/tests/Query/Filter/TagsField.test.ts
@@ -10,17 +10,13 @@ expect.extend({
 
 describe('tag/tags', () => {
     it('should honour any # in query', () => {
-        const filter = new TagsField().createFilterOrErrorMessage(
-            'tags include #home',
-        );
+        const filter = new TagsField().createFilterOrErrorMessage('tags include #home');
         expect(filter).toMatchTaskFromLine('- [ ] stuff #home');
         expect(filter).not.toMatchTaskFromLine('- [ ] stuff #location/home');
     });
 
     it('should match any position if no # in query', () => {
-        const filter = new TagsField().createFilterOrErrorMessage(
-            'tags include home',
-        );
+        const filter = new TagsField().createFilterOrErrorMessage('tags include home');
         expect(filter).toMatchTaskFromLine('- [ ] stuff #home');
         expect(filter).toMatchTaskFromLine('- [ ] stuff #location/home');
     });
@@ -138,9 +134,7 @@ describe('tag/tags', () => {
                 {
                     filters: ['tags include TopLevelItem'],
                     tasks: defaultTasksWithTags,
-                    expectedResult: [
-                        '- [ ] #task something to do #later #work #TopLevelItem/sub',
-                    ],
+                    expectedResult: ['- [ ] #task something to do #later #work #TopLevelItem/sub'],
                 },
             ],
             [
@@ -213,11 +207,7 @@ describe('tag/tags', () => {
 
         it('should filter tags without globalFilter by tag presence when there is no global filter', () => {
             // Act, Assert
-            shouldSupportFiltering(
-                ['tags include task'],
-                defaultTasksWithTags,
-                defaultTasksWithTags,
-            );
+            shouldSupportFiltering(['tags include task'], defaultTasksWithTags, defaultTasksWithTags);
         });
 
         it('should ignore the tag which is the global filter', () => {

--- a/tests/Query/Matchers/SubstringMatcher.test.ts
+++ b/tests/Query/Matchers/SubstringMatcher.test.ts
@@ -10,11 +10,7 @@ describe('SubstringMatcher', () => {
 
     it('should match any values in array of text', () => {
         const matcher = new SubstringMatcher('find me');
-        expect(
-            matcher.matchesAnyOf(['wibble', 'stuff', 'FIND ME']),
-        ).toStrictEqual(true);
-        expect(
-            matcher.matchesAnyOf(['wibble', 'stuff', 'LOSE ME']),
-        ).not.toStrictEqual(true);
+        expect(matcher.matchesAnyOf(['wibble', 'stuff', 'FIND ME'])).toStrictEqual(true);
+        expect(matcher.matchesAnyOf(['wibble', 'stuff', 'LOSE ME'])).not.toStrictEqual(true);
     });
 });

--- a/tests/Query/Urgency.test.ts
+++ b/tests/Query/Urgency.test.ts
@@ -21,15 +21,9 @@ function testUrgency(builder: TaskBuilder, expectedScore: number) {
  * @param builder
  * @param expectedScore
  */
-function testUrgencyOnDate(
-    today: string,
-    builder: TaskBuilder,
-    expectedScore: number,
-) {
+function testUrgencyOnDate(today: string, builder: TaskBuilder, expectedScore: number) {
     // TODO Remove this duplication from Task.test.ts
-    const todaySpy = jest
-        .spyOn(Date, 'now')
-        .mockReturnValue(moment(today).valueOf());
+    const todaySpy = jest.spyOn(Date, 'now').mockReturnValue(moment(today).valueOf());
 
     testUrgency(builder, expectedScore);
 
@@ -66,11 +60,7 @@ function testUrgencyForDueDate(daysToDate: number, expectedScore: number) {
     const today = '2022-10-31';
     const dueAsString = calculateRelativeDate(today, daysToDate);
 
-    testUrgencyOnDate(
-        today,
-        lowPriorityBuilder().dueDate(dueAsString),
-        expectedScore,
-    );
+    testUrgencyOnDate(today, lowPriorityBuilder().dueDate(dueAsString), expectedScore);
 }
 
 describe('urgency - due date component', () => {
@@ -103,18 +93,11 @@ describe('urgency - due date component', () => {
 // -----------------------------------------------------------------
 // Scheduled Date tests
 
-function testUrgencyForScheduledDate(
-    daysToDate: number,
-    expectedScore: number,
-) {
+function testUrgencyForScheduledDate(daysToDate: number, expectedScore: number) {
     const today = '2029-12-31';
     const scheduledAsString = calculateRelativeDate(today, daysToDate);
 
-    testUrgencyOnDate(
-        today,
-        lowPriorityBuilder().scheduledDate(scheduledAsString),
-        expectedScore,
-    );
+    testUrgencyOnDate(today, lowPriorityBuilder().scheduledDate(scheduledAsString), expectedScore);
 }
 
 describe('urgency - scheduled date component', () => {
@@ -142,11 +125,7 @@ function testUrgencyForStartDate(daysToDate: number, expectedScore: number) {
     const today = '1997-03-27';
     const startAsString = calculateRelativeDate(today, daysToDate);
 
-    testUrgencyOnDate(
-        today,
-        lowPriorityBuilder().startDate(startAsString),
-        expectedScore,
-    );
+    testUrgencyOnDate(today, lowPriorityBuilder().startDate(startAsString), expectedScore);
 }
 
 describe('urgency - start date component', () => {

--- a/tests/Recurrence.test.ts
+++ b/tests/Recurrence.test.ts
@@ -39,21 +39,15 @@ describe('identicalTo', () => {
 
     it('differing only in "when done"', () => {
         const weekly = new RecurrenceBuilder().rule('every week').build();
-        const weeklyWhenDone = new RecurrenceBuilder()
-            .rule('every week when done')
-            .build();
+        const weeklyWhenDone = new RecurrenceBuilder().rule('every week when done').build();
         expect(weekly?.identicalTo(weeklyWhenDone)).toBe(false);
     });
 
     it('differing only in startDate', () => {
         // Two different dates
-        const date1Recurrence = new RecurrenceBuilder()
-            .startDate('2021-10-21')
-            .build();
+        const date1Recurrence = new RecurrenceBuilder().startDate('2021-10-21').build();
 
-        const date2Recurrence = new RecurrenceBuilder()
-            .startDate('1998-03-13')
-            .build();
+        const date2Recurrence = new RecurrenceBuilder().startDate('1998-03-13').build();
 
         const nullRecurrence = new RecurrenceBuilder().startDate(null).build();
 
@@ -66,13 +60,9 @@ describe('identicalTo', () => {
     it('differing only in scheduledDate', () => {
         // Two different dates
         // No need to replicate the null checks in startDate
-        const date1Recurrence = new RecurrenceBuilder()
-            .scheduledDate('2021-10-21')
-            .build();
+        const date1Recurrence = new RecurrenceBuilder().scheduledDate('2021-10-21').build();
 
-        const date2Recurrence = new RecurrenceBuilder()
-            .scheduledDate('1998-03-13')
-            .build();
+        const date2Recurrence = new RecurrenceBuilder().scheduledDate('1998-03-13').build();
 
         expect(date1Recurrence?.identicalTo(date1Recurrence)).toBe(true);
         expect(date1Recurrence?.identicalTo(date2Recurrence)).toBe(false);
@@ -81,13 +71,9 @@ describe('identicalTo', () => {
     it('differing only in dueDate', () => {
         // Two different dates
         // No need to replicate the null checks in startDate
-        const date1Recurrence = new RecurrenceBuilder()
-            .dueDate('2021-10-21')
-            .build();
+        const date1Recurrence = new RecurrenceBuilder().dueDate('2021-10-21').build();
 
-        const date2Recurrence = new RecurrenceBuilder()
-            .dueDate('1998-03-13')
-            .build();
+        const date2Recurrence = new RecurrenceBuilder().dueDate('1998-03-13').build();
 
         expect(date1Recurrence?.identicalTo(date1Recurrence)).toBe(true);
         expect(date1Recurrence?.identicalTo(date2Recurrence)).toBe(false);

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -18,9 +18,7 @@ describe('Sort', () => {
         const five = fromLine({ line: '- [x] b 📅 1970-01-02', path: '3' });
         const six = fromLine({ line: '- [x] d 📅 1970-01-03', path: '2' });
         const expectedOrder = [one, two, three, four, five, six];
-        expect(
-            Sort.by({ sorting: [] }, [six, five, one, four, two, three]),
-        ).toEqual(expectedOrder);
+        expect(Sort.by({ sorting: [] }, [six, five, one, four, two, three])).toEqual(expectedOrder);
     });
 
     it('sorts correctly by due', () => {
@@ -426,21 +424,7 @@ describe('Sort by tags', () => {
         const t12 = fromLine({ line: '- [ ] #task a #jjj #hhh' });
         const t13 = fromLine({ line: '- [ ] #task a' });
 
-        const expectedOrder = [
-            t1,
-            t2,
-            t3,
-            t4,
-            t5,
-            t6,
-            t7,
-            t8,
-            t9,
-            t10,
-            t11,
-            t12,
-            t13,
-        ];
+        const expectedOrder = [t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13];
 
         // Act
         expect(
@@ -480,21 +464,7 @@ describe('Sort by tags', () => {
         const t12 = fromLine({ line: '- [ ] #task a #jjj #hhh' });
         const t13 = fromLine({ line: '- [ ] #task a' });
 
-        const expectedOrder = [
-            t13,
-            t12,
-            t11,
-            t10,
-            t9,
-            t8,
-            t7,
-            t6,
-            t5,
-            t4,
-            t3,
-            t2,
-            t1,
-        ];
+        const expectedOrder = [t13, t12, t11, t10, t9, t8, t7, t6, t5, t4, t3, t2, t1];
 
         // Act
         expect(

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -26,13 +26,9 @@ describe('parsing', () => {
         expect(task!.description).toEqual('this is a done task');
         expect(task!.status).toStrictEqual(Status.Done);
         expect(task!.dueDate).not.toBeNull();
-        expect(
-            task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD')),
-        ).toStrictEqual(true);
+        expect(task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD'))).toStrictEqual(true);
         expect(task!.doneDate).not.toBeNull();
-        expect(
-            task!.doneDate!.isSame(moment('2021-06-20', 'YYYY-MM-DD')),
-        ).toStrictEqual(true);
+        expect(task!.doneDate!.isSame(moment('2021-06-20', 'YYYY-MM-DD'))).toStrictEqual(true);
     });
 
     it('returns null when task does not have global filter', () => {
@@ -66,19 +62,14 @@ describe('parsing', () => {
         expect(task!.description).toEqual('this is a ✅ done task');
         expect(task!.status).toStrictEqual(Status.Done);
         expect(task!.dueDate).not.toBeNull();
-        expect(
-            task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD')),
-        ).toStrictEqual(true);
+        expect(task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD'))).toStrictEqual(true);
         expect(task!.doneDate).not.toBeNull();
-        expect(
-            task!.doneDate!.isSame(moment('2021-06-20', 'YYYY-MM-DD')),
-        ).toStrictEqual(true);
+        expect(task!.doneDate!.isSame(moment('2021-06-20', 'YYYY-MM-DD'))).toStrictEqual(true);
     });
 
     it('also works with block links and trailing spaces', () => {
         // Arrange
-        const line =
-            '- [x] this is a ✅ done task 🗓 2021-09-12 ✅ 2021-06-20 ^my-precious  ';
+        const line = '- [x] this is a ✅ done task 🗓 2021-09-12 ✅ 2021-06-20 ^my-precious  ';
 
         // Act
         const task = fromLine({
@@ -90,20 +81,15 @@ describe('parsing', () => {
         expect(task!.description).toEqual('this is a ✅ done task');
         expect(task!.status).toStrictEqual(Status.Done);
         expect(task!.dueDate).not.toBeNull();
-        expect(
-            task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD')),
-        ).toStrictEqual(true);
+        expect(task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD'))).toStrictEqual(true);
         expect(task!.doneDate).not.toBeNull();
-        expect(
-            task!.doneDate!.isSame(moment('2021-06-20', 'YYYY-MM-DD')),
-        ).toStrictEqual(true);
+        expect(task!.doneDate!.isSame(moment('2021-06-20', 'YYYY-MM-DD'))).toStrictEqual(true);
         expect(task!.blockLink).toEqual(' ^my-precious');
     });
 
     it('supports tag anywhere in the description and separates them correctly from signifier emojis', () => {
         // Arrange
-        const line =
-            '- [ ] this is a task due 📅 2021-09-12 #inside_tag ⏫ #some/tags_with_underscore';
+        const line = '- [ ] this is a task due 📅 2021-09-12 #inside_tag ⏫ #some/tags_with_underscore';
 
         // Act
         const task = fromLine({
@@ -112,13 +98,8 @@ describe('parsing', () => {
 
         // Assert
         expect(task).not.toBeNull();
-        expect(task!.description).toEqual(
-            'this is a task due #inside_tag #some/tags_with_underscore',
-        );
-        expect(task!.tags).toEqual([
-            '#inside_tag',
-            '#some/tags_with_underscore',
-        ]);
+        expect(task!.description).toEqual('this is a task due #inside_tag #some/tags_with_underscore');
+        expect(task!.tags).toEqual(['#inside_tag', '#some/tags_with_underscore']);
         expect(task!.dueDate).not.toBeNull();
         expect(task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD')));
         expect(task!.priority == Priority.High);
@@ -136,9 +117,7 @@ describe('parsing', () => {
 
         // Assert
         expect(task).not.toBeNull();
-        expect(task!.description).toEqual(
-            'Wobble #tag1 #tag2 #tag3 #tag4 #tag5 #tag6 #tag7 #tag8 #tag9 #tag10',
-        );
+        expect(task!.description).toEqual('Wobble #tag1 #tag2 #tag3 #tag4 #tag5 #tag6 #tag7 #tag8 #tag9 #tag10');
         expect(task!.dueDate!.isSame(moment('022-07-02', 'YYYY-MM-DD')));
         expect(task!.doneDate!.isSame(moment('022-07-02', 'YYYY-MM-DD')));
         expect(task!.startDate!.isSame(moment('022-07-02', 'YYYY-MM-DD')));
@@ -244,80 +223,65 @@ function constructTaskFromLine(line: string) {
 describe('parsing tags', () => {
     test.each<TagParsingExpectations>([
         {
-            markdownTask:
-                '- [x] this is a done task #tagone 🗓 2021-09-12 #another-tag ✅ 2021-06-20 #and_another',
-            expectedDescription:
-                'this is a done task #tagone #another-tag #and_another',
+            markdownTask: '- [x] this is a done task #tagone 🗓 2021-09-12 #another-tag ✅ 2021-06-20 #and_another',
+            expectedDescription: 'this is a done task #tagone #another-tag #and_another',
             extractedTags: ['#tagone', '#another-tag', '#and_another'],
             globalFilter: '',
         },
         {
-            markdownTask:
-                '- [x] this is a done task #tagone #tagtwo 🗓 2021-09-12 ✅ 2021-06-20',
+            markdownTask: '- [x] this is a done task #tagone #tagtwo 🗓 2021-09-12 ✅ 2021-06-20',
             expectedDescription: 'this is a done task #tagone #tagtwo',
             extractedTags: ['#tagone', '#tagtwo'],
             globalFilter: '',
         },
         {
-            markdownTask:
-                '- [ ] this is a normal task #tagone 🗓 2021-09-12 ✅ 2021-06-20',
+            markdownTask: '- [ ] this is a normal task #tagone 🗓 2021-09-12 ✅ 2021-06-20',
             expectedDescription: 'this is a normal task #tagone',
             extractedTags: ['#tagone'],
             globalFilter: '',
         },
         {
-            markdownTask:
-                '- [ ] this is a normal task #tagone #tagtwo 🗓 2021-09-12 ✅ 2021-06-20',
+            markdownTask: '- [ ] this is a normal task #tagone #tagtwo 🗓 2021-09-12 ✅ 2021-06-20',
             expectedDescription: 'this is a normal task #tagone #tagtwo',
             extractedTags: ['#tagone', '#tagtwo'],
             globalFilter: '',
         },
         {
-            markdownTask:
-                '- [ ] this is a normal task #tagone #tag/with/depth #tagtwo 🗓 2021-09-12 ✅ 2021-06-20',
-            expectedDescription:
-                'this is a normal task #tagone #tag/with/depth #tagtwo',
+            markdownTask: '- [ ] this is a normal task #tagone #tag/with/depth #tagtwo 🗓 2021-09-12 ✅ 2021-06-20',
+            expectedDescription: 'this is a normal task #tagone #tag/with/depth #tagtwo',
             extractedTags: ['#tagone', '#tag/with/depth', '#tagtwo'],
             globalFilter: '',
         },
 
         {
-            markdownTask:
-                '- [x] #someglobaltasktag this is a done task #tagone 🗓 2021-09-12 ✅ 2021-06-20',
-            expectedDescription:
-                '#someglobaltasktag this is a done task #tagone',
+            markdownTask: '- [x] #someglobaltasktag this is a done task #tagone 🗓 2021-09-12 ✅ 2021-06-20',
+            expectedDescription: '#someglobaltasktag this is a done task #tagone',
             extractedTags: ['#tagone'],
             globalFilter: '#someglobaltasktag',
         },
         {
-            markdownTask:
-                '- [x] #someglobaltasktag this is a done task #tagone #tagtwo 🗓 2021-09-12 ✅ 2021-06-20',
-            expectedDescription:
-                '#someglobaltasktag this is a done task #tagone #tagtwo',
+            markdownTask: '- [x] #someglobaltasktag this is a done task #tagone #tagtwo 🗓 2021-09-12 ✅ 2021-06-20',
+            expectedDescription: '#someglobaltasktag this is a done task #tagone #tagtwo',
             extractedTags: ['#tagone', '#tagtwo'],
             globalFilter: '#someglobaltasktag',
         },
         {
-            markdownTask:
-                '- [ ] #someglobaltasktag this is a normal task #tagone 🗓 2021-09-12 ✅ 2021-06-20',
-            expectedDescription:
-                '#someglobaltasktag this is a normal task #tagone',
+            markdownTask: '- [ ] #someglobaltasktag this is a normal task #tagone 🗓 2021-09-12 ✅ 2021-06-20',
+            expectedDescription: '#someglobaltasktag this is a normal task #tagone',
             extractedTags: ['#tagone'],
             globalFilter: '#someglobaltasktag',
         },
         {
             markdownTask:
                 '- [ ] #someglobaltasktag this is a normal task #tagone #tagtwo 🗓 2021-09-12 #tagthree ✅ 2021-06-20 #tagfour',
-            expectedDescription:
-                '#someglobaltasktag this is a normal task #tagone #tagtwo #tagthree #tagfour',
+            expectedDescription: '#someglobaltasktag this is a normal task #tagone #tagtwo #tagthree #tagfour',
             extractedTags: ['#tagone', '#tagtwo', '#tagthree', '#tagfour'],
             globalFilter: '#someglobaltasktag',
         },
         {
             markdownTask:
                 '- [ ] #someglobaltasktag this is a normal task #tagone #tag/with/depth #tagtwo 🗓 2021-09-12 ✅ 2021-06-20',
-            expectedDescription:
-                '#someglobaltasktag this is a normal task #tagone #tag/with/depth #tagtwo',
+            expectedDescription: '#someglobaltasktag this is a normal task #tagone #tag/with/depth #tagtwo',
             extractedTags: ['#tagone', '#tag/with/depth', '#tagtwo'],
             globalFilter: '#someglobaltasktag',
         },
@@ -352,21 +316,14 @@ describe('parsing tags', () => {
             globalFilter: '',
         },
         {
-            markdownTask:
-                '>>> * [ ] Task inside a nested blockquote or callout #tagone',
-            expectedDescription:
-                'Task inside a nested blockquote or callout #tagone',
+            markdownTask: '>>> * [ ] Task inside a nested blockquote or callout #tagone',
+            expectedDescription: 'Task inside a nested blockquote or callout #tagone',
             extractedTags: ['#tagone'],
             globalFilter: '',
         },
     ])(
         'should parse "$markdownTask" and extract "$extractedTags"',
-        ({
-            markdownTask,
-            expectedDescription,
-            extractedTags,
-            globalFilter,
-        }) => {
+        ({ markdownTask, expectedDescription, extractedTags, globalFilter }) => {
             // Arrange
             if (globalFilter != '') {
                 updateSettings({ globalFilter: globalFilter });
@@ -417,8 +374,7 @@ describe('to string', () => {
 
     it('retains the tags', () => {
         // Arrange
-        const line =
-            '- [x] this is a done task #tagone 📅 2021-09-12 ✅ 2021-06-20 #journal/daily';
+        const line = '- [x] this is a done task #tagone 📅 2021-09-12 ✅ 2021-06-20 #journal/daily';
 
         // Act
         const task: Task = fromLine({
@@ -426,8 +382,7 @@ describe('to string', () => {
         }) as Task;
 
         // Assert
-        const expectedLine =
-            '- [x] this is a done task #tagone #journal/daily 📅 2021-09-12 ✅ 2021-06-20';
+        const expectedLine = '- [x] this is a done task #tagone #journal/daily 📅 2021-09-12 ✅ 2021-06-20';
         expect(task.toFileLineString()).toStrictEqual(expectedLine);
     });
 });
@@ -688,19 +643,8 @@ describe('toggle done', () => {
 
     test.concurrent.each<RecurrenceCase>(recurrenceCases)(
         'recurs correctly (%j)',
-        ({
-            interval,
-            due,
-            scheduled,
-            start,
-            today,
-            nextDue,
-            nextScheduled,
-            nextStart,
-        }) => {
-            const todaySpy = jest
-                .spyOn(Date, 'now')
-                .mockReturnValue(moment(today).valueOf());
+        ({ interval, due, scheduled, start, today, nextDue, nextScheduled, nextStart }) => {
+            const todaySpy = jest.spyOn(Date, 'now').mockReturnValue(moment(today).valueOf());
 
             const line = [
                 '- [ ] I am task',
@@ -746,9 +690,7 @@ describe('toggle done', () => {
         // Assert
         expect(task).not.toBeNull();
         expect(task!.dueDate).not.toBeNull();
-        expect(
-            task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD')),
-        ).toStrictEqual(true);
+        expect(task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD'))).toStrictEqual(true);
 
         const nextTask: Task = task!.toggle()[0];
         expect({
@@ -786,8 +728,7 @@ export function toBeIdenticalTo(builder1: TaskBuilder, builder2: TaskBuilder) {
 
     if (pass) {
         return {
-            message: () =>
-                'Tasks treated as identical, but should be different',
+            message: () => 'Tasks treated as identical, but should be different',
             pass: true,
         };
     }
@@ -812,26 +753,16 @@ describe('identicalTo', () => {
 
     it('should check description', () => {
         const lhs = new TaskBuilder().description('same long initial text');
-        expect(lhs).toBeIdenticalTo(
-            new TaskBuilder().description('same long initial text'),
-        );
-        expect(lhs).not.toBeIdenticalTo(
-            new TaskBuilder().description('different text'),
-        );
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().description('same long initial text'));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().description('different text'));
     });
 
     it('should check path', () => {
         const lhs = new TaskBuilder().path('same test file.md');
-        expect(lhs).toBeIdenticalTo(
-            new TaskBuilder().path('same test file.md'),
-        );
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().path('same test file.md'));
         // Check it is case-sensitive
-        expect(lhs).not.toBeIdenticalTo(
-            new TaskBuilder().path('Same Test File.md'),
-        );
-        expect(lhs).not.toBeIdenticalTo(
-            new TaskBuilder().path('different text.md'),
-        );
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().path('Same Test File.md'));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().path('different text.md'));
     });
 
     it('should check indentation', () => {
@@ -854,73 +785,49 @@ describe('identicalTo', () => {
 
     it('should check originalStatusCharacter', () => {
         const lhs = new TaskBuilder().originalStatusCharacter(' ');
-        expect(lhs).toBeIdenticalTo(
-            new TaskBuilder().originalStatusCharacter(' '),
-        );
-        expect(lhs).not.toBeIdenticalTo(
-            new TaskBuilder().originalStatusCharacter('x'),
-        );
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().originalStatusCharacter(' '));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().originalStatusCharacter('x'));
     });
 
     it('should check precedingHeader', () => {
         const lhs = new TaskBuilder().precedingHeader('Heading 1');
-        expect(lhs).toBeIdenticalTo(
-            new TaskBuilder().precedingHeader('Heading 1'),
-        );
-        expect(lhs).not.toBeIdenticalTo(
-            new TaskBuilder().precedingHeader('Different Heading'),
-        );
-        expect(lhs).not.toBeIdenticalTo(
-            new TaskBuilder().precedingHeader(null),
-        );
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().precedingHeader('Heading 1'));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().precedingHeader('Different Heading'));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().precedingHeader(null));
     });
 
     it('should check priority', () => {
         const lhs = new TaskBuilder().priority(Priority.Medium);
-        expect(lhs).toBeIdenticalTo(
-            new TaskBuilder().priority(Priority.Medium),
-        );
-        expect(lhs).not.toBeIdenticalTo(
-            new TaskBuilder().priority(Priority.None),
-        );
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().priority(Priority.Medium));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().priority(Priority.None));
     });
 
     it('should check startDate', () => {
         const lhs = new TaskBuilder().startDate('2012-12-27');
         expect(lhs).toBeIdenticalTo(new TaskBuilder().startDate('2012-12-27'));
         expect(lhs).not.toBeIdenticalTo(new TaskBuilder().startDate(null));
-        expect(lhs).not.toBeIdenticalTo(
-            new TaskBuilder().startDate('2012-12-26'),
-        );
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().startDate('2012-12-26'));
     });
 
     it('should check scheduledDate', () => {
         const lhs = new TaskBuilder().scheduledDate('2012-12-27');
-        expect(lhs).toBeIdenticalTo(
-            new TaskBuilder().scheduledDate('2012-12-27'),
-        );
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().scheduledDate('2012-12-27'));
         expect(lhs).not.toBeIdenticalTo(new TaskBuilder().scheduledDate(null));
-        expect(lhs).not.toBeIdenticalTo(
-            new TaskBuilder().scheduledDate('2012-12-26'),
-        );
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().scheduledDate('2012-12-26'));
     });
 
     it('should check dueDate', () => {
         const lhs = new TaskBuilder().dueDate('2012-12-27');
         expect(lhs).toBeIdenticalTo(new TaskBuilder().dueDate('2012-12-27'));
         expect(lhs).not.toBeIdenticalTo(new TaskBuilder().dueDate(null));
-        expect(lhs).not.toBeIdenticalTo(
-            new TaskBuilder().dueDate('2012-12-26'),
-        );
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().dueDate('2012-12-26'));
     });
 
     it('should check doneDate', () => {
         const lhs = new TaskBuilder().doneDate('2012-12-27');
         expect(lhs).toBeIdenticalTo(new TaskBuilder().doneDate('2012-12-27'));
         expect(lhs).not.toBeIdenticalTo(new TaskBuilder().doneDate(null));
-        expect(lhs).not.toBeIdenticalTo(
-            new TaskBuilder().doneDate('2012-12-26'),
-        );
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().doneDate('2012-12-26'));
     });
 
     describe('should check recurrence', () => {
@@ -929,9 +836,7 @@ describe('identicalTo', () => {
 
         const weekly = new RecurrenceBuilder().rule('every week').build();
         const daily = new RecurrenceBuilder().rule('every day').build();
-        expect(new TaskBuilder().recurrence(weekly)).not.toBeIdenticalTo(
-            new TaskBuilder().recurrence(daily),
-        );
+        expect(new TaskBuilder().recurrence(weekly)).not.toBeIdenticalTo(new TaskBuilder().recurrence(daily));
         // Note: There are more thorough tests of Recurrence.identicalTo() in Recurrence.test.ts.
     });
 
@@ -1009,23 +914,18 @@ describe('check removal of the global filter', () => {
         },
         {
             globalFilter: '#t',
-            markdownTask:
-                '- [ ] task with global filter in the end and some spaces  #t  ',
-            expectedDescription:
-                'task with global filter in the end and some spaces',
+            markdownTask: '- [ ] task with global filter in the end and some spaces  #t  ',
+            expectedDescription: 'task with global filter in the end and some spaces',
         },
         {
             globalFilter: '#complex/global/filter',
-            markdownTask:
-                '- [ ] task with #complex/global/filter in the middle',
+            markdownTask: '- [ ] task with #complex/global/filter in the middle',
             expectedDescription: 'task with in the middle',
         },
         {
             globalFilter: '#task',
-            markdownTask:
-                '- [ ] task with an extension of the global filter #task/with/extension',
-            expectedDescription:
-                'task with an extension of the global filter #task/with/extension',
+            markdownTask: '- [ ] task with an extension of the global filter #task/with/extension',
+            expectedDescription: 'task with an extension of the global filter #task/with/extension',
         },
         {
             globalFilter: '#t',
@@ -1050,9 +950,7 @@ describe('check removal of the global filter', () => {
 
             // Assert
             expect(task).not.toBeNull();
-            expect(task!.getDescriptionWithoutGlobalFilter()).toEqual(
-                expectedDescription,
-            );
+            expect(task!.getDescriptionWithoutGlobalFilter()).toEqual(expectedDescription);
 
             // Cleanup
             if (globalFilter != '') {
@@ -1067,17 +965,12 @@ describe('check removal of the global filter exhaustively', () => {
         globalFilter: string;
     };
 
-    function checkDescription(
-        markdownLine: string,
-        expectedDescription: string,
-    ) {
+    function checkDescription(markdownLine: string, expectedDescription: string) {
         const task = constructTaskFromLine(markdownLine);
 
         // Assert
         expect(task).not.toBeNull();
-        expect(task!.getDescriptionWithoutGlobalFilter()).toEqual(
-            expectedDescription,
-        );
+        expect(task!.getDescriptionWithoutGlobalFilter()).toEqual(expectedDescription);
     }
 
     test.each<GlobalFilterRemoval>([
@@ -1152,36 +1045,33 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '\\',
         },
-    ])(
-        'should parse global filter "$globalFilter" edge cases correctly',
-        ({ globalFilter }) => {
-            // Arrange
-            if (globalFilter != '') {
-                updateSettings({ globalFilter: globalFilter });
-            }
+    ])('should parse global filter "$globalFilter" edge cases correctly', ({ globalFilter }) => {
+        // Arrange
+        if (globalFilter != '') {
+            updateSettings({ globalFilter: globalFilter });
+        }
 
-            // Act
+        // Act
 
-            // global filter removed at beginning, middle and end
-            let markdownLine = `- [ ] ${globalFilter} 1 ${globalFilter} 2 ${globalFilter}`;
-            let expectedDescription = '1 2';
-            checkDescription(markdownLine, expectedDescription);
+        // global filter removed at beginning, middle and end
+        let markdownLine = `- [ ] ${globalFilter} 1 ${globalFilter} 2 ${globalFilter}`;
+        let expectedDescription = '1 2';
+        checkDescription(markdownLine, expectedDescription);
 
-            // global filter not removed if non-empty non-tag characters before or after it
-            markdownLine = `- [ ] ${globalFilter}x 1 x${globalFilter} ${globalFilter}x 2 x${globalFilter}`;
-            expectedDescription = `${globalFilter}x 1 x${globalFilter} ${globalFilter}x 2 x${globalFilter}`;
-            checkDescription(markdownLine, expectedDescription);
+        // global filter not removed if non-empty non-tag characters before or after it
+        markdownLine = `- [ ] ${globalFilter}x 1 x${globalFilter} ${globalFilter}x 2 x${globalFilter}`;
+        expectedDescription = `${globalFilter}x 1 x${globalFilter} ${globalFilter}x 2 x${globalFilter}`;
+        checkDescription(markdownLine, expectedDescription);
 
-            // global filter not removed if non-empty sub-tag characters after it.
-            // Include at least one occurrence of global filter, so we don't pass by luck.
-            markdownLine = `- [ ] ${globalFilter}/x 1 x${globalFilter} ${globalFilter}/x 2 ${globalFilter} ${globalFilter}/x`;
-            expectedDescription = `${globalFilter}/x 1 x${globalFilter} ${globalFilter}/x 2 ${globalFilter}/x`;
-            checkDescription(markdownLine, expectedDescription);
+        // global filter not removed if non-empty sub-tag characters after it.
+        // Include at least one occurrence of global filter, so we don't pass by luck.
+        markdownLine = `- [ ] ${globalFilter}/x 1 x${globalFilter} ${globalFilter}/x 2 ${globalFilter} ${globalFilter}/x`;
+        expectedDescription = `${globalFilter}/x 1 x${globalFilter} ${globalFilter}/x 2 ${globalFilter}/x`;
+        checkDescription(markdownLine, expectedDescription);
 
-            // Cleanup
-            if (globalFilter != '') {
-                resetSettings();
-            }
-        },
-    );
+        // Cleanup
+        if (globalFilter != '') {
+            resetSettings();
+        }
+    });
 });

--- a/tests/TestHelpers.ts
+++ b/tests/TestHelpers.ts
@@ -18,11 +18,7 @@ export function fromLine({
     })!;
 }
 
-export function createTasksFromMarkdown(
-    tasksAsMarkdown: string,
-    path: string,
-    precedingHeader: string,
-): Task[] {
+export function createTasksFromMarkdown(tasksAsMarkdown: string, path: string, precedingHeader: string): Task[] {
     const taskLines = tasksAsMarkdown.split('\n');
     const tasks: Task[] = [];
     for (const line of taskLines) {

--- a/tests/TestingTools/FilterTestHelpers.ts
+++ b/tests/TestingTools/FilterTestHelpers.ts
@@ -11,11 +11,7 @@ import type { TaskBuilder } from './TaskBuilder';
  *                          new TaskBuilder().startDate('2022-04-15')
  * @param expected true if the task should match the filter, and false otherwise.
  */
-export function testFilter(
-    filter: FilterOrErrorMessage,
-    taskBuilder: TaskBuilder,
-    expected: boolean,
-) {
+export function testFilter(filter: FilterOrErrorMessage, taskBuilder: TaskBuilder, expected: boolean) {
     const task = taskBuilder.build();
     testTaskFilter(filter, task, expected);
 }
@@ -27,11 +23,7 @@ export function testFilter(
  * @param task - the Task to filter.
  * @param expected true if the task should match the filter, and false otherwise.
  */
-export function testTaskFilter(
-    filter: FilterOrErrorMessage,
-    task: Task,
-    expected: boolean,
-) {
+export function testTaskFilter(filter: FilterOrErrorMessage, task: Task, expected: boolean) {
     expect(filter.filter).toBeDefined();
     expect(filter.error).toBeUndefined();
     expect(filter.filter!(task)).toEqual(expected);
@@ -48,11 +40,7 @@ export function testTaskFilter(
  * @param task - the Task to filter
  * @param expected - true if the task should match the filter, and false otherwise.
  */
-export function testTaskFilterViaQuery(
-    filter: string,
-    task: Task,
-    expected: boolean,
-) {
+export function testTaskFilterViaQuery(filter: string, task: Task, expected: boolean) {
     // Arrange
     const query = new Query({ source: filter });
 
@@ -101,8 +89,6 @@ export function shouldSupportFiltering(
     });
 
     // Assert
-    const filteredTaskLines = filteredTasks.map(
-        (task) => `- [ ] ${task.toString()}`,
-    );
+    const filteredTaskLines = filteredTasks.map((task) => `- [ ] ${task.toString()}`);
     expect(filteredTaskLines).toMatchObject(expectedResult);
 }

--- a/tests/TestingTools/RecurrenceBuilder.test.ts
+++ b/tests/TestingTools/RecurrenceBuilder.test.ts
@@ -10,10 +10,7 @@ window.moment = moment;
 describe('RecurrenceBuilder', () => {
     it('should build a Recurrence object', () => {
         const builder = new RecurrenceBuilder();
-        const recurrence = builder
-            .rule('every week when done')
-            .startDate('2022-07-14')
-            .build();
+        const recurrence = builder.rule('every week when done').startDate('2022-07-14').build();
         expect(recurrence).not.toEqual(null);
         expect(recurrence.toText())!.toBe('every week when done');
     });

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -105,9 +105,7 @@ export class TaskBuilder {
         return this;
     }
 
-    public originalStatusCharacter(
-        originalStatusCharacter: string,
-    ): TaskBuilder {
+    public originalStatusCharacter(originalStatusCharacter: string): TaskBuilder {
         this._originalStatusCharacter = originalStatusCharacter;
         return this;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- refactor: Reformat code to match the format used by tasks-x plugin

Format settings copied from
https://github.com/sytone/obsidian-tasks-x/blob/58e375684a48acd15a35cab914c81244a310c1c1/package.json#L149-L156

There were two copies of the prettier settings in the Tasks code, so I copied the new settings in to both of them:

- `.eslintrc.js`
- `.prettierrc.js`

## Motivation and Context

See #1052 for motivation

## How has this been tested?

- `yarn run lint`
- and running all the tests

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
