### PR TITLE
feat: Add checkbox to disable forwardDate in Task editor

### DIFF
--- a/docs/getting-started/create-or-edit-task.md
+++ b/docs/getting-started/create-or-edit-task.md
@@ -62,7 +62,9 @@ There is a lot of flexibility here. For example:
 
 - You can type in exact dates, such as `2022-11-28`.
 - You can also enter parts of dates, such as `6 oct`.
-- You can enter relative dates, such as `today` or `tomorrow`.
+- You can enter relative dates, such as `today` or `tomorrow` or `Saturday`.
+
+Note that relative dates will be always interpreted as being in the future, because that is usually what you want. You can change this behavior by unchecking "Only future dates" if you want to enter an overdue task or experiment with the way how relative dates in the past would be interpreted in queries.
 
 ### Date abbreviations
 

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -26,6 +26,7 @@
         scheduledDate: string;
         dueDate: string;
         doneDate: string;
+        forwardOnly: boolean;
     } = {
         description: '',
         status: Status.TODO,
@@ -35,6 +36,7 @@
         scheduledDate: '',
         dueDate: '',
         doneDate: '',
+        forwardOnly: true
     };
 
     let parsedStartDate: string = '';
@@ -70,7 +72,7 @@
         parsedStartDate = parseDate(
             'start',
             editableTask.startDate,
-            new Date(),
+            editableTask.forwardOnly ? new Date() : undefined,
         );
     }
 
@@ -79,13 +81,17 @@
         parsedScheduledDate = parseDate(
             'scheduled',
             editableTask.scheduledDate,
-            new Date(),
+            editableTask.forwardOnly ? new Date() : undefined,
         );
     }
 
     $: {
         editableTask.dueDate = doAutocomplete(editableTask.dueDate);
-        parsedDueDate = parseDate('due', editableTask.dueDate, new Date());
+        parsedDueDate = parseDate(
+            'due',
+            editableTask.dueDate,
+            editableTask.forwardOnly ? new Date() : undefined,
+        );
     }
 
     $: {
@@ -140,6 +146,7 @@
                 : '',
             dueDate: task.dueDate ? task.dueDate.format('YYYY-MM-DD') : '',
             doneDate: task.doneDate ? task.doneDate.format('YYYY-MM-DD') : '',
+            forwardOnly: true,
         };
         setTimeout(() => {
             descriptionInput.focus();
@@ -157,7 +164,7 @@
         const parsedStartDate = chrono.parseDate(
             editableTask.startDate,
             new Date(),
-            { forwardDate: true },
+            { forwardDate: editableTask.forwardOnly },
         );
         if (parsedStartDate !== null) {
             startDate = window.moment(parsedStartDate);
@@ -167,7 +174,7 @@
         const parsedScheduledDate = chrono.parseDate(
             editableTask.scheduledDate,
             new Date(),
-            { forwardDate: true },
+            { forwardDate: editableTask.forwardOnly },
         );
         if (parsedScheduledDate !== null) {
             scheduledDate = window.moment(parsedScheduledDate);
@@ -177,7 +184,7 @@
         const parsedDueDate = chrono.parseDate(
             editableTask.dueDate,
             new Date(),
-            { forwardDate: true },
+            { forwardDate: editableTask.forwardOnly },
         );
         if (parsedDueDate !== null) {
             dueDate = window.moment(parsedDueDate);
@@ -298,12 +305,24 @@
                 />
                 <code>{startDateSymbol} {@html parsedStartDate}</code>
             </div>
+            <div class="tasks-modal-date">
+                <div>
+                    <label for="forwardOnly">Force future dates:</label>
+                    <input
+                        bind:checked={editableTask.forwardOnly}
+                        id="forwardOnly"
+                        type="checkbox"
+                        class="task-list-item-checkbox tasks-modal-checkbox"
+                    />
+                </div>
+            </div>
         </div>
         <hr />
         <div class="tasks-modal-section">
             <div>
-                Status:
+                <label for="status">Status:</label>
                 <input
+                    id="status"
                     type="checkbox"
                     class="task-list-item-checkbox tasks-modal-checkbox"
                     checked={editableTask.status === Status.DONE}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -307,7 +307,7 @@
             </div>
             <div class="tasks-modal-date">
                 <div>
-                    <label for="forwardOnly">Force future dates:</label>
+                    <label for="forwardOnly">Only future dates:</label>
                     <input
                         bind:checked={editableTask.forwardOnly}
                         id="forwardOnly"

--- a/styles.css
+++ b/styles.css
@@ -52,3 +52,8 @@
 .tasks-modal-date {
     margin-bottom: 10px;
 }
+
+.tasks-modal label + input {
+    margin-left: .67em;
+}
+

--- a/styles.css
+++ b/styles.css
@@ -53,7 +53,7 @@
     margin-bottom: 10px;
 }
 
-.tasks-modal label + input {
-    margin-left: .67em;
+.tasks-modal label + input[type="checkbox"] {
+    margin-left: 0.67em;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -53,7 +53,7 @@
     margin-bottom: 10px;
 }
 
-.tasks-modal label + input[type="checkbox"] {
+.tasks-modal label + input[type=checkbox] {
     margin-left: 0.67em;
 }
 


### PR DESCRIPTION
# Description

This PR adds a new checkbox labelled "Force future dates" to the "Edit task" dialog.

This checkbox is checked by default. If you uncheck it, relative dates entered in the date fields are no longer enforced to be in the future, but you can also specify dates in the past.

## Motivation and Context

Assume it is Sunday and you enter "last Saturday" in the "Due" field. Then this is interpreted as *next* Saturday (in 6 days) by default, because all dates are assumed to be in the future (using the "forwardDate" option of chrono which is set by default).

But sometimes, you may actually want to enter a date in the past, like if you missed a deadline something last Saturday but still want to work on the task and have it shown as "overdue". Another reason to disable the "fowardDate" feature is to experiment with how natural language date expressions are interpreted by chrono, in order to use these expressions in filters (where the the "forwardDate" option is not set when comparing task dates).

## How has this been tested?

Manual testing only.

Open the task editor. Enter "last Monday" in the "Due", "Scheduled" or "Start field". Observe that this is interpreted as being the next Monday in the future. Uncheck "Force future dates". Observe that dates are now one week earlier, really the last Monday.

This is fully backward compatible, since by default "force future dates" is checked, which corresponds to the current behavior.

## Screenshots (if appropriate)

### "Force future dates" on (default):

![only-future-dates-on](https://user-images.githubusercontent.com/464599/192140999-df5c009a-4adc-4374-886c-887c33cc6aae.png)

### "Force future dates" off:

![only-future-dates-off](https://user-images.githubusercontent.com/464599/192141017-579b0cbd-ed64-4c9c-81e5-159efbcb158b.png)

## Types of changes

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
