### PR TITLE
docs: How to download Tasks-Demo vault with plugin build installed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -548,9 +548,13 @@ Then do one of the following options...
 
 #### Option 1: Download Tasks-Demo test vault with the build's Tasks plugin installed
 
-1. In the Artifacts section at the bottom, click on the link whose name starts with **Tasks-Demo-...**, for example  **Tasks-Demo-VerifyCommit-Build1367-Run1**. This will download a zip file containing a copy of the Tasks-Demo sample vault, including the build of the plugin. (The numbers in the file name will vary.)
-2. Optionally, rename the zip file to give it a meaningful name. For example, you could append 'testing PR 1234 - nicer styling'.
-3. Expand the zip file. It will create a folder of the same name.
+1. In the Artifacts section at the bottom, click on the link whose name starts with **Tasks-Demo-...**, for example  **Tasks-Demo-VerifyCommit-Build1367-Run1**.
+    - This will download a zip file containing a copy of the Tasks-Demo sample vault, including the build of the plugin.
+    - The numbers in the file name will vary.
+2. Optionally, rename the zip file to give it a meaningful name.
+    - For example, you could append 'testing PR 1234 - nicer styling'.
+3. Expand the zip file.
+    - It will create a folder of the same name.
 4. Open the expanded folder in Obsidian:
     - Open Obsidian
     - Click 'Open another vault' button
@@ -563,7 +567,8 @@ Then do one of the following options...
 You can use these steps to install the built plugin either in to the Tasks-Demo vault inside a clone of the [obsidian-tasks repo](https://github.com/obsidian-tasks-group/obsidian-tasks) or in to one of your own vaults.
 
 1. In the Artifacts section at the bottom, click on **dist-verified** to download a build of the plugin.
-2. Optionally, rename the zip file to give it a meaningful name. For example, you could append 'testing PR 1234 - nicer styling'.
+2. Optionally, rename the zip file to give it a meaningful name.
+    - For example, you could append 'testing PR 1234 - nicer styling'.
 3. Expand the downloaded zip file
 4. Copy the files in the expanded folder to the `.obsidian/plugins/obsidian-tasks-plugin/` folder in your vault, over-writing the previous files.
 5. Restart Obsidian.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@
     - [Update doc/](#update-doc)
     - [Examples Pull Requests](#examples-pull-requests)
   - [How do I test a GitHub build of the Tasks plugin?](#how-do-i-test-a-github-build-of-the-tasks-plugin)
+    - [Option 1: Download Tasks-Demo test vault with the build's Tasks plugin installed](#option-1-download-tasks-demo-test-vault-with-the-builds-tasks-plugin-installed)
+    - [Option 2: Download the built plugin to add to your vault](#option-2-download-the-built-plugin-to-add-to-your-vault)
   - [How do I smoke-test the Tasks plugin?](#how-do-i-smoke-test-the-tasks-plugin)
   - [How do I make a release?](#how-do-i-make-a-release)
   - [How do I update the Tables of Contents in CONTRIBUTING and similar?](#how-do-i-update-the-tables-of-contents-in-contributing-and-similar)<!-- endToc -->
@@ -537,12 +539,32 @@ For help on editing the documentation, see [Updating documentation](https://gith
 
 ### How do I test a GitHub build of the Tasks plugin?
 
+First...
+
 1. Go to the [Verify Commit actions page](https://github.com/obsidian-tasks-group/obsidian-tasks/actions/workflows/verify.yml).
 2. Click on the build of the code version you want to test. For example, you might click on the build for a particular pull request, or the most recent build on `main`.
-3. In the Artifacts section at the bottom, click on **dist-verified** to download a build of the plugin.
-4. Expand the downloaded `dist-verified.zip` file
-5. Copy the files in the expanded folder to the `.obsidian/plugins/obsidian-tasks-plugin/` folder in your vault, over-writing the previous files.
-6. Restart Obsidian.
+
+Then do one of the following options...
+
+#### Option 1: Download Tasks-Demo test vault with the build's Tasks plugin installed
+
+1. In the Artifacts section at the bottom, click on the link whose name starts with **Tasks-Demo-...**, for example  **Tasks-Demo-VerifyCommit-Build1367-Run1**. This will download a zip file containing a copy of the Tasks-Demo sample vault, including the build of the plugin. (The numbers in the file name will vary.)
+2. Optionally, rename the zip file to give it a meaningful name. For example, you could append 'testing PR 1234 - nicer styling'.
+3. Expand the zip file. It will create a folder of the same name.
+4. Open the expanded folder in Obsidian:
+    - Open Obsidian
+    - Click 'Open another vault' button
+    - Click 'Open folder as vault' button
+    - Navigate to the downloaded folder
+    - Click 'Open'
+
+#### Option 2: Download the built plugin to add to your vault
+
+1. In the Artifacts section at the bottom, click on **dist-verified** to download a build of the plugin.
+2. Optionally, rename the zip file to give it a meaningful name. For example, you could append 'testing PR 1234 - nicer styling'.
+3. Expand the downloaded zip file
+4. Copy the files in the expanded folder to the `.obsidian/plugins/obsidian-tasks-plugin/` folder in your vault, over-writing the previous files.
+5. Restart Obsidian.
 
 ### How do I smoke-test the Tasks plugin?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -560,6 +560,8 @@ Then do one of the following options...
 
 #### Option 2: Download the built plugin to add to your vault
 
+You can use these steps to install the built plugin either in to the Tasks-Demo vault inside a clone of the [obsidian-tasks repo](https://github.com/obsidian-tasks-group/obsidian-tasks) or in to one of your own vaults.
+
 1. In the Artifacts section at the bottom, click on **dist-verified** to download a build of the plugin.
 2. Optionally, rename the zip file to give it a meaningful name. For example, you could append 'testing PR 1234 - nicer styling'.
 3. Expand the downloaded zip file

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
@@ -13,7 +13,13 @@
 
 ## How the tests work
 
-- Make sure you have the [obsidian-tasks repo](https://github.com/obsidian-tasks-group/obsidian-tasks)cloned and up-to-date on your machine.
+### Get the Tasks-Demo vault with the build to be tested
+
+You can either [download the Tasks-demo vault with the build's Tasks plugin installed](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#how-do-i-test-a-github-build-of-the-tasks-plugin).
+
+Or you can install a download of the build's Tasks plugin inside your clone of the Tasks repo:
+
+- Make sure you have the [obsidian-tasks repo](https://github.com/obsidian-tasks-group/obsidian-tasks) cloned and up-to-date on your machine.
 - Open the Tasks-Demo vault on a machine of your choice:
   - Open Obsidian
   - Click 'Open another vault' button
@@ -22,6 +28,9 @@
   - Click 'Open'
 - Install the candidate build for the pull request or release inside the `Tasks-Demo` vault
   - See the [FAQs in the CONTRIBUTING page](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#faqs).
+
+### Follow the tests
+
 - This note is a self-contained set of steps to check. You should check off tasks beginning `- [ ] check:` as you complete each section.
 
 > [!Important]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This updates CONTRIBUTING and the Smoke Tests for the improvements made in  #1193.

## Motivation and Context

Share the knowledge that smoke-testing is a lot easier now.

## How has this been tested?

By previewing the edits in WebStorm.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates) - **changes to docs for contributors.**

## Checklist

not applicable.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
