### PR TITLE
fix: Editing via Pencil can now change auto-scheduled date

### DIFF
--- a/src/Commands/CreateOrEdit.ts
+++ b/src/Commands/CreateOrEdit.ts
@@ -23,20 +23,8 @@ export const createOrEdit = (checking: boolean, editor: Editor, view: View, app:
     const line = editor.getLine(lineNumber);
     const task = taskFromLine({ line, path });
 
-    // save the inferred scheduled to compare it later
-    const inferredScheduledDate = task.scheduledDateIsInferred ? task.scheduledDate : null;
-
     const onSubmit = (updatedTasks: Task[]): void => {
-        const serialized = updatedTasks
-            .map((task: Task) => {
-                if (inferredScheduledDate !== null && !inferredScheduledDate.isSame(task.scheduledDate, 'day')) {
-                    // if a fallback date was used before modification, and the scheduled date was modified, we have to mark
-                    // the scheduled date as not inferred anymore.
-                    task = new Task({ ...task, scheduledDateIsInferred: false });
-                }
-
-                return task;
-            })
+        const serialized = DateFallback.removeInferredStatusIfNeeded(task, updatedTasks)
             .map((task: Task) => task.toFileLineString())
             .join('\n');
         editor.setLine(lineNumber, serialized);

--- a/src/DateFallback.ts
+++ b/src/DateFallback.ts
@@ -119,4 +119,22 @@ export class DateFallback {
             scheduledDateIsInferred,
         });
     }
+
+    /**
+     * Update an array of updated tasks to remove the inferred scheduled date status if the scheduled date has been
+     * modified as compared to the original date
+     */
+    public static removeInferredStatusIfNeeded(originalTask: Task, updatedTasks: Task[]): Task[] {
+        const inferredScheduledDate = originalTask.scheduledDateIsInferred ? originalTask.scheduledDate : null;
+
+        return updatedTasks.map((task: Task) => {
+            if (inferredScheduledDate !== null && !inferredScheduledDate.isSame(task.scheduledDate, 'day')) {
+                // if a fallback date was used before modification, and the scheduled date was modified, we have to mark
+                // the scheduled date as not inferred anymore.
+                task = new Task({ ...task, scheduledDateIsInferred: false });
+            }
+
+            return task;
+        });
+    }
 }

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -9,6 +9,7 @@ import type { GroupHeading } from './Query/GroupHeading';
 import { TaskModal } from './TaskModal';
 import type { TasksEvents } from './TasksEvents';
 import type { Task } from './Task';
+import {DateFallback} from "./DateFallback";
 
 export class QueryRenderer {
     private readonly app: App;
@@ -216,7 +217,7 @@ class QueryRenderChild extends MarkdownRenderChild {
             const onSubmit = (updatedTasks: Task[]): void => {
                 replaceTaskWithTasks({
                     originalTask: task,
-                    newTasks: updatedTasks,
+                    newTasks: DateFallback.removeInferredStatusIfNeeded(task, updatedTasks),
                 });
             };
 

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -9,7 +9,7 @@ import type { GroupHeading } from './Query/GroupHeading';
 import { TaskModal } from './TaskModal';
 import type { TasksEvents } from './TasksEvents';
 import type { Task } from './Task';
-import {DateFallback} from "./DateFallback";
+import { DateFallback } from './DateFallback';
 
 export class QueryRenderer {
     private readonly app: App;

--- a/tests/DateFallback.test.ts
+++ b/tests/DateFallback.test.ts
@@ -384,3 +384,44 @@ describe('update fallback date when path is changed', () => {
         expect(updatedTask.scheduledDateIsInferred).toBe(expectedIsInferred);
     });
 });
+
+describe('remove inferred status if scheduled date changed', () => {
+    it('should keep the status if the date is the same', () => {
+        // arrange
+        const task = new TaskBuilder().scheduledDate('2022-11-11').scheduledDateIsInferred(true).build();
+
+        const updatedTask = new TaskBuilder().scheduledDate('2022-11-11').scheduledDateIsInferred(true).build();
+
+        // act
+        const [processedTask] = DateFallback.removeInferredStatusIfNeeded(task, [updatedTask]);
+
+        // assert
+        expect(processedTask.scheduledDateIsInferred).toBe(true);
+    });
+
+    it('should remove the status if the date was changed', () => {
+        // arrange
+        const task = new TaskBuilder().scheduledDate('2022-11-11').scheduledDateIsInferred(true).build();
+
+        const updatedTask = new TaskBuilder().scheduledDate('2022-11-15').scheduledDateIsInferred(false).build();
+
+        // act
+        const [processedTask] = DateFallback.removeInferredStatusIfNeeded(task, [updatedTask]);
+
+        // assert
+        expect(processedTask.scheduledDateIsInferred).toBe(false);
+    });
+
+    it('should not set the status if a scheduled date was added', () => {
+        // arrange
+        const task = new TaskBuilder().scheduledDateIsInferred(false).build();
+
+        const updatedTask = new TaskBuilder().scheduledDate('2022-11-11').scheduledDateIsInferred(false).build();
+
+        // act
+        const [processedTask] = DateFallback.removeInferredStatusIfNeeded(task, [updatedTask]);
+
+        // assert
+        expect(processedTask.scheduledDateIsInferred).toBe(false);
+    });
+});

--- a/tests/DateFallback.test.ts
+++ b/tests/DateFallback.test.ts
@@ -386,7 +386,7 @@ describe('update fallback date when path is changed', () => {
 });
 
 describe('remove inferred status if scheduled date changed', () => {
-    it('should keep the status if the date is the same', () => {
+    it('should keep scheduled-date-is-inferred if the date is the same', () => {
         // arrange
         const task = new TaskBuilder().scheduledDate('2022-11-11').scheduledDateIsInferred(true).build();
 
@@ -399,7 +399,7 @@ describe('remove inferred status if scheduled date changed', () => {
         expect(processedTask.scheduledDateIsInferred).toBe(true);
     });
 
-    it('should remove the status if the date was changed', () => {
+    it('should remove scheduled-date-is-inferred if the date was changed', () => {
         // arrange
         const task = new TaskBuilder().scheduledDate('2022-11-11').scheduledDateIsInferred(true).build();
 
@@ -412,7 +412,7 @@ describe('remove inferred status if scheduled date changed', () => {
         expect(processedTask.scheduledDateIsInferred).toBe(false);
     });
 
-    it('should not set the status if a scheduled date was added', () => {
+    it('should not set scheduled-date-is-inferred if a scheduled date was added', () => {
         // arrange
         const task = new TaskBuilder().scheduledDateIsInferred(false).build();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Allows a scheduled date that was set automatically to be modified using the edit icon.

## Motivation and Context

Fixes #1300 

## How has this been tested?

- Added unit tests for the logic. 
- Verified that the scheduled date can be modified using the edit button
- Verified that there are no regressions when modifying a task using the edit dialog

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
