### PR TITLE
refactor: Reimplement FilterOrErrorMessage using new Filter class

### DIFF
--- a/src/Query/Filter/Filter.ts
+++ b/src/Query/Filter/Filter.ts
@@ -37,15 +37,23 @@ export class Filter {
  * problem line, and perhaps listing allowed options).
  */
 export class FilterOrErrorMessage {
-    private _filterFunction: FilterFunction | undefined;
+    private _filter: Filter | undefined;
     error: string | undefined;
 
     get filterFunction(): FilterFunction | undefined {
-        return this._filterFunction;
+        if (this._filter) {
+            return this._filter.filterFunction;
+        } else {
+            return undefined;
+        }
     }
 
     set filterFunction(value: FilterFunction | undefined) {
-        this._filterFunction = value;
+        if (value) {
+            this._filter = new Filter(value);
+        } else {
+            this._filter = undefined;
+        }
     }
 
     /**
@@ -54,7 +62,7 @@ export class FilterOrErrorMessage {
      */
     public static fromFilter(filter: FilterFunction): FilterOrErrorMessage {
         const result = new FilterOrErrorMessage();
-        result._filterFunction = filter;
+        result.filterFunction = filter;
         return result;
     }
 

--- a/src/Query/Filter/Filter.ts
+++ b/src/Query/Filter/Filter.ts
@@ -37,8 +37,16 @@ export class Filter {
  * problem line, and perhaps listing allowed options).
  */
 export class FilterOrErrorMessage {
-    filterFunction: FilterFunction | undefined;
+    private _filterFunction: FilterFunction | undefined;
     error: string | undefined;
+
+    get filterFunction(): FilterFunction | undefined {
+        return this._filterFunction;
+    }
+
+    set filterFunction(value: FilterFunction | undefined) {
+        this._filterFunction = value;
+    }
 
     /**
      * Construct a FilterOrErrorMessage with the filter.
@@ -46,7 +54,7 @@ export class FilterOrErrorMessage {
      */
     public static fromFilter(filter: FilterFunction): FilterOrErrorMessage {
         const result = new FilterOrErrorMessage();
-        result.filterFunction = filter;
+        result._filterFunction = filter;
         return result;
     }
 

--- a/src/Query/Filter/Filter.ts
+++ b/src/Query/Filter/Filter.ts
@@ -7,6 +7,23 @@ import type { Task } from '../../Task';
 export type FilterFunction = (task: Task) => boolean;
 
 /**
+ * A class that represents a parsed filtering instruction from a tasks code block.
+ *
+ * Currently it provides access to:
+ *
+ * - The {@link filterFunction} - a {@link FilterFunction} which tests whether a task matches the filter
+ *
+ * Later, the plan is to add storage of the user's instruction, and a human-readable explanation of the filter.
+ */
+export class Filter {
+    public filterFunction: FilterFunction;
+
+    public constructor(filterFunction: FilterFunction) {
+        this.filterFunction = filterFunction;
+    }
+}
+
+/**
  * A class which stores one of:
  * - A Filter
  * - An error message

--- a/tests/Query/Filter/Filter.test.ts
+++ b/tests/Query/Filter/Filter.test.ts
@@ -1,0 +1,18 @@
+import { Filter } from '../../../src/Query/Filter/Filter';
+import type { FilterFunction } from '../../../src/Query/Filter/Filter';
+import type { Task } from '../../../src/Task';
+import { toMatchTaskFromLine } from '../../CustomMatchers/CustomMatchersForFilters';
+
+expect.extend({
+    toMatchTaskFromLine,
+});
+
+describe('Filter', () => {
+    it('should create a Filter object', () => {
+        const filterFunction: FilterFunction = (task: Task) => {
+            return task.description.length > 20;
+        };
+        const filter = new Filter(filterFunction);
+        expect(filter.filterFunction).not.toBeUndefined();
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Add new (unused) `Filter` class
- Encapsulate `filterFunction` in `FilterOrErrorMessage`
- `FilterOrErrorMessage` now stores a `Filter`

## Motivation and Context

This is in preparation for adding new features to the Filter class

## How has this been tested?

Running existing tests.
Adding a new test for `Filter`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
