### PR TITLE
docs: Better cross-linking of info on priority

### DIFF
--- a/docs/getting-started/priority.md
+++ b/docs/getting-started/priority.md
@@ -8,6 +8,21 @@ has_toc: false
 
 # Priority
 
+{: .no_toc }
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Priorities and Order
+
 Tasks can have a priority.
 In order to specify the priority of a task, you can append one of the "priority signifiers", shown here in decreasing order of priority:
 
@@ -24,9 +39,24 @@ The idea is that you can easily filter out unimportant tasks without needing to 
 - [ ] take out the trash 🔼
 ```
 
+## Easy adding of Priorities
+
 Instead of adding the emoji manually, you can:
 
 - Use the `Tasks: Create or edit` command when creating or editing a task.
   You will be able to select the priority from the options in the [‘Create or edit Task’ Modal]({{ site.baseurl }}{% link getting-started/create-or-edit-task.md %}).
 - Using [Intelligent Auto-Suggest]({{ site.baseurl }}{% link getting-started/auto-suggest.md %}),
   start typing the first few characters of `high`, `medium` or `low`, and press <return> to accept the suggested signifier.
+
+## Related Tasks Block Instructions
+
+The following instructions use the priority signifiers in tasks.
+
+- `priority is (above, below)? (low, none, medium, high)`
+  - [Documentation]({{ site.baseurl }}{% link queries/filters.md %}#priority)
+- `sort by priority`
+  - [Documentation]({{ site.baseurl }}{% link queries/sorting.md %}#basics)
+- `group by priority`
+  - [Documentation]({{ site.baseurl }}{% link queries/grouping.md %}#basics)
+- `hide priority`
+  - [Documentation]({{ site.baseurl }}{% link queries/layout.md %})

--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -191,6 +191,15 @@ For example:
 
 - `priority is (above|below)? (low|none|medium|high)`
 
+The available priorities are (from high to low):
+
+1. ⏫ for high priority
+2. 🔼 for medium priority
+3. use no signifier to indicate no priority
+4. 🔽 for low priority
+
+For more information, see [Priorities]({{ site.baseurl }}{% link getting-started/priority.md %}) .
+
 #### Examples
 
 {: .no_toc }

--- a/docs/queries/sorting.md
+++ b/docs/queries/sorting.md
@@ -30,7 +30,7 @@ You can sort tasks by the following properties:
 
 1. `urgency` ([urgency]({{ site.baseurl }}{% link advanced/urgency.md %}))
 2. `status` (done or todo)
-3. `priority` (priority of the task; "low" is below "none")
+3. `priority` (priority of the task; "low" is below "none": [priorities]({{ site.baseurl }}{% link getting-started/priority.md %}))
 4. `start` (the date when the task starts)
 5. `scheduled` (the date when the task is scheduled)
 6. `due` (the date when the task is due)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add cross-linking between multiple references to priority in the documentation.
See the list of commits for details.

## Motivation and Context

I forgot the following comment by @Cito in https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1250#issuecomment-1288781587 - so this PR deals with it, and makes other improvements too:

> Maybe we should mention this also [here](https://obsidian-tasks-group.github.io/obsidian-tasks/queries/filters/#priority) because it's not obvious (although the syntax already shows the order)?


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

By viewing the docs locally.

## Screenshots (if appropriate)

## Types of changes

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
