### PR TITLE
docs: Document iPhone scrollbar issue in Create/edit task.

### DIFF
--- a/docs/getting-started/create-or-edit-task.md
+++ b/docs/getting-started/create-or-edit-task.md
@@ -104,3 +104,16 @@ To close the modal and cancel your edits, do one of:
 - click or tap outside the modal,
 - click the close button at the corner of the modal (if one exists on your operating system),
 - hit the `Esc` key.
+
+## Known limitations
+
+### Need to scroll on phone screens
+
+On phone screens the 'Create or edit Task' Modal may be too tall to fit on the screen.
+It does support scrolling, and on Android, the scrollbar is visible.
+
+Unfortunately iPhones don't display the scrollbar until you actually start scrolling.
+Tap on the screen and drag down, and you will see a scrollbar appear temporarily.
+More importantly, the scrolling does then work fine.
+
+We are tracking the iPhone scrollbar issue in [issue #1238](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1238).


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

Document the iPhone scrollbar issue in Create/edit task modal.

## Motivation and Context

See #1238.

If it helps a few iPhone users know that they can scroll, it was worthwhile.

## How has this been tested?

By viewing the docs locally.

## Screenshots (if appropriate)

Changes to contents list:
![image](https://user-images.githubusercontent.com/4840096/196807205-9b57a076-05bf-4bbd-b2d5-1345739a3ac7.png)

The new words:

![image](https://user-images.githubusercontent.com/4840096/196807253-4fcefa93-383b-4c92-99a4-bc8a6975bf31.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
