### PR TITLE
feat: 'group by filename' now links to the note

### DIFF
--- a/docs/queries/grouping.md
+++ b/docs/queries/grouping.md
@@ -37,7 +37,7 @@ File locations:
 1. `path` (the path to the file that contains the task, that is, the folder and the filename)
 1. `root` (the top-level folder of the file that contains the task, that is, the first directory in the path, which will be `/` for files in root of the vault)
 1. `folder` (the folder to the file that contains the task, which will be `/` for files in root of the vault)
-1. `filename` (the filename of the file that contains the task, without the `.md` extension)
+1. `filename` (the link to the file that contains the task, without the `.md` extension)
     - Note that tasks from different notes with the same file name will be grouped together in the same group.
 
 > `root` grouping option was introduced in Tasks 1.11.0.

--- a/src/Query/Group.ts
+++ b/src/Query/Group.ts
@@ -168,7 +168,12 @@ export class Group {
 
         // Markdown characters in the file name must be escaped.
         // Markdown characters in the heading must NOT be escaped.
-        const filenameComponent = Group.groupByFileName(task)[0];
+        let filenameComponent = 'Unknown Location';
+
+        if (task.filename !== null) {
+            filenameComponent = Group.escapeMarkdownCharacters(task.filename);
+        }
+
         if (task.precedingHeader === null || task.precedingHeader.length === 0) {
             return [filenameComponent];
         }

--- a/src/Query/Group.ts
+++ b/src/Query/Group.ts
@@ -148,7 +148,7 @@ export class Group {
         if (filename === null) {
             return ['Unknown Location'];
         }
-        return [Group.escapeMarkdownCharacters(filename)];
+        return ['[[' + Group.escapeMarkdownCharacters(filename) + ']]'];
     }
 
     private static groupByRoot(task: Task): string[] {

--- a/src/Query/Group.ts
+++ b/src/Query/Group.ts
@@ -166,17 +166,18 @@ export class Group {
             return ['Unknown Location'];
         }
 
-        // Markdown characters in the file name must be escaped.
-        // Markdown characters in the heading must NOT be escaped.
         let filenameComponent = 'Unknown Location';
 
         if (task.filename !== null) {
+            // Markdown characters in the file name must be escaped.
             filenameComponent = Group.escapeMarkdownCharacters(task.filename);
         }
 
         if (task.precedingHeader === null || task.precedingHeader.length === 0) {
             return [filenameComponent];
         }
+
+        // Markdown characters in the heading must NOT be escaped.
         const headingComponent = Group.groupByHeading(task)[0];
 
         if (filenameComponent === headingComponent) {

--- a/tests/Group.test.ts
+++ b/tests/Group.test.ts
@@ -193,22 +193,22 @@ describe('Grouping tasks', () => {
         // Assert
         expect(groups.toString()).toMatchInlineSnapshot(`
             "
-            Group names: [folder\\_a/folder\\_b/,file\\_c]
+            Group names: [folder\\_a/folder\\_b/,[[file\\_c]]]
             #### folder\\_a/folder\\_b/
-            ##### file\\_c
+            ##### [[file\\_c]]
             - [ ] Task 3 - but path is 1st, alphabetically
 
             ---
 
-            Group names: [folder\\_b/folder\\_c/,file\\_c]
+            Group names: [folder\\_b/folder\\_c/,[[file\\_c]]]
             #### folder\\_b/folder\\_c/
-            ##### file\\_c
+            ##### [[file\\_c]]
             - [ ] Task 1 - but path is 2nd, alphabetically
 
             ---
 
-            Group names: [folder\\_b/folder\\_c/,file\\_d]
-            ##### file\\_d
+            Group names: [folder\\_b/folder\\_c/,[[file\\_d]]]
+            ##### [[file\\_d]]
             - [ ] Task 2 - but path is 2nd, alphabetically
 
             ---
@@ -300,13 +300,13 @@ describe('Group names', () => {
         {
             groupBy: 'filename',
             taskLine: '- [ ] a',
-            expectedGroupNames: ['c'],
+            expectedGroupNames: ['[[c]]'],
             path: 'a/b/c.md',
         },
         {
             groupBy: 'filename',
             taskLine: '- [ ] a',
-            expectedGroupNames: ['\\_c\\_'], // underscores in file names are escaped
+            expectedGroupNames: ['[[\\_c\\_]]'], // underscores in file names are escaped
             path: 'a/b/_c_.md',
         },
 


### PR DESCRIPTION
_Copy paste from original pull request #1418, first part of the discussion is there_

<!--- Provide a general summary of your changes in the Title above -->

# Description
Hello. First of all thanks a lot for your work on the plugin that I enjoy a lot. Please note I'm not an active programmer nowadays and JS is not my main competence, I just wish to contribute as much as I can and bring the functionalities I need myself instead of asking others to spend their time. If I have done something wrong please let me know how to fix that.

Add another option for group by - filelink = [[filename]]

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When grouping by filename, the backlinks are redundant information, so they could/should be hidden by the user. However it would be good to have a link somewhere to the file, where the task is described. This mode permits to have this functionality

<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I did run the plugin in my Obsidian setup. I don't think new tests are necessary since I'm using the same functionality as `filename` option, but with adding a markdown link to that.

<!--- Include details of your testing environment, tests ran to see how -->
I did run the included yarn tests (yarn run jest --coverage) without issue

<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
