### PR TITLE
docs: Add How-to page 'Find tasks for coming 7 days'

### DIFF
--- a/docs/how-to/find-tasks-for-coming-7-days.md
+++ b/docs/how-to/find-tasks-for-coming-7-days.md
@@ -1,0 +1,103 @@
+---
+layout: default
+title: Find tasks for coming 7 days
+nav_order: 2
+parent: How Tos
+---
+
+# Find all tasks for the coming 7 days
+
+{: .no_toc }
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Motivation
+
+I would like to create a list of tasks that will be due in the coming 7 days.
+
+How can I write this without using a hard-coded (fixed) date?
+
+## tl;dr
+
+Use `due before in 7 days`.
+
+## The hard-coded way
+
+This page was written on 8th September 2022, that is 2022-09-08, and the following search gave the desired results, using a fixed date:
+
+    ```tasks
+    not done
+    due before 2022-09-15
+    ```
+
+## Setting up data to test the rules
+
+Just as when writing software, when writing a new search rule it's worth generating good test data to satisfy yourself you really are getting the tasks you want.
+
+In this case, as of `2022-09-08`, we want tasks up to and including `2022-09-15`, but no further. So here is a good continuous range of due dates, for testing our new search on that date:
+
+```text
+Example tasks, to test the filter:
+
+- [ ] 0 days 📅 2022-09-08
+- [ ] 1 days 📅 2022-09-09
+- [ ] 2 days 📅 2022-09-10
+- [ ] 3 days 📅 2022-09-11
+- [ ] 4 days 📅 2022-09-12
+- [ ] 5 days 📅 2022-09-13
+- [ ] 6 days 📅 2022-09-14
+- [ ] 7 days 📅 2022-09-15
+- [ ] 8 days 📅 2022-09-16
+- [ ] 9 days 📅 2022-09-17
+```
+
+With the above search, these tasks give this result:
+
+```text
+0 days 📅 2022-09-08
+1 days 📅 2022-09-09
+2 days 📅 2022-09-10
+3 days 📅 2022-09-11
+4 days 📅 2022-09-12
+5 days 📅 2022-09-13
+6 days 📅 2022-09-14
+7 tasks
+```
+
+## The general way
+
+The way to select dates before a specific future date is `before in ...`. So for our current search, we would use `due before in 7 days`:
+
+    ```tasks
+    not done
+    due before in 7 days
+    ```
+
+With the above date, that search give the desired result:
+
+```text
+0 days 📅 2022-09-08
+1 days 📅 2022-09-09
+2 days 📅 2022-09-10
+3 days 📅 2022-09-11
+4 days 📅 2022-09-12
+5 days 📅 2022-09-13
+6 days 📅 2022-09-14
+7 tasks
+```
+
+## More Information
+
+Relevant documentation sections:
+
+- Some examples are written in the [Dates section of the Filters docs]({{ site.baseurl }}{% link queries/filters.md %}#dates).
+- And perhaps more useful are the date-based examples in the [Queries Examples page]({{ site.baseurl }}{% link queries/examples.md %}).

--- a/docs/how-to/get-tasks-in-current-file.md
+++ b/docs/how-to/get-tasks-in-current-file.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: How to get tasks in current file
-nav_order: 2
+nav_order: 3
 parent: How Tos
 ---
 

--- a/docs/how-to/style-backlinks.md
+++ b/docs/how-to/style-backlinks.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: How to style backlinks
-nav_order: 2
+nav_order: 4
 parent: How Tos
 ---
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

Add How-to page 'Find tasks for coming 7 days'

## Motivation and Context

This is an answer for https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/1129
> Tasks for the coming week

## How has this been tested?

By viewing the docs locally.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4840096/189232396-4bdc2630-ccdc-43ad-9629-a421b177de89.png)


## Types of changes

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)


## Terms

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
