### PR TITLE
refactor: DueDateField now implements 'sort by due'

### DIFF
--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -1,5 +1,7 @@
 import type { Moment } from 'moment';
 import type { Task } from '../../Task';
+import type { Comparator } from '../Sort';
+import { Sort, Sorting } from '../Sort';
 import { DateField } from './DateField';
 
 /**
@@ -19,5 +21,59 @@ export class DueDateField extends DateField {
     }
     protected filterResultIfFieldMissing() {
         return false;
+    }
+
+    /**
+     * Parse a sort instruction line, creating either a {@link Sorting} object or undefined,
+     * if the line is unrecognised.
+     * @param line - One of 'sort by due' or 'sort by due reverse'
+     */
+    public parseInstructionAndCreateSorter(line: string): Sorting | undefined {
+        const sortByRegexp = /^sort by (due)( reverse)?/;
+        const fieldMatch = line.match(sortByRegexp);
+        if (fieldMatch !== null) {
+            // const propertyName = fieldMatch[1];
+            const reverse = !!fieldMatch[2];
+            return this.createSorter(reverse);
+        } else {
+            return undefined;
+        }
+    }
+
+    /**
+     * Create a {@link Sorting} object for sorting tasks by their Status,
+     * in the standard/normal sort order for this field.
+     *
+     * @see {@link createReverseSorter}
+     */
+    public createNormalSorter(): Sorting {
+        return this.createSorter(false);
+    }
+
+    /**
+     * Create a {@link Sorting} object for sorting tasks by their Status,
+     * in the reverse of the standard/normal sort order for this field.
+     *
+     * @see {@link createNormalSorter}
+     */
+    public createReverseSorter(): Sorting {
+        return this.createSorter(true);
+    }
+
+    /**
+     * Create a {@link Sorting} object for sorting tasks by their Status.
+     * @param reverse - false for normal sort order, true for reverse sort order.
+     */
+    protected createSorter(reverse: boolean): Sorting {
+        return new Sorting(reverse, 1, 'due', DueDateField.comparator());
+    }
+
+    /**
+     * Return a function to compare two Task objects, for use in sorting by due.
+     */
+    public static comparator(): Comparator {
+        return (a: Task, b: Task) => {
+            return Sort.compareByDate(a.dueDate, b.dueDate);
+        };
     }
 }

--- a/src/Query/Filter/DueDateField.ts
+++ b/src/Query/Filter/DueDateField.ts
@@ -72,6 +72,7 @@ export class DueDateField extends DateField {
      * Return a function to compare two Task objects, for use in sorting by due.
      */
     public static comparator(): Comparator {
+        // TODO Refactor to make non-static and use this.date(a), this.date(b)
         return (a: Task, b: Task) => {
             return Sort.compareByDate(a.dueDate, b.dueDate);
         };

--- a/src/Query/Filter/StatusField.ts
+++ b/src/Query/Filter/StatusField.ts
@@ -24,9 +24,9 @@ export class StatusField extends FilterInstructionsBasedField {
         const sortByRegexp = /^sort by (status)( reverse)?/;
         const fieldMatch = line.match(sortByRegexp);
         if (fieldMatch !== null) {
-            const propertyName = fieldMatch[1];
+            // const propertyName = fieldMatch[1];
             const reverse = !!fieldMatch[2];
-            return this.createSorter(reverse, propertyName);
+            return this.createSorter(reverse);
         } else {
             return undefined;
         }
@@ -35,10 +35,9 @@ export class StatusField extends FilterInstructionsBasedField {
     /**
      * Create a {@link Sorting} object for sorting tasks by their Status.
      * @param reverse - false for normal sort order, true for reverse sort order.
-     * @param propertyName
      */
-    public createSorter(reverse: boolean, propertyName: string): Sorting {
-        return new Sorting(reverse, 1, propertyName, StatusField.comparator());
+    public createSorter(reverse: boolean): Sorting {
+        return new Sorting(reverse, 1, 'status', StatusField.comparator());
     }
 
     /**

--- a/src/Query/Filter/StatusField.ts
+++ b/src/Query/Filter/StatusField.ts
@@ -18,17 +18,27 @@ export class StatusField extends FilterInstructionsBasedField {
     /**
      * Parse a sort instruction line, creating either a {@link Sorting} object or undefined,
      * if the line is unrecognised.
-     * TODO Separate the parsing of the line and construction of the {@link Sorting} in to two separate methods.
      * @param line - One of 'sort by status' or 'sort by status reverse'
      */
-    public createSorter(line: string): Sorting | undefined {
+    public parseInstructionAndCreateSorter(line: string): Sorting | undefined {
         const sortByRegexp = /^sort by (status)( reverse)?/;
         const fieldMatch = line.match(sortByRegexp);
         if (fieldMatch !== null) {
-            return new Sorting(!!fieldMatch[2], 1, fieldMatch[1], StatusField.comparator());
+            const propertyName = fieldMatch[1];
+            const reverse = !!fieldMatch[2];
+            return this.createSorter(reverse, propertyName);
         } else {
             return undefined;
         }
+    }
+
+    /**
+     * Create a {@link Sorting} object for sorting tasks by their Status.
+     * @param reverse - false for normal sort order, true for reverse sort order.
+     * @param propertyName
+     */
+    public createSorter(reverse: boolean, propertyName: string): Sorting {
+        return new Sorting(reverse, 1, propertyName, StatusField.comparator());
     }
 
     /**

--- a/src/Query/Filter/StatusField.ts
+++ b/src/Query/Filter/StatusField.ts
@@ -33,10 +33,30 @@ export class StatusField extends FilterInstructionsBasedField {
     }
 
     /**
+     * Create a {@link Sorting} object for sorting tasks by their Status,
+     * in the standard/normal sort order for this field.
+     *
+     * @see {@link createReverseSorter}
+     */
+    public createNormalSorter(): Sorting {
+        return this.createSorter(false);
+    }
+
+    /**
+     * Create a {@link Sorting} object for sorting tasks by their Status,
+     * in the reverse of the standard/normal sort order for this field.
+     *
+     * @see {@link createNormalSorter}
+     */
+    public createReverseSorter(): Sorting {
+        return this.createSorter(true);
+    }
+
+    /**
      * Create a {@link Sorting} object for sorting tasks by their Status.
      * @param reverse - false for normal sort order, true for reverse sort order.
      */
-    public createSorter(reverse: boolean): Sorting {
+    protected createSorter(reverse: boolean): Sorting {
         return new Sorting(reverse, 1, 'status', StatusField.comparator());
     }
 

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -242,7 +242,7 @@ export class Query implements IQuery {
         // TODO Once a few more Field classes have comparator implementations,
         //      convert this to look like Query.parseFilter(),
         //      which will call a new function in FilterParser - parseSorter() or parseSortBy()
-        const statusSorter = new StatusField().createSorter(line);
+        const statusSorter = new StatusField().parseInstructionAndCreateSorter(line);
         if (statusSorter) {
             this._sorting.push(statusSorter);
             return;

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -55,7 +55,7 @@ export class Query implements IQuery {
     // If a tag is specified the user can also add a number to specify
     // which one to sort by if there is more than one.
     private readonly sortByRegexp =
-        /^sort by (urgency|status|priority|start|scheduled|due|done|path|description|tag)( reverse)?[\s]*(\d+)?/;
+        /^sort by (urgency|priority|start|scheduled|due|done|path|description|tag)( reverse)?[\s]*(\d+)?/;
 
     private readonly groupByRegexp =
         /^group by (backlink|done|due|filename|folder|happens|heading|path|priority|recurrence|recurring|root|scheduled|start|status|tags)/;
@@ -89,6 +89,8 @@ export class Query implements IQuery {
                         break;
                     case this.sortByRegexp.test(line):
                         this.parseSortBy({ line });
+                        break;
+                    case this.parseSortBy2({ line }):
                         break;
                     case this.groupByRegexp.test(line):
                         this.parseGroupBy({ line });
@@ -236,7 +238,7 @@ export class Query implements IQuery {
         }
     }
 
-    private parseSortBy({ line }: { line: string }): void {
+    private parseSortBy2({ line }: { line: string }): boolean {
         // New style parsing, which is done by the Field classes.
         // Initially this is only implemented for status.
         // TODO Once a few more Field classes have comparator implementations,
@@ -245,9 +247,12 @@ export class Query implements IQuery {
         const statusSorter = new StatusField().parseInstructionAndCreateSorter(line);
         if (statusSorter) {
             this._sorting.push(statusSorter);
-            return;
+            return true;
         }
+        return false;
+    }
 
+    private parseSortBy({ line }: { line: string }): void {
         // Old-style parsing, based on all the values in SortingProperty above.
         // TODO Migrate all the compare functions in Sort over to the
         //      corresponding fields, so that the block below can be removed.

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -8,20 +8,12 @@ import { parseFilter } from './FilterParser';
 import { Group } from './Group';
 import type { Filter } from './Filter/Filter';
 import { StatusField } from './Filter/StatusField';
+import { DueDateField } from './Filter/DueDateField';
 
 // TODO Work through the values in SortingProperty, moving their comparison
 //      functions to the corresponding Field implementations.
 //      Then remove SortingProperty.
-export type SortingProperty =
-    | 'urgency'
-    | 'priority'
-    | 'start'
-    | 'scheduled'
-    | 'due'
-    | 'done'
-    | 'path'
-    | 'description'
-    | 'tag';
+export type SortingProperty = 'urgency' | 'priority' | 'start' | 'scheduled' | 'done' | 'path' | 'description' | 'tag';
 
 export type GroupingProperty =
     | 'backlink'
@@ -55,7 +47,7 @@ export class Query implements IQuery {
     // If a tag is specified the user can also add a number to specify
     // which one to sort by if there is more than one.
     private readonly sortByRegexp =
-        /^sort by (urgency|priority|start|scheduled|due|done|path|description|tag)( reverse)?[\s]*(\d+)?/;
+        /^sort by (urgency|priority|start|scheduled|done|path|description|tag)( reverse)?[\s]*(\d+)?/;
 
     private readonly groupByRegexp =
         /^group by (backlink|done|due|filename|folder|happens|heading|path|priority|recurrence|recurring|root|scheduled|start|status|tags)/;
@@ -240,14 +232,23 @@ export class Query implements IQuery {
 
     private parseSortBy2({ line }: { line: string }): boolean {
         // New style parsing, which is done by the Field classes.
-        // Initially this is only implemented for status.
+        // Initially this is only implemented for a few fields.
         // TODO Once a few more Field classes have comparator implementations,
         //      convert this to look like Query.parseFilter(),
         //      which will call a new function in FilterParser - parseSorter() or parseSortBy()
-        const statusSorter = new StatusField().parseInstructionAndCreateSorter(line);
-        if (statusSorter) {
-            this._sorting.push(statusSorter);
-            return true;
+        {
+            const sorter = new StatusField().parseInstructionAndCreateSorter(line);
+            if (sorter) {
+                this._sorting.push(sorter);
+                return true;
+            }
+        }
+        {
+            const sorter = new DueDateField().parseInstructionAndCreateSorter(line);
+            if (sorter) {
+                this._sorting.push(sorter);
+                return true;
+            }
         }
         return false;
     }

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -55,3 +55,28 @@ describe('explain due date queries', () => {
         expect(filterOrMessage).toHaveExplanation('due date is on 2023-01-02 (Monday 2nd January 2023)');
     });
 });
+
+describe('sorting by status', () => {
+    const date1 = new TaskBuilder().dueDate('2021-01-12').build();
+    const date2 = new TaskBuilder().dueDate('2022-12-23').build();
+
+    it('sort by due', () => {
+        // Arrange
+        const sorter = new DueDateField().createNormalSorter();
+
+        // Assert
+        expect(sorter.comparator(date1, date2)).toEqual(-1);
+        expect(sorter.comparator(date2, date1)).toEqual(1);
+        expect(sorter.comparator(date2, date2)).toEqual(0);
+    });
+
+    it('sort by due reverse', () => {
+        // Arrange
+        const sorter = new DueDateField().createReverseSorter();
+
+        // Assert
+        expect(sorter.comparator(date1, date2)).toEqual(1);
+        expect(sorter.comparator(date2, date1)).toEqual(-1);
+        expect(sorter.comparator(date2, date2)).toEqual(-0);
+    });
+});

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -35,7 +35,7 @@ describe('sorting by status', () => {
 
     it('sort by status', () => {
         // Arrange
-        const sorter = new StatusField().createSorter(false);
+        const sorter = new StatusField().createNormalSorter();
 
         // Assert
         expect(sorter.comparator(doneTask, todoTask)).toEqual(1);
@@ -43,7 +43,7 @@ describe('sorting by status', () => {
 
     it('sort by status reverse', () => {
         // Arrange
-        const sorter = new StatusField().createSorter(true);
+        const sorter = new StatusField().createReverseSorter();
 
         // Assert
         expect(sorter.comparator(doneTask, todoTask)).toEqual(-1);

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -35,7 +35,7 @@ describe('sorting by status', () => {
 
     it('sort by status', () => {
         // Arrange
-        const sorter = new StatusField().createSorter('sort by status');
+        const sorter = new StatusField().parseInstructionAndCreateSorter('sort by status');
 
         // Assert
         expect(sorter).toBeDefined();
@@ -44,7 +44,7 @@ describe('sorting by status', () => {
 
     it('sort by status reverse', () => {
         // Arrange
-        const sorter = new StatusField().createSorter('sort by status reverse');
+        const sorter = new StatusField().parseInstructionAndCreateSorter('sort by status reverse');
 
         // Assert
         expect(sorter).toBeDefined();

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -35,19 +35,17 @@ describe('sorting by status', () => {
 
     it('sort by status', () => {
         // Arrange
-        const sorter = new StatusField().parseInstructionAndCreateSorter('sort by status');
+        const sorter = new StatusField().createSorter(false);
 
         // Assert
-        expect(sorter).toBeDefined();
-        expect(sorter!.comparator(doneTask, todoTask)).toEqual(1);
+        expect(sorter.comparator(doneTask, todoTask)).toEqual(1);
     });
 
     it('sort by status reverse', () => {
         // Arrange
-        const sorter = new StatusField().parseInstructionAndCreateSorter('sort by status reverse');
+        const sorter = new StatusField().createSorter(true);
 
         // Assert
-        expect(sorter).toBeDefined();
-        expect(sorter!.comparator(doneTask, todoTask)).toEqual(-1);
+        expect(sorter.comparator(doneTask, todoTask)).toEqual(-1);
     });
 });

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -141,7 +141,7 @@ describe('Sort', () => {
                     sorting: [
                         new Sorting(false, 1, 'due'),
                         new Sorting(false, 1, 'path'),
-                        new StatusField().parseInstructionAndCreateSorter('sort by status')!, // TODO Remove the need to invent a line to write this test
+                        new StatusField().createSorter(false),
                     ],
                 },
                 [one, four, two, three],
@@ -221,7 +221,7 @@ describe('Sort', () => {
             Sort.by(
                 {
                     sorting: [
-                        new StatusField().parseInstructionAndCreateSorter('sort by status reverse')!, // TODO Remove the need to invent a line to write this test
+                        new StatusField().createSorter(true),
                         new Sorting(true, 1, 'due'),
                         new Sorting(false, 1, 'path'),
                     ],

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -141,7 +141,7 @@ describe('Sort', () => {
                     sorting: [
                         new Sorting(false, 1, 'due'),
                         new Sorting(false, 1, 'path'),
-                        new StatusField().createSorter('sort by status')!, // TODO Remove the need to invent a line to write this test
+                        new StatusField().parseInstructionAndCreateSorter('sort by status')!, // TODO Remove the need to invent a line to write this test
                     ],
                 },
                 [one, four, two, three],
@@ -221,7 +221,7 @@ describe('Sort', () => {
             Sort.by(
                 {
                     sorting: [
-                        new StatusField().createSorter('sort by status reverse')!, // TODO Remove the need to invent a line to write this test
+                        new StatusField().parseInstructionAndCreateSorter('sort by status reverse')!, // TODO Remove the need to invent a line to write this test
                         new Sorting(true, 1, 'due'),
                         new Sorting(false, 1, 'path'),
                     ],

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -141,7 +141,7 @@ describe('Sort', () => {
                     sorting: [
                         new Sorting(false, 1, 'due'),
                         new Sorting(false, 1, 'path'),
-                        new StatusField().createSorter(false),
+                        new StatusField().createNormalSorter(),
                     ],
                 },
                 [one, four, two, three],
@@ -221,7 +221,7 @@ describe('Sort', () => {
             Sort.by(
                 {
                     sorting: [
-                        new StatusField().createSorter(true),
+                        new StatusField().createReverseSorter(),
                         new Sorting(true, 1, 'due'),
                         new Sorting(false, 1, 'path'),
                     ],

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -11,6 +11,7 @@ import { resetSettings, updateSettings } from '../src/Config/Settings';
 import { DateParser } from '../src/Query/DateParser';
 import type { Task } from '../src/Task';
 import { StatusField } from '../src/Query/Filter/StatusField';
+import { DueDateField } from '../src/Query/Filter/DueDateField';
 import { fromLine } from './TestHelpers';
 import { TaskBuilder } from './TestingTools/TaskBuilder';
 
@@ -60,38 +61,6 @@ describe('Sort', () => {
     //      is in a Field class, and the Field's tests exercise the particular sorting.
     //      Then the only testing needed here will probably be the testing of composite sorting.
 
-    // TODO Replace this with something simpler but equivalent in DueDateField.test.ts.
-    it('sorts correctly by due', () => {
-        const one = fromLine({
-            line: '- [x] bring out the trash 📅 2021-09-12',
-            path: '',
-        });
-        const two = fromLine({
-            line: '- [ ] pet the cat 📅 2021-09-15',
-            path: '',
-        });
-        const three = fromLine({
-            line: '- [ ] pet the cat 📅 2021-09-18',
-            path: '',
-        });
-        expect(
-            Sort.by(
-                {
-                    sorting: [new Sorting(false, 1, 'due')],
-                },
-                [one, two, three],
-            ),
-        ).toEqual([one, two, three]);
-        expect(
-            Sort.by(
-                {
-                    sorting: [new Sorting(false, 1, 'due')],
-                },
-                [two, three, one],
-            ),
-        ).toEqual([one, two, three]);
-    });
-
     // TODO Replace this with something simpler but equivalent in DoneDateField.test.ts.
     it('sorts correctly by done', () => {
         const one = fromLine({
@@ -139,7 +108,7 @@ describe('Sort', () => {
             Sort.by(
                 {
                     sorting: [
-                        new Sorting(false, 1, 'due'),
+                        new DueDateField().createNormalSorter(),
                         new Sorting(false, 1, 'path'),
                         new StatusField().createNormalSorter(),
                     ],
@@ -222,7 +191,7 @@ describe('Sort', () => {
                 {
                     sorting: [
                         new StatusField().createReverseSorter(),
-                        new Sorting(true, 1, 'due'),
+                        new DueDateField().createReverseSorter(),
                         new Sorting(false, 1, 'path'),
                     ],
                 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- `DueDateField` now implements `sort by due`
- There is a lot of duplication of code now, which will be removed in a later step.

## Motivation and Context

This is step 3 in splitting out all the sort functions to the relevant fields, to make it easier to add new sort instructions, and to be able to re-use the sort code to sort groups in reverse order.

## How has this been tested?

- By running existing tests
- By adding new tests

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
