### PR TITLE
docs: Use hyphen for unordered lists

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,4 +1,7 @@
 {
+  "MD004": { // Unordered list style
+  			"style": "dash"
+  		   },
   "MD013": false, // Ignore the line length rule.
   "MD025": false, // Allow the title in the front matter and markdown heading one to match.
   "MD033": false, // Allow Inline HTML.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities

--- a/docs/queries/grouping.md
+++ b/docs/queries/grouping.md
@@ -38,7 +38,7 @@ File locations:
 1. `root` (the top-level folder of the file that contains the task, that is, the first directory in the path, which will be `/` for files in root of the vault)
 1. `folder` (the folder to the file that contains the task, which will be `/` for files in root of the vault)
 1. `filename` (the filename of the file that contains the task, without the `.md` extension)
-    * Note that tasks from different notes with the same file name will be grouped together in the same group.
+    - Note that tasks from different notes with the same file name will be grouped together in the same group.
 
 > `root` grouping option was introduced in Tasks 1.11.0.
 
@@ -50,36 +50,36 @@ File contents:
 Task date properties:
 
 1. `start`
-   * The start date of the task, including the week-day, or `No start date`.
+   - The start date of the task, including the week-day, or `No start date`.
 1. `scheduled`
-    * The scheduled date of the task, including the week-day, or `No scheduled date`.
+    - The scheduled date of the task, including the week-day, or `No scheduled date`.
 1. `due`
-    * The due date of the task, including the week-day, or `No due date`.
+    - The due date of the task, including the week-day, or `No due date`.
 1. `done`
-    * The done date of the task, including the week-day, or `No done date`.
+    - The done date of the task, including the week-day, or `No done date`.
 1. `happens`
-    * The earliest of start date, scheduled date, and due date, including the week-day, or `No happens date` if none of those are set.
+    - The earliest of start date, scheduled date, and due date, including the week-day, or `No happens date` if none of those are set.
 
 > `happens` grouping option was introduced in Tasks 1.11.0.
 
 Task properties - other:
 
 1. `status` (Done or Todo, which is capitalized for visibility in the headings)
-    * Note that the Done group is displayed before the Todo group,
+    - Note that the Done group is displayed before the Todo group,
       which differs from the Sorting ordering of this property.
 1. `priority`
-    * The priority of the task, namely one of:
-        * `Priority 1: High`
-        * `Priority 2: Medium`
-        * `Priority 3: None`
-        * `Priority 4: Low`
+    - The priority of the task, namely one of:
+        - `Priority 1: High`
+        - `Priority 2: Medium`
+        - `Priority 3: None`
+        - `Priority 4: Low`
 1. `recurring`
-    * Whether the task is recurring: either `Recurring` or `Not Recurring`.
+    - Whether the task is recurring: either `Recurring` or `Not Recurring`.
 1. `recurrence`
-    * The recurrence rule of the task, for example `every week on Sunday`, or `None` for non-recurring tasks.
-    * Note that the text displayed is generated programmatically and standardised, and so may not exactly match the text in any manually typed tasks. For example, a task with `🔁 every Sunday` is grouped in `every week on Sunday`.
+    - The recurrence rule of the task, for example `every week on Sunday`, or `None` for non-recurring tasks.
+    - Note that the text displayed is generated programmatically and standardised, and so may not exactly match the text in any manually typed tasks. For example, a task with `🔁 every Sunday` is grouped in `every week on Sunday`.
 1. `tags`
-    * The tags of the tasks or `(No tags)`. If the task has multiple tags, it will show up under every tag.
+    - The tags of the tasks or `(No tags)`. If the task has multiple tags, it will show up under every tag.
 
 > `start`, `scheduled`, `due` and `done` grouping options were introduced in Tasks 1.7.0.
 >
@@ -95,9 +95,9 @@ The first group has the highest priority.
 
 Each subsequent `group by` will generate a new heading-level within the existing grouping:
 
-* First `group by` is displayed as `h4` headings
-* Second `group by` is displayed as `h5` headings
-* Third and subsequent `group by` are displayed as `h6` headings
+- First `group by` is displayed as `h4` headings
+- Second `group by` is displayed as `h5` headings
+- Third and subsequent `group by` are displayed as `h6` headings
 
 See the [screenshots below](#screenshots) for how this looks in practice.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Configure markdownlint to use hyphens for unordered lists
- And run it, to standardise bullets in a couple of files

## Motivation and Context

I am going to be using [markdownlint](https://github.com/simonCropp/MarkdownSnippets) to add tables of contents to a few markdown files used by maintainers.

This puts `*` in as the first UL in the file, meaning that the previous setting of 'consistent' would have converted all later bullets to `*` instead of `-`.

I want to standardise on `-`. because Obsidian's habit of putting in 2 `*` - for bold - when starting new lists with that setting is irritating. 

## How has this been tested?

As one of the files changed is in the user docs (grouping), I generated the docs locally, and compared them side by side with the published copy. They were identical.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Two markdown files were changed, but there were no visible changes in the content.

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
