### PR TITLE
refactor: Query now stores Filter instead of FilterFunction

### DIFF
--- a/src/Query/Filter/Filter.ts
+++ b/src/Query/Filter/Filter.ts
@@ -40,6 +40,10 @@ export class FilterOrErrorMessage {
     private _filter: Filter | undefined;
     error: string | undefined;
 
+    public get filter(): Filter | undefined {
+        return this._filter;
+    }
+
     get filterFunction(): FilterFunction | undefined {
         if (this._filter) {
             return this._filter.filterFunction;

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -5,6 +5,7 @@ import { Sort } from './Sort';
 import type { TaskGroups } from './TaskGroups';
 import { parseFilter } from './FilterParser';
 import { Group } from './Group';
+import type { FilterFunction } from './Filter/Filter';
 
 export type SortingProperty =
     | 'urgency'
@@ -47,7 +48,7 @@ export class Query implements IQuery {
 
     private _limit: number | undefined = undefined;
     private _layoutOptions: LayoutOptions = new LayoutOptions();
-    private _filters: ((task: Task) => boolean)[] = [];
+    private _filters: FilterFunction[] = [];
     private _error: string | undefined = undefined;
     private _sorting: Sorting[] = [];
     private _grouping: Grouping[] = [];
@@ -111,7 +112,7 @@ export class Query implements IQuery {
         return this._layoutOptions;
     }
 
-    public get filters(): ((task: Task) => boolean)[] {
+    public get filters(): FilterFunction[] {
         return this._filters;
     }
 

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -5,7 +5,7 @@ import { Sort } from './Sort';
 import type { TaskGroups } from './TaskGroups';
 import { parseFilter } from './FilterParser';
 import { Group } from './Group';
-import type { FilterFunction } from './Filter/Filter';
+import type { Filter } from './Filter/Filter';
 
 export type SortingProperty =
     | 'urgency'
@@ -48,7 +48,7 @@ export class Query implements IQuery {
 
     private _limit: number | undefined = undefined;
     private _layoutOptions: LayoutOptions = new LayoutOptions();
-    private _filters: FilterFunction[] = [];
+    private _filters: Filter[] = [];
     private _error: string | undefined = undefined;
     private _sorting: Sorting[] = [];
     private _grouping: Grouping[] = [];
@@ -112,7 +112,7 @@ export class Query implements IQuery {
         return this._layoutOptions;
     }
 
-    public get filters(): FilterFunction[] {
+    public get filters(): Filter[] {
         return this._filters;
     }
 
@@ -130,7 +130,7 @@ export class Query implements IQuery {
 
     public applyQueryToTasks(tasks: Task[]): TaskGroups {
         this.filters.forEach((filter) => {
-            tasks = tasks.filter(filter);
+            tasks = tasks.filter(filter.filterFunction);
         });
 
         const tasksSortedLimited = Sort.by(this, tasks).slice(0, this.limit);
@@ -183,7 +183,7 @@ export class Query implements IQuery {
     private parseFilter(line: string) {
         const filterOrError = parseFilter(line);
         if (filterOrError != null) {
-            if (filterOrError.filterFunction) this._filters.push(filterOrError.filterFunction);
+            if (filterOrError.filter) this._filters.push(filterOrError.filter);
             else this._error = filterOrError.error;
             return true;
         }

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -112,7 +112,7 @@ describe('Query parsing', () => {
             expect(query.filters.length).toEqual(1);
             expect(query.filters[0]).toBeDefined();
             // If the boolean query and its sub-query are parsed correctly, the expression should always be true
-            expect(query.filters[0](task)).toBeTruthy();
+            expect(query.filters[0].filterFunction(task)).toBeTruthy();
         });
     });
 
@@ -289,7 +289,7 @@ describe('Query', () => {
             // Act
             let filteredTasks = [...tasks];
             query.filters.forEach((filter) => {
-                filteredTasks = filteredTasks.filter(filter);
+                filteredTasks = filteredTasks.filter(filter.filterFunction);
             });
 
             // Assert

--- a/tests/TestingTools/FilterTestHelpers.ts
+++ b/tests/TestingTools/FilterTestHelpers.ts
@@ -49,7 +49,7 @@ export function testTaskFilterViaQuery(filter: string, task: Task, expected: boo
     // Act
     let filteredTasks = [...tasks];
     query.filters.forEach((filter) => {
-        filteredTasks = filteredTasks.filter(filter);
+        filteredTasks = filteredTasks.filter(filter.filterFunction);
     });
     const matched = filteredTasks.length === 1;
 
@@ -85,7 +85,7 @@ export function shouldSupportFiltering(
     // Act
     let filteredTasks = [...tasks];
     query.filters.forEach((filter) => {
-        filteredTasks = filteredTasks.filter(filter);
+        filteredTasks = filteredTasks.filter(filter.filterFunction);
     });
 
     // Assert


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Refactored to that Query now stores Filter instead of FilterFunction.

## Motivation and Context

This is a step towards adding more storage to Filter, potentially including the original instruction and also an explanation of the search logic.

## How has this been tested?

Running existing tests

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms


- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
