### PR TITLE
chore: Document developer steps to add a new field to Task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@
   - [Notes and Special Cases](#notes-and-special-cases)
 - [FAQs](#faqs)
   - [How does Tasks handle status changes?](#how-does-tasks-handle-status-changes)
+  - [How do I add a new field to the Task class?](#how-do-i-add-a-new-field-to-the-task-class)
   - [How do I add a new task filter?](#how-do-i-add-a-new-task-filter)
     - [Update src/](#update-src)
     - [Update tests/](#update-tests)
@@ -393,6 +394,23 @@ Toggle behavior:
 - Number 3. toggles the line directly where the checkbox is on the "document" of CodeMirror (the library that Obsidian uses to show text on screen). That, in turn, updates the file in Obsidian's Vault.
 
 Obsidian writes the changes to disk at its own pace.
+
+### How do I add a new field to the Task class?
+
+- In [tests/Task.test.ts](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/tests/Task.test.ts):
+  - Add a new failing block to the `'identicalTo'` section.
+  - Here is an existing example: ['should check path'](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/5b0831c36a80c4cde2d64a6cd281bb4b51e9a142/tests/Task.test.ts#L834-L840).
+- In [src/Task.ts](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/src/Task.ts), update `Task.identicalTo()`:
+  - Once you have a failing test in `Task.test.ts`, implement the check for changed value of your new field in `Task.identicalTo()`.
+  - This important method is used to detect whether any edits of any kind have been made to a task, to detect whether task block results need to be updated.
+  - Here is the code for the method as of 2022-11-12:
+    - [Task.identicalTo() in 5b0831c36a80c4cde2d64a6cd281bb4b51e9a142](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/5b0831c36a80c4cde2d64a6cd281bb4b51e9a142/src/Task.ts#L732-L802)
+- In [tests/TestingTools/TaskBuilder.ts](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/tests/TestingTools/TaskBuilder.ts):
+  - Add the new field and a corresponding method.
+  - Keep the same field order as in the `Task` class.
+  - Update the `build()` method.
+- In [tests/TestingTools/TaskBuilder.test.ts](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/tests/TestingTools/TaskBuilder.test.ts):
+  - If the code in TaskBuild will be non-trivial, first add a failing test for it.
 
 ### How do I add a new task filter?
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Edited CONTRIBUTING.md to list the steps to remember when adding a new field to the Task class

## Motivation and Context

- To save me and others have to work it out
- The need to update `Task.identicalTo()` when adding new fields was requested in code review feedback in https://github.com/obsidian-tasks-group/obsidian-tasks/pull/894#discussion_r923406689

## How has this been tested?

By viewing in WebStorm

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
