### PR TITLE
feat: Parse dataview compatible dates

### DIFF
--- a/docs/getting-started/dates.md
+++ b/docs/getting-started/dates.md
@@ -49,6 +49,12 @@ For example: `📅 2021-04-09` means the task is due on the 9th of April, 2021.
 - [ ] take out the trash 📅 2021-04-09
 ```
 
+Alternatively, `due::` can be used instead of the due date signifier.
+
+```markdown
+- [ ] take out the trash due::2021-04-09
+```
+
 ---
 
 ## ⏳ Scheduled
@@ -60,6 +66,12 @@ Scheduled dates use an hourglass emoji instead of a calendar emoji.
 
 ```markdown
 - [ ] take out the trash ⏳ 2021-04-09
+```
+
+Alternatively, `scheduled::` can be used instead of the scheduled date signifier.
+
+```markdown
+- [ ] take out the trash scheduled::2021-04-09
 ```
 
 ---
@@ -75,6 +87,13 @@ Start dates use a departing airplane emoji instead of a calendar emoji.
 ```markdown
 - [ ] take out the trash 🛫 2021-04-09
 ```
+
+Alternatively, `start::` can be used instead of the start date signifier.
+
+```markdown
+- [ ] take out the trash start::2021-04-09
+```
+
 
 When [filtering]({{ site.baseurl }}{% link queries/filters.md %}#start-date) queries by start date,
 the result will include tasks without a start date.

--- a/docs/getting-started/recurring-tasks.md
+++ b/docs/getting-started/recurring-tasks.md
@@ -38,6 +38,12 @@ Take as an example the following task:
 - [ ] take out the trash 🔁 every Sunday 📅 2021-04-25
 ```
 
+Alternatively, `recur::` can be used instead of the recurrence signifier.
+
+```markdown
+- [ ] take out the trash recur::every Sunday due::2021-04-25
+```
+
 If you mark the above task "done", the file will now look like this:
 
 ```markdown

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -95,11 +95,11 @@ export class TaskRegularExpressions {
     // The following regex's end with `$` because they will be matched and
     // removed from the end until none are left.
     public static readonly priorityRegex = /([⏫🔼🔽])$/u;
-    public static readonly startDateRegex = /🛫 *(\d{4}-\d{2}-\d{2})$/u;
-    public static readonly scheduledDateRegex = /[⏳⌛] *(\d{4}-\d{2}-\d{2})$/u;
-    public static readonly dueDateRegex = /[📅📆🗓] *(\d{4}-\d{2}-\d{2})$/u;
-    public static readonly doneDateRegex = /✅ *(\d{4}-\d{2}-\d{2})$/u;
-    public static readonly recurrenceRegex = /🔁 ?([a-zA-Z0-9, !]+)$/iu;
+    public static readonly startDateRegex = /(🛫|start::) *(\d{4}-\d{2}-\d{2})$/u;
+    public static readonly scheduledDateRegex = /([⏳⌛]|scheduled::) *(\d{4}-\d{2}-\d{2})$/u;
+    public static readonly dueDateRegex = /([📅📆🗓]|due::) *(\d{4}-\d{2}-\d{2})$/u;
+    public static readonly doneDateRegex = /(✅|completion::) *(\d{4}-\d{2}-\d{2})$/u;
+    public static readonly recurrenceRegex = /(🔁|recur::) ?([a-zA-Z0-9, !]+)$/iu;
 
     // Regex to match all hash tags, basically hash followed by anything but the characters in the negation.
     // To ensure URLs are not caught it is looking of beginning of string tag and any
@@ -314,28 +314,28 @@ export class Task {
 
             const doneDateMatch = description.match(TaskRegularExpressions.doneDateRegex);
             if (doneDateMatch !== null) {
-                doneDate = window.moment(doneDateMatch[1], TaskRegularExpressions.dateFormat);
+                doneDate = window.moment(doneDateMatch[2], TaskRegularExpressions.dateFormat);
                 description = description.replace(TaskRegularExpressions.doneDateRegex, '').trim();
                 matched = true;
             }
 
             const dueDateMatch = description.match(TaskRegularExpressions.dueDateRegex);
             if (dueDateMatch !== null) {
-                dueDate = window.moment(dueDateMatch[1], TaskRegularExpressions.dateFormat);
+                dueDate = window.moment(dueDateMatch[2], TaskRegularExpressions.dateFormat);
                 description = description.replace(TaskRegularExpressions.dueDateRegex, '').trim();
                 matched = true;
             }
 
             const scheduledDateMatch = description.match(TaskRegularExpressions.scheduledDateRegex);
             if (scheduledDateMatch !== null) {
-                scheduledDate = window.moment(scheduledDateMatch[1], TaskRegularExpressions.dateFormat);
+                scheduledDate = window.moment(scheduledDateMatch[2], TaskRegularExpressions.dateFormat);
                 description = description.replace(TaskRegularExpressions.scheduledDateRegex, '').trim();
                 matched = true;
             }
 
             const startDateMatch = description.match(TaskRegularExpressions.startDateRegex);
             if (startDateMatch !== null) {
-                startDate = window.moment(startDateMatch[1], TaskRegularExpressions.dateFormat);
+                startDate = window.moment(startDateMatch[2], TaskRegularExpressions.dateFormat);
                 description = description.replace(TaskRegularExpressions.startDateRegex, '').trim();
                 matched = true;
             }
@@ -345,7 +345,7 @@ export class Task {
                 // Save the recurrence rule, but *do not parse it yet*.
                 // Creating the Recurrence object requires a reference date (e.g. a due date),
                 // and it might appear in the next (earlier in the line) tokens to parse
-                recurrenceRule = recurrenceMatch[1].trim();
+                recurrenceRule = recurrenceMatch[2].trim();
                 description = description.replace(TaskRegularExpressions.recurrenceRegex, '').trim();
                 matched = true;
             }

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1074,4 +1074,35 @@ describe('check removal of the global filter exhaustively', () => {
             resetSettings();
         }
     });
+
+    it('parses dataview compatible dates', () => {
+        // Arrange
+        const line = '- [ ] test task start::2022-09-08 due::2022-09-12 scheduled::2022-09-10 completion::2022-09-13';
+
+        // Act
+        const task = fromLine({
+            line,
+        });
+
+        // Assert
+        expect(task).not.toBeNull();
+        expect(task!.startDate!.isSame(moment('2022-09-08', 'YYYY-MM-DD'))).toStrictEqual(true);
+        expect(task!.dueDate!.isSame(moment('2022-09-12', 'YYYY-MM-DD'))).toStrictEqual(true);
+        expect(task!.scheduledDate!.isSame(moment('2022-09-10', 'YYYY-MM-DD'))).toStrictEqual(true);
+        expect(task!.doneDate!.isSame(moment('2022-09-13', 'YYYY-MM-DD'))).toStrictEqual(true);
+    });
+
+    it('parses ascii-prefixed recurrence rule', () => {
+        // Arrange
+        const line = '- [ ] test task due::2022-09-12 recur::every week';
+
+        // Act
+        const task = fromLine({
+            line,
+        });
+
+        // Assert
+        expect(task!.recurrence?.toText()).toEqual('every week');
+        expect(task!.recurrence?.next()?.dueDate?.isSame(moment('2022-09-19', 'YYYY-MM-DD'))).toStrictEqual(true);
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Adds the ability of using the following prefixes instead of emoji:
* `start::`
* `scheduled::`
* `due::`
* `completion::`
* `recur::`

These are the same that are supported by the dataview plugin: https://blacksmithgu.github.io/obsidian-dataview/data-annotation/#tasks

Note: The last one is not found in dataview, I made that one up

<!--- Describe your changes in detail -->

## Motivation and Context

Coming from zim's tasklist plugin, I missed the ability to fully type out a task without having to type special characters or wait for intellisense to pop up - both of which I feel like break my 'flow' of typing. I quite like zims format of using `>` for start dates and `<` for due dates (e.g. `- [ ] do the thing > 2022-10-10 < 2022-10-31`) but suspected that this would produce a lot of parsing errors / difficulties.

Through searching Issues & Discussions, I found a couple of threads mentioning dataviews tasks and one where it was mentioned, that parsing them would be implemented at some point (https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/373 / https://forum.obsidian.md/t/task-management-devs-define-a-shared-date-and-action-format/26464/78)



<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I implemented a unit test for this

## Screenshots (if appropriate)

not applicable

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)


---

Notes:

* I am not 100% happy with the docs I added, maybe someone else has a better idea for this. Maybe just make an 'alternative formatting' page?
* Thank you for having extensive tests for this code base. It made it very easy to judge the extent of a change even when I was completely new to the project.