### PR TITLE
fix: Redraw Tasks results when dates change from valid to invalid 

### DIFF
--- a/src/Query/Sort.ts
+++ b/src/Query/Sort.ts
@@ -132,6 +132,12 @@ export class Sort {
         } else if (a === null && b !== null) {
             return 1;
         } else if (a !== null && b !== null) {
+            if (a.isValid() && !b.isValid()) {
+                return -1;
+            } else if (!a.isValid() && b.isValid()) {
+                return 1;
+            }
+
             if (a.isAfter(b)) {
                 return 1;
             } else if (a.isBefore(b)) {

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -307,7 +307,6 @@ expect.extend({
 
         const pass = actual === expected;
         const message = () => `${dateA} < ${dateB}: expected=${expected} actual=${actual}`;
-        console.log(message());
 
         return { pass, message };
     },

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -320,7 +320,7 @@ declare global {
     }
 }
 
-// These low-level tests
+// These are lower-level tests that the Task-based ones above, for ease of test coverage.
 describe('compareBy', () => {
     it('compares correctly by date', () => {
         const equal = 0;

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -291,7 +291,7 @@ describe('Sort', () => {
 });
 
 expect.extend({
-    toGiveCompareToResult(dates, expected) {
+    toGiveCompareToResult(dates: (string | null)[], expected: -1 | 0 | 1) {
         expect(dates.length).toEqual(2);
 
         const dateA = dates[0];

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -290,6 +290,37 @@ describe('Sort', () => {
     });
 });
 
+expect.extend({
+    toGiveCompareToResult(dates, expected) {
+        expect(dates.length).toEqual(2);
+
+        const dateA = dates[0];
+        const dateB = dates[1];
+
+        let a: moment.Moment | null = null;
+        if (dateA !== null) a = DateParser.parseDate(dateA);
+
+        let b: moment.Moment | null = null;
+        if (dateB !== null) b = DateParser.parseDate(dateB);
+
+        const actual = Sort.compareByDate(a, b);
+
+        const pass = actual === expected;
+        const message = () => `${dateA} < ${dateB}: expected=${expected} actual=${actual}`;
+        console.log(message());
+
+        return { pass, message };
+    },
+});
+
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toGiveCompareToResult(expected: number): R;
+        }
+    }
+}
+
 // These low-level tests
 describe('compareBy', () => {
     it('compares correctly by date', () => {
@@ -313,17 +344,10 @@ describe('compareBy', () => {
         testCompareByDateBothWays(invalidDate, earlierDate, after); // invalid dates sort after valid ones
 
         function testCompareByDateBothWays(dateA: string | null, dateB: string | null, expected: -1 | 0 | 1) {
-            let a: moment.Moment | null = null;
-            if (dateA !== null) a = DateParser.parseDate(dateA);
-
-            let b: moment.Moment | null = null;
-            if (dateB !== null) b = DateParser.parseDate(dateB);
-
-            // TODO Try to make these tests write out meaningful information if they value
-            expect(Sort.compareByDate(a, b)).toEqual(expected);
+            expect([dateA, dateB]).toGiveCompareToResult(expected);
 
             const reverseExpected = expected === equal ? equal : -expected;
-            expect(Sort.compareByDate(b, a)).toEqual(reverseExpected);
+            expect([dateB, dateA]).toGiveCompareToResult(reverseExpected);
         }
     });
 });

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -294,23 +294,23 @@ describe('Sort', () => {
 describe('compareBy', () => {
     it('compares correctly by date', () => {
         const equal = 0;
-        const greaterThan = 1;
-        const lessThan = -1;
+        const after = 1;
+        const before = -1;
 
         const earlierDate = '2022-01-01';
         const latererDate = '2022-02-01'; // intentional type - laterer - so all variable names align in code
         const invalidDate = '2022-02-30';
 
-        testCompareByDateBothWays(earlierDate, latererDate, lessThan);
+        testCompareByDateBothWays(earlierDate, latererDate, before);
         testCompareByDateBothWays(earlierDate, earlierDate, equal);
-        testCompareByDateBothWays(latererDate, earlierDate, greaterThan);
+        testCompareByDateBothWays(latererDate, earlierDate, after);
 
-        testCompareByDateBothWays(null, earlierDate, greaterThan); // no date sorts after valid dates
+        testCompareByDateBothWays(null, earlierDate, after); // no date sorts after valid dates
         testCompareByDateBothWays(null, null, equal);
 
-        testCompareByDateBothWays(invalidDate, null, lessThan); // invalid dates sort before no date
+        testCompareByDateBothWays(invalidDate, null, before); // invalid dates sort before no date
         testCompareByDateBothWays(invalidDate, invalidDate, equal);
-        testCompareByDateBothWays(invalidDate, earlierDate, greaterThan); // invalid dates sort after valid ones
+        testCompareByDateBothWays(invalidDate, earlierDate, after); // invalid dates sort after valid ones
 
         function testCompareByDateBothWays(dateA: string | null, dateB: string | null, expected: -1 | 0 | 1) {
             let a: moment.Moment | null = null;

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -310,9 +310,9 @@ describe('compareBy', () => {
 
         testCompareByDateBothWays(invalidDate, null, lessThan); // invalid dates sort before no date
         testCompareByDateBothWays(invalidDate, invalidDate, equal);
-        testCompareByDateBothWays(invalidDate, earlierDate, equal); // TODO See #1227 - should be greaterThan
+        testCompareByDateBothWays(invalidDate, earlierDate, greaterThan); // invalid dates sort after valid ones
 
-        function testCompareByDateBothWays(dateA: string | null, dateB: string | null, expected: number) {
+        function testCompareByDateBothWays(dateA: string | null, dateB: string | null, expected: -1 | 0 | 1) {
             let a: moment.Moment | null = null;
             if (dateA !== null) a = DateParser.parseDate(dateA);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Fixes an error that valid and invalid dates were considered to be identical when sorting, which meant that if a user edited a task to change its due date from invalid to valid, no tasks blocks were updated to show the new data.

## Motivation and Context

This fixes #1227:
"Failure to redraw Tasks block results when signifier dates change from valid to invalid - and the reverse"

## How has this been tested?

- Running existing tests
- Adding new tests
- Manually testing a new build of the plugin, to confirm that the bug is fixed

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
