### PR TITLE
feat: Group by functions

### DIFF
--- a/src/Query/IntermediateTaskGroups.ts
+++ b/src/Query/IntermediateTaskGroups.ts
@@ -78,7 +78,7 @@ export class IntermediateTaskGroups {
             const nextTreeLevel = [];
             for (const currentTreeNode of currentTreeLevel) {
                 for (const task of currentTreeNode.values) {
-                    const groupNames = Group.getGroupNamesForTask(grouping.property, task);
+                    const groupNames = Group.getGroupNamesForTask(grouping, task);
                     for (const groupName of groupNames) {
                         let child = currentTreeNode.children.get(groupName);
                         if (child === undefined) {

--- a/tests/Group.test.ts
+++ b/tests/Group.test.ts
@@ -10,7 +10,8 @@ import { fromLine } from './TestHelpers';
 window.moment = moment;
 
 function checkGroupNamesOfTask(task: Task, property: GroupingProperty, expectedGroupNames: string[]) {
-    const group = Group.getGroupNamesForTask(property, task);
+    const grouping: Grouping = { property };
+    const group = Group.getGroupNamesForTask(grouping, task);
     expect(group).toEqual(expectedGroupNames);
 }
 


### PR DESCRIPTION
# Description

Proposal to add a `group by fn` feature, to group tasks by the return value of JavaScript expressions.

```
not done
group by fn root === "journal/" ? root : path
```

In this example the value of `root` and `path` are available in the expression body via [named arguments passed to the function](https://github.com/seanomlor/obsidian-tasks/commit/a18762ae6f48ecc0bfe53181563b73c8f0ca7733#diff-8d08a76c1dd5e1f1c1cd6d3ac4f8b5439931cef52da1d32ffd9e6210cf1b9ac0R167).

## Motivation and Context

My initial motivation was simply the example above, to group tasks from my daily log notes under a single "journal" heading, otherwise group all other tasks by the full note path.

## How has this been tested?

This is just a proposal. Happy to add tests if accepted.

## Screenshots (if appropriate)

## Types of changes

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
