### PR TITLE
chore: Faster PRs by running CodeQL on release

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,11 +12,12 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "*" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
+# Not run on PRs as too slow: See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1415
+#  push:
+#    branches: [ "*" ]
+#  pull_request:
+#    # The branches below must be a subset of the branches above
+#    branches: [ main ]
   schedule:
     - cron: '35 18 * * 0'
   workflow_dispatch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -563,21 +563,24 @@ Follow the steps in `resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Tes
 
 ### How do I make a release?
 
-1. Check out the `main` branch
-2. Check for the current version in `package.json` (for example, `1.4.1`) and decide on a next version
+1. Go to the [CodeQL Actions page](https://github.com/obsidian-tasks-group/obsidian-tasks/actions/workflows/codeql-analysis.yml) and click `Run workflow` to run the CodeQL checks
+    - Wait for them to succeed
+    - If they fail, put the release on hold and fix any issues first. (Failures are very rare.)
+2. Check out the `main` branch
+3. Check for the current version in `package.json` (for example, `1.4.1`) and decide on a next version
     - Backwards incompatible change: increase major version
     - New functionality: increase minor version
     - Only bug fixes: increase patch version
-3. Having decided on the new version, replace all `X.Y.Z` in the documentation with the new version number.
-4. Check the current version of the obsidian dependency in `package.json` (for example, `0.13.21`)
-5. Run `./release.sh <new tasks version> <obsidian version>`
+4. Having decided on the new version, replace all `X.Y.Z` in the documentation with the new version number.
+5. Check the current version of the obsidian dependency in `package.json` (for example, `0.13.21`)
+6. Run `./release.sh <new tasks version> <obsidian version>`
     - Make sure there are no uncommitted changes. Stash them if necessary.
-6. Wait for [GitHub Actions](https://github.com/obsidian-tasks-group/obsidian-tasks/actions/workflows/release.yml) to create the new release
-7. Update the release description with the changes of the release, which will be a Draft.
+7. Wait for [GitHub Actions](https://github.com/obsidian-tasks-group/obsidian-tasks/actions/workflows/release.yml) to create the new release
+8. Update the release description with the changes of the release, which will be a Draft.
     - On the release page, GitHub provides a button to auto-generate release notes which works nicely as a good starting point.
-8. When you are happy with the release notes, hit the Publish button.
+9. When you are happy with the release notes, hit the Publish button.
     - At this point, GitHub will send an email automatically to everyone who is subscribed to Tasks releases.
-9. Optional: Post to
+10. Optional: Post to
     - Obsidian Discord
         - Add a post in the `#updates` channel, with detail about the release
         - Add a one-liner in the `#task-management` channel, linking to the first post


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

1. Turn off running of CodeQL on PRs and merges, to speed up PRs
2. Document running CodeQL before each release

/CC @schemar for info.

## Motivation and Context

Fixes #1415, which explains the motivation. This will greatly increase my development turnaround, whilst still running these checks before each release.

In theory this will also run a weekly cron job - although that trigger has been there for some time and is not actually running.

Maybe this edit to the file will enable it???

## How has this been tested?

By first adding a manual trigger to the CodeQL action (see #1416) and then using it to do a manual run of CodeQL to confirm that manual execution really does work.

## Screenshots (if appropriate)

## Types of changes


Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

Not applicable.

## Terms


- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
