### PR TITLE
fix: Multiple 'sort by tag' lines ignore all but last one

### DIFF
--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -101,7 +101,7 @@ export abstract class Field {
      * @param reverse - false for normal sort order, true for reverse sort order.
      */
     public createSorter(reverse: boolean): Sorting {
-        return new Sorting(reverse, 1, this.fieldName(), this.comparator());
+        return new Sorting(reverse, this.fieldName(), this.comparator());
     }
 
     /**

--- a/src/Query/Sort.ts
+++ b/src/Query/Sort.ts
@@ -41,7 +41,7 @@ export class Sort {
      */
     public static makeLegacySorting(reverse: boolean, propertyInstance: number, property: SortingProperty): Sorting {
         const comparator = Sort.makeLegacyComparator(property, propertyInstance);
-        return new Sorting(reverse, propertyInstance, property, comparator);
+        return new Sorting(reverse, property, comparator);
     }
 
     /**

--- a/src/Query/Sort.ts
+++ b/src/Query/Sort.ts
@@ -10,8 +10,6 @@ import { PathField } from './Filter/PathField';
 import { UrgencyField } from './Filter/UrgencyField';
 
 export class Sort {
-    static tagPropertyInstance: number = 1;
-
     public static by(query: Pick<Query, 'sorting'>, tasks: Task[]): Task[] {
         // TODO Move code for creating default comparators to separate file
         const defaultComparators: Comparator[] = [
@@ -26,17 +24,10 @@ export class Sort {
 
         for (const sorting of query.sorting) {
             userComparators.push(sorting.comparator);
-            if (sorting.property === 'tag') {
-                Sort.tagPropertyInstance = sorting.propertyInstance;
-            }
         }
 
         return tasks.sort(Sort.makeCompositeComparator([...userComparators, ...defaultComparators]));
     }
-
-    public static comparators: Record<SortingProperty, Comparator> = {
-        tag: Sort.compareByTag,
-    };
 
     /**
      * Legacy function, for creating a Sorting object for a SortingProperty type.
@@ -49,7 +40,7 @@ export class Sort {
      *                   one of the values in ${@link SortingProperty}.
      */
     public static makeLegacySorting(reverse: boolean, propertyInstance: number, property: SortingProperty): Sorting {
-        const comparator = Sort.makeLegacyComparator(property);
+        const comparator = Sort.makeLegacyComparator(property, propertyInstance);
         return new Sorting(reverse, propertyInstance, property, comparator);
     }
 
@@ -60,13 +51,14 @@ export class Sort {
      * @param property - the name of the property. This string must match
      *                   one of the values in ${@link SortingProperty}.
      *                   Throws if property not recognised.
+     * @param propertyInstance - for tag sorting, this is a 1-based index for the tag number in the task to sort by.
+     *                           TODO eventually, move this number to the comparator used for sorting by tag.
      */
-    public static makeLegacyComparator(property: SortingProperty): Comparator {
-        const comparator = Sort.comparators[property];
-        if (!comparator) {
+    public static makeLegacyComparator(property: SortingProperty, propertyInstance: number): Comparator {
+        if (property !== 'tag') {
             throw Error('Unrecognised legacy sort keyword: ' + property);
         }
-        return comparator;
+        return Sort.makeCompareByTagComparator(propertyInstance);
     }
 
     private static makeCompositeComparator(comparators: Comparator[]): Comparator {
@@ -81,35 +73,37 @@ export class Sort {
         };
     }
 
-    private static compareByTag(a: Task, b: Task): -1 | 0 | 1 {
-        // If no tags then assume they are equal.
-        if (a.tags.length === 0 && b.tags.length === 0) {
-            return 0;
-        } else if (a.tags.length === 0) {
-            // a is less than b
-            return 1;
-        } else if (b.tags.length === 0) {
-            // b is less than a
-            return -1;
-        }
+    private static makeCompareByTagComparator(propertyInstance: number): Comparator {
+        return (a: Task, b: Task) => {
+            // If no tags then assume they are equal.
+            if (a.tags.length === 0 && b.tags.length === 0) {
+                return 0;
+            } else if (a.tags.length === 0) {
+                // a is less than b
+                return 1;
+            } else if (b.tags.length === 0) {
+                // b is less than a
+                return -1;
+            }
 
-        // Arrays start at 0 but the users specify a tag starting at 1.
-        const tagInstanceToSortBy = Sort.tagPropertyInstance - 1;
+            // Arrays start at 0 but the users specify a tag starting at 1.
+            const tagInstanceToSortBy = propertyInstance - 1;
 
-        if (a.tags.length < Sort.tagPropertyInstance && b.tags.length >= Sort.tagPropertyInstance) {
-            return 1;
-        } else if (b.tags.length < Sort.tagPropertyInstance && a.tags.length >= Sort.tagPropertyInstance) {
-            return -1;
-        } else if (a.tags.length < Sort.tagPropertyInstance && b.tags.length < Sort.tagPropertyInstance) {
-            return 0;
-        }
+            if (a.tags.length < propertyInstance && b.tags.length >= propertyInstance) {
+                return 1;
+            } else if (b.tags.length < propertyInstance && a.tags.length >= propertyInstance) {
+                return -1;
+            } else if (a.tags.length < propertyInstance && b.tags.length < propertyInstance) {
+                return 0;
+            }
 
-        if (a.tags[tagInstanceToSortBy] < b.tags[tagInstanceToSortBy]) {
-            return -1;
-        } else if (a.tags[tagInstanceToSortBy] > b.tags[tagInstanceToSortBy]) {
-            return 1;
-        } else {
-            return 0;
-        }
+            if (a.tags[tagInstanceToSortBy] < b.tags[tagInstanceToSortBy]) {
+                return -1;
+            } else if (a.tags[tagInstanceToSortBy] > b.tags[tagInstanceToSortBy]) {
+                return 1;
+            } else {
+                return 0;
+            }
+        };
     }
 }

--- a/src/Query/Sorting.ts
+++ b/src/Query/Sorting.ts
@@ -18,7 +18,6 @@ export type Comparator = (a: Task, b: Task) => number;
 export class Sorting {
     public readonly property: string;
     public readonly comparator: Comparator;
-    public readonly propertyInstance: number;
 
     /**
      * Constructor.
@@ -26,15 +25,12 @@ export class Sorting {
      * TODO Once SortingProperty has been removed, re-order the parameters so the comparator comes first.
      *
      * @param reverse - whether the sort order should be reversed.
-     * @param propertyInstance - for tag sorting, this is a 1-based index for the tag number in the task to sort by.
-     *                           TODO eventually, move this number to the comparator used for sorting by tag.
      * @param property - the name of the property. If {@link comparator} is not supplied, this string must match
      *                   one of the values in ${@link SortingProperty}.
      * @param comparator - {@link Comparator} function.
      */
-    constructor(reverse: boolean, propertyInstance: number, property: string, comparator: Comparator) {
+    constructor(reverse: boolean, property: string, comparator: Comparator) {
         this.property = property;
-        this.propertyInstance = propertyInstance;
         this.comparator = Sorting.maybeReverse(reverse, comparator);
     }
 

--- a/tests/Query/Filter/TagsField.test.ts
+++ b/tests/Query/Filter/TagsField.test.ts
@@ -488,7 +488,7 @@ describe('Sort by tags', () => {
         resetSettings();
     });
 
-    // Issue #1407 - Multiple 'sort by tag' lines ignore all but last one
+    // Issue #1407 - Multiple 'sort by tag' lines ignored all but last one
     it('should sort correctly with two sort by tag lines', () => {
         const input = [
             fromLine({ line: '- [ ] random 2 #a #a 0' }),
@@ -501,28 +501,16 @@ describe('Sort by tags', () => {
             fromLine({ line: '- [ ] random 8 #c #b 7' }),
             fromLine({ line: '- [ ] random 6 #c #c 8' }),
         ];
-        // This is the correct order
-        // const correctExpectedOrder = [
-        //     input[0], // 3 values with tag 2 = '#a' - then sorted by tag 1
-        //     input[3],
-        //     input[6],
-        //     input[1], // 3 values with tag 2 = '#b' - then sorted by tag 1
-        //     input[4],
-        //     input[7],
-        //     input[2], // 3 values with tag 2 = '#c' - then sorted by tag 1
-        //     input[5],
-        //     input[8],
-        // ];
-        const buggyExpectedOrder = [
-            input[0], // 3 values with tag 1 = '#a' - then sorted by description
-            input[2],
-            input[1],
-            input[4], // 3 values with tag 1 = '#b' - then sorted by description
-            input[5],
+        const correctExpectedOrder = [
+            input[0], // 3 values with tag 2 = '#a' - then sorted by tag 1
             input[3],
-            input[6], // 3 values with tag 1 = '#c' - then sorted by description
-            input[8],
+            input[6],
+            input[1], // 3 values with tag 2 = '#b' - then sorted by tag 1
+            input[4],
             input[7],
+            input[2], // 3 values with tag 2 = '#c' - then sorted by tag 1
+            input[5],
+            input[8],
         ];
         expect(
             Sort.by(
@@ -535,6 +523,6 @@ describe('Sort by tags', () => {
                 },
                 input,
             ),
-        ).toEqual(buggyExpectedOrder);
+        ).toEqual(correctExpectedOrder);
     });
 });

--- a/tests/Query/Filter/TagsField.test.ts
+++ b/tests/Query/Filter/TagsField.test.ts
@@ -3,6 +3,7 @@ import type { FilteringCase } from '../../TestingTools/FilterTestHelpers';
 import { shouldSupportFiltering } from '../../TestingTools/FilterTestHelpers';
 import { toMatchTaskFromLine } from '../../CustomMatchers/CustomMatchersForFilters';
 import { TagsField } from '../../../src/Query/Filter/TagsField';
+import { DescriptionField } from '../../../src/Query/Filter/DescriptionField';
 import { fromLine } from '../../TestHelpers';
 import { Sort } from '../../../src/Query/Sort';
 
@@ -485,5 +486,55 @@ describe('Sort by tags', () => {
 
         // Cleanup
         resetSettings();
+    });
+
+    // Issue #1407 - Multiple 'sort by tag' lines ignore all but last one
+    it('should sort correctly with two sort by tag lines', () => {
+        const input = [
+            fromLine({ line: '- [ ] random 2 #a #a 0' }),
+            fromLine({ line: '- [ ] random 9 #a #b 1' }),
+            fromLine({ line: '- [ ] random 4 #a #c 2' }),
+            fromLine({ line: '- [ ] random 7 #b #a 3' }),
+            fromLine({ line: '- [ ] random 1 #b #b 4' }),
+            fromLine({ line: '- [ ] random 5 #b #c 5' }),
+            fromLine({ line: '- [ ] random 3 #c #a 6' }),
+            fromLine({ line: '- [ ] random 8 #c #b 7' }),
+            fromLine({ line: '- [ ] random 6 #c #c 8' }),
+        ];
+        // This is the correct order
+        // const correctExpectedOrder = [
+        //     input[0], // 3 values with tag 2 = '#a' - then sorted by tag 1
+        //     input[3],
+        //     input[6],
+        //     input[1], // 3 values with tag 2 = '#b' - then sorted by tag 1
+        //     input[4],
+        //     input[7],
+        //     input[2], // 3 values with tag 2 = '#c' - then sorted by tag 1
+        //     input[5],
+        //     input[8],
+        // ];
+        const buggyExpectedOrder = [
+            input[0], // 3 values with tag 1 = '#a' - then sorted by description
+            input[2],
+            input[1],
+            input[4], // 3 values with tag 1 = '#b' - then sorted by description
+            input[5],
+            input[3],
+            input[6], // 3 values with tag 1 = '#c' - then sorted by description
+            input[8],
+            input[7],
+        ];
+        expect(
+            Sort.by(
+                {
+                    sorting: [
+                        Sort.makeLegacySorting(false, 2, 'tag'), // tag 2 - ascending
+                        Sort.makeLegacySorting(false, 1, 'tag'), // tag 1 - ascending
+                        new DescriptionField().createNormalSorter(), // then description - ascending
+                    ],
+                },
+                input,
+            ),
+        ).toEqual(buggyExpectedOrder);
     });
 });

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -38,7 +38,7 @@ describe('Sort', () => {
 
         // Normal way round
         {
-            const sortByDescriptionLength = new Sorting(false, 1, 'junk', comparator);
+            const sortByDescriptionLength = new Sorting(false, 'junk', comparator);
             expect(sortByDescriptionLength.comparator(short, long)).toEqual(1);
             expect(sortByDescriptionLength.comparator(short, short)).toEqual(0);
             expect(sortByDescriptionLength.comparator(long, short)).toEqual(-1);
@@ -46,7 +46,7 @@ describe('Sort', () => {
 
         // Reversed
         {
-            const sortByDescriptionLength = new Sorting(true, 1, 'junk', comparator);
+            const sortByDescriptionLength = new Sorting(true, 'junk', comparator);
             expect(sortByDescriptionLength.comparator(short, long)).toEqual(-1);
             expect(sortByDescriptionLength.comparator(short, short)).toEqual(-0);
             expect(sortByDescriptionLength.comparator(long, short)).toEqual(1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Added test which proved the bug existed
- Each `sort by tag` comparator stores its own tag number
    - instead of them all using a single global tag number - which was stored in `Sort.tagPropertyInstance`
- Removed the `propertyInstance` field from `Sorting`, as no longer used


## Motivation and Context

This fixes #1407
"Multiple 'sort by tag' lines ignore all but last one"

## How has this been tested?

- By adding a failing test and then showing that it now gives the right answer
- Checking the existing tests still pass

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
