### PR TITLE
chore: add 'Linking to other pages in the docs' section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ This is _not_ mandatory, but it helps improve the process and reduce unnecessary
 Once you want to propose your changes, create a PR and we'll have a look when we have time.
 Discussion will take place inside the PR.
 
-If you can, please add/update tests and documentation where appropriate.
+If you can, please add/update [tests](#maintaining-the-tests) and [documentation](#updating-documentation) where appropriate.
 
 ## Local setup and workflow for changes to code and tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 
 - [Thank you](#thank-you)
 - [Updating documentation](#updating-documentation)
+  - [Linking to other pages in the docs](#linking-to-other-pages-in-the-docs)
   - [Documentation and branches](#documentation-and-branches)
   - [Screenshots in documentation](#screenshots-in-documentation)
   - [Version numbers in documentation](#version-numbers-in-documentation)
@@ -43,6 +44,31 @@ Every contribution is much appreciated!
 The documentation resides under the `./docs` directory.
 It consists of markdown files, which [Jekyll](https://jekyllrb.com/) will transform into web pages that you can view at <https://obsidian-tasks-group.github.io/obsidian-tasks/> .
 In the simplest case, you can update the existing markdown file and create a pull request (PR) with your changes.
+
+### Linking to other pages in the docs
+
+Linking to other pages in the documentation is non-obvious and a bit tedious.
+
+Here are some examples to copy-and-paste:
+
+To pages:
+
+```text
+[‘Create or edit Task’ Modal]({{ site.baseurl }}{% link getting-started/create-or-edit-task.md %})
+[Dates]({{ site.baseurl }}{% link getting-started/dates.md %})
+[Filters]({{ site.baseurl }}{% link queries/filters.md %})
+[Global Filter]({{ site.baseurl }}{% link getting-started/global-filter.md %})
+[Priorities]({{ site.baseurl }}{% link getting-started/priority.md %})
+[Recurring Tasks]({{ site.baseurl }}{% link getting-started/recurring-tasks.md %})
+```
+
+To sections:
+
+```text
+[due]({{ site.baseurl }}{% link getting-started/dates.md %}#-due)
+[scheduled]({{ site.baseurl }}{% link getting-started/dates.md %}#-scheduled)
+[start]({{ site.baseurl }}{% link getting-started/dates.md %}#-start)
+```
 
 ### Documentation and branches
 
@@ -270,7 +296,7 @@ Look at the `package.json` entry for a package and search for which files import
   - `svelte-check` (but not other svelte things, which are used in the build system)
   - anything with `prettier`
   - `lefthook`
-  - anything with `jest` in it (but see [the note below on Dependency Groups](dependency-groups) for details).
+  - anything with `jest` in it (but see [the note below on Dependency Groups](#dependency-groups) for details).
 - For anything else, where and how is it being used? If it's only in tests, or only used by developers, no need to smoke test.
 
 ### Dependency Groups

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@
 
 - [Thank you](#thank-you)
 - [Updating documentation](#updating-documentation)
-  - [Linking to other pages in the docs](#linking-to-other-pages-in-the-docs)
   - [Documentation and branches](#documentation-and-branches)
+  - [Linking to other pages in the docs](#linking-to-other-pages-in-the-docs)
   - [Screenshots in documentation](#screenshots-in-documentation)
   - [Version numbers in documentation](#version-numbers-in-documentation)
   - [How the documentation is generated](#how-the-documentation-is-generated)
@@ -45,6 +45,15 @@ The documentation resides under the `./docs` directory.
 It consists of markdown files, which [Jekyll](https://jekyllrb.com/) will transform into web pages that you can view at <https://obsidian-tasks-group.github.io/obsidian-tasks/> .
 In the simplest case, you can update the existing markdown file and create a pull request (PR) with your changes.
 
+### Documentation and branches
+
+For documentation changes to show up at <https://obsidian-tasks-group.github.io/obsidian-tasks/> , they must be in the `gh-pages` branch.
+If you want to see your changes available immediately and not only after the next release, you should make your changes on the `gh-pages` branch.
+When you create a PR, it should merge into the `gh-pages` branch as well.
+If you document an unreleased feature, you should update the documentation on `main` instead. Ideally together with the related code changes.
+If this is confusing, don't worry.
+We will help you make this right once you opened the PR.
+
 ### Linking to other pages in the docs
 
 Linking to other pages in the documentation is non-obvious and a bit tedious.
@@ -69,15 +78,6 @@ To sections:
 [scheduled]({{ site.baseurl }}{% link getting-started/dates.md %}#-scheduled)
 [start]({{ site.baseurl }}{% link getting-started/dates.md %}#-start)
 ```
-
-### Documentation and branches
-
-For documentation changes to show up at <https://obsidian-tasks-group.github.io/obsidian-tasks/> , they must be in the `gh-pages` branch.
-If you want to see your changes available immediately and not only after the next release, you should make your changes on the `gh-pages` branch.
-When you create a PR, it should merge into the `gh-pages` branch as well.
-If you document an unreleased feature, you should update the documentation on `main` instead. Ideally together with the related code changes.
-If this is confusing, don't worry.
-We will help you make this right once you opened the PR.
 
 ### Screenshots in documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -396,7 +396,7 @@ The ToCs will eventually be automated automatically via GitHub Actions, but for 
 2. Run:
 
 ```bash
-mdsnippets && git add --renormalize . && yarn run lint:markdown
+mdsnippets && yarn run lint:markdown && git add --renormalize .
 ```
 
 The background to this is in [PR #1248](https://github.com/obsidian-tasks-group/obsidian-tasks/pull/1248).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Assorted improvements  to `CONTRIBUTING.md`

- Add 'Linking to other pages in the docs' section
- Add links to docs and tests instructions, for those interested in adding a PR
- Fix the `mdsnippets` command line

## Motivation and Context

To make it easier to add internal links between pages in the user docs

## How has this been tested?

Reviewed in WebStorm preview.


## Types of changes

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

Not applicable

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
