### PR TITLE
Make TextField more universal and relax syntax

### DIFF
--- a/src/Query/Filter/TagsField.ts
+++ b/src/Query/Filter/TagsField.ts
@@ -1,9 +1,4 @@
 import type { Task } from '../../Task';
-import { SubstringMatcher } from '../Matchers/SubstringMatcher';
-import { RegexMatcher } from '../Matchers/RegexMatcher';
-import type { IStringMatcher } from '../Matchers/IStringMatcher';
-import { Field } from './Field';
-import { FilterOrErrorMessage } from './Filter';
 import { TextField } from './TextField';
 
 /**
@@ -11,50 +6,21 @@ import { TextField } from './TextField';
  *
  * Tags can be searched for with and without the hash tag at the start.
  */
-export class TagsField extends Field {
-    // Handles both ways of referencing the tags query.
-    private static readonly tagRegexp =
-        /^(tag|tags) (includes|does not include|include|do not include|regex matches|regex does not match) (.*)/;
-
-    public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
-        const match = Field.getMatch(this.filterRegexp(), line);
-        if (match === null) {
-            return FilterOrErrorMessage.fromError(`do not understand query filter (${this.fieldName()})`);
-        }
-        const filterMethod = match[2];
-        const search = match[3];
-        let matcher: IStringMatcher | null = null;
-        if (filterMethod.includes('include')) {
-            matcher = new SubstringMatcher(search);
-        } else if (filterMethod.includes('regex')) {
-            matcher = RegexMatcher.validateAndConstruct(search);
-            if (matcher === null) {
-                return FilterOrErrorMessage.fromError(
-                    `cannot parse regex (${this.fieldName()}); check your leading and trailing slashes for your query`,
-                );
-            }
-        }
-
-        if (matcher === null) {
-            // It's likely this can now never be reached.
-            // Retained for safety, for now.
-            return FilterOrErrorMessage.fromError(`do not understand query filter (${this.fieldName()})`);
-        }
-
-        return FilterOrErrorMessage.fromFilter((task: Task) => {
-            return TextField.maybeNegate(matcher!.matchesAnyOf(task.tags), filterMethod);
-        });
-    }
-
+export class TagsField extends TextField {
     /**
-     * Returns both forms of the field name, singular and plural.
+     * Allow both forms of the field name, singular and plural,
+     * since this field can have multiple values.
      * @protected
      */
     public fieldName(): string {
         return 'tag/tags';
     }
 
-    protected filterRegexp(): RegExp {
-        return TagsField.tagRegexp;
+    public value(task: Task): string {
+        return task.tags.join(', ');
+    }
+
+    public values(task: Task): string[] {
+        return task.tags;
     }
 }

--- a/src/Query/Filter/TextField.ts
+++ b/src/Query/Filter/TextField.ts
@@ -23,10 +23,6 @@ export abstract class TextField extends Field {
             if (usedFieldName) {
                 fieldName = usedFieldName;
 
-                if (line.includes('garbage')) {
-                    console.log('GARBAGE');
-                }
-
                 if (filterMethod && searchString) {
                     // should always be the case if the filterRegexp is correct
 

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -107,22 +107,26 @@ describe('description', () => {
         resetSettings();
     });
 
-    it('works with regex', () => {
+    test.concurrent.each([
+        'matches',
+        'regex matches',
+        'regexp matches',
+        'matches regex',
+        'matches regexp',
+        'does not match',
+        'regex does not match',
+        'regexp does not match',
+        'does not match regex',
+        'does not match regexp',
+    ])('description %s works', (op) => {
         // Arrange
-        const filter = new DescriptionField().createFilterOrErrorMessage('description regex matches /^task/');
+        const filter = new DescriptionField().createFilterOrErrorMessage(`description ${op} /^foo/`);
+        const tasks = ['- [ ] foo task matches our pattern', '- [ ] bar task does not start with foo'];
+        if (op.includes('not')) tasks.reverse();
 
         // Assert
-        expect(filter).not.toMatchTaskFromLine('- [ ] this does not start with the pattern');
-        expect(filter).toMatchTaskFromLine('- [ ] task does start with the pattern');
-    });
-
-    it('works negating regexes', () => {
-        // Arrange
-        const filter = new DescriptionField().createFilterOrErrorMessage('description regex does not match /^task/');
-
-        // Assert
-        expect(filter).toMatchTaskFromLine('- [ ] this does not start with the pattern');
-        expect(filter).not.toMatchTaskFromLine('- [ ] task does start with the pattern');
+        expect(filter).toMatchTaskFromLine(tasks[0]);
+        expect(filter).not.toMatchTaskFromLine(tasks[1]);
     });
 });
 

--- a/tests/Query/Filter/TagsField.test.ts
+++ b/tests/Query/Filter/TagsField.test.ts
@@ -263,4 +263,66 @@ describe('tag/tags', () => {
         expect(filter).not.toMatchTaskFromLine('- [ ] stuff #HOME');
         expect(filter).not.toMatchTaskFromLine('- [ ] stuff #work #HOME'); // searches multiple tags
     });
+
+    describe('filtering with all positive variants', () => {
+        test.concurrent.each([
+            'tag matches',
+            'tag regex matches',
+            'tag regexp matches',
+            'tag matches regex',
+            'tag matches regexp',
+            'tags matches',
+            'tags regex matches',
+            'tags regexp matches',
+            'tags matches regex',
+            'tags matches regexp',
+            'tags match',
+            'tags regex match',
+            'tags regexp match',
+            'tags match regex',
+            'tags match regexp',
+        ])('%s short tag', (cmd) => {
+            // Arrange
+            const filter = new TagsField().createFilterOrErrorMessage(String.raw`${cmd} /#foo/`);
+
+            // Act, Assert
+            expect(filter).toMatchTaskFromLine('- [ ] Do #foo stuff');
+            expect(filter).not.toMatchTaskFromLine('- [ ] Do foo stuff');
+            expect(filter).not.toMatchTaskFromLine('- [ ] Do #bar stuff');
+            expect(filter).toMatchTaskFromLine('- [ ] Do #bar and some #foo stuff');
+            expect(filter).toMatchTaskFromLine('- [ ] Do #foobar stuff');
+            expect(filter).not.toMatchTaskFromLine('- [ ] Do #barfoo stuff');
+        });
+    });
+
+    describe('filtering with all negative variants', () => {
+        test.concurrent.each([
+            'tag does not match',
+            'tag regex does not match',
+            'tag regexp does not match',
+            'tag does not match regex',
+            'tag does not match match regexp',
+            'tags does not match',
+            'tags regex does not match',
+            'tags regexp does not match',
+            'tags does not match regex',
+            'tags does not match regexp',
+            'tags do not match',
+            'tags regex do not match',
+            'tags regexp do not match',
+            'tags do not match regex',
+            'tags do not match regexp',
+        ])('%s short tag', (cmd) => {
+            // Arrange
+            const filter = new TagsField().createFilterOrErrorMessage(String.raw`${cmd} /#foo/`);
+
+            // Act, Assert
+            expect(filter).toMatchTaskFromLine('- [ ] Do #bar stuff');
+            expect(filter).toMatchTaskFromLine('- [ ] Do foo stuff');
+            expect(filter).not.toMatchTaskFromLine('- [ ] Do #foo stuff');
+            expect(filter).not.toMatchTaskFromLine('- [ ] Do #bar and some #foo stuff');
+            expect(filter).not.toMatchTaskFromLine('- [ ] Do #foobar stuff');
+            expect(filter).toMatchTaskFromLine('- [ ] Do #barfoo stuff');
+        });
+    });
 });


### PR DESCRIPTION
## Description

I noticed that the `TagsField` class is not DRY, it has a lot of repetition of the code of the `TextField` class.

This PR makes the `TextField` class a bit more universal by also supporting fields with multiple values, so that it can be used as base class for the `TagsField` as well, and we do not need that code repetition.

In the case of the tags field, the filter syntax now also allows the plural forms, i.e. instead of `tags regex matches` and `tags regex does not match` you can now also write the grammatically better sounding `tags regex match` and `tags regex do not match`. The `regex` clause can now also be spelled as `regexp` or even be left out completely, so you can also simply write `tags match` or `tags do not match`.

## Motivation and Context

Making the `TextField` more universal avoids repetition in the code and makes it easier maintainable.

The alternate spelling `regexp` for the `regex` clause has been requested in #1143 because it is frequently used, e.g. in JavaScript.

Making the `regexp` clause optional makes the syntax easier to read and write. The slashes and the `matches` clause make it sufficiently clear that this is a regular expression match.

## What still needs ot be done

I have not yet updated the documentation, because I first want to check if this PR is generally accepted in that form. Also, we should declare one of the syntax variants as the "standard syntax" that should be used everywhere in the docs and examples, and we must decide which one. My suggestion is to leave out the regex clause, and use the plural form for tags as standard syntax.

## How has this been tested?

I have added parametrized tests for the various syntax variants in `TagsField.test` and `DescriptionField.test`.

Everything should be backward compatible. I.e. I did not try to forbid the current singular spelling even though it is grammatically not correct.

## Types of changes

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly - **see above**
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
