### PR TITLE
docs: Add row headings to divide up Quick Reference page

### DIFF
--- a/docs/how-to/find-tasks-for-coming-7-days.md
+++ b/docs/how-to/find-tasks-for-coming-7-days.md
@@ -82,7 +82,7 @@ The way to select dates before a specific future date is `before in ...`. So for
     due before in 7 days
     ```
 
-With the above date, that search give the desired result:
+With the above date, that search gives the desired result:
 
 ```text
 0 days 📅 2022-09-08

--- a/docs/quick-reference/index.md
+++ b/docs/quick-reference/index.md
@@ -46,9 +46,7 @@ This table summarizes the filters and other options available inside a `tasks` b
 | **Other Filter Options**                                                                                                                                                                            |                                             |                       |                        |
 | `exclude sub-items`                                                                                                                                                                                 |                                             |                       |                        |
 | `limit to <number> tasks`<br>`limit <number>`                                                                                                                                                       |                                             |                       |                        |
-
-Other layout options:
-
-- `hide edit button`
-- `hide task count`
-- `short mode`
+| **Other Layout options**                                                                                                                                                                            |                                             |                       |                        |
+| `hide edit button`                                                                                                                                                                                  |                                             |                       |                        |
+| `hide task count`                                                                                                                                                                                   |                                             |                       |                        |
+| `short mode`                                                                                                                                                                                        |                                             |                       |                        |

--- a/docs/quick-reference/index.md
+++ b/docs/quick-reference/index.md
@@ -11,6 +11,7 @@ has_toc: false
 [2]: https://obsidian-tasks-group.github.io/obsidian-tasks/queries/sorting/
 [3]: https://obsidian-tasks-group.github.io/obsidian-tasks/queries/grouping/
 [4]: https://obsidian-tasks-group.github.io/obsidian-tasks/queries/layout/
+[5]: https://obsidian-tasks-group.github.io/obsidian-tasks/queries/combining-filters/
 
 This table summarizes the filters and other options available inside a `tasks` block.
 
@@ -34,6 +35,7 @@ This table summarizes the filters and other options available inside a `tasks` b
 |                                                                                                                                                                                                     |                                             | `group by backlink`   | `hide backlink`        |
 | `description (includes, does not include) <string>`<br>`description (regex matches, regex does not match) /regex/i`                                                                                 | `sort by description`                       |                       |                        |
 | `tag (includes, does not include) <tag>`<br>`tags (include, do not include) <tag>`<br>`tag (regex matches, regex does not match) /regex/i`<br>`tags (regex matches, regex does not match) /regex/i` | `sort by tag`<br>`sort by tag <tag_number>` | `group by tags`       |                        |
+| [**Combining Filters**][5]                                                                                                                                                                          |                                             |                       |                        |
 | `(filter 1) AND (filter 2)`                                                                                                                                                                         |                                             |                       |                        |
 | `(filter 1) OR (filter 2)`                                                                                                                                                                          |                                             |                       |                        |
 | `NOT (filter 1)`                                                                                                                                                                                    |                                             |                       |                        |
@@ -41,6 +43,7 @@ This table summarizes the filters and other options available inside a `tasks` b
 | `(filter 1) AND NOT (filter 2)`                                                                                                                                                                     |                                             |                       |                        |
 | `(filter 1) OR NOT (filter 2)`                                                                                                                                                                      |                                             |                       |                        |
 | `(filter 1) AND ((filter 2) OR (filter 3))`                                                                                                                                                         |                                             |                       |                        |
+| **Other Filter Options**                                                                                                                                                                            |                                             |                       |                        |
 | `exclude sub-items`                                                                                                                                                                                 |                                             |                       |                        |
 | `limit to <number> tasks`<br>`limit <number>`                                                                                                                                                       |                                             |                       |                        |
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Better grouping of instructions in the Quick Reference page
- Also fixed a typo in `find-tasks-for-coming-7-days.md`

## Motivation and Context

For readability of Quick Reference page, and ease of navigation to the Boolean filters docs from there.

## How has this been tested?

Viewing the docs built locally.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

## Checklist

Not applicable

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
