### PR TITLE
chore: Enable manual running of codeql-analysis.yml CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,9 @@ on:
     branches: [ main ]
   schedule:
     - cron: '35 18 * * 0'
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
 
 jobs:
   analyze:


### PR DESCRIPTION
This is part of fixing addressing #1415.

<!--- Provide a general summary of your changes in the Title above -->

# Description

Enable manual running of codeql-analysis.yml CI.

If I can confirm that I can trigger it manually, then I can run it as release preparation, instead of waiting on every PR build, for something is very slow and almost never fails.

## Motivation and Context

This is part of fixing addressing #1415, which explains the motivation and pain points behind this.


## How has this been tested?

It will be tested after merge.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->



Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

not applicable.

## Terms


- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
