### PR TITLE
Refactor status settings more

### DIFF
--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -417,14 +417,14 @@ export class SettingsTab extends PluginSettingTab {
 /**
  * Create the row to see and modify settings for a single task status type.
  * @param containerEl
- * @param status_type - The status type to be edited.
+ * @param statusType - The status type to be edited.
  * @param statusTypes - All the status types already in the user's settings, EXCEPT the standard ones.
  * @param settings
  * @param plugin
  */
 function createRowForTaskStatus(
     containerEl: HTMLElement,
-    status_type: StatusConfiguration,
+    statusType: StatusConfiguration,
     statusTypes: StatusConfiguration[],
     settings: SettingsTab,
     plugin: TasksPlugin,
@@ -432,7 +432,7 @@ function createRowForTaskStatus(
     //const taskStatusDiv = containerEl.createEl('div');
 
     const taskStatusPreview = containerEl.createEl('pre');
-    taskStatusPreview.textContent = StatusSettingsHelpers.statusPreviewText(status_type);
+    taskStatusPreview.textContent = StatusSettingsHelpers.statusPreviewText(statusType);
 
     const setting = new Setting(containerEl);
 
@@ -444,7 +444,7 @@ function createRowForTaskStatus(
                 .setIcon('cross')
                 .setTooltip('Delete')
                 .onClick(async () => {
-                    const index = statusTypes.indexOf(status_type);
+                    const index = statusTypes.indexOf(statusType);
                     if (index > -1) {
                         statusTypes.splice(index, 1);
                         await updateAndSaveStatusSettings(statusTypes, settings);
@@ -457,11 +457,11 @@ function createRowForTaskStatus(
                 .setIcon('pencil')
                 .setTooltip('Edit')
                 .onClick(async () => {
-                    const modal = new CustomStatusModal(plugin, status_type);
+                    const modal = new CustomStatusModal(plugin, statusType);
 
                     modal.onClose = async () => {
                         if (modal.saved) {
-                            const index = statusTypes.indexOf(status_type);
+                            const index = statusTypes.indexOf(statusType);
                             if (index > -1) {
                                 statusTypes.splice(index, 1, modal.statusConfiguration());
                                 await updateAndSaveStatusSettings(statusTypes, settings);

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -362,6 +362,7 @@ export class SettingsTab extends PluginSettingTab {
      */
     insertTaskStatusSettings(containerEl: HTMLElement, settings: SettingsTab) {
         const { statusTypes } = getSettings();
+        const plugin = settings.plugin;
         statusTypes.forEach((status_type) => {
             //const taskStatusDiv = containerEl.createEl('div');
 
@@ -391,7 +392,7 @@ export class SettingsTab extends PluginSettingTab {
                         .setIcon('pencil')
                         .setTooltip('Edit')
                         .onClick(async () => {
-                            const modal = new CustomStatusModal(settings.plugin, status_type);
+                            const modal = new CustomStatusModal(plugin, status_type);
 
                             modal.onClose = async () => {
                                 if (modal.saved) {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -364,51 +364,7 @@ export class SettingsTab extends PluginSettingTab {
         const { statusTypes } = getSettings();
         const plugin = settings.plugin;
         statusTypes.forEach((status_type) => {
-            //const taskStatusDiv = containerEl.createEl('div');
-
-            const taskStatusPreview = containerEl.createEl('pre');
-            taskStatusPreview.textContent = StatusSettingsHelpers.statusPreviewText(status_type);
-
-            const setting = new Setting(containerEl);
-
-            setting.infoEl.replaceWith(taskStatusPreview);
-
-            setting
-                .addExtraButton((extra) => {
-                    extra
-                        .setIcon('cross')
-                        .setTooltip('Delete')
-                        .onClick(async () => {
-                            const index = statusTypes.indexOf(status_type);
-                            if (index > -1) {
-                                statusTypes.splice(index, 1);
-                                await updateAndSaveStatusSettings(statusTypes, settings);
-                            }
-                        });
-                })
-
-                .addExtraButton((extra) => {
-                    extra
-                        .setIcon('pencil')
-                        .setTooltip('Edit')
-                        .onClick(async () => {
-                            const modal = new CustomStatusModal(plugin, status_type);
-
-                            modal.onClose = async () => {
-                                if (modal.saved) {
-                                    const index = statusTypes.indexOf(status_type);
-                                    if (index > -1) {
-                                        statusTypes.splice(index, 1, modal.statusConfiguration());
-                                        await updateAndSaveStatusSettings(statusTypes, settings);
-                                    }
-                                }
-                            };
-
-                            modal.open();
-                        });
-                });
-
-            setting.infoEl.remove();
+            createRowForTaskStatus(containerEl, status_type, statusTypes, settings, plugin);
         });
 
         containerEl.createEl('div');
@@ -454,6 +410,60 @@ export class SettingsTab extends PluginSettingTab {
         });
         addStatusesSupportedByITSTheme.infoEl.remove();
     }
+}
+
+function createRowForTaskStatus(
+    containerEl: HTMLElement,
+    status_type: StatusConfiguration,
+    statusTypes: StatusConfiguration[],
+    settings: SettingsTab,
+    plugin: TasksPlugin,
+) {
+    //const taskStatusDiv = containerEl.createEl('div');
+
+    const taskStatusPreview = containerEl.createEl('pre');
+    taskStatusPreview.textContent = StatusSettingsHelpers.statusPreviewText(status_type);
+
+    const setting = new Setting(containerEl);
+
+    setting.infoEl.replaceWith(taskStatusPreview);
+
+    setting
+        .addExtraButton((extra) => {
+            extra
+                .setIcon('cross')
+                .setTooltip('Delete')
+                .onClick(async () => {
+                    const index = statusTypes.indexOf(status_type);
+                    if (index > -1) {
+                        statusTypes.splice(index, 1);
+                        await updateAndSaveStatusSettings(statusTypes, settings);
+                    }
+                });
+        })
+
+        .addExtraButton((extra) => {
+            extra
+                .setIcon('pencil')
+                .setTooltip('Edit')
+                .onClick(async () => {
+                    const modal = new CustomStatusModal(plugin, status_type);
+
+                    modal.onClose = async () => {
+                        if (modal.saved) {
+                            const index = statusTypes.indexOf(status_type);
+                            if (index > -1) {
+                                statusTypes.splice(index, 1, modal.statusConfiguration());
+                                await updateAndSaveStatusSettings(statusTypes, settings);
+                            }
+                        }
+                    };
+
+                    modal.open();
+                });
+        });
+
+    setting.infoEl.remove();
 }
 
 async function addCustomStatesToSettings(

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -414,6 +414,14 @@ export class SettingsTab extends PluginSettingTab {
     }
 }
 
+/**
+ * Create the row to see and modify settings for a single task status type.
+ * @param containerEl
+ * @param status_type - The status type to be edited.
+ * @param statusTypes - All the status types already in the user's settings, EXCEPT the standard ones.
+ * @param settings
+ * @param plugin
+ */
 function createRowForTaskStatus(
     containerEl: HTMLElement,
     status_type: StatusConfiguration,

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -362,13 +362,15 @@ export class SettingsTab extends PluginSettingTab {
      */
     insertTaskStatusSettings(containerEl: HTMLElement, settings: SettingsTab) {
         const { statusTypes } = getSettings();
-        const plugin = settings.plugin;
+
+        /* -------------------- One row per status in the settings -------------------- */
         statusTypes.forEach((status_type) => {
-            createRowForTaskStatus(containerEl, status_type, statusTypes, settings, plugin);
+            createRowForTaskStatus(containerEl, status_type, statusTypes, settings, settings.plugin);
         });
 
         containerEl.createEl('div');
 
+        /* -------------------- 'Add New Task Status' button -------------------- */
         const setting = new Setting(containerEl).addButton((button) => {
             button
                 .setButtonText('Add New Task Status')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

Extract function `createRowForTaskStatus()`, so it can be re-used later on.

## Motivation and Context

- Partly to shorten `SettingsTab.insertTaskStatusSettings()` further
- Mainly because I want to allow users to edit the `TODO` status, to have the ability to turn on `TODO` -> `IN_PROGRESS` -> `DONE` -> `TODO`
  - And I think I will need the ability to re-use `createRowForTaskStatus()` for that.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Manually in Obsidian.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [ ] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
