### PR TITLE
ui: Group related settings together, with headings

### DIFF
--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -82,6 +82,30 @@ export class SettingsTab extends PluginSettingTab {
                 });
             });
 
+        new Setting(containerEl)
+            .setName('Use filename as date fallback')
+            .setDesc('Automatically schedule tasks at the date contained in the filename if no other date is set.')
+            .addToggle((toggle) => {
+                const settings = getSettings();
+                toggle.setValue(settings.enableDateFallback).onChange(async (value) => {
+                    updateSettings({ enableDateFallback: value });
+                    await this.plugin.saveSettings();
+                });
+            });
+
+        new Setting(containerEl)
+            .setName('Folders with date fallback')
+            .setDesc('Leave empty if you want to use fallback everywhere, or enter a comma-separated list of folders.')
+            .addText(async (input) => {
+                const settings = getSettings();
+                await this.plugin.saveSettings();
+                input.setValue(SettingsTab.renderFolderArray(settings.dateFallbackFolders)).onChange(async (value) => {
+                    const folders = SettingsTab.parseCommaSeparatedFolders(value);
+                    updateSettings({ dateFallbackFolders: folders });
+                    await this.plugin.saveSettings();
+                });
+            });
+
         // ---------------------------------------------------------------------------
         containerEl.createEl('h4', { text: 'Auto-suggest Settings' });
         // ---------------------------------------------------------------------------
@@ -147,34 +171,6 @@ export class SettingsTab extends PluginSettingTab {
                 const settings = getSettings();
                 toggle.setValue(settings.provideAccessKeys).onChange(async (value) => {
                     updateSettings({ provideAccessKeys: value });
-                    await this.plugin.saveSettings();
-                });
-            });
-
-        // ---------------------------------------------------------------------------
-        containerEl.createEl('h4', { text: 'More Date Settings' });
-        // ---------------------------------------------------------------------------
-
-        new Setting(containerEl)
-            .setName('Use filename as date fallback')
-            .setDesc('Automatically schedule tasks at the date contained in the filename if no other date is set.')
-            .addToggle((toggle) => {
-                const settings = getSettings();
-                toggle.setValue(settings.enableDateFallback).onChange(async (value) => {
-                    updateSettings({ enableDateFallback: value });
-                    await this.plugin.saveSettings();
-                });
-            });
-
-        new Setting(containerEl)
-            .setName('Folders with date fallback')
-            .setDesc('Leave empty if you want to use fallback everywhere, or enter a comma-separated list of folders.')
-            .addText(async (input) => {
-                const settings = getSettings();
-                await this.plugin.saveSettings();
-                input.setValue(SettingsTab.renderFolderArray(settings.dateFallbackFolders)).onChange(async (value) => {
-                    const folders = SettingsTab.parseCommaSeparatedFolders(value);
-                    updateSettings({ dateFallbackFolders: folders });
                     await this.plugin.saveSettings();
                 });
             });

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -15,11 +15,18 @@ export class SettingsTab extends PluginSettingTab {
         const { containerEl } = this;
 
         containerEl.empty();
-        containerEl.createEl('h2', { text: 'Tasks Settings' });
+
+        // For reasons I don't understand, 'h2' is tiny in Settings,
+        // so I have used 'h3' as the largest heading.
+        containerEl.createEl('h3', { text: 'Tasks Settings' });
         containerEl.createEl('p', {
             cls: 'tasks-setting-important',
             text: 'Changing any settings requires a restart of obsidian.',
         });
+
+        // ---------------------------------------------------------------------------
+        containerEl.createEl('h4', { text: 'Global filter Settings' });
+        // ---------------------------------------------------------------------------
 
         new Setting(containerEl)
             .setName('Global task filter')
@@ -60,6 +67,10 @@ export class SettingsTab extends PluginSettingTab {
                 });
             });
 
+        // ---------------------------------------------------------------------------
+        containerEl.createEl('h4', { text: 'Date Settings' });
+        // ---------------------------------------------------------------------------
+
         new Setting(containerEl)
             .setName('Set done date on every completed task')
             .setDesc('Enabling this will add a timestamp ✅ YYYY-MM-DD at the end when a task is toggled to done')
@@ -70,6 +81,10 @@ export class SettingsTab extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 });
             });
+
+        // ---------------------------------------------------------------------------
+        containerEl.createEl('h4', { text: 'Auto-suggest Settings' });
+        // ---------------------------------------------------------------------------
 
         new Setting(containerEl)
             .setName('Auto-suggest task content')
@@ -116,6 +131,10 @@ export class SettingsTab extends PluginSettingTab {
                     });
             });
 
+        // ---------------------------------------------------------------------------
+        containerEl.createEl('h4', { text: 'Dialog Settings' });
+        // ---------------------------------------------------------------------------
+
         new Setting(containerEl)
             .setName('Provide access keys in dialogs')
             .setDesc(
@@ -131,6 +150,10 @@ export class SettingsTab extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 });
             });
+
+        // ---------------------------------------------------------------------------
+        containerEl.createEl('h4', { text: 'More Date Settings' });
+        // ---------------------------------------------------------------------------
 
         new Setting(containerEl)
             .setName('Use filename as date fallback')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

The settings dialog has become long and a bit hard to see the structure.
The same is true of the code.

Changes:

- Add some headings in the settings to show the groups of options
- Move the fallback-date settings next to completion-date settings
- Add some comments in code to delimit the sections in settings

## Motivation and Context

Wanting to make the settings easier to understand at a glance

## How has this been tested?

Running locally

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4840096/199334128-daafb4f7-9f12-498e-bad5-ebdeedb641d2.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **User interface** (prefix: `ui` - non-breaking change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms


- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
