### PR TITLE
feat: Add support for numbered checkboxes

### DIFF
--- a/src/Task.ts
+++ b/src/Task.ts
@@ -52,8 +52,8 @@ export class TaskRegularExpressions {
     // Matches indentation before a list marker (including > for potentially nested blockquotes or Obsidian callouts)
     public static readonly indentationRegex = /^([\s\t>]*)/;
 
-    // Matches (but does not save) - or * list markers.
-    public static readonly listMarkerRegex = /[-*]/;
+    // Matches (but does not save) - or * list markers, or numbered list markers (eg 1.)
+    public static readonly listMarkerRegex = /(?:[-*]|[0-9]+\.)/;
 
     // Matches a checkbox and saves the status character inside
     public static readonly checkboxRegex = /\[(.)\]/u;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -33,6 +33,46 @@ describe('parsing', () => {
         expect(task!.originalMarkdown).toStrictEqual(line);
     });
 
+    it('parses a task from a line (numbered)', () => {
+        // Arrange
+        const line = '1. [x] this is a done task 🗓 2021-09-12 ✅ 2021-06-20';
+
+        // Act
+        const task = fromLine({
+            line,
+        });
+
+        // Assert
+        expect(task).not.toBeNull();
+        expect(task!.description).toEqual('this is a done task');
+        expect(task!.status).toStrictEqual(Status.DONE);
+        expect(task!.dueDate).not.toBeNull();
+        expect(task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD'))).toStrictEqual(true);
+        expect(task!.doneDate).not.toBeNull();
+        expect(task!.doneDate!.isSame(moment('2021-06-20', 'YYYY-MM-DD'))).toStrictEqual(true);
+        expect(task!.originalMarkdown).toStrictEqual(line);
+    });
+
+    it('parses a task from a line (big number)', () => {
+        // Arrange
+        const line = '909999. [x] this is a done task 🗓 2021-09-12 ✅ 2021-06-20';
+
+        // Act
+        const task = fromLine({
+            line,
+        });
+
+        // Assert
+        expect(task).not.toBeNull();
+        expect(task!.description).toEqual('this is a done task');
+        expect(task!.status).toStrictEqual(Status.DONE);
+        expect(task!.dueDate).not.toBeNull();
+        expect(task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD'))).toStrictEqual(true);
+        expect(task!.doneDate).not.toBeNull();
+        expect(task!.doneDate!.isSame(moment('2021-06-20', 'YYYY-MM-DD'))).toStrictEqual(true);
+        expect(task!.originalMarkdown).toStrictEqual(line);
+    });
+
     it('returns null when task does not have global filter', () => {
         // Arrange
         updateSettings({ globalFilter: '#task' });

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -35,7 +35,7 @@ describe('parsing', () => {
 
     it('parses a task from a line (numbered)', () => {
         // Arrange
-        const line = '1. [x] this is a done task 🗓 2021-09-12 ✅ 2021-06-20';
+        const line = '1. [x] this is a done task';
 
         // Act
         const task = fromLine({
@@ -46,16 +46,12 @@ describe('parsing', () => {
         expect(task).not.toBeNull();
         expect(task!.description).toEqual('this is a done task');
         expect(task!.status).toStrictEqual(Status.DONE);
-        expect(task!.dueDate).not.toBeNull();
-        expect(task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD'))).toStrictEqual(true);
-        expect(task!.doneDate).not.toBeNull();
-        expect(task!.doneDate!.isSame(moment('2021-06-20', 'YYYY-MM-DD'))).toStrictEqual(true);
         expect(task!.originalMarkdown).toStrictEqual(line);
     });
 
     it('parses a task from a line (big number)', () => {
         // Arrange
-        const line = '909999. [x] this is a done task 🗓 2021-09-12 ✅ 2021-06-20';
+        const line = '909999. [ ] this is a todo task';
 
         // Act
         const task = fromLine({
@@ -64,12 +60,8 @@ describe('parsing', () => {
 
         // Assert
         expect(task).not.toBeNull();
-        expect(task!.description).toEqual('this is a done task');
-        expect(task!.status).toStrictEqual(Status.DONE);
-        expect(task!.dueDate).not.toBeNull();
-        expect(task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD'))).toStrictEqual(true);
-        expect(task!.doneDate).not.toBeNull();
-        expect(task!.doneDate!.isSame(moment('2021-06-20', 'YYYY-MM-DD'))).toStrictEqual(true);
+        expect(task!.description).toEqual('this is a todo task');
+        expect(task!.status).toStrictEqual(Status.TODO);
         expect(task!.originalMarkdown).toStrictEqual(line);
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
This PR addresses the following discussion topic: https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/1011

Added support for numbered checkboxes in obsidian-tasks

Expand the list marker regex to recognize either a - or * as it did before, in addition to a numeric identifier (such as 1.).

<!--- Describe your changes in detail -->

## Motivation and Context
There are times when it's useful to create a numbered list of steps that must be followed in a particular sequence that also qualify as tasks that should be checked off when completed. Obsidian already supports numbered checkboxes, this change allows them to also be registered by obsidian-tasks.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Two new tests have been added to Task.tests.ts and both are passing. I've also built obsidian-tasks locally and verified that the change works as intended. To verify I built and installed obsidian-tasks into my test vault. I added some numbered checkboxes and verified that they showed up in my task list. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/13754603/204964605-e7cb9b29-0aa3-489d-971a-7aabdb390cf6.png)
![image](https://user-images.githubusercontent.com/13754603/204964699-c8c00ee1-6264-4555-882d-b8e9a59647cd.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
