### PR TITLE
docs: Tables in docs now easier to read, as aligned

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -6,3 +6,7 @@ blockquote {
     padding-left: 15px;
     border-left: 3px solid #ccc;
 }
+
+td {
+    vertical-align: top;
+}


### PR DESCRIPTION
The Quick Reference table, especially, was quite hard to glance over quickly due to the inconsistent vertical alignment.

<!--- Provide a general summary of your changes in the Title above -->

# Description

Made the text in all tables in the User Guide easier to read by top-aligning all content.

This especially makes the Quick Reference page more readable.

## Motivation and Context

I'm filling in gaps in the quick reference - it was too hard to read quickly.

## How has this been tested?

By building docs locally.

## Screenshots (if appropriate)


![image](https://user-images.githubusercontent.com/4840096/209322361-bb16c5d1-54b6-4197-aa79-078a8c5529e8.png)

_Caption: Before on the left - After on the right_

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)


## Checklist

Not applicable

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
