### PR TITLE
docs: Document using regex to find empty fields

### DIFF
--- a/docs/queries/regular-expressions.md
+++ b/docs/queries/regular-expressions.md
@@ -167,13 +167,13 @@ description regex matches /^Log/i
 
 ### Finding empty fields
 
-I want to find tasks that have no description, perhaps because they were created from a template.
+I want to find tasks that have no description, perhaps because they were created from a template:
 
 ```text
 description regex matches /^$/
 ```
 
-I want to filter out tasks that have no description, perhaps because they were created from a template.
+I want to exclude tasks with no description:
 
 ```text
 description regex does not match /^$/

--- a/docs/queries/regular-expressions.md
+++ b/docs/queries/regular-expressions.md
@@ -141,8 +141,6 @@ Please be aware of the following limitations in Tasks' implementation of regular
   - Logged in [#1037](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1037)
 - Illegal flags are ignored.
   - For example, the query `description regex matches /CASE/&` should give an error that `&` (and similar) are unrecognised flags.
-- The `tag` or `tags` instruction does not yet support regular expression searches.
-  - Logged in [#1040](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/1040)
 - [Lookahead and Lookbehind](https://www.regular-expressions.info/lookaround.html) searches are untested, and are presumed not to work on Apple mobile devices, or to cause serious performance problems with slow searches.
 
 ## Regular expression examples
@@ -166,6 +164,22 @@ Find tasks whose description begins with Log, ignoring capitalisation
 ```text
 description regex matches /^Log/i
 ```
+
+### Empty fields
+
+I want to find tasks that have no description, perhaps because they were created from a template.
+
+```text
+description regex matches /^$/
+```
+
+I want to filter out tasks that have no description, perhaps because they were created from a template.
+
+```text
+description regex does not match /^$/
+```
+
+How this works: in regular expressions, `/^$/` matches text where there is nothing between the start and the end.
 
 ### Finding tasks that are waiting
 

--- a/docs/queries/regular-expressions.md
+++ b/docs/queries/regular-expressions.md
@@ -165,7 +165,7 @@ Find tasks whose description begins with Log, ignoring capitalisation
 description regex matches /^Log/i
 ```
 
-### Empty fields
+### Finding empty fields
 
 I want to find tasks that have no description, perhaps because they were created from a template.
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Description

- Document using regex to find empty fields
- Also remove another out-of-date reference to tags and regex searches

## Motivation and Context

The was prompted by the support question in https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/1339

<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Viewing the docs locally.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
