### PR TITLE
feat: adopt tasks-x's JSON settings facility

### DIFF
--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -1,6 +1,14 @@
 import { Feature } from './Feature';
 import type { FeatureFlag } from './Feature';
 
+interface SettingsMap {
+    [key: string]: string | boolean;
+}
+
+export type HeadingState = {
+    [id: string]: boolean;
+};
+
 export interface Settings {
     globalFilter: string;
     removeGlobalFilter: boolean;
@@ -14,6 +22,13 @@ export interface Settings {
 
     // Collection of feature flag IDs and their state.
     features: FeatureFlag;
+
+    // Settings are moved to a more general map to allow the settings UI to be
+    // dynamically generated.
+    generalSettings: SettingsMap;
+
+    // Tracks the stage of the headings in the settings UI.
+    headingOpened: HeadingState;
 }
 
 const defaultSettings: Settings = {
@@ -27,6 +42,17 @@ const defaultSettings: Settings = {
     useFilenameAsScheduledDate: false,
     filenameAsDateFolders: [],
     features: Feature.settingsFlags,
+    generalSettings: {
+        globalFilter: '',
+        removeGlobalFilter: false,
+        setDoneDate: true,
+
+        // Allows the filter to be pushed to the end of the tag. Available if APPEND_GLOBAL_FILTER feature enabled.
+        appendGlobalFilter: false,
+
+        defaultRenderTemplate: '',
+    },
+    headingOpened: {},
 };
 
 let settings: Settings = { ...defaultSettings };
@@ -58,6 +84,19 @@ export const updateSettings = (newSettings: Partial<Settings>): Settings => {
 
 export const resetSettings = (): Settings => {
     return updateSettings(defaultSettings);
+};
+
+export const updateGeneralSetting = (name: string, value: string | boolean): Settings => {
+    settings.generalSettings[name] = value;
+
+    // sync the old settings for the moment so a larger change is not needed.
+    updateSettings({
+        globalFilter: <string>settings.generalSettings['globalFilter'],
+        removeGlobalFilter: <boolean>settings.generalSettings['removeGlobalFilter'],
+        setDoneDate: <boolean>settings.generalSettings['setDoneDate'],
+    });
+
+    return getSettings();
 };
 
 /**

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -88,12 +88,16 @@ export const resetSettings = (): Settings => {
 export const updateGeneralSetting = (name: string, value: string | boolean): Settings => {
     settings.generalSettings[name] = value;
 
+    /* Prevent duplicate values in user settings for now,
+       at least until I start porting the pre-1.23.0 settings
+       code to be generated from settingsConfiguration.json.
+     */
     // sync the old settings for the moment so a larger change is not needed.
-    updateSettings({
-        globalFilter: <string>settings.generalSettings['globalFilter'],
-        removeGlobalFilter: <boolean>settings.generalSettings['removeGlobalFilter'],
-        setDoneDate: <boolean>settings.generalSettings['setDoneDate'],
-    });
+    // updateSettings({
+    //     globalFilter: <string>settings.generalSettings['globalFilter'],
+    //     removeGlobalFilter: <boolean>settings.generalSettings['removeGlobalFilter'],
+    //     setDoneDate: <boolean>settings.generalSettings['setDoneDate'],
+    // });
 
     return getSettings();
 };

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -43,14 +43,13 @@ const defaultSettings: Settings = {
     filenameAsDateFolders: [],
     features: Feature.settingsFlags,
     generalSettings: {
-        globalFilter: '',
-        removeGlobalFilter: false,
-        setDoneDate: true,
-
-        // Allows the filter to be pushed to the end of the tag. Available if APPEND_GLOBAL_FILTER feature enabled.
-        appendGlobalFilter: false,
-
-        defaultRenderTemplate: '',
+        /* Prevent duplicate values in user settings for now,
+           at least until I start porting the pre-1.23.0 settings
+           code to be generated from settingsConfiguration.json.
+         */
+        // globalFilter: '',
+        // removeGlobalFilter: false,
+        // setDoneDate: true,
     },
     headingOpened: {},
 };

--- a/src/Config/settingsConfiguration.json
+++ b/src/Config/settingsConfiguration.json
@@ -5,7 +5,7 @@
     "class": "",
     "open": true,
     "notice": {
-      "class": "",
+      "class": "setting-item-description",
       "text": "This will end up allowing customisation of task statuses.",
       "html": ""
     },

--- a/src/Config/settingsConfiguration.json
+++ b/src/Config/settingsConfiguration.json
@@ -1,0 +1,14 @@
+[
+  {
+    "text": "Placeholder for Tasks Status Types",
+    "level": "h1",
+    "class": "",
+    "open": true,
+    "notice": {
+      "class": "",
+      "text": "This will end up allowing customisation of task statuses.",
+      "html": ""
+    },
+    "settings": []
+  }
+]

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,8 @@
+:root {
+    --tasks-details-icon: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42z'/></svg>");
+
+}
+
 .plugin-tasks-query-explanation{
     /* Prevent long explanation lines wrapping, so they are more readable,
        especially on small screens.
@@ -59,6 +64,10 @@
     color: red;
     font-weight: bold;
 }
+
+/**------------------------------------------------------------------------
+ **                            MODAL
+ *------------------------------------------------------------------------**/
 
 .tasks-modal-section + .tasks-modal-section {
     margin-top: 16px;
@@ -196,4 +205,74 @@
     .tasks-modal-priorities > label {
         grid-row: 1;
     }
+}
+
+/**------------------------------------------------------------------------
+ **                            SETTINGS
+ *------------------------------------------------------------------------**/
+
+
+ .tasks-settings .additional {
+    margin: 6px 12px;
+}
+.tasks-settings .additional > .setting-item {
+    border-top: 0;
+    padding-top: 9px;
+}
+
+
+.tasks-settings details > summary {
+    outline: none;
+    display: block !important;
+    list-style: none !important;
+    list-style-type: none !important;
+    min-height: 1rem;
+    border-top-left-radius: 0.1rem;
+    border-top-right-radius: 0.1rem;
+    cursor: pointer;
+    position: relative;
+}
+
+.tasks-settings details > summary::-webkit-details-marker,
+.tasks-settings details > summary::marker {
+    display: none !important;
+}
+
+.tasks-settings details > summary > .collapser {
+    position: absolute;
+    top: 50%;
+    right: 8px;
+    transform: translateY(-50%);
+    content: "";
+}
+
+.tasks-settings details > summary > .collapser > .handle {
+    transform: rotate(0deg);
+    transition: transform 0.25s;
+    background-color: currentColor;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-image: var(--tasks-details-icon);
+    mask-image: var(--tasks-details-icon);
+    width: 20px;
+    height: 20px;
+}
+
+.tasks-settings details[open] > summary > .collapser > .handle {
+    transform: rotate(90deg);
+}
+
+.tasks-nested-settings .setting-item {
+    border: 0px;
+    padding-bottom: 0;
+}
+.tasks-nested-settings {
+    padding-bottom: 18px;
+}
+.tasks-nested-settings[open] .setting-item-heading,
+.tasks-nested-settings:not(details) .setting-item-heading {
+    border-top: 0px;
+    border-bottom: 1px solid var(--background-modifier-border);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

The 'Tasks SQL Powered' fork of Tasks uses a JSON file to specify almost all of the content of its Settings pane.

This mechanism will be needed in order to port over its code for allowing users to customise the custom task statuses they wish to use.

In preparation for pulling in the task statuses settings, I have pulled in the code for populating settings from a JSON file.

In order to test this, I put in a temporary place-holder setting for where the statuses will be placed.

Notes:

- All the existing settings UI code is unchanged. It can be ported to the JSON mechanism separately in future.
- One advantage of doing this port is that it will then allow the existing settings sections to be collapsible, which is convenient.

## Credit

Credit: Much of this code in this pull request is a derived copy of the code in @sytone's fork https://github.com/sytone/obsidian-tasks-x from its `main-tasks-sql branch`.

The direct revision copied from is in @claremacrae's fork of sytone's obsidian-tasks-x, with some refactoring to extract methods for re-use and to re reduce repetition, on the branch `refactor-settings-code-for-reuse`:
https://github.com/claremacrae/obsidian-tasks-x/commit/4f59b9dd16b4ede25ecc9957deb51967f99a1106

(This refactoring was needed to allow me to adopt the new JSON mechanism incrementally, postponing the need to rewrite all the current settings in JSON.)

The original revision copied from is:
https://github.com/sytone/obsidian-tasks-x/commit/2c0b659457cc80806ff18585c955496c76861b87

Co-Authored-By: Sytone <1399443+sytone@users.noreply.github.com>

## Motivation and Context

Preparing to allow editing of task statues.

## How has this been tested?

By building the code locally and testing it manually.

## Screenshots (if appropriate)

_Note that the new section is collapsible._

![image](https://user-images.githubusercontent.com/4840096/210572064-64350905-8879-4ae2-be32-1d11926a1e10.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

_It's not strictly a refactor, but the actual change in behaviour will be removed in the next PR._

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
