### PR TITLE
feat: Enable adding & editing of custom statuses

### DIFF
--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -1,0 +1,150 @@
+import { Modal, Setting, TextComponent } from 'obsidian';
+import type { StatusConfiguration } from '../Status';
+import type TasksPlugin from '../main';
+
+export class CustomStatusModal extends Modal {
+    statusSymbol: string;
+    statusName: string;
+    statusNextSymbol: string;
+    statusAvailableAsCommand: boolean;
+    saved: boolean = false;
+    error: boolean = false;
+    constructor(public plugin: TasksPlugin, statusType: StatusConfiguration) {
+        super(plugin.app);
+        this.statusSymbol = statusType.indicator;
+        this.statusName = statusType.name;
+        this.statusNextSymbol = statusType.nextStatusIndicator;
+        this.statusAvailableAsCommand = statusType.availableAsCommand;
+    }
+
+    async display() {
+        const { contentEl } = this;
+
+        contentEl.empty();
+
+        const settingDiv = contentEl.createDiv();
+        //const title = this.title ?? '...';
+
+        let statusSymbolText: TextComponent;
+        new Setting(settingDiv)
+            .setName('Task Status Symbol')
+            .setDesc('This is the character between the square braces.')
+            .addText((text) => {
+                statusSymbolText = text;
+                statusSymbolText.setValue(this.statusSymbol).onChange((v) => {
+                    if (!v.length) {
+                        CustomStatusModal.setValidationError(text, 'Task status type cannot be empty.');
+                        return;
+                    }
+
+                    if (v.includes(' ')) {
+                        CustomStatusModal.setValidationError(text, 'Task status type cannot include spaces.');
+                        return;
+                    }
+
+                    if (v.length > 1) {
+                        CustomStatusModal.setValidationError(text, 'Task status must be a single character.');
+                        return;
+                    }
+                    CustomStatusModal.removeValidationError(text);
+                    this.statusSymbol = v;
+                });
+            });
+
+        new Setting(settingDiv)
+            .setName('Task Status Name')
+            .setDesc('This is the friendly name of the task status.')
+            .addText((text) => {
+                text.setValue(this.statusName).onChange((v) => {
+                    this.statusName = v;
+                });
+            });
+
+        new Setting(settingDiv)
+            .setName('Task Next Status Symbol')
+            .setDesc('When clicked on this is the symbol that should be used next.')
+            .addText((text) => {
+                text.setValue(this.statusNextSymbol).onChange((v) => {
+                    this.statusNextSymbol = v;
+                });
+            });
+
+        new Setting(settingDiv)
+            .setName('Available as command')
+            .setDesc(
+                'If enabled this status will be available as a command so you can assign a hotkey and toggle the status using it.',
+            )
+            .addToggle((toggle) => {
+                toggle.setValue(this.statusAvailableAsCommand).onChange(async (value) => {
+                    this.statusAvailableAsCommand = value;
+                });
+            });
+
+        const footerEl = contentEl.createDiv();
+        const footerButtons = new Setting(footerEl);
+        footerButtons.addButton((b) => {
+            b.setTooltip('Save')
+                .setIcon('checkmark')
+                .onClick(async () => {
+                    // let error = false;
+                    // if (!this.statusSymbol.length) {
+                    //     SettingsModal.setValidationError(this.statusSymbol, 'Task status type cannot be empty.');
+                    //     error = true;
+                    //     return;
+                    // }
+
+                    // if (error) {
+                    //     new Notice('Fix errors before saving.');
+                    //     return;
+                    // }
+                    this.saved = true;
+                    this.close();
+                });
+            return b;
+        });
+        footerButtons.addExtraButton((b) => {
+            b.setIcon('cross')
+                .setTooltip('Cancel')
+                .onClick(() => {
+                    this.saved = false;
+                    this.close();
+                });
+            return b;
+        });
+    }
+
+    // updateTitle(admonitionPreview: HTMLElement, title: string) {
+    //     let titleSpan = admonitionPreview.querySelector('.admonition-title-content');
+    //     let iconEl = admonitionPreview.querySelector('.admonition-title-icon');
+    //     titleSpan.textContent = title;
+    //     titleSpan.prepend(iconEl);
+    // }
+    onOpen() {
+        this.display();
+    }
+
+    static setValidationError(textInput: TextComponent, message?: string) {
+        textInput.inputEl.addClass('is-invalid');
+        if (message) {
+            textInput.inputEl.parentElement?.addClasses(['has-invalid-message', 'unset-align-items']);
+            textInput.inputEl.parentElement?.parentElement?.addClass('.unset-align-items');
+            let mDiv = textInput.inputEl.parentElement?.querySelector('.invalid-feedback') as HTMLDivElement;
+
+            if (!mDiv) {
+                mDiv = createDiv({ cls: 'invalid-feedback' });
+            }
+            mDiv.innerText = message;
+            mDiv.insertAfter(textInput.inputEl);
+        }
+    }
+    static removeValidationError(textInput: TextComponent) {
+        textInput.inputEl.removeClass('is-invalid');
+        textInput.inputEl.parentElement?.removeClasses(['has-invalid-message', 'unset-align-items']);
+        textInput.inputEl.parentElement?.parentElement?.removeClass('.unset-align-items');
+
+        const invalidFeedback = textInput.inputEl.parentElement?.querySelector('.invalid-feedback');
+        if (invalidFeedback) {
+            textInput.inputEl.parentElement?.removeChild(invalidFeedback);
+        }
+    }
+}

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -1,3 +1,4 @@
+import type { StatusConfiguration } from '../Status';
 import { Feature } from './Feature';
 import type { FeatureFlag } from './Feature';
 
@@ -20,6 +21,9 @@ export interface Settings {
     useFilenameAsScheduledDate: boolean;
     filenameAsDateFolders: string[];
 
+    // The custom status states.
+    statusTypes: StatusConfiguration[];
+
     // Collection of feature flag IDs and their state.
     features: FeatureFlag;
 
@@ -41,6 +45,7 @@ const defaultSettings: Settings = {
     provideAccessKeys: true,
     useFilenameAsScheduledDate: false,
     filenameAsDateFolders: [],
+    statusTypes: [],
     features: Feature.settingsFlags,
     generalSettings: {
         /* Prevent duplicate values in user settings for now,

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -1,14 +1,19 @@
-import { PluginSettingTab, Setting, debounce } from 'obsidian';
+import { Notice, PluginSettingTab, Setting, debounce } from 'obsidian';
+import { StatusConfiguration } from 'Status';
 import type TasksPlugin from '../main';
 import { getSettings, isFeatureEnabled, updateGeneralSetting, updateSettings } from './Settings';
 import type { HeadingState } from './Settings';
 import settingsJson from './settingsConfiguration.json';
 
+import { CustomStatusModal } from './CustomStatusModal';
+
 export class SettingsTab extends PluginSettingTab {
     // If the UI needs a more complex setting you can create a
     // custom function and specify it from the json file. It will
     // then be rendered instead of a normal checkbox or text box.
-    customFunctions: { [K: string]: Function } = {};
+    customFunctions: { [K: string]: Function } = {
+        insertTaskStatusSettings: this.insertTaskStatusSettings,
+    };
 
     private readonly plugin: TasksPlugin;
 
@@ -345,5 +350,214 @@ export class SettingsTab extends PluginSettingTab {
 
     private static renderFolderArray(folders: string[]): string {
         return folders.join(',');
+    }
+
+    /**
+     * Settings for Custom Task Status
+     *
+     * @param {HTMLElement} containerEl
+     * @param {SettingsTab} settings
+     * @memberof SettingsTab
+     */
+    insertTaskStatusSettings(containerEl: HTMLElement, settings: SettingsTab) {
+        const { statusTypes } = getSettings();
+        statusTypes.forEach((status_type) => {
+            //const taskStatusDiv = containerEl.createEl('div');
+
+            const taskStatusPreview = containerEl.createEl('pre');
+            let commandNotice = '';
+            if (status_type.availableAsCommand) {
+                commandNotice = 'Available as a command.';
+            }
+            taskStatusPreview.textContent = `- [${status_type.indicator}] ${status_type.name}, next status is '${status_type.nextStatusIndicator}'. ${commandNotice}`;
+
+            const setting = new Setting(containerEl);
+
+            setting.infoEl.replaceWith(taskStatusPreview);
+
+            setting
+                .addExtraButton((extra) => {
+                    extra
+                        .setIcon('cross')
+                        .setTooltip('Delete')
+                        .onClick(async () => {
+                            const index = statusTypes.indexOf(status_type);
+                            if (index > -1) {
+                                statusTypes.splice(index, 1);
+                                updateSettings({
+                                    statusTypes: statusTypes,
+                                });
+
+                                await settings.saveSettings(true);
+                            }
+                        });
+                })
+
+                .addExtraButton((extra) => {
+                    extra
+                        .setIcon('pencil')
+                        .setTooltip('Edit')
+                        .onClick(async () => {
+                            const modal = new CustomStatusModal(settings.plugin, status_type);
+
+                            modal.onClose = async () => {
+                                if (modal.saved) {
+                                    const index = statusTypes.indexOf(status_type);
+                                    if (index > -1) {
+                                        statusTypes.splice(
+                                            index,
+                                            1,
+                                            new StatusConfiguration(
+                                                modal.statusSymbol,
+                                                modal.statusName,
+                                                modal.statusNextSymbol,
+                                                modal.statusAvailableAsCommand,
+                                            ),
+                                        );
+                                        updateSettings({
+                                            statusTypes: statusTypes,
+                                        });
+
+                                        await settings.saveSettings(true);
+                                    }
+                                }
+                            };
+
+                            modal.open();
+                        });
+                });
+
+            setting.infoEl.remove();
+        });
+
+        containerEl.createEl('div');
+
+        const setting = new Setting(containerEl).addButton((button) => {
+            button
+                .setButtonText('Add New Task Status')
+                .setCta()
+                .onClick(async () => {
+                    statusTypes.push(new StatusConfiguration('', '', '', false));
+                    updateSettings({
+                        statusTypes: statusTypes,
+                    });
+
+                    await settings.saveSettings(true);
+                });
+        });
+        setting.infoEl.remove();
+
+        /* -------------------- Minimal Theme Supported Status Types -------------------- */
+        const addStatusesSupportedByMinimalTheme = new Setting(containerEl).addButton((button) => {
+            button
+                .setButtonText('Add all Status types supported by Minimal Theme')
+                .setCta()
+                .onClick(async () => {
+                    const minimalSupportedStatuses: Array<[string, string, string]> = [
+                        ['>', 'Forwarded', 'x'],
+                        ['<', 'Schedule', 'x'],
+                        ['?', 'Question', 'x'],
+                        // ['/', 'Incomplete', 'x'], This is used for In Progress
+                        ['!', 'Important', 'x'],
+                        ['"', 'Quote', 'x'],
+                        ['-', 'Canceled', 'x'],
+                        ['*', 'Star', 'x'],
+                        ['l', 'Location', 'x'],
+                        ['i', 'Info', 'x'],
+                        ['S', 'Amount/savings/money', 'x'],
+                        ['I', 'Idea/lightbulb', 'x'],
+                        ['f', 'Fire', 'x'],
+                        ['k', 'Key', 'x'],
+                        ['u', 'Up', 'x'],
+                        ['d', 'Down', 'x'],
+                        ['w', 'Win', 'x'],
+                        ['p', 'Pros', 'x'],
+                        ['c', 'Cons', 'x'],
+                        ['b', 'Bookmark', 'x'],
+                    ];
+
+                    minimalSupportedStatuses.forEach((importedStatus) => {
+                        const hasStatus = statusTypes.find((element) => {
+                            return (
+                                element.indicator == importedStatus[0] &&
+                                element.name == importedStatus[1] &&
+                                element.nextStatusIndicator == importedStatus[2]
+                            );
+                        });
+                        if (!hasStatus) {
+                            statusTypes.push(
+                                new StatusConfiguration(importedStatus[0], importedStatus[1], importedStatus[2], false),
+                            );
+                        } else {
+                            new Notice(`The status ${importedStatus[1]} (${importedStatus[0]}) is already added.`);
+                        }
+                    });
+
+                    updateSettings({
+                        statusTypes: statusTypes,
+                    });
+
+                    await settings.saveSettings(true);
+                });
+        });
+        addStatusesSupportedByMinimalTheme.infoEl.remove();
+
+        /* -------------------- ITS Theme Supported Status Types -------------------- */
+        const addStatusesSupportedByITSTheme = new Setting(containerEl).addButton((button) => {
+            button
+                .setButtonText('Add all Status types supported by ITS Theme')
+                .setCta()
+                .onClick(async () => {
+                    const supportedStatuses: Array<[string, string, string]> = [
+                        //['X', 'Checked', 'x'],
+                        ['>', 'Forward', 'x'],
+                        ['D', 'Deferred/Scheduled', 'x'],
+                        //['-', 'Cancelled/Non-Task', 'x'],
+                        ['?', 'Question', 'x'],
+                        ['!', 'Important', 'x'],
+                        ['+', 'Add', 'x'],
+                        //['/', 'Half Done', 'x'],
+                        ['R', 'Research', 'x'],
+                        ['i', 'Idea', 'x'],
+                        ['B', 'Brainstorm', 'x'],
+                        ['P', 'Pro', 'x'],
+                        ['C', 'Con', 'x'],
+                        ['I', 'Info', 'x'],
+                        ['Q', 'Quote', 'x'],
+                        ['N', 'Note', 'x'],
+                        ['b', 'Bookmark', 'x'],
+                        ['p', 'Paraphrase', 'x'],
+                        ['E', 'Example', 'x'],
+                        ['L', 'Location', 'x'],
+                        ['A', 'Answer', 'x'],
+                        ['r', 'Reward', 'x'],
+                        ['c', 'Choice', 'x'],
+                    ];
+
+                    supportedStatuses.forEach((importedStatus) => {
+                        const hasStatus = statusTypes.find((element) => {
+                            return (
+                                element.indicator == importedStatus[0] &&
+                                element.name == importedStatus[1] &&
+                                element.nextStatusIndicator == importedStatus[2]
+                            );
+                        });
+                        if (!hasStatus) {
+                            statusTypes.push(
+                                new StatusConfiguration(importedStatus[0], importedStatus[1], importedStatus[2], false),
+                            );
+                        } else {
+                            new Notice(`The status ${importedStatus[1]} (${importedStatus[0]}) is already added.`);
+                        }
+                    });
+
+                    updateSettings({
+                        statusTypes: statusTypes,
+                    });
+
+                    await settings.saveSettings(true);
+                });
+        });
+        addStatusesSupportedByITSTheme.infoEl.remove();
     }
 }

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -476,28 +476,7 @@ export class SettingsTab extends PluginSettingTab {
                         ['b', 'Bookmark', 'x'],
                     ];
 
-                    minimalSupportedStatuses.forEach((importedStatus) => {
-                        const hasStatus = statusTypes.find((element) => {
-                            return (
-                                element.indicator == importedStatus[0] &&
-                                element.name == importedStatus[1] &&
-                                element.nextStatusIndicator == importedStatus[2]
-                            );
-                        });
-                        if (!hasStatus) {
-                            statusTypes.push(
-                                new StatusConfiguration(importedStatus[0], importedStatus[1], importedStatus[2], false),
-                            );
-                        } else {
-                            new Notice(`The status ${importedStatus[1]} (${importedStatus[0]}) is already added.`);
-                        }
-                    });
-
-                    updateSettings({
-                        statusTypes: statusTypes,
-                    });
-
-                    await settings.saveSettings(true);
+                    await addCustomStatesToSettings(minimalSupportedStatuses, statusTypes, settings);
                 });
         });
         addStatusesSupportedByMinimalTheme.infoEl.remove();
@@ -508,7 +487,7 @@ export class SettingsTab extends PluginSettingTab {
                 .setButtonText('Add all Status types supported by ITS Theme')
                 .setCta()
                 .onClick(async () => {
-                    const supportedStatuses: Array<[string, string, string]> = [
+                    const itsSupportedStatuses: Array<[string, string, string]> = [
                         //['X', 'Checked', 'x'],
                         ['>', 'Forward', 'x'],
                         ['D', 'Deferred/Scheduled', 'x'],
@@ -534,30 +513,36 @@ export class SettingsTab extends PluginSettingTab {
                         ['c', 'Choice', 'x'],
                     ];
 
-                    supportedStatuses.forEach((importedStatus) => {
-                        const hasStatus = statusTypes.find((element) => {
-                            return (
-                                element.indicator == importedStatus[0] &&
-                                element.name == importedStatus[1] &&
-                                element.nextStatusIndicator == importedStatus[2]
-                            );
-                        });
-                        if (!hasStatus) {
-                            statusTypes.push(
-                                new StatusConfiguration(importedStatus[0], importedStatus[1], importedStatus[2], false),
-                            );
-                        } else {
-                            new Notice(`The status ${importedStatus[1]} (${importedStatus[0]}) is already added.`);
-                        }
-                    });
-
-                    updateSettings({
-                        statusTypes: statusTypes,
-                    });
-
-                    await settings.saveSettings(true);
+                    await addCustomStatesToSettings(itsSupportedStatuses, statusTypes, settings);
                 });
         });
         addStatusesSupportedByITSTheme.infoEl.remove();
     }
+}
+
+async function addCustomStatesToSettings(
+    supportedStatuses: Array<[string, string, string]>,
+    statusTypes: StatusConfiguration[],
+    settings: SettingsTab,
+) {
+    supportedStatuses.forEach((importedStatus) => {
+        const hasStatus = statusTypes.find((element) => {
+            return (
+                element.indicator == importedStatus[0] &&
+                element.name == importedStatus[1] &&
+                element.nextStatusIndicator == importedStatus[2]
+            );
+        });
+        if (!hasStatus) {
+            statusTypes.push(new StatusConfiguration(importedStatus[0], importedStatus[1], importedStatus[2], false));
+        } else {
+            new Notice(`The status ${importedStatus[1]} (${importedStatus[0]}) is already added.`);
+        }
+    });
+
+    updateSettings({
+        statusTypes: statusTypes,
+    });
+
+    await settings.saveSettings(true);
 }

--- a/src/Config/settingsConfiguration.json
+++ b/src/Config/settingsConfiguration.json
@@ -7,7 +7,7 @@
     "notice": {
       "class": "",
       "text": "If you want to have the tasks support additional statuses outside of the default ones add them here with the status indicator. ",
-      "html": "By default the following statuses are supported:<ul><li><strong>- [ ] Todo</strong> - This has a {space} between the brackets. Will toggle to In Progress.</li><li><strong>- [/] In Progress</strong> - This has a {/} between the brackets. Will toggle to Done.</li><li><strong>- [x] Done</strong> - This has a {x} between the brackets. Will toggle to Todo.</li><li><strong>- [-] Cancelled</strong> - This has a {-} between the brackets. Will toggle to Todo.</li></ul>"
+      "html": "By default the following statuses are supported:<ul><li><strong>- [ ] Todo</strong> - This has a {space} between the brackets. Will toggle to Done.</li><li><strong>- [/] In Progress</strong> - This has a {/} between the brackets. Will toggle to Done.</li><li><strong>- [x] Done</strong> - This has a {x} between the brackets. Will toggle to Todo.</li><li><strong>- [-] Cancelled</strong> - This has a {-} between the brackets. Will toggle to Todo.</li></ul>"
     },
     "settings": [
       {

--- a/src/Config/settingsConfiguration.json
+++ b/src/Config/settingsConfiguration.json
@@ -1,14 +1,25 @@
 [
   {
-    "text": "Placeholder for Tasks Status Types",
-    "level": "h1",
+    "text": "Tasks Status Types",
+    "level": "h3",
     "class": "",
-    "open": true,
+    "open": false,
     "notice": {
-      "class": "setting-item-description",
-      "text": "This will end up allowing customisation of task statuses.",
-      "html": ""
+      "class": "",
+      "text": "If you want to have the tasks support additional statuses outside of the default ones add them here with the status indicator. ",
+      "html": "By default the following statuses are supported:<ul><li><strong>- [ ] Todo</strong> - This has a {space} between the brackets. Will toggle to In Progress.</li><li><strong>- [/] In Progress</strong> - This has a {/} between the brackets. Will toggle to Done.</li><li><strong>- [x] Done</strong> - This has a {x} between the brackets. Will toggle to Todo.</li><li><strong>- [-] Cancelled</strong> - This has a {-} between the brackets. Will toggle to Todo.</li></ul>"
     },
-    "settings": []
+    "settings": [
+      {
+        "name": "",
+        "description": "",
+        "type": "function",
+        "initialValue": "",
+        "placeholder": "",
+        "settingName": "insertTaskStatusSettings",
+        "featureFlag": "",
+        "notice": null
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This adds a new section in settings to allow users to edit the available custom statuses.

It basically works really very well indeed. There are a few infelicities in the error-checking that will need fixing before release, but it it's a brilliant body of work - thank you @sytone 🙏 🎉 .

## Credit

Credit: This is a partial copy of the code in @sytone's fork https://github.com/sytone/obsidian-tasks-x on the `main-tasks-sql` branch.

The revision copied from:
https://github.com/sytone/obsidian-tasks-x/commit/2c0b659457cc80806ff18585c955496c76861b87

Co-Authored-By: Sytone <1399443+sytone@users.noreply.github.com>

## Motivation and Context

Essential new feature for support of custom task status types.

It has been requested many times, including:

- https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/312
- https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/564
- https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/674

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

1. The initial state:

    ![image](https://user-images.githubusercontent.com/4840096/210587279-623991d2-1a21-4416-b4c4-0218f07b7465.png)

2. After adding Minimal Theme types:

    ![image](https://user-images.githubusercontent.com/4840096/210587643-eb0dceaf-50ed-4a16-9a67-f4f99437f119.png)

3. Editing one of the types:

    ![image](https://user-images.githubusercontent.com/4840096/210587890-2cbb291d-fa89-4563-aaba-da7731d92021.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
