### PR TITLE
feat: More clearly arranged layout of the task edit dialog

### DIFF
--- a/src/TaskModal.ts
+++ b/src/TaskModal.ts
@@ -11,7 +11,7 @@ export class TaskModal extends Modal {
 
         this.task = task;
         this.onSubmit = (updatedTasks: Task[]) => {
-            onSubmit(updatedTasks);
+            updatedTasks.length && onSubmit(updatedTasks);
             this.close();
         };
     }

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -285,11 +285,10 @@
                 accesskey="t"
             />
         </div>
-        <div class="tasks-modal-section" on:keyup={_onPriorityKeyup}>
+        <div class="tasks-modal-section tasks-modal-priorities" on:keyup={_onPriorityKeyup}>
             <label for="priority-{editableTask.priority}">Priority</label>
             {#each priorityOptions as {value, label, symbol}}
-                <span></span> <!-- possible line break -->
-                <span class="tasks-modal-priority">
+                <span>
                     <!-- svelte-ignore a11y-accesskey -->
                     <input
                         type="radio"

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -184,6 +184,10 @@
         }
     }
 
+    const _onClose = () => {
+        onSubmit([]);
+    }
+
     const _onSubmit = () => {
         const { globalFilter } = getSettings();
         let description = editableTask.description.trim();
@@ -269,7 +273,8 @@
 <div class="tasks-modal">
     <form on:submit|preventDefault={_onSubmit}>
         <div class="tasks-modal-section">
-            <label for="description">Description</label>
+            <label for="description">Descrip<span class="accesskey">t</span>ion</label>
+            <!-- svelte-ignore a11y-accesskey -->
             <input
                 bind:value={editableTask.description}
                 bind:this={descriptionInput}
@@ -277,9 +282,9 @@
                 type="text"
                 class="tasks-modal-description"
                 placeholder="Take out the trash"
+                accesskey="t"
             />
         </div>
-        <hr />
         <div class="tasks-modal-section" on:keyup={_onPriorityKeyup}>
             <label for="priority-{editableTask.priority}">Priority</label>
             {#each priorityOptions as {value, label, symbol}}
@@ -295,71 +300,65 @@
                     />
                     <label for="priority-{value}">
                         <span>{symbol}</span>
-                        <span>{label}</span>
+                        <span class="accesskey-first">{label}</span>
                     </label>
                 </span>
             {/each}
         </div>
-        <hr />
-        <div class="tasks-modal-section">
-            <label for="recurrence">Recurrence</label>
+        <div class="tasks-modal-section tasks-modal-dates">
+            <label for="recurrence" class="accesskey-first">Recurs</label>
+            <!-- svelte-ignore a11y-accesskey -->
             <input
                 bind:value={editableTask.recurrenceRule}
                 id="description"
                 type="text"
                 placeholder="Try 'every 2 weeks on Thursday'."
+                accesskey="r"
             />
             <code>{recurrenceSymbol} {@html parsedRecurrence}</code>
-        </div>
-        <hr />
-        <div class="tasks-modal-section">
-            <div class="tasks-modal-date">
-                <label for="due">Due</label>
+            <label for="due" class="accesskey-first">Due</label>
+            <!-- svelte-ignore a11y-accesskey -->
+            <input
+                bind:value={editableTask.dueDate}
+                id="due"
+                type="text"
+                placeholder={datePlaceholder}
+                accesskey="d"
+            />
+            <code>{dueDateSymbol} {@html parsedDueDate}</code>
+            <label for="scheduled" class="accesskey-first">Scheduled</label>
+            <!-- svelte-ignore a11y-accesskey -->
+            <input
+                bind:value={editableTask.scheduledDate}
+                id="scheduled"
+                type="text"
+                placeholder={datePlaceholder}
+                accesskey="s"
+            />
+            <code>{scheduledDateSymbol} {@html parsedScheduledDate}</code>
+            <label for="start">St<span class="accesskey">a</span>rt</label>
+            <!-- svelte-ignore a11y-accesskey -->
+            <input
+                bind:value={editableTask.startDate}
+                id="start"
+                type="text"
+                placeholder={datePlaceholder}
+                accesskey="a"
+            />
+            <code>{startDateSymbol} {@html parsedStartDate}</code>
+            <div>
+                <label for="forwardOnly">Only <span class="accesskey">f</span>uture dates:</label>
+                <!-- svelte-ignore a11y-accesskey -->
                 <input
-                    bind:value={editableTask.dueDate}
-                    id="due"
-                    type="text"
-                    placeholder={datePlaceholder}
+                    bind:checked={editableTask.forwardOnly}
+                    id="forwardOnly"
+                    type="checkbox"
+                    class="task-list-item-checkbox tasks-modal-checkbox"
+                    accesskey="f"
                 />
-                <code>{dueDateSymbol} {@html parsedDueDate}</code>
-            </div>
-            <hr />
-            <div class="tasks-modal-date">
-                <label for="scheduled">Scheduled</label>
-                <input
-                    bind:value={editableTask.scheduledDate}
-                    id="scheduled"
-                    type="text"
-                    placeholder={datePlaceholder}
-                />
-                <code>{scheduledDateSymbol} {@html parsedScheduledDate}</code>
-            </div>
-            <hr />
-            <div class="tasks-modal-date">
-                <label for="start">Start</label>
-                <input
-                    bind:value={editableTask.startDate}
-                    id="start"
-                    type="text"
-                    placeholder={datePlaceholder}
-                />
-                <code>{startDateSymbol} {@html parsedStartDate}</code>
-            </div>
-            <hr />
-            <div class="tasks-modal-date">
-                <div>
-                    <label for="forwardOnly">Only future dates:</label>
-                    <input
-                        bind:checked={editableTask.forwardOnly}
-                        id="forwardOnly"
-                        type="checkbox"
-                        class="task-list-item-checkbox tasks-modal-checkbox"
-                    />
-                </div>
             </div>
         </div>
-        <hr />
-        <div class="tasks-modal-section">
+        <div class="tasks-modal-section tasks-modal-status">
             <div>
                 <label for="status">Status:</label>
                 <input
@@ -372,14 +371,13 @@
                 <code>{editableTask.status}</code>
             </div>
             <div>
-                Done on:
+                <span>Done on:</span>
                 <code>{@html parsedDone}</code>
             </div>
         </div>
-        <hr />
-        <div class="tasks-modal-section" />
-        <div class="tasks-modal-section">
+        <div class="tasks-modal-section tasks-modal-buttons">
             <button type="submit" class="mod-cta">Apply</button>
+            <button type="button" on:click={_onClose}>Cancel</button>
         </div>
     </form>
 </div>

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -298,7 +298,7 @@
                         accesskey={label.charAt(0).toLowerCase()}
                     />
                     <label for="priority-{value}">
-                        <span>{symbol}</span>
+                        {#if symbol && symbol.charCodeAt(0) >= 0x100}<span>{symbol}</span>{/if}
                         <span class="accesskey-first">{label}</span>
                     </label>
                 </span>

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -346,7 +346,7 @@
             />
             <code>{startDateSymbol} {@html parsedStartDate}</code>
             <div>
-                <label for="forwardOnly">Only <span class="accesskey">f</span>uture dates:</label>
+                <label for="forwardOnly">Only <span class="accesskey-first">future</span> dates:</label>
                 <!-- svelte-ignore a11y-accesskey -->
                 <input
                     bind:checked={editableTask.forwardOnly}

--- a/styles.css
+++ b/styles.css
@@ -59,6 +59,10 @@
     margin-bottom: 4px;
 }
 
+.tasks-modal-section label > span {
+    display: inline-block;
+}
+
 .tasks-modal .accesskey-first::first-letter, .tasks-modal .accesskey {
     text-decoration: underline;
     text-underline-offset: 1pt;

--- a/styles.css
+++ b/styles.css
@@ -59,8 +59,9 @@
     margin-bottom: 4px;
 }
 
-.tasks-modal input[type="text"] {
-    width: 100%;
+.tasks-modal .accesskey-first::first-letter, .tasks-modal .accesskey {
+    text-decoration: underline;
+    text-underline-offset: 1pt;
 }
 
 .tasks-modal-buttons {
@@ -73,46 +74,43 @@
     margin-left: 0.67em;
 }
 
-.tasks-modal-priority {
+.tasks-modal input[type="text"] {
+    width: 100%;
+}
+
+.tasks-modal-priorities {
+    display: grid;
+    grid-template-columns: 4em 5em 5em 7em 5em;
+    grid-column-gap: 1.33em;
+}
+
+.tasks-modal-priorities span {
     line-height: 1.41;
     white-space: nowrap;
 }
 
-.tasks-modal-priority input {
-    margin-left: 1.5em;
-}
-
-.tasks-modal-priority label {
+.tasks-modal-priorities label {
     border-radius: var(--input-radius);
     padding: 2px 3px;
 }
 
-.tasks-modal-priority input:focus + label {
+.tasks-modal-priorities input:focus + label {
     box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
     border-color: var(--background-modifier-border-focus);
 }
 
-.tasks-modal-priority label > span:nth-child(2) {
-    display: inline-block;
+.tasks-modal-priorities input:checked + label > span:nth-child(2) {
+    font-weight: bold;
 }
 
-.tasks-modal-priority input:not(:checked) + label > span:first-child {
+.tasks-modal-priorities input:not(:checked) + label > span:first-child {
     filter: grayscale(100%) opacity(60%);
-}
-
-.tasks-modal .accesskey-first::first-letter, .tasks-modal .accesskey {
-    text-decoration: underline;
-    text-underline-offset: 1pt;
-}
-
-.tasks-modal-priority input:checked + label > span:nth-child(2) {
-    text-shadow: 0px 0px 1px var(--text-normal);
 }
 
 .tasks-modal-dates {
     display: grid;
     grid-template-columns: min-content auto;
-    column-gap: .67em;
+    column-gap: 1em;
     row-gap: 5px;
 }
 
@@ -141,6 +139,13 @@
 }
 
 @media (max-width: 649px) {
+    .tasks-modal-priorities {
+        grid-template-columns: 4em 7.5em 5em;
+        margin-bottom: -10px;
+    }
+    .tasks-modal-priorities > label {
+        grid-row: 1 / span 2;
+    }
     .tasks-modal-dates {
         grid-template-columns: 1fr;
     }
@@ -153,10 +158,26 @@
     .tasks-modal-dates > div {
         grid-column-end: 1;
     }
-    .tasks-modal-dates > label {
-        margin-bottom: 0;
-    }
     .tasks-modal-status {
         display: block;
+    }
+}
+
+@media (max-width: 399px) {
+    .tasks-modal-priorities {
+        grid-template-columns: 3em 7em;
+    }
+    .tasks-modal-priorities > label {
+        grid-row: 1 / span 4;
+    }
+}
+
+@media (max-width: 249px) {
+    .tasks-modal-priorities {
+        grid-template-columns: 5em;
+        margin-bottom: 0;
+    }
+    .tasks-modal-priorities > label {
+        grid-row: 1;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,7 @@
     background-color: var(--text-faint);
     mask-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20aria-hidden%3D%22true%22%20focusable%3D%22false%22%20width%3D%221em%22%20height%3D%221em%22%20style%3D%22-ms-transform%3A%20rotate(360deg)%3B%20-webkit-transform%3A%20rotate(360deg)%3B%20transform%3A%20rotate(360deg)%3B%22%20preserveAspectRatio%3D%22xMidYMid%20meet%22%20viewBox%3D%220%200%201536%201536%22%3E%3Cpath%20d%3D%22M363%201408l91-91l-235-235l-91%2091v107h128v128h107zm523-928q0-22-22-22q-10%200-17%207l-542%20542q-7%207-7%2017q0%2022%2022%2022q10%200%2017-7l542-542q7-7%207-17zm-54-192l416%20416l-832%20832H0v-416zm683%2096q0%2053-37%2090l-166%20166l-416-416l166-165q36-38%2090-38q53%200%2091%2038l235%20234q37%2039%2037%2091z%22%20fill%3D%22%23626262%22%2F%3E%3C%2Fsvg%3E");
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20aria-hidden%3D%22true%22%20focusable%3D%22false%22%20width%3D%221em%22%20height%3D%221em%22%20style%3D%22-ms-transform%3A%20rotate(360deg)%3B%20-webkit-transform%3A%20rotate(360deg)%3B%20transform%3A%20rotate(360deg)%3B%22%20preserveAspectRatio%3D%22xMidYMid%20meet%22%20viewBox%3D%220%200%201536%201536%22%3E%3Cpath%20d%3D%22M363%201408l91-91l-235-235l-91%2091v107h128v128h107zm523-928q0-22-22-22q-10%200-17%207l-542%20542q-7%207-7%2017q0%2022%2022%2022q10%200%2017-7l542-542q7-7%207-17zm-54-192l416%20416l-832%20832H0v-416zm683%2096q0%2053-37%2090l-166%20166l-416-416l166-165q36-38%2090-38q53%200%2091%2038l235%20234q37%2039%2037%2091z%22%20fill%3D%22%23626262%22%2F%3E%3C%2Fsvg%3E");
+    mask-size: contain;
     -webkit-mask-size: contain;
     display: inline-block;
     width: 1em;
@@ -49,20 +50,23 @@
     font-weight: bold;
 }
 
-.tasks-modal label {
-    margin: 5px 0 5px 0;
+.tasks-modal-section + .tasks-modal-section {
+    margin-top: 16px;
+}
+
+.tasks-modal-section label {
+    display: inline-block;
+    margin-bottom: 4px;
 }
 
 .tasks-modal input[type="text"] {
     width: 100%;
 }
 
-.tasks-modal hr {
-    margin: 10px 0 10px 0;
-}
-
-.tasks-modal-date {
-    margin-bottom: 10px;
+.tasks-modal-buttons {
+    display: grid;
+    grid-template-columns: 3fr 1fr;
+    column-gap: .5em;
 }
 
 .tasks-modal label + input[type="checkbox"] {
@@ -96,11 +100,63 @@
     filter: grayscale(100%) opacity(60%);
 }
 
-.tasks-modal-priority label > span:nth-child(2)::first-letter {
+.tasks-modal .accesskey-first::first-letter, .tasks-modal .accesskey {
     text-decoration: underline;
     text-underline-offset: 1pt;
 }
 
 .tasks-modal-priority input:checked + label > span:nth-child(2) {
     text-shadow: 0px 0px 1px var(--text-normal);
+}
+
+.tasks-modal-dates {
+    display: grid;
+    grid-template-columns: min-content auto;
+    column-gap: .67em;
+    row-gap: 5px;
+}
+
+.tasks-modal-dates > label {
+    grid-column: 1;
+    margin-top: 4px;
+}
+
+.tasks-modal-dates > input, .tasks-modal-dates > code {
+    grid-column: 2;
+    align-items: stretch; 
+}
+
+.tasks-modal-dates > code {
+    margin-bottom: 5px;
+}
+
+.tasks-modal-dates > div {
+    grid-column-start: 1;
+    grid-column-end: 3;
+}
+
+.tasks-modal-status {
+    display: flex;
+    justify-content: space-between;
+}
+
+@media (max-width: 649px) {
+    .tasks-modal-dates {
+        grid-template-columns: 1fr;
+    }
+    .tasks-modal-dates > label {
+        margin: 0;
+    }
+    .tasks-modal-dates > input, .tasks-modal-dates > code {
+        grid-column: 1;
+    }
+    .tasks-modal-dates > div {
+        grid-column-end: 1;
+    }
+    .tasks-modal-dates > label {
+        margin-bottom: 0;
+    }
+    .tasks-modal-status {
+        display: block;
+    }
 }

--- a/styles.css
+++ b/styles.css
@@ -114,14 +114,14 @@
 
 .tasks-modal-dates {
     display: grid;
-    grid-template-columns: min-content auto;
-    column-gap: 1em;
+    grid-template-columns: 5.5em auto;
+    column-gap: .5em;
     row-gap: 5px;
 }
 
 .tasks-modal-dates > label {
     grid-column: 1;
-    margin-top: 4px;
+    margin-top: 6px;
 }
 
 .tasks-modal-dates > input, .tasks-modal-dates > code {

--- a/styles.css
+++ b/styles.css
@@ -170,16 +170,16 @@
 
 @media (max-width: 399px) {
     .tasks-modal-priorities {
-        grid-template-columns: 3em 7em;
+        grid-template-columns: 4em auto;
     }
     .tasks-modal-priorities > label {
         grid-row: 1 / span 4;
     }
 }
 
-@media (max-width: 249px) {
+@media (max-width: 259px) {
     .tasks-modal-priorities {
-        grid-template-columns: 5em;
+        grid-template-columns: 1fr;
         margin-bottom: 0;
     }
     .tasks-modal-priorities > label {

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,7 @@
 
 .tasks-modal label + input[type="checkbox"] {
     margin-left: 0.67em;
+    top: 2px;
 }
 
 .tasks-modal input[type="text"] {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

With this PR I try to arrange the "Create or edit Task" dialog more clearly and nicely.

This is done by:
- Using [whitespace](https://medium.com/successivetech/importance-of-whitespace-in-good-design-de03ea0ab4db) instead of horizontal lines
- Using a grid layout with labels on the left side

This emphasizes the similarity in purpose and function of the date fields. Also, even though whitespace is used to separate the fields, the whole dialog is much smaller and easier to grasp at a glance. And the date fields are not so large that they need the whole horizontal space (contrary to the task description).

For small screen sizes, the layout automatically switches back to a single column.

This PR also enlarges the "Apply" button and adds a "Cancel" button. This makes the apply button abit easier to click or tap. The dialog can currently only be cancelled via the small "X", but it is less clear and a bit more difficult to find and hit with he mouse.

Also, this PR adds access keys to all the fields of the form (Alt-Key on Windows, Ctrl-Option+Key on Mac). The access keys are dsiplayed as the underlined letters of the labels.

## Motivation and Context

This emphasizes the similarity in purpose and function of the date fields. Also, even though whitespace is used to separate the fields, the whole dialog is much smaller and easier to grasp at a glance.

Overall, the dialog now looks much more clearly arranged (at least in my view, it's of course also a matter of taste).

## How has this been tested?

Manually on Windows, with different window sizes. Will test this on Mac, Linux and Android as well if wanted.

## Screenshots

This is the new layout of the dialog proposed in this PR:

![after](https://user-images.githubusercontent.com/464599/198282052-5a183e84-6459-43e9-a116-7f4a9ae191c5.png)

For comparison, this is the current layout of the dialog:

![before](https://user-images.githubusercontent.com/464599/198282083-1054aeb4-e71e-4120-afbb-97403aa5ab24.png)

This is the new layout of the dialog on a very narrow screen (mobile):

![narrow](https://user-images.githubusercontent.com/464599/198298217-77c64a1a-00b7-4867-9da6-5d1e5ca7c38b.png)

On even narrower screens, the priorities collapse to 2 or even 1 column.

## Types of changes

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [X] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content) 
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [X] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour) - minor refactoring of the styles.css
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [X] My code follows the code style of this project and passes `yarn run lint`.
- [X] My change requires a change to the documentation. - we may need to recreate some screenshots and maybe mention the access keys, I have not done that yet
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

- [X] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [X] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
