### PR TITLE
test: Add Jest support for easier testing of sorting

### DIFF
--- a/tests/CustomMatchers/CustomMatchersForSorting.ts
+++ b/tests/CustomMatchers/CustomMatchersForSorting.ts
@@ -36,15 +36,15 @@ const equal = 0;
 const after = 1;
 const before = -1;
 
-export function testDateComparesBefore(dateA: string | null, dateB: string | null) {
+export function expectDateComparesBefore(dateA: string | null, dateB: string | null) {
     testCompareByDateBothWays(dateA, dateB, before);
 }
 
-export function testDateComparesEqual(dateA: string | null, dateB: string | null) {
+export function expectDateComparesEqual(dateA: string | null, dateB: string | null) {
     testCompareByDateBothWays(dateA, dateB, equal);
 }
 
-export function testDateComparesAfter(dateA: string | null, dateB: string | null) {
+export function expectDateComparesAfter(dateA: string | null, dateB: string | null) {
     testCompareByDateBothWays(dateA, dateB, after);
 }
 

--- a/tests/CustomMatchers/CustomMatchersForSorting.ts
+++ b/tests/CustomMatchers/CustomMatchersForSorting.ts
@@ -40,7 +40,9 @@ expect.extend({
         const taskB = tasks[1];
         const actual = sorting.comparator(taskA, taskB);
         const pass = actual === expected;
-        const message = () => `${taskA} < ${taskB}: expected=${expected} actual=${actual}`;
+        // TODO Try to make meaning of 1, -1 or 0 clearer - somehow saying "less", "greater", "equal"
+        const message = () =>
+            `\n"${taskA.toFileLineString()}" < \n"${taskB.toFileLineString()}"\n:expected=${expected} actual=${actual}`;
 
         return { pass, message };
     },

--- a/tests/CustomMatchers/CustomMatchersForSorting.ts
+++ b/tests/CustomMatchers/CustomMatchersForSorting.ts
@@ -1,11 +1,14 @@
 import type moment from 'moment';
 import { DateParser } from '../../src/Query/DateParser';
 import { DateField } from '../../src/Query/Filter/DateField';
+import type { Sorting } from '../../src/Query/Sorting';
+import type { Task } from '../../src/Task';
 
 declare global {
     namespace jest {
         interface Matchers<R> {
             toGiveCompareToResult(expected: number): R;
+            toCompareTasksWithResult(expected: number): R;
         }
     }
 }
@@ -30,12 +33,26 @@ expect.extend({
 
         return { pass, message };
     },
+
+    toCompareTasksWithResult({ sorting: sorting, tasks: tasks }, expected: -1 | 0 | 1) {
+        expect(tasks.length).toEqual(2);
+        const taskA = tasks[0];
+        const taskB = tasks[1];
+        const actual = sorting.comparator(taskA, taskB);
+        const pass = actual === expected;
+        const message = () => `${taskA} < ${taskB}: expected=${expected} actual=${actual}`;
+
+        return { pass, message };
+    },
 });
 
 const equal = 0;
 const after = 1;
 const before = -1;
 
+// ---------------------------------------------------------------------
+// Sorting Dates
+// ---------------------------------------------------------------------
 export function expectDateComparesBefore(dateA: string | null, dateB: string | null) {
     testCompareByDateBothWays(dateA, dateB, before);
 }
@@ -53,4 +70,27 @@ function testCompareByDateBothWays(dateA: string | null, dateB: string | null, e
 
     const reverseExpected = expected === equal ? equal : -expected;
     expect([dateB, dateA]).toGiveCompareToResult(reverseExpected);
+}
+
+// ---------------------------------------------------------------------
+// Sorting Tasks
+// ---------------------------------------------------------------------
+
+export function expectTaskComparesBefore(sorting: Sorting, taskA: Task, taskB: Task) {
+    testCompareTasksBothWays(sorting, taskA, taskB, before);
+}
+
+export function expectTaskComparesEqual(sorting: Sorting, taskA: Task, taskB: Task) {
+    testCompareTasksBothWays(sorting, taskA, taskB, equal);
+}
+
+export function expectTaskComparesAfter(sorting: Sorting, taskA: Task, taskB: Task) {
+    testCompareTasksBothWays(sorting, taskA, taskB, after);
+}
+
+function testCompareTasksBothWays(sorting: Sorting, taskA: Task, taskB: Task, expected: -1 | 0 | 1) {
+    expect({ sorting, tasks: [taskA, taskB] }).toCompareTasksWithResult(expected);
+
+    const reverseExpected = expected === equal ? equal : -expected;
+    expect({ sorting, tasks: [taskB, taskA] }).toCompareTasksWithResult(reverseExpected);
 }

--- a/tests/CustomMatchers/CustomMatchersForSorting.ts
+++ b/tests/CustomMatchers/CustomMatchersForSorting.ts
@@ -1,0 +1,56 @@
+import type moment from 'moment';
+import { DateParser } from '../../src/Query/DateParser';
+import { DateField } from '../../src/Query/Filter/DateField';
+
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toGiveCompareToResult(expected: number): R;
+        }
+    }
+}
+
+expect.extend({
+    toGiveCompareToResult(dates: (string | null)[], expected: -1 | 0 | 1) {
+        expect(dates.length).toEqual(2);
+
+        const dateA = dates[0];
+        const dateB = dates[1];
+
+        let a: moment.Moment | null = null;
+        if (dateA !== null) a = DateParser.parseDate(dateA);
+
+        let b: moment.Moment | null = null;
+        if (dateB !== null) b = DateParser.parseDate(dateB);
+
+        const actual = DateField.compareByDate(a, b);
+
+        const pass = actual === expected;
+        const message = () => `${dateA} < ${dateB}: expected=${expected} actual=${actual}`;
+
+        return { pass, message };
+    },
+});
+
+const equal = 0;
+const after = 1;
+const before = -1;
+
+export function testDateComparesBefore(dateA: string | null, dateB: string | null) {
+    testCompareByDateBothWays(dateA, dateB, before);
+}
+
+export function testDateComparesEqual(dateA: string | null, dateB: string | null) {
+    testCompareByDateBothWays(dateA, dateB, equal);
+}
+
+export function testDateComparesAfter(dateA: string | null, dateB: string | null) {
+    testCompareByDateBothWays(dateA, dateB, after);
+}
+
+function testCompareByDateBothWays(dateA: string | null, dateB: string | null, expected: -1 | 0 | 1) {
+    expect([dateA, dateB]).toGiveCompareToResult(expected);
+
+    const reverseExpected = expected === equal ? equal : -expected;
+    expect([dateB, dateA]).toGiveCompareToResult(reverseExpected);
+}

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -7,6 +7,11 @@ import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { testFilter } from '../../TestingTools/FilterTestHelpers';
 import { toHaveExplanation } from '../../CustomMatchers/CustomMatchersForFilters';
+import {
+    expectTaskComparesAfter,
+    expectTaskComparesBefore,
+    expectTaskComparesEqual,
+} from '../../CustomMatchers/CustomMatchersForSorting';
 
 window.moment = moment;
 
@@ -70,10 +75,9 @@ describe('sorting by status', () => {
         const sorter = new DueDateField().createNormalSorter();
 
         // Assert
-        // TODO Create expressive Jest custom matchers for sorting tasks
-        expect(sorter.comparator(date1, date2)).toEqual(-1);
-        expect(sorter.comparator(date2, date1)).toEqual(1);
-        expect(sorter.comparator(date2, date2)).toEqual(0);
+        expectTaskComparesBefore(sorter, date1, date2);
+        expectTaskComparesAfter(sorter, date2, date1);
+        expectTaskComparesEqual(sorter, date2, date2);
     });
 
     it('sort by due reverse', () => {
@@ -81,8 +85,8 @@ describe('sorting by status', () => {
         const sorter = new DueDateField().createReverseSorter();
 
         // Assert
-        expect(sorter.comparator(date1, date2)).toEqual(1);
-        expect(sorter.comparator(date2, date1)).toEqual(-1);
-        expect(sorter.comparator(date2, date2)).toEqual(-0);
+        expectTaskComparesAfter(sorter, date1, date2);
+        expectTaskComparesBefore(sorter, date2, date1);
+        expectTaskComparesEqual(sorter, date2, date2);
     });
 });

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -61,7 +61,7 @@ describe('explain due date queries', () => {
     });
 });
 
-describe('sorting by status', () => {
+describe('sorting by due', () => {
     const date1 = new TaskBuilder().dueDate('2021-01-12').build();
     const date2 = new TaskBuilder().dueDate('2022-12-23').build();
 

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -3,6 +3,11 @@ import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { testFilter } from '../../TestingTools/FilterTestHelpers';
 import { Status } from '../../../src/Task';
+import {
+    expectTaskComparesAfter,
+    expectTaskComparesBefore,
+    expectTaskComparesEqual,
+} from '../../CustomMatchers/CustomMatchersForSorting';
 
 function testStatusFilter(filter: FilterOrErrorMessage, status: Status, expected: boolean) {
     const builder = new TaskBuilder();
@@ -43,7 +48,9 @@ describe('sorting by status', () => {
         const sorter = new StatusField().createNormalSorter();
 
         // Assert
-        expect(sorter.comparator(doneTask, todoTask)).toEqual(1);
+        expectTaskComparesAfter(sorter, doneTask, todoTask);
+        expectTaskComparesBefore(sorter, todoTask, doneTask);
+        expectTaskComparesEqual(sorter, doneTask, doneTask);
     });
 
     it('sort by status reverse', () => {
@@ -51,6 +58,8 @@ describe('sorting by status', () => {
         const sorter = new StatusField().createReverseSorter();
 
         // Assert
-        expect(sorter.comparator(doneTask, todoTask)).toEqual(-1);
+        expectTaskComparesBefore(sorter, doneTask, todoTask);
+        expectTaskComparesAfter(sorter, todoTask, doneTask);
+        expectTaskComparesEqual(sorter, doneTask, doneTask);
     });
 });

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -7,15 +7,18 @@ window.moment = moment;
 
 import type { Comparator } from '../src/Query/Sorting';
 import { Sort } from '../src/Query/Sort';
-import { DateField } from '../src/Query/Filter/DateField';
 import { Sorting } from '../src/Query/Sorting';
 import { resetSettings, updateSettings } from '../src/Config/Settings';
-import { DateParser } from '../src/Query/DateParser';
 import type { Task } from '../src/Task';
 import { StatusField } from '../src/Query/Filter/StatusField';
 import { DueDateField } from '../src/Query/Filter/DueDateField';
 import { fromLine } from './TestHelpers';
 import { TaskBuilder } from './TestingTools/TaskBuilder';
+import {
+    testDateComparesAfter,
+    testDateComparesBefore,
+    testDateComparesEqual,
+} from './CustomMatchers/CustomMatchersForSorting';
 
 describe('Sort', () => {
     it('constructs Sorting both ways from Comparator function', () => {
@@ -235,44 +238,10 @@ describe('Sort', () => {
     });
 });
 
-expect.extend({
-    toGiveCompareToResult(dates: (string | null)[], expected: -1 | 0 | 1) {
-        expect(dates.length).toEqual(2);
-
-        const dateA = dates[0];
-        const dateB = dates[1];
-
-        let a: moment.Moment | null = null;
-        if (dateA !== null) a = DateParser.parseDate(dateA);
-
-        let b: moment.Moment | null = null;
-        if (dateB !== null) b = DateParser.parseDate(dateB);
-
-        const actual = DateField.compareByDate(a, b);
-
-        const pass = actual === expected;
-        const message = () => `${dateA} < ${dateB}: expected=${expected} actual=${actual}`;
-
-        return { pass, message };
-    },
-});
-
-declare global {
-    namespace jest {
-        interface Matchers<R> {
-            toGiveCompareToResult(expected: number): R;
-        }
-    }
-}
-
 // These are lower-level tests that the Task-based ones above, for ease of test coverage.
 // TODO Replace this with something simpler but equivalent in the tests for DateField.test.ts.
 describe('compareBy', () => {
     it('compares correctly by date', () => {
-        const equal = 0;
-        const after = 1;
-        const before = -1;
-
         const earlierDate = '2022-01-01';
         const latererDate = '2022-02-01'; // intentional typo - laterer - so all variable names align in code
         const invalidDate = '2022-02-30';
@@ -287,25 +256,6 @@ describe('compareBy', () => {
         testDateComparesBefore(invalidDate, null); // invalid dates sort before no date
         testDateComparesEqual(invalidDate, invalidDate);
         testDateComparesAfter(invalidDate, earlierDate); // invalid dates sort after valid ones
-
-        function testDateComparesBefore(dateA: string | null, dateB: string | null) {
-            testCompareByDateBothWays(dateA, dateB, before);
-        }
-
-        function testDateComparesEqual(dateA: string | null, dateB: string | null) {
-            testCompareByDateBothWays(dateA, dateB, equal);
-        }
-
-        function testDateComparesAfter(dateA: string | null, dateB: string | null) {
-            testCompareByDateBothWays(dateA, dateB, after);
-        }
-
-        function testCompareByDateBothWays(dateA: string | null, dateB: string | null, expected: -1 | 0 | 1) {
-            expect([dateA, dateB]).toGiveCompareToResult(expected);
-
-            const reverseExpected = expected === equal ? equal : -expected;
-            expect([dateB, dateA]).toGiveCompareToResult(reverseExpected);
-        }
     });
 });
 

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -274,19 +274,31 @@ describe('compareBy', () => {
         const before = -1;
 
         const earlierDate = '2022-01-01';
-        const latererDate = '2022-02-01'; // intentional type - laterer - so all variable names align in code
+        const latererDate = '2022-02-01'; // intentional typo - laterer - so all variable names align in code
         const invalidDate = '2022-02-30';
 
-        testCompareByDateBothWays(earlierDate, latererDate, before);
-        testCompareByDateBothWays(earlierDate, earlierDate, equal);
-        testCompareByDateBothWays(latererDate, earlierDate, after);
+        testDateComparesBefore(earlierDate, latererDate);
+        testDateComparesEqual(earlierDate, earlierDate);
+        testDateComparesAfter(latererDate, earlierDate);
 
-        testCompareByDateBothWays(null, earlierDate, after); // no date sorts after valid dates
-        testCompareByDateBothWays(null, null, equal);
+        testDateComparesAfter(null, earlierDate); // no date sorts after valid dates
+        testDateComparesEqual(null, null);
 
-        testCompareByDateBothWays(invalidDate, null, before); // invalid dates sort before no date
-        testCompareByDateBothWays(invalidDate, invalidDate, equal);
-        testCompareByDateBothWays(invalidDate, earlierDate, after); // invalid dates sort after valid ones
+        testDateComparesBefore(invalidDate, null); // invalid dates sort before no date
+        testDateComparesEqual(invalidDate, invalidDate);
+        testDateComparesAfter(invalidDate, earlierDate); // invalid dates sort after valid ones
+
+        function testDateComparesBefore(dateA: string | null, dateB: string | null) {
+            testCompareByDateBothWays(dateA, dateB, before);
+        }
+
+        function testDateComparesEqual(dateA: string | null, dateB: string | null) {
+            testCompareByDateBothWays(dateA, dateB, equal);
+        }
+
+        function testDateComparesAfter(dateA: string | null, dateB: string | null) {
+            testCompareByDateBothWays(dateA, dateB, after);
+        }
 
         function testCompareByDateBothWays(dateA: string | null, dateB: string | null, expected: -1 | 0 | 1) {
             expect([dateA, dateB]).toGiveCompareToResult(expected);

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -243,12 +243,12 @@ describe('Sort', () => {
 describe('compareBy', () => {
     it('compares correctly by date', () => {
         const earlierDate = '2022-01-01';
-        const latererDate = '2022-02-01'; // intentional typo - laterer - so all variable names align in code
+        const laterDate = '2022-02-01';
         const invalidDate = '2022-02-30';
 
-        testDateComparesBefore(earlierDate, latererDate);
+        testDateComparesBefore(earlierDate, laterDate);
         testDateComparesEqual(earlierDate, earlierDate);
-        testDateComparesAfter(latererDate, earlierDate);
+        testDateComparesAfter(laterDate, earlierDate);
 
         testDateComparesAfter(null, earlierDate); // no date sorts after valid dates
         testDateComparesEqual(null, null);

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -15,9 +15,9 @@ import { DueDateField } from '../src/Query/Filter/DueDateField';
 import { fromLine } from './TestHelpers';
 import { TaskBuilder } from './TestingTools/TaskBuilder';
 import {
-    testDateComparesAfter,
-    testDateComparesBefore,
-    testDateComparesEqual,
+    expectDateComparesAfter,
+    expectDateComparesBefore,
+    expectDateComparesEqual,
 } from './CustomMatchers/CustomMatchersForSorting';
 
 describe('Sort', () => {
@@ -246,16 +246,16 @@ describe('compareBy', () => {
         const laterDate = '2022-02-01';
         const invalidDate = '2022-02-30';
 
-        testDateComparesBefore(earlierDate, laterDate);
-        testDateComparesEqual(earlierDate, earlierDate);
-        testDateComparesAfter(laterDate, earlierDate);
+        expectDateComparesBefore(earlierDate, laterDate);
+        expectDateComparesEqual(earlierDate, earlierDate);
+        expectDateComparesAfter(laterDate, earlierDate);
 
-        testDateComparesAfter(null, earlierDate); // no date sorts after valid dates
-        testDateComparesEqual(null, null);
+        expectDateComparesAfter(null, earlierDate); // no date sorts after valid dates
+        expectDateComparesEqual(null, null);
 
-        testDateComparesBefore(invalidDate, null); // invalid dates sort before no date
-        testDateComparesEqual(invalidDate, invalidDate);
-        testDateComparesAfter(invalidDate, earlierDate); // invalid dates sort after valid ones
+        expectDateComparesBefore(invalidDate, null); // invalid dates sort before no date
+        expectDateComparesEqual(invalidDate, invalidDate);
+        expectDateComparesAfter(invalidDate, earlierDate); // invalid dates sort after valid ones
     });
 });
 


### PR DESCRIPTION
# Description

The focus of this PR is to make it easier to write expressive tests for testing sorting of Task  and date objects.

- Create `tests/CustomMatchers/CustomMatchersForSorting.ts`
    - This has the following for testing sorting of date values - based on functions that were previously in `tests/Sort.test.ts`
        - `expectDateComparesBefore()`
        - `expectDateComparesEqual()`
        - `expectDateComparesAfter()`
    - And this for testing sorting via `Sorting` objects
        - `expectTaskComparesBefore()`
        - `expectTaskComparesEqual()`
        - `expectTaskComparesAfter()`
- `tests/Query/Filter/DueDateField.test.ts`
    - reworked to use these new functions
- `tests/Query/Filter/StatusField.test.ts`
    - More tests added

## Motivation and Context

This is step 6 in splitting out all the sort functions to the relevant fields, to make it easier to add new sort instructions, and to be able to re-use the sort code to sort groups in reverse order.

## How has this been tested?

- By running existing tests

## Screenshots (if appropriate)

## Types of changes


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
