### PR TITLE
fix: Make 'sort by path' sort ignoring capitalisation

### DIFF
--- a/src/Query/Filter/PathField.ts
+++ b/src/Query/Filter/PathField.ts
@@ -1,5 +1,4 @@
 import type { Task } from '../../Task';
-import type { Comparator } from '../Sorter';
 import { TextField } from './TextField';
 
 /** Support the 'path' search instruction.
@@ -24,17 +23,5 @@ export class PathField extends TextField {
 
     public supportsSorting(): boolean {
         return true;
-    }
-
-    public comparator(): Comparator {
-        return (a: Task, b: Task) => {
-            if (a.path < b.path) {
-                return -1;
-            } else if (a.path > b.path) {
-                return 1;
-            } else {
-                return 0;
-            }
-        };
     }
 }

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -270,7 +270,11 @@ describe('sorting by description', () => {
         // Assert
         expectTaskComparesEqual(sorter, with_description('Aaa'), with_description('Aaa'));
         expectTaskComparesBefore(sorter, with_description('AAA'), with_description('ZZZ'));
-        expectTaskComparesAfter(sorter, with_description('AAA'), with_description('aaa')); // case-sensitive - capitals come last - TODO WHY? In description searches, capitals appear to come first.
+
+        // Ignores case if strings differ
+        expectTaskComparesBefore(sorter, with_description('AAA'), with_description('bbb'));
+        expectTaskComparesBefore(sorter, with_description('aaa'), with_description('BBB'));
+        expectTaskComparesBefore(sorter, with_description('aaa'), with_description('AAA'));
     });
 
     it('sort by description reverse', () => {

--- a/tests/Query/Filter/PathField.test.ts
+++ b/tests/Query/Filter/PathField.test.ts
@@ -134,7 +134,11 @@ describe('sorting by path', () => {
         // Assert
         expectTaskComparesEqual(sorter, with_path('a/b.md'), with_path('a/b.md'));
         expectTaskComparesBefore(sorter, with_path('a/b.md'), with_path('c/d.md'));
-        expectTaskComparesBefore(sorter, with_path('c/D.md'), with_path('c/d.md')); // case-sensitive - capitals come first
+
+        // Ignores case if strings differ
+        expectTaskComparesBefore(sorter, with_path('aaaa/bbbb.md'), with_path('CCCC/DDDD.md'));
+        expectTaskComparesBefore(sorter, with_path('AAAA/BBBB.md'), with_path('cccc/dddd.md'));
+        expectTaskComparesBefore(sorter, with_path('aaaa/bbbb.md'), with_path('AAAA/BBBB.md'));
 
         // Beginning with numbers
         expectTaskComparesBefore(sorter, with_path('c/1.md'), with_path('c/9.md'));


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Description

Make 'sort by path' ignore capitalisation

Also add more tests of 'sort by description' to show that it ignores case.

## Motivation and Context

Fixes #1432.

## How has this been tested?

Updating unit tests.
Once this PR has built the plugin, I will test it manually as well.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
