### PR TITLE
fix: Improve stripping of format chars in 'sort by description'

### DIFF
--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -69,11 +69,11 @@ export class DescriptionField extends TextField {
                 innerLinkText.substring(innerLinkText.indexOf('|') + 1) + description.replace(startsWithLinkRegex, '');
         }
 
-        description = this.replaceFormatting(description, /^\*\*([^*]*)\*\*/);
-        description = this.replaceFormatting(description, /^\*([^*]*)\*/);
-        description = this.replaceFormatting(description, /^==([^=]*)==/);
-        description = this.replaceFormatting(description, /^__([^_]*)__/);
-        description = this.replaceFormatting(description, /^_([^_]*)_/);
+        description = this.replaceFormatting(description, /^\*\*([^*]+)\*\*/);
+        description = this.replaceFormatting(description, /^\*([^*]+)\*/);
+        description = this.replaceFormatting(description, /^==([^=]+)==/);
+        description = this.replaceFormatting(description, /^__([^_]+)__/);
+        description = this.replaceFormatting(description, /^_([^_]+)_/);
 
         return description;
     }

--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -82,11 +82,16 @@ export class DescriptionField extends TextField {
         return description;
     }
 
-    private static replaceFormatting(description: string, startsWithItalicOrBoldRegex: RegExp) {
-        const italicBoldRegexMatch = description.match(startsWithItalicOrBoldRegex);
+    /**
+     * Remove some formatting from text
+     * @param description
+     * @param regExp A regular expression - all matching text is discarded except the first group
+     */
+    private static replaceFormatting(description: string, regExp: RegExp) {
+        const italicBoldRegexMatch = description.match(regExp);
         if (italicBoldRegexMatch !== null) {
             const innerItalicBoldText = italicBoldRegexMatch[1];
-            description = innerItalicBoldText + description.replace(startsWithItalicOrBoldRegex, '');
+            description = innerItalicBoldText + description.replace(regExp, '');
         }
         return description;
     }

--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -71,13 +71,7 @@ export class DescriptionField extends TextField {
 
         description = this.replaceFormatting(description, /^\*\*([^*]*)\*\*/);
         description = this.replaceFormatting(description, /^\*([^*]*)\*/);
-
-        const startsWithHighlightRegex = /^==?([^=]*)==/;
-        const highlightRegexMatch = description.match(startsWithHighlightRegex);
-        if (highlightRegexMatch !== null) {
-            const innerHighlightsText = highlightRegexMatch[1];
-            description = innerHighlightsText + description.replace(startsWithHighlightRegex, '');
-        }
+        description = this.replaceFormatting(description, /^==([^=]*)==/);
 
         return description;
     }

--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -73,7 +73,7 @@ export class DescriptionField extends TextField {
         const italicBoldRegexMatch = description.match(startsWithItalicOrBoldRegex);
         if (italicBoldRegexMatch !== null) {
             const innerItalicBoldText = italicBoldRegexMatch[1];
-            description = innerItalicBoldText + description.replace(startsWithLinkRegex, '');
+            description = innerItalicBoldText + description.replace(startsWithItalicOrBoldRegex, '');
         }
 
         const startsWithHighlightRegex = /^==?([^=]*)==/;

--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -55,7 +55,7 @@ export class DescriptionField extends TextField {
      * Will remove them only if they are closing.
      * Properly reads links [[like this|one]] (note pipe).
      */
-    private static cleanDescription(description: string): string {
+    public static cleanDescription(description: string): string {
         const globalFilter = getSettings().globalFilter;
         description = description.replace(globalFilter, '').trim();
 

--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -72,6 +72,8 @@ export class DescriptionField extends TextField {
         description = this.replaceFormatting(description, /^\*\*([^*]*)\*\*/);
         description = this.replaceFormatting(description, /^\*([^*]*)\*/);
         description = this.replaceFormatting(description, /^==([^=]*)==/);
+        description = this.replaceFormatting(description, /^__([^_]*)__/);
+        description = this.replaceFormatting(description, /^_([^_]*)_/);
 
         return description;
     }

--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -59,7 +59,7 @@ export class DescriptionField extends TextField {
         const globalFilter = getSettings().globalFilter;
         description = description.replace(globalFilter, '').trim();
 
-        const startsWithLinkRegex = /^\[\[?([^\]]*)\]/;
+        const startsWithLinkRegex = /^\[\[?([^\]]*)\]\]?/;
         const linkRegexMatch = description.match(startsWithLinkRegex);
         if (linkRegexMatch !== null) {
             const innerLinkText = linkRegexMatch[1];

--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -59,7 +59,7 @@ export class DescriptionField extends TextField {
         const globalFilter = getSettings().globalFilter;
         description = description.replace(globalFilter, '').trim();
 
-        const startsWithLinkRegex = /^\[\[?([^\]]*)\]\]?/;
+        const startsWithLinkRegex = /^\[\[?([^\]]*)]]?/;
         const linkRegexMatch = description.match(startsWithLinkRegex);
         if (linkRegexMatch !== null) {
             const innerLinkText = linkRegexMatch[1];

--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -69,12 +69,8 @@ export class DescriptionField extends TextField {
                 innerLinkText.substring(innerLinkText.indexOf('|') + 1) + description.replace(startsWithLinkRegex, '');
         }
 
-        const startsWithItalicOrBoldRegex = /^\*\*?([^*]*)\*/;
-        const italicBoldRegexMatch = description.match(startsWithItalicOrBoldRegex);
-        if (italicBoldRegexMatch !== null) {
-            const innerItalicBoldText = italicBoldRegexMatch[1];
-            description = innerItalicBoldText + description.replace(startsWithItalicOrBoldRegex, '');
-        }
+        description = this.replaceFormatting(description, /^\*\*([^*]*)\*\*/);
+        description = this.replaceFormatting(description, /^\*([^*]*)\*/);
 
         const startsWithHighlightRegex = /^==?([^=]*)==/;
         const highlightRegexMatch = description.match(startsWithHighlightRegex);
@@ -83,6 +79,15 @@ export class DescriptionField extends TextField {
             description = innerHighlightsText + description.replace(startsWithHighlightRegex, '');
         }
 
+        return description;
+    }
+
+    private static replaceFormatting(description: string, startsWithItalicOrBoldRegex: RegExp) {
+        const italicBoldRegexMatch = description.match(startsWithItalicOrBoldRegex);
+        if (italicBoldRegexMatch !== null) {
+            const innerItalicBoldText = italicBoldRegexMatch[1];
+            description = innerItalicBoldText + description.replace(startsWithItalicOrBoldRegex, '');
+        }
         return description;
     }
 }

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -300,6 +300,21 @@ describe('sorting by description', () => {
             );
         });
 
+        // All the strings should be treated as though they contain 'un-format'
+        it.each([
+            '*un-format*',
+            '**un-format**',
+            // '_un-format_',
+            // '__un-format__',
+            // '[[un-format]]',
+            // '[[some-other-file-name|un-format]]',
+            '[un-format]',
+            // '=un-format=',
+            '==un-format==',
+        ])('simple description "%s" is cleaned to "un-format"', (originalDescription: string) => {
+            expect(DescriptionField.cleanDescription(originalDescription)).toStrictEqual('un-format');
+        });
+
         // Each of these pairs of strings is:
         // 1. A task description
         // 2. The result of running that description through the description-cleaning code.
@@ -331,7 +346,7 @@ describe('sorting by description', () => {
             ],
             [
                 '**bold** then ordinary text', // (comment to override formatting)
-                'bold* then ordinary text',
+                'bold then ordinary text',
             ],
             [
                 '*italic* then ordinary text', // (comment to override formatting)

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -366,6 +366,17 @@ describe('sorting by description', () => {
         });
     });
 
+    // All the strings are expected to be treated as unchanged.
+    // They typically have unbalanced numbers of formatting characters,
+    // or other behaviours not yet supported by Description.
+    it.each([
+        '**originalDescription* following text',
+        '__originalDescription_ following text',
+        '**hello * world** - formatting character inside formatting', // it would be nice for this to become 'hello * world'
+    ])('description "%s" is unchanged when cleaned"', (originalDescription: string) => {
+        expect(DescriptionField.cleanDescription(originalDescription)).toStrictEqual(originalDescription);
+    });
+
     it('sorts correctly by the link name and not the markdown', () => {
         const one = fromLine({
             line: '- [ ] *ZZZ An early task that starts with an A; actually not italic since only one asterisk',

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -304,8 +304,8 @@ describe('sorting by description', () => {
         it.each([
             '*un-format*',
             '**un-format**',
-            // '_un-format_',
-            // '__un-format__',
+            '_un-format_',
+            '__un-format__',
             '[[un-format]]',
             '[[some-other-file-name|un-format]]',
             '[un-format]',

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -309,7 +309,6 @@ describe('sorting by description', () => {
             '[[un-format]]',
             '[[some-other-file-name|un-format]]',
             '[un-format]',
-            // '=un-format=',
             '==un-format==',
         ])('simple description "%s" is cleaned to "un-format"', (originalDescription: string) => {
             expect(DescriptionField.cleanDescription(originalDescription)).toStrictEqual('un-format');

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -338,6 +338,7 @@ describe('sorting by description', () => {
                 'italic*italic* then ordinary text',
             ],
         ])('description "%s" is cleaned to "%s"', (originalDescription: string, cleanedDescription: string) => {
+            expect(DescriptionField.cleanDescription(originalDescription)).toStrictEqual(cleanedDescription);
             expectTaskComparesEqual(
                 sorter,
                 new TaskBuilder().description(originalDescription).build(),

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -313,8 +313,8 @@ describe('sorting by description', () => {
                 'Third it should be] alias is used from 1st link but not 2nd [last|ZZZ]',
             ],
             [
-                '*Very italic text* - this looks completely wrong',
-                'Very italic text*Very italic text* - this looks completely wrong',
+                '*Very italic text*', // (comment to override formatting)
+                'Very italic text',
             ],
             [
                 '[@Zebra|Zebra] alias is used single []*', // (comment to override formatting)
@@ -331,11 +331,11 @@ describe('sorting by description', () => {
             ],
             [
                 '**bold** then ordinary text', // (comment to override formatting)
-                'bold**bold** then ordinary text',
+                'bold* then ordinary text',
             ],
             [
                 '*italic* then ordinary text', // (comment to override formatting)
-                'italic*italic* then ordinary text',
+                'italic then ordinary text',
             ],
         ])('description "%s" is cleaned to "%s"', (originalDescription: string, cleanedDescription: string) => {
             expect(DescriptionField.cleanDescription(originalDescription)).toStrictEqual(cleanedDescription);

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -306,8 +306,8 @@ describe('sorting by description', () => {
             '**un-format**',
             // '_un-format_',
             // '__un-format__',
-            // '[[un-format]]',
-            // '[[some-other-file-name|un-format]]',
+            '[[un-format]]',
+            '[[some-other-file-name|un-format]]',
             '[un-format]',
             // '=un-format=',
             '==un-format==',
@@ -321,11 +321,11 @@ describe('sorting by description', () => {
         it.each([
             [
                 '[[Better be second]] most [] removed so these sort equal',
-                'Better be second] most [] removed so these sort equal',
+                'Better be second most [] removed so these sort equal',
             ],
             [
                 '[[Another|Third it should be]] alias is used from 1st link but not 2nd [last|ZZZ]',
-                'Third it should be] alias is used from 1st link but not 2nd [last|ZZZ]',
+                'Third it should be alias is used from 1st link but not 2nd [last|ZZZ]',
             ],
             [
                 '*Very italic text*', // (comment to override formatting)

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -351,10 +351,6 @@ describe('sorting by description', () => {
                 '*italic* then ordinary text', // (comment to override formatting)
                 'italic then ordinary text',
             ],
-            [
-                '=un-format= single hyphen is not a valid formatting, so do not remove it', // (comment to override formatting)
-                '=un-format= single hyphen is not a valid formatting, so do not remove it',
-            ],
         ])('description "%s" is cleaned to "%s"', (originalDescription: string, cleanedDescription: string) => {
             expect(DescriptionField.cleanDescription(originalDescription)).toStrictEqual(cleanedDescription);
             expectTaskComparesEqual(
@@ -372,6 +368,7 @@ describe('sorting by description', () => {
         '**originalDescription* following text',
         '__originalDescription_ following text',
         '**hello * world** - formatting character inside formatting', // it would be nice for this to become 'hello * world'
+        '=un-format= single hyphen is not a valid formatting, so do not remove it',
     ])('description "%s" is unchanged when cleaned"', (originalDescription: string) => {
         expect(DescriptionField.cleanDescription(originalDescription)).toStrictEqual(originalDescription);
     });

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -352,6 +352,10 @@ describe('sorting by description', () => {
                 '*italic* then ordinary text', // (comment to override formatting)
                 'italic then ordinary text',
             ],
+            [
+                '=un-format= single hyphen is not a valid formatting, so do not remove it', // (comment to override formatting)
+                '=un-format= single hyphen is not a valid formatting, so do not remove it',
+            ],
         ])('description "%s" is cleaned to "%s"', (originalDescription: string, cleanedDescription: string) => {
             expect(DescriptionField.cleanDescription(originalDescription)).toStrictEqual(cleanedDescription);
             expectTaskComparesEqual(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- fix: Prevent 'sort by description' from duplicating text
    - This fixes the incorrect regex used when attempting to remove bold and italic formatting.
- fix: The removal of ** for bold no longer leaves a stray *
- fix: The removal of [[ for links no longer leaves a stray ]
- fix: Recognise `_italic_` and `__bold__` formatting
- fix: Don't allow formatting of empty strings

Also added multiple extra tests.

## Limitations

Note that this is not a perfect parsing of markdown.

For example with this:

`**hello * world**`

It would be nice for that to become:

`hello * world`

But it remains unchanged, because the search pattern does not allow any occurrences of the formatting character inside the formatted string.

## Motivation and Context

This fixes #1431.

## How has this been tested?

By adding new tests and running existing ones.

I will test manually once this PR has been built.

## Screenshots (if appropriate)

With these tasks:

```
- [ ] #task *un-format* me 4
- [ ] #task **un-format** me 1
- [ ] #task _un-format_ me 5
- [ ] #task __un-format__ me 3
- [ ] #task [[un-format]] me 7
- [ ] #task [[un-format|un-format]] me 6
- [ ] #task [un-format] me 8
- [ ] #task ==un-format== me 2
```

**Before**

![image](https://user-images.githubusercontent.com/4840096/209726136-a202aeba-951f-402d-92c9-724e9a3f5877.png)

**After**

![image](https://user-images.githubusercontent.com/4840096/209726220-63cf899e-99d9-4a9f-9208-65352b13fef5.png)

Note: After creating the screenshots, I realised that the `[un-format]` case was intended to be for things like `[un-format](https://github.com/)`. I'm not going to bother redoing them, but I confirmed that this case worked too.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
