### PR TITLE
docs: Prevent 2 lines running together in the published docs.

### DIFF
--- a/docs/advanced/styling.md
+++ b/docs/advanced/styling.md
@@ -22,5 +22,5 @@ following styles are available.
 | task-list-item-checkbox        | This is applied to the INPUT element for the task.                                                              |
 | tasks-group-heading            | This is applied to H4, H5 and H6 group headings                                                                 |
 
-> `tasks-group-heading` was introduced in Tasks 1.6.0.
+> `tasks-group-heading` was introduced in Tasks 1.6.0.<br>
 > `plugin-tasks-query-explanation` was introduced in Tasks 1.19.0.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Fix a formatting error in the published docs - 2 lines in a block quote ran together.
