### PR TITLE
chore: How to add Table of Contents to published docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 - [Thank you](#thank-you)
 - [Updating documentation](#updating-documentation)
   - [Documentation and branches](#documentation-and-branches)
+  - [Adding Tables of Contents to rendered docs](#adding-tables-of-contents-to-rendered-docs)
   - [Linking to other pages in the docs](#linking-to-other-pages-in-the-docs)
   - [Screenshots in documentation](#screenshots-in-documentation)
   - [Version numbers in documentation](#version-numbers-in-documentation)
@@ -53,6 +54,25 @@ When you create a PR, it should merge into the `gh-pages` branch as well.
 If you document an unreleased feature, you should update the documentation on `main` instead. Ideally together with the related code changes.
 If this is confusing, don't worry.
 We will help you make this right once you opened the PR.
+
+### Adding Tables of Contents to rendered docs
+
+Add the following between the H1 and the first H2, to show a table of contents in a page on the published documentation.
+
+```text
+{: .no_toc }
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+```
 
 ### Linking to other pages in the docs
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I had to keep looking up how to add a table of contents to the start of pages in the published docs.

So I added the code to copy in to CONTRIBUTING.

## How has this been tested?

Viewed locally.

## Types of changes

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)


## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
