### PR TITLE
Add setting to switch access keys off

### DIFF
--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -8,6 +8,7 @@ export interface Settings {
     autoSuggestInEditor: boolean;
     autoSuggestMinMatch: number;
     autoSuggestMaxItems: number;
+    provideAccessKeys: boolean;
 
     // Collection of feature flag IDs and their state.
     features: FeatureFlag;
@@ -20,6 +21,7 @@ const defaultSettings: Settings = {
     autoSuggestInEditor: true,
     autoSuggestMinMatch: 0,
     autoSuggestMaxItems: 6,
+    provideAccessKeys: true,
     features: Feature.settingsFlags,
 };
 

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -63,9 +63,9 @@ export class SettingsTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName('Set done date on every completed task')
             .setDesc('Enabling this will add a timestamp ✅ YYYY-MM-DD at the end when a task is toggled to done')
-            .addToggle((toogle) => {
+            .addToggle((toggle) => {
                 const settings = getSettings();
-                toogle.setValue(settings.setDoneDate).onChange(async (value) => {
+                toggle.setValue(settings.setDoneDate).onChange(async (value) => {
                     updateSettings({ setDoneDate: value });
                     await this.plugin.saveSettings();
                 });
@@ -114,6 +114,17 @@ export class SettingsTab extends PluginSettingTab {
                         updateSettings({ autoSuggestMaxItems: value });
                         await this.plugin.saveSettings();
                     });
+            });
+
+        new Setting(containerEl)
+            .setName('Provide access keys in dialogs')
+            .setDesc('Whether Obsidian Tasks should provide keyboard shortcuts for form controls in dialog boxes.')
+            .addToggle((toggle) => {
+                const settings = getSettings();
+                toggle.setValue(settings.provideAccessKeys).onChange(async (value) => {
+                    updateSettings({ provideAccessKeys: value });
+                    await this.plugin.saveSettings();
+                });
             });
     }
 }

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -45,6 +45,7 @@
     let parsedRecurrence: string = '';
     let parsedDone: string = '';
     let addGlobalFilterOnSave: boolean = false;
+    let withAccessKeys: boolean = true;
 
     // 'weekend' abbreviation ommitted due to lack of space.
     let datePlaceholder =
@@ -136,7 +137,8 @@
     }
 
     onMount(() => {
-        const { globalFilter } = getSettings();
+        const { globalFilter, provideAccessKeys } = getSettings();
+        withAccessKeys = provideAccessKeys;
         const description = task.getDescriptionWithoutGlobalFilter();
         // If we're displaying to the user the description without the global filter (i.e. it was removed in the method
         // above), or if the description did not include a global filter in the first place, we'll add the global filter
@@ -273,7 +275,7 @@
 <div class="tasks-modal">
     <form on:submit|preventDefault={_onSubmit}>
         <div class="tasks-modal-section">
-            <label for="description">Descrip<span class="accesskey">t</span>ion</label>
+            <label for="description">Descrip<span class:accesskey="{withAccessKeys}">t</span>ion</label>
             <!-- svelte-ignore a11y-accesskey -->
             <input
                 bind:value={editableTask.description}
@@ -282,7 +284,7 @@
                 type="text"
                 class="tasks-modal-description"
                 placeholder="Take out the trash"
-                accesskey="t"
+                accesskey={withAccessKeys ? "t" : null}
             />
         </div>
         <div class="tasks-modal-section tasks-modal-priorities" on:keyup={_onPriorityKeyup}>
@@ -295,65 +297,65 @@
                         id="priority-{value}"
                         {value}
                         bind:group={editableTask.priority}
-                        accesskey={label.charAt(0).toLowerCase()}
+                        accesskey={withAccessKeys ? label.charAt(0).toLowerCase() : null}
                     />
                     <label for="priority-{value}">
                         {#if symbol && symbol.charCodeAt(0) >= 0x100}<span>{symbol}</span>{/if}
-                        <span class="accesskey-first">{label}</span>
+                        <span class:accesskey-first="{withAccessKeys}">{label}</span>
                     </label>
                 </span>
             {/each}
         </div>
         <div class="tasks-modal-section tasks-modal-dates">
-            <label for="recurrence" class="accesskey-first">Recurs</label>
+            <label for="recurrence" class:accesskey-first="{withAccessKeys}">Recurs</label>
             <!-- svelte-ignore a11y-accesskey -->
             <input
                 bind:value={editableTask.recurrenceRule}
                 id="description"
                 type="text"
                 placeholder="Try 'every 2 weeks on Thursday'."
-                accesskey="r"
+                accesskey={withAccessKeys ? "r" : null}
             />
             <code>{recurrenceSymbol} {@html parsedRecurrence}</code>
-            <label for="due" class="accesskey-first">Due</label>
+            <label for="due" class:accesskey-first="{withAccessKeys}">Due</label>
             <!-- svelte-ignore a11y-accesskey -->
             <input
                 bind:value={editableTask.dueDate}
                 id="due"
                 type="text"
                 placeholder={datePlaceholder}
-                accesskey="d"
+                accesskey={withAccessKeys ? "d" : null}
             />
             <code>{dueDateSymbol} {@html parsedDueDate}</code>
-            <label for="scheduled" class="accesskey-first">Scheduled</label>
+            <label for="scheduled" class:accesskey-first="{withAccessKeys}">Scheduled</label>
             <!-- svelte-ignore a11y-accesskey -->
             <input
                 bind:value={editableTask.scheduledDate}
                 id="scheduled"
                 type="text"
                 placeholder={datePlaceholder}
-                accesskey="s"
+                accesskey={withAccessKeys ? "s" : null}
             />
             <code>{scheduledDateSymbol} {@html parsedScheduledDate}</code>
-            <label for="start">St<span class="accesskey">a</span>rt</label>
+            <label for="start">St<span class:accesskey="{withAccessKeys}">a</span>rt</label>
             <!-- svelte-ignore a11y-accesskey -->
             <input
                 bind:value={editableTask.startDate}
                 id="start"
                 type="text"
                 placeholder={datePlaceholder}
-                accesskey="a"
+                accesskey={withAccessKeys ? "a" : null}
             />
             <code>{startDateSymbol} {@html parsedStartDate}</code>
             <div>
-                <label for="forwardOnly">Only <span class="accesskey-first">future</span> dates:</label>
+                <label for="forwardOnly">Only <span class:accesskey-first="{withAccessKeys}">future</span> dates:</label>
                 <!-- svelte-ignore a11y-accesskey -->
                 <input
                     bind:checked={editableTask.forwardOnly}
                     id="forwardOnly"
                     type="checkbox"
                     class="task-list-item-checkbox tasks-modal-checkbox"
-                    accesskey="f"
+                    accesskey={withAccessKeys ? "f" : null}
                 />
             </div>
         </div>


### PR DESCRIPTION
# Description

This PR adds a plugin setting that allows users to disable access keys in dialog boxes (actually only the "Create or Edit Task" dialog). By default, they are enabled.

When the acces keys are disabled, the hints for the keys (underlined letters in the control labels) are not shown any more as well.

## Motivation and Context

The access keys might interfere with some other global shortcuts on the platform, or with shortcuts used by screen readers. Or the platform (like a smartphone or tablet) is usually not used with a keyboard anyway, so the hints are only disctracting.

## How has this been tested?

Manually.

## Types of changes

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
