### PR TITLE
docs: Start documenting custom statuses

### DIFF
--- a/docs/getting-started/auto-suggest.md
+++ b/docs/getting-started/auto-suggest.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Auto-Suggest
-nav_order: 6
+nav_order: 7
 parent: Getting Started
 has_toc: false
 ---

--- a/docs/getting-started/create-or-edit-task.md
+++ b/docs/getting-started/create-or-edit-task.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Create or edit Task
-nav_order: 7
+nav_order: 8
 parent: Getting Started
 has_toc: false
 ---

--- a/docs/getting-started/dates.md
+++ b/docs/getting-started/dates.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Dates
-nav_order: 3
+nav_order: 4
 parent: Getting Started
 ---
 

--- a/docs/getting-started/priority.md
+++ b/docs/getting-started/priority.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Priority
-nav_order: 2
+nav_order: 3
 parent: Getting Started
 has_toc: false
 ---

--- a/docs/getting-started/recurring-tasks.md
+++ b/docs/getting-started/recurring-tasks.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Recurring Tasks
-nav_order: 4
+nav_order: 5
 parent: Getting Started
 has_toc: false
 ---

--- a/docs/getting-started/statuses.md
+++ b/docs/getting-started/statuses.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Statuses
+nav_order: 2
+parent: Getting Started
+has_toc: false
+---
+
+# Statuses
+
+{: .no_toc }
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Introduction
+
+Tasks have a status.
+
+The convention in markdown is:
+
+```text
+- [ ] I am a task that is not yet done
+- [x] I am a task that has been done
+```

--- a/docs/getting-started/statuses.md
+++ b/docs/getting-started/statuses.md
@@ -23,6 +23,8 @@ has_toc: false
 
 ## Introduction
 
+### Standard Markdown task statuses
+
 Tasks have a status.
 
 The convention in markdown is:
@@ -31,3 +33,11 @@ The convention in markdown is:
 - [ ] I am a task that is not yet done
 - [x] I am a task that has been done
 ```
+
+### Custom Markdown task statuses
+
+## Credit: Sytone and the 'Tasks SQL Powered' plugin
+
+This plugin's implementation of reading, searching and editing custom statuses was entirely made possible by the work of [Sytone](https://github.com/sytone) and his fork of Tasks called ['Tasks SQL Powered'](https://github.com/sytone/obsidian-tasks-x).
+
+When code in Tasks has been copied from 'Tasks SQL Powered', Sytone has been specifically credited as a co-author, that is, joint author, and these commits can be seen on the GitHub site: [Commits "Co-Authored-By: Sytone"](https://github.com/search?q=repo%3Aobsidian-tasks-group%2Fobsidian-tasks+%22Co-Authored-By%3A+Sytone%22&type=commits).

--- a/docs/getting-started/statuses.md
+++ b/docs/getting-started/statuses.md
@@ -41,3 +41,20 @@ The convention in markdown is:
 This plugin's implementation of reading, searching and editing custom statuses was entirely made possible by the work of [Sytone](https://github.com/sytone) and his fork of Tasks called ['Tasks SQL Powered'](https://github.com/sytone/obsidian-tasks-x).
 
 When code in Tasks has been copied from 'Tasks SQL Powered', Sytone has been specifically credited as a co-author, that is, joint author, and these commits can be seen on the GitHub site: [Commits "Co-Authored-By: Sytone"](https://github.com/search?q=repo%3Aobsidian-tasks-group%2Fobsidian-tasks+%22Co-Authored-By%3A+Sytone%22&type=commits).
+
+### Differences between 'Tasks' and 'Tasks SQL Powered'
+
+These two plugins are developed with justifiably different requirements:
+
+- As a released plugin, a priority of 'Tasks' is ensuring **backwards compatibility** with previous plugin releases, to avoid changing any (non-broken) behaviour of users' existing searches.
+- As an independent fork of 'Tasks', 'Tasks SQL Powered' is free to make changes to existing Tasks behaviour that could well be seen by users as improvements, and is **not required to maintain backwards compatibility** with 'Tasks'.
+
+The notes below may help anyone who is switching their vaults between the 'Tasks' and 'Tasks SQL Powered' to update their tasks or their queries to retain their intended results.
+
+They describe the changes made when back-porting the 'Tasks SQL Powered' custom status code, to retain backwards compatibility.
+
+| Topic                                                 | 'Tasks SQL Powered' [^task-x-version]                                                                                                                                                                                                                | 'Tasks'                                                                         |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Handling unknown status characters, for example `[%]` | Stores and displays the task with no status character:<br>- this affects any custom CSS styling,<br>- toggling changes the line to `[]` - with no status character.<br>(The fix is to ensure all status characters are added in the plugin's settings) | Retains any unknown status characters:<br> - styling and toggling are unchanged |
+
+[^task-x-version]: 'Tasks SQL Powered' as of [revision 2c0b659](https://github.com/sytone/obsidian-tasks-x/tree/2c0b659457cc80806ff18585c955496c76861b87) on 2 August 2022

--- a/docs/getting-started/use-filename-as-default-date.md
+++ b/docs/getting-started/use-filename-as-default-date.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Use Filename as Default Date
-nav_order: 5
+nav_order: 6
 parent: Getting Started
 has_toc: false
 ---


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This is an evolving page for:

- documenting statuses and custom statuses
- crediting @sytone for the work that enabled the capability
- letting 'Tasks SQL Powered' users know of any differences in 'Tasks'.

## Motivation and Context

Start capturing user-focussed info on custom statuses as I discover things to mention...

## How has this been tested?

Viewing docs locally.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
