### PR TITLE
fix: Prevent many cases of Tasks treating non-tag strings as tags

### DIFF
--- a/src/Task.ts
+++ b/src/Task.ts
@@ -111,7 +111,7 @@ export class TaskRegularExpressions {
     // EXAMPLE:
     // description: '#dog #car http://www/ddd#ere #house'
     // matches: #dog, #car, #house
-    public static readonly hashTags = /(^|\s)#[^ !@#$%^&*()[\],.?":;{}|<>]*/g;
+    public static readonly hashTags = /(^|\s)#[^ !@#$%^&*()[\],.?":;{}|<>]+/g;
     public static readonly hashTagsFromEnd = new RegExp(this.hashTags.source + '$');
 }
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -111,7 +111,9 @@ export class TaskRegularExpressions {
     // EXAMPLE:
     // description: '#dog #car http://www/ddd#ere #house'
     // matches: #dog, #car, #house
-    public static readonly hashTags = /(^|\s)#[^ !@#$%^&*()[\],.?":;{}|<>]+/g;
+    // TODO Remove the repetition in this expression:
+    public static readonly hashTags =
+        /(^|\s)#[^ !@#$%^&*()[\],.?":;{}|<>]*[^ !@#$%^&*()[\],.?":;{}|<>0-9]+[^ !@#$%^&*()[\],.?":;{}|<>]*/g;
     public static readonly hashTagsFromEnd = new RegExp(this.hashTags.source + '$');
 }
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -112,8 +112,10 @@ export class TaskRegularExpressions {
     // description: '#dog #car http://www/ddd#ere #house'
     // matches: #dog, #car, #house
     // TODO Remove the repetition in this expression:
-    public static readonly hashTags =
-        /(^|\s)#[^ !@#$%^&*()[\],.?":;{}|<>]*[^ !@#$%^&*()[\],.?":;{}|<>0-9]+[^ !@#$%^&*()[\],.?":;{}|<>]*/g;
+    public static readonly hashTags = new RegExp(
+        '(^|\\s)#[^ !@#$%^&*()[\\],.?":;{}|<>]*[^ !@#$%^&*()[\\],.?":;{}|<>0-9]+[^ !@#$%^&*()[\\],.?":;{}|<>]*',
+        'g',
+    );
     public static readonly hashTagsFromEnd = new RegExp(this.hashTags.source + '$');
 }
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -111,15 +111,17 @@ export class TaskRegularExpressions {
     // EXAMPLE:
     // description: '#dog #car http://www/ddd#ere #house'
     // matches: #dog, #car, #house
-    public static readonly hashTagsInvalidChars = /[^ !@#$%^&*()[\],.?":;{}|<>]/;
+    public static readonly hashTagsValidChars = /[^ !@#$%^&*()[\],.?":;{}|<>]/;
+    public static readonly hashTagsValidCharsExceptDigits = new RegExp(
+        TaskRegularExpressions.hashTagsValidChars.source.slice(0, -1) + '0-9]',
+    );
     public static readonly hashTags = new RegExp(
         '(^|\\s)#' +
-            TaskRegularExpressions.hashTagsInvalidChars.source +
+            TaskRegularExpressions.hashTagsValidChars.source +
             '*' +
-            TaskRegularExpressions.hashTagsInvalidChars.source.slice(0, -1) +
-            '0-9]' +
+            TaskRegularExpressions.hashTagsValidCharsExceptDigits.source +
             '+' +
-            TaskRegularExpressions.hashTagsInvalidChars.source +
+            TaskRegularExpressions.hashTagsValidChars.source +
             '*',
         'g',
     );

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -111,13 +111,14 @@ export class TaskRegularExpressions {
     // EXAMPLE:
     // description: '#dog #car http://www/ddd#ere #house'
     // matches: #dog, #car, #house
-    // TODO Remove the repetition in this expression:
     public static readonly hashTagsInvalidChars = /[^ !@#$%^&*()[\],.?":;{}|<>]/;
     public static readonly hashTags = new RegExp(
         '(^|\\s)#' +
             TaskRegularExpressions.hashTagsInvalidChars.source +
             '*' +
-            '[^ !@#$%^&*()[\\],.?":;{}|<>0-9]+' +
+            TaskRegularExpressions.hashTagsInvalidChars.source.slice(0, -1) +
+            '0-9]' +
+            '+' +
             TaskRegularExpressions.hashTagsInvalidChars.source +
             '*',
         'g',

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -104,7 +104,7 @@ export class TaskRegularExpressions {
     public static readonly doneDateRegex = /✅ *(\d{4}-\d{2}-\d{2})$/u;
     public static readonly recurrenceRegex = /🔁 ?([a-zA-Z0-9, !]+)$/iu;
 
-    // Regex to match all hash tags, basically hash followed by anything but the characters in the negation.
+    // Create a regex to match all hash tags, basically hash followed by anything but the characters in the negation.
     // To ensure URLs are not caught it is looking of beginning of string tag and any
     // tag that has a space in front of it. Any # that has a character in front
     // of it will be ignored.
@@ -117,12 +117,9 @@ export class TaskRegularExpressions {
     );
     public static readonly hashTags = new RegExp(
         '(^|\\s)#' +
-            TaskRegularExpressions.hashTagsValidChars.source +
-            '*' +
-            TaskRegularExpressions.hashTagsValidCharsExceptDigits.source +
-            '+' +
-            TaskRegularExpressions.hashTagsValidChars.source +
-            '*',
+            (TaskRegularExpressions.hashTagsValidChars.source + '*') + //               Any number of valid tag characters
+            (TaskRegularExpressions.hashTagsValidCharsExceptDigits.source + '+') + //   At least 1 valid non-digit character - to prevent all-digit and empty tags
+            (TaskRegularExpressions.hashTagsValidChars.source + '*'), //                Any number of valid tag characters
         'g',
     );
     public static readonly hashTagsFromEnd = new RegExp(this.hashTags.source + '$');

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -111,7 +111,7 @@ export class TaskRegularExpressions {
     // EXAMPLE:
     // description: '#dog #car http://www/ddd#ere #house'
     // matches: #dog, #car, #house
-    public static readonly hashTags = /(^|\s)#[^ !@#$%^&*(),.?":{}|<>]*/g;
+    public static readonly hashTags = /(^|\s)#[^ !@#$%^&*(),.?":;{}|<>]*/g;
     public static readonly hashTagsFromEnd = new RegExp(this.hashTags.source + '$');
 }
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -115,10 +115,11 @@ export class TaskRegularExpressions {
     public static readonly hashTagsInvalidChars = /[^ !@#$%^&*()[\],.?":;{}|<>]/;
     public static readonly hashTags = new RegExp(
         '(^|\\s)#' +
-            '[^ !@#$%^&*()[\\],.?":;{}|<>]' +
+            TaskRegularExpressions.hashTagsInvalidChars.source +
             '*' +
             '[^ !@#$%^&*()[\\],.?":;{}|<>0-9]+' +
-            '[^ !@#$%^&*()[\\],.?":;{}|<>]*',
+            TaskRegularExpressions.hashTagsInvalidChars.source +
+            '*',
         'g',
     );
     public static readonly hashTagsFromEnd = new RegExp(this.hashTags.source + '$');

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -112,8 +112,13 @@ export class TaskRegularExpressions {
     // description: '#dog #car http://www/ddd#ere #house'
     // matches: #dog, #car, #house
     // TODO Remove the repetition in this expression:
+    public static readonly hashTagsInvalidChars = /[^ !@#$%^&*()[\],.?":;{}|<>]/;
     public static readonly hashTags = new RegExp(
-        '(^|\\s)#[^ !@#$%^&*()[\\],.?":;{}|<>]*[^ !@#$%^&*()[\\],.?":;{}|<>0-9]+[^ !@#$%^&*()[\\],.?":;{}|<>]*',
+        '(^|\\s)#' +
+            '[^ !@#$%^&*()[\\],.?":;{}|<>]' +
+            '*' +
+            '[^ !@#$%^&*()[\\],.?":;{}|<>0-9]+' +
+            '[^ !@#$%^&*()[\\],.?":;{}|<>]*',
         'g',
     );
     public static readonly hashTagsFromEnd = new RegExp(this.hashTags.source + '$');

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -111,7 +111,7 @@ export class TaskRegularExpressions {
     // EXAMPLE:
     // description: '#dog #car http://www/ddd#ere #house'
     // matches: #dog, #car, #house
-    public static readonly hashTags = /(^|\s)#[^ !@#$%^&*(),.?":;{}|<>]*/g;
+    public static readonly hashTags = /(^|\s)#[^ !@#$%^&*()[\],.?":;{}|<>]*/g;
     public static readonly hashTagsFromEnd = new RegExp(this.hashTags.source + '$');
 }
 

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -406,7 +406,7 @@ describe('parsing tags', () => {
         {
             markdownTask: '- [ ] Should not find zero-length tags #.',
             expectedDescription: 'Should not find zero-length tags #.',
-            extractedTags: ['#'], // No tag should be found, as there is no valid character after the hash symbol.
+            extractedTags: [],
             globalFilter: '',
         },
         {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -376,7 +376,7 @@ describe('parsing tags', () => {
         {
             markdownTask: '- [ ] digit-only tag values are ignored by Obsidian so should be ignored by Tasks #1234',
             expectedDescription: 'digit-only tag values are ignored by Obsidian so should be ignored by Tasks #1234',
-            extractedTags: ['#1234'], // This is wrong: it should be empty as number-only tags are not valid
+            extractedTags: [],
             globalFilter: '',
         },
         {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -3,7 +3,7 @@
  */
 import moment from 'moment';
 import type { Moment } from 'moment';
-import { Priority, Status, Task } from '../src/Task';
+import { Priority, Status, Task, TaskRegularExpressions } from '../src/Task';
 import { resetSettings, updateSettings } from '../src/Config/Settings';
 import { fromLine } from './TestHelpers';
 import { TaskBuilder } from './TestingTools/TaskBuilder';
@@ -797,6 +797,13 @@ describe('toggle done', () => {
             nextStart: '2022-02-28',
         },
     ];
+
+    it('Temporary test of hashTags source', () => {
+        expect(TaskRegularExpressions.hashTags.source).toMatchInlineSnapshot(
+            '"(^|\\s)#[^ !@#$%^&*()[\\],.?":;{}|<>]*[^ !@#$%^&*()[\\],.?":;{}|<>0-9]+[^ !@#$%^&*()[\\],.?":;{}|<>]*"',
+        );
+        expect(TaskRegularExpressions.hashTags.flags).toMatchInlineSnapshot('"g"');
+    });
 
     test.concurrent.each<RecurrenceCase>(recurrenceCases)(
         'recurs correctly (%j)',

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -382,7 +382,7 @@ describe('parsing tags', () => {
         {
             markdownTask: '- [ ] <mark style="background: #FFF3A3A6;">Make phone call 10:50 today</mark>',
             expectedDescription: '<mark style="background: #FFF3A3A6;">Make phone call 10:50 today</mark>',
-            extractedTags: ['#FFF3A3A6;'], // This is wrong: a) semi-colon not in tag, b)should be empty as "tag" is in markdown formatting
+            extractedTags: ['#FFF3A3A6'], // This is wrong: should be empty as "tag" is in markdown formatting
             globalFilter: '',
         },
         {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -374,6 +374,36 @@ describe('parsing tags', () => {
             globalFilter: '',
         },
         {
+            markdownTask: '- [ ] digit-only tag values are ignored by Obsidian so should be ignored by Tasks #1234',
+            expectedDescription: 'digit-only tag values are ignored by Obsidian so should be ignored by Tasks #1234',
+            extractedTags: ['#1234'], // This is wrong: it should be empty as number-only tags are not valid
+            globalFilter: '',
+        },
+        {
+            markdownTask: '- [ ] <mark style="background: #FFF3A3A6;">Make phone call 10:50 today</mark>',
+            expectedDescription: '<mark style="background: #FFF3A3A6;">Make phone call 10:50 today</mark>',
+            extractedTags: ['#FFF3A3A6;'], // This is wrong: a) semi-colon not in tag, b)should be empty as "tag" is in markdown formatting
+            globalFilter: '',
+        },
+        {
+            markdownTask: '- [ ] Should realise that section links are not tags [[Article#Section]]',
+            expectedDescription: 'Should realise that section links are not tags [[Article#Section]]',
+            extractedTags: [],
+            globalFilter: '',
+        },
+        {
+            markdownTask: '- [ ] Extracted tag should not include `]` [some hyperlink #abcdef](https://google.co.uk)',
+            expectedDescription: 'Extracted tag should not include `]` [some hyperlink #abcdef](https://google.co.uk)',
+            extractedTags: ['#abcdef]'], // Tag should not include ]
+            globalFilter: '',
+        },
+        {
+            markdownTask: '- [ ] Should not find zero-length tags #.',
+            expectedDescription: 'Should not find zero-length tags #.',
+            extractedTags: ['#'], // No tag should be found, as there is no valid character after the hash symbol.
+            globalFilter: '',
+        },
+        {
             markdownTask: '> - [ ] Task inside a blockquote or callout #tagone',
             expectedDescription: 'Task inside a blockquote or callout #tagone',
             extractedTags: ['#tagone'],

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -3,7 +3,7 @@
  */
 import moment from 'moment';
 import type { Moment } from 'moment';
-import { Priority, Status, Task, TaskRegularExpressions } from '../src/Task';
+import { Priority, Status, Task } from '../src/Task';
 import { resetSettings, updateSettings } from '../src/Config/Settings';
 import { fromLine } from './TestHelpers';
 import { TaskBuilder } from './TestingTools/TaskBuilder';
@@ -797,13 +797,6 @@ describe('toggle done', () => {
             nextStart: '2022-02-28',
         },
     ];
-
-    it('Temporary test of hashTags source', () => {
-        expect(TaskRegularExpressions.hashTags.source).toMatchInlineSnapshot(
-            '"(^|\\s)#[^ !@#$%^&*()[\\],.?":;{}|<>]*[^ !@#$%^&*()[\\],.?":;{}|<>0-9]+[^ !@#$%^&*()[\\],.?":;{}|<>]*"',
-        );
-        expect(TaskRegularExpressions.hashTags.flags).toMatchInlineSnapshot('"g"');
-    });
 
     test.concurrent.each<RecurrenceCase>(recurrenceCases)(
         'recurs correctly (%j)',

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -392,9 +392,15 @@ describe('parsing tags', () => {
             globalFilter: '',
         },
         {
+            markdownTask: '- [ ] Extracted tag should not include `[` #abcdef[',
+            expectedDescription: 'Extracted tag should not include `[` #abcdef[',
+            extractedTags: ['#abcdef'],
+            globalFilter: '',
+        },
+        {
             markdownTask: '- [ ] Extracted tag should not include `]` [some hyperlink #abcdef](https://google.co.uk)',
             expectedDescription: 'Extracted tag should not include `]` [some hyperlink #abcdef](https://google.co.uk)',
-            extractedTags: ['#abcdef]'], // Tag should not include ]
+            extractedTags: ['#abcdef'],
             globalFilter: '',
         },
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- fix: Disallow semi-colon (';') in tags
- fix: Disallow [ and ] in tags
- fix: Disallow 0-length tags, that is a # followed by invalid tag characters
- fix: Disallow digit-only tags

~~The only known~~ One remaining limitation in tag-parsing is that the colour in the following is treated as a tag, as it is not understood to be inside formatting.

`- [ ] <mark style="background: #FFF3A3A6;">Make phone call 10:50 today</mark>`

See comments below for more incorrect cases.

## Motivation and Context

To ~~almost fully~~ partially address #929.

## How has this been tested?

Adding new tests and running existing ones.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
