### PR TITLE
fix: Address minor usability issues when editing status

### DIFF
--- a/src/TaskModal.ts
+++ b/src/TaskModal.ts
@@ -1,6 +1,8 @@
 import { App, Modal } from 'obsidian';
 import EditTask from './ui/EditTask.svelte';
 import type { Task } from './Task';
+import { StatusRegistry } from './StatusRegistry';
+import { Status } from './Status';
 
 export class TaskModal extends Modal {
     public readonly task: Task;
@@ -19,10 +21,27 @@ export class TaskModal extends Modal {
     public onOpen(): void {
         this.titleEl.setText('Create or edit Task');
         const { contentEl } = this;
+
+        const statusOptions = this.getKnownStatusesAndCurrentTaskStatusIfNotKnown();
+
         new EditTask({
             target: contentEl,
-            props: { task: this.task, onSubmit: this.onSubmit },
+            props: { task: this.task, statusOptions: statusOptions, onSubmit: this.onSubmit },
         });
+    }
+
+    /**
+     * If the task being edited has an unknown status, make sure it is added
+     * to the dropdown list.
+     * This allows the user to switch to a different status and then change their
+     * mind and return to the initial status.
+     */
+    private getKnownStatusesAndCurrentTaskStatusIfNotKnown() {
+        const statusOptions: Status[] = StatusRegistry.getInstance().registeredStatuses;
+        if (StatusRegistry.getInstance().byIndicator(this.task.status.indicator) === Status.EMPTY) {
+            statusOptions.push(this.task.status);
+        }
+        return statusOptions;
     }
 
     public onClose(): void {

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -4,7 +4,6 @@
     import { Recurrence } from '../Recurrence';
     import { getSettings } from '../Config/Settings';
     import { Status } from '../Status';
-    import { StatusRegistry } from '../StatusRegistry';
     import { Priority, Task } from '../Task';
     import {
         prioritySymbols,
@@ -15,8 +14,10 @@
     } from '../Task';
     import { doAutocomplete } from '../DateAbbreviations';
 
+    // These exported variables are passed in as props by TaskModal.onOpen():
     export let task: Task;
     export let onSubmit: (updatedTasks: Task[]) => void | Promise<void>;
+    export let statusOptions: Status[];
 
     let descriptionInput: HTMLInputElement;
     let editableTask: {
@@ -48,7 +49,6 @@
     let parsedDone: string = '';
     let addGlobalFilterOnSave: boolean = false;
     let withAccessKeys: boolean = true;
-    let statusOptions = StatusRegistry.getInstance().registeredStatuses;
 
     // 'weekend' abbreviation ommitted due to lack of space.
     let datePlaceholder =

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -382,7 +382,7 @@
                     id="status"
                     type="checkbox"
                     class="task-list-item-checkbox tasks-modal-checkbox"
-                    checked={editableTask.status === Status.DONE}
+                    checked={editableTask.status.isCompleted()}
                     disabled
                 />
             </div>

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -371,7 +371,7 @@
             <label for="status">Status </label>
             <select bind:value={editableTask.status} id="status-type" class="dropdown">
                 {#each statusOptions as status}
-                    <option value={status}>{status.name}</option>
+                    <option value={status}>{status.name} [{status.indicator}]</option>
                 {/each}
             </select>
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Fixed a few things I found when exploratory-testing the new Status dropdown in the Edit modal.

- Show the status character in dropdown list - for example, `In Progress [/]` instead of `In Progress`.
- Show '[X]' as completed, in addition to '[x]'
- Better behaviour in Edit modal with unknown status
    - Previously, if editing a task with an unknown status (for example, [%]) the status dropdown would start empty, and if another status was selected, it would not be possible to return to the initial value.
    - Now, unknown status is shown in the dropdown as 'Unknown [%]',
and is selectable.

## Motivation and Context

Just improving usability, especially as people adopt this feature and before they have started (eventually) customising their statuses.

## How has this been tested?

Extensive local testing in Obsidian.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4840096/210477658-e09a7bc1-6950-4162-9311-ab09649c031f.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
