### PR TITLE
test: Address 5 TODOs in Sort.test.ts

### DIFF
--- a/tests/Query/Filter/DateField.test.ts
+++ b/tests/Query/Filter/DateField.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+import moment from 'moment';
+
+window.moment = moment;
+
+import {
+    expectDateComparesAfter,
+    expectDateComparesBefore,
+    expectDateComparesEqual,
+} from '../../CustomMatchers/CustomMatchersForSorting';
+
+// These are lower-level tests that the Task-based ones above, for ease of test coverage.
+describe('compareBy', () => {
+    it('compares correctly by date', () => {
+        const earlierDate = '2022-01-01';
+        const laterDate = '2022-02-01';
+        const invalidDate = '2022-02-30';
+
+        expectDateComparesBefore(earlierDate, laterDate);
+        expectDateComparesEqual(earlierDate, earlierDate);
+        expectDateComparesAfter(laterDate, earlierDate);
+
+        expectDateComparesAfter(null, earlierDate); // no date sorts after valid dates
+        expectDateComparesEqual(null, null);
+
+        expectDateComparesBefore(invalidDate, null); // invalid dates sort before no date
+        expectDateComparesEqual(invalidDate, invalidDate);
+        expectDateComparesAfter(invalidDate, earlierDate); // invalid dates sort after valid ones
+    });
+});

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -16,11 +16,6 @@ import { PathField } from '../src/Query/Filter/PathField';
 import { DescriptionField } from '../src/Query/Filter/DescriptionField';
 import { fromLine } from './TestHelpers';
 import { TaskBuilder } from './TestingTools/TaskBuilder';
-import {
-    expectDateComparesAfter,
-    expectDateComparesBefore,
-    expectDateComparesEqual,
-} from './CustomMatchers/CustomMatchersForSorting';
 
 describe('Sort', () => {
     it('constructs Sorting both ways from Comparator function', () => {
@@ -122,33 +117,6 @@ describe('Sort', () => {
         ).toEqual(expectedOrder);
     });
 
-    // TODO Replace this with something simpler but equivalent in DescriptionField.test.ts.
-    it('sorts correctly by description reverse, done', () => {
-        const one = fromLine({
-            line: '- [ ] b 📅 1970-01-01 ✅ 1971-01-01',
-            path: '',
-        });
-        const two = fromLine({
-            line: '- [ ] b 📅 1970-01-02 ✅ 1971-01-02',
-            path: '',
-        });
-        const three = fromLine({
-            line: '- [ ] a 📅 1970-01-02 ✅ 1971-01-01',
-            path: '',
-        });
-        const four = fromLine({
-            line: '- [ ] a 📅 1970-01-02 ✅ 1971-01-03',
-            path: '',
-        });
-        const expectedOrder = [one, two, three, four];
-        expect(
-            Sort.by(
-                [new DescriptionField().createReverseSorter(), new DoneDateField().createNormalSorter()],
-                [two, four, three, one],
-            ),
-        ).toEqual(expectedOrder);
-    });
-
     it('sorts correctly by complex sorting incl. reverse', () => {
         const one = fromLine({ line: '- [x] a 📅 1970-01-03', path: '3' });
         const two = fromLine({ line: '- [x] c 📅 1970-01-02', path: '2' });
@@ -169,26 +137,5 @@ describe('Sort', () => {
                 [six, five, one, four, three, two],
             ),
         ).toEqual(expectedOrder);
-    });
-});
-
-// These are lower-level tests that the Task-based ones above, for ease of test coverage.
-// TODO Replace this with something simpler but equivalent in the tests for DateField.test.ts.
-describe('compareBy', () => {
-    it('compares correctly by date', () => {
-        const earlierDate = '2022-01-01';
-        const laterDate = '2022-02-01';
-        const invalidDate = '2022-02-30';
-
-        expectDateComparesBefore(earlierDate, laterDate);
-        expectDateComparesEqual(earlierDate, earlierDate);
-        expectDateComparesAfter(laterDate, earlierDate);
-
-        expectDateComparesAfter(null, earlierDate); // no date sorts after valid dates
-        expectDateComparesEqual(null, null);
-
-        expectDateComparesBefore(invalidDate, null); // invalid dates sort before no date
-        expectDateComparesEqual(invalidDate, invalidDate);
-        expectDateComparesAfter(invalidDate, earlierDate); // invalid dates sort after valid ones
     });
 });

--- a/tests/Sort.test.ts
+++ b/tests/Sort.test.ts
@@ -10,10 +10,8 @@ import { Sort } from '../src/Query/Sort';
 import { Sorter } from '../src/Query/Sorter';
 import type { Task } from '../src/Task';
 import { StatusField } from '../src/Query/Filter/StatusField';
-import { DoneDateField } from '../src/Query/Filter/DoneDateField';
 import { DueDateField } from '../src/Query/Filter/DueDateField';
 import { PathField } from '../src/Query/Filter/PathField';
-import { DescriptionField } from '../src/Query/Filter/DescriptionField';
 import { fromLine } from './TestHelpers';
 import { TaskBuilder } from './TestingTools/TaskBuilder';
 
@@ -59,13 +57,8 @@ describe('Sort', () => {
         expect(Sort.by([], [six, five, one, four, two, three])).toEqual(expectedOrder);
     });
 
-    // TODO Add some tests based on easy-to-reason-about custom comparators, then delete the remaining old-style tests
-    //  - Basic sorting with a single comparator
-    //  - Nested sorting with 2 more more comparators
-
-    // TODO Most of these will become redundant once each of the sort implementations
-    //      is in a Field class, and the Field's tests exercise the particular sorting.
-    //      Then the only testing needed here will probably be the testing of composite sorting.
+    // Just a couple of tests to verify the handling of
+    // composite sorts, and reverse sort order.
 
     it('sorts correctly by due, path, status', () => {
         const one = fromLine({ line: '- [ ] a 📅 1970-01-01', path: '1' });
@@ -86,33 +79,6 @@ describe('Sort', () => {
                     new StatusField().createNormalSorter(),
                 ],
                 [one, four, two, three],
-            ),
-        ).toEqual(expectedOrder);
-    });
-
-    // TODO Replace this with something simpler but equivalent in DescriptionField.test.ts.
-    it('sorts correctly by description, done', () => {
-        const one = fromLine({
-            line: '- [ ] a 📅 1970-01-02 ✅ 1971-01-01',
-            path: '',
-        });
-        const two = fromLine({
-            line: '- [ ] a 📅 1970-01-02 ✅ 1971-01-03',
-            path: '',
-        });
-        const three = fromLine({
-            line: '- [ ] b 📅 1970-01-01 ✅ 1971-01-01',
-            path: '',
-        });
-        const four = fromLine({
-            line: '- [ ] b 📅 1970-01-02 ✅ 1971-01-02',
-            path: '',
-        });
-        const expectedOrder = [one, two, three, four];
-        expect(
-            Sort.by(
-                [new DescriptionField().createNormalSorter(), new DoneDateField().createNormalSorter()],
-                [three, one, two, four],
             ),
         ).toEqual(expectedOrder);
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I'd been meaning to pick up these TODOs in Sort.test.ts that were left over from:

- 747e5d9ac9e2121c99e573f1c59ec305211dee1a
- 1eee0d66df0a61bf608b16a68641bf78d10ce8e0

## Motivation and Context

Just trying to make the code a little bit better.

## How has this been tested?

By running the tests, and confirming that the removed tests did have equivalents elsewhere in the project.

## Screenshots (if appropriate)

## Types of changes

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
