### PR TITLE
test: Make TaskBuilder handle status consistently

### DIFF
--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -1,3 +1,4 @@
+import { Status } from '../../src/Task';
 import { TaskBuilder } from './TaskBuilder';
 
 export {};
@@ -7,5 +8,39 @@ describe('TaskBuilder', () => {
         const builder = new TaskBuilder().description('hello').tags(['#tag1', '#tag2']);
         const task = builder.build();
         expect(task.toFileLineString()).toStrictEqual('- [ ] hello #tag1 #tag2');
+    });
+
+    describe('status and originalStatusCharacter', () => {
+        it('should set custom status character when setting status TODO', () => {
+            const builder = new TaskBuilder().status(Status.TODO);
+            const task = builder.build();
+            expect(task.status).toStrictEqual(Status.TODO);
+            expect(task.originalStatusCharacter).toStrictEqual(' ');
+            expect(task.toFileLineString()).toStrictEqual('- [ ] my description');
+        });
+
+        it('should set custom status character when setting status DONE', () => {
+            const builder = new TaskBuilder().status(Status.DONE);
+            const task = builder.build();
+            expect(task.status).toStrictEqual(Status.DONE);
+            expect(task.originalStatusCharacter).toStrictEqual('x');
+            expect(task.toFileLineString()).toStrictEqual('- [x] my description');
+        });
+
+        it('should not change status when changing originalStatusCharacter to TODO', () => {
+            const builder = new TaskBuilder().status(Status.DONE).originalStatusCharacter(' ');
+            const task = builder.build();
+            expect(task.status).toStrictEqual(Status.DONE);
+            expect(task.originalStatusCharacter).toStrictEqual(' ');
+            expect(task.toFileLineString()).toStrictEqual('- [ ] my description');
+        });
+
+        it('should not change status when changing originalStatusCharacter to Half Done', () => {
+            const builder = new TaskBuilder().status(Status.DONE).originalStatusCharacter('/');
+            const task = builder.build();
+            expect(task.status).toStrictEqual(Status.DONE);
+            expect(task.originalStatusCharacter).toStrictEqual('/');
+            expect(task.toFileLineString()).toStrictEqual('- [/] my description');
+        });
     });
 });

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -18,13 +18,13 @@ describe('TaskBuilder', () => {
         }
 
         it('should set originalStatusCharacter when setting status TODO', () => {
-            const builder = new TaskBuilder().status(Status.TODO);
+            const builder = new TaskBuilder().originalStatusCharacter('?').status(Status.TODO);
             const task = builder.build();
             checkStatuses(task, Status.TODO, ' ', '- [ ] my description');
         });
 
         it('should set originalStatusCharacter when setting status DONE', () => {
-            const builder = new TaskBuilder().status(Status.DONE);
+            const builder = new TaskBuilder().originalStatusCharacter('?').status(Status.DONE);
             const task = builder.build();
             checkStatuses(task, Status.DONE, 'x', '- [x] my description');
         });

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -17,13 +17,13 @@ describe('TaskBuilder', () => {
             expect(task.toFileLineString()).toStrictEqual(description);
         }
 
-        it('should set custom status character when setting status TODO', () => {
+        it('should set originalStatusCharacter when setting status TODO', () => {
             const builder = new TaskBuilder().status(Status.TODO);
             const task = builder.build();
             checkStatuses(task, Status.TODO, ' ', '- [ ] my description');
         });
 
-        it('should set custom status character when setting status DONE', () => {
+        it('should set originalStatusCharacter when setting status DONE', () => {
             const builder = new TaskBuilder().status(Status.DONE);
             const task = builder.build();
             checkStatuses(task, Status.DONE, 'x', '- [x] my description');

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -1,4 +1,4 @@
-import { Status } from '../../src/Task';
+import { Status, Task } from '../../src/Task';
 import { TaskBuilder } from './TaskBuilder';
 
 export {};
@@ -11,36 +11,34 @@ describe('TaskBuilder', () => {
     });
 
     describe('status and originalStatusCharacter', () => {
+        function checkStatuses(task: Task, status: Status, originalStatusCharacter: string, description: string) {
+            expect(task.status).toStrictEqual(status);
+            expect(task.originalStatusCharacter).toStrictEqual(originalStatusCharacter);
+            expect(task.toFileLineString()).toStrictEqual(description);
+        }
+
         it('should set custom status character when setting status TODO', () => {
             const builder = new TaskBuilder().status(Status.TODO);
             const task = builder.build();
-            expect(task.status).toStrictEqual(Status.TODO);
-            expect(task.originalStatusCharacter).toStrictEqual(' ');
-            expect(task.toFileLineString()).toStrictEqual('- [ ] my description');
+            checkStatuses(task, Status.TODO, ' ', '- [ ] my description');
         });
 
         it('should set custom status character when setting status DONE', () => {
             const builder = new TaskBuilder().status(Status.DONE);
             const task = builder.build();
-            expect(task.status).toStrictEqual(Status.DONE);
-            expect(task.originalStatusCharacter).toStrictEqual('x');
-            expect(task.toFileLineString()).toStrictEqual('- [x] my description');
+            checkStatuses(task, Status.DONE, 'x', '- [x] my description');
         });
 
         it('should not change status when changing originalStatusCharacter to TODO', () => {
             const builder = new TaskBuilder().status(Status.DONE).originalStatusCharacter(' ');
             const task = builder.build();
-            expect(task.status).toStrictEqual(Status.DONE);
-            expect(task.originalStatusCharacter).toStrictEqual(' ');
-            expect(task.toFileLineString()).toStrictEqual('- [ ] my description');
+            checkStatuses(task, Status.DONE, ' ', '- [ ] my description');
         });
 
         it('should not change status when changing originalStatusCharacter to Half Done', () => {
             const builder = new TaskBuilder().status(Status.DONE).originalStatusCharacter('/');
             const task = builder.build();
-            expect(task.status).toStrictEqual(Status.DONE);
-            expect(task.originalStatusCharacter).toStrictEqual('/');
-            expect(task.toFileLineString()).toStrictEqual('- [/] my description');
+            checkStatuses(task, Status.DONE, '/', '- [/] my description');
         });
     });
 });

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -79,8 +79,15 @@ export class TaskBuilder {
         });
     }
 
+    /**
+     * Set the status.
+     *
+     * This also sets {@link originalStatusCharacter}
+     * @param status
+     */
     public status(status: Status): TaskBuilder {
         this._status = status;
+        this._originalStatusCharacter = status === Status.TODO ? ' ' : 'x';
         return this;
     }
 
@@ -119,6 +126,13 @@ export class TaskBuilder {
         return this;
     }
 
+    /**
+     * Set the originalStatusCharacter.
+     *
+     * This does NOT set {@link status}, so call that method before calling this one,
+     * if you want to use a character other than ' ' or 'x'.
+     * @param originalStatusCharacter
+     */
     public originalStatusCharacter(originalStatusCharacter: string): TaskBuilder {
         this._originalStatusCharacter = originalStatusCharacter;
         return this;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This is purely changing helper code in the unit tests.

Now, calling `TaskBuilder.status()`also sets the `TaskBuilder.originalStatusCharacter()`.

## Motivation and Context

I found when writing some tests that used `TaskBuilder.originalStatusCharacter()` and `TaskBuilder.status()` that I was having to call both methods in order to get to a consistent state.

This was tedious and error-prone.


## How has this been tested?

By adding new tests - and running all the existing ones.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
