### PR TITLE
docs: Remove obsolete warning from regex docs - tags now supported

### DIFF
--- a/docs/queries/regular-expressions.md
+++ b/docs/queries/regular-expressions.md
@@ -75,8 +75,6 @@ description regex matches /pc_abigail|pc_edwina|at_work/i
 - Regex searches are **case-sensitive**, unlike the simpler  `includes` and  `does not include`
 - A regex search can be made **insensitive** by appending a `i` flag after the closing `/`, for example: `/I aM cAsE INsensitive because of the LiTle i after the closing slash/i`
 - Tasks does not support multi-line regex searches, as each task is a single line.
-- Note that `tags` searches do not yet support regex searches.
-  - As a workaround, search `description` instead.
 
 ## Escaping special characters
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

Remove inaccurate statement:

> - Note that tags searches do not yet support regex searches.
>     - As a workaround, search description instead.


## Motivation and Context

Fixes #1310

## How has this been tested?

Previewing edited file locally

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
