### PR TITLE
feat: Show core statuses, read-only

### DIFF
--- a/src/Config/settingsConfiguration.json
+++ b/src/Config/settingsConfiguration.json
@@ -3,7 +3,7 @@
     "text": "Tasks Status Types",
     "level": "h3",
     "class": "",
-    "open": false,
+    "open": true,
     "notice": {
       "class": "",
       "text": "If you want to have the tasks support additional statuses outside of the default ones add them here with the status indicator. ",

--- a/src/Config/settingsConfiguration.json
+++ b/src/Config/settingsConfiguration.json
@@ -1,13 +1,36 @@
 [
   {
-    "text": "Tasks Status Types",
+    "text": "Core Status Types",
     "level": "h3",
     "class": "",
     "open": true,
     "notice": {
       "class": "",
-      "text": "If you want to have the tasks support additional statuses outside of the default ones add them here with the status indicator. ",
-      "html": "By default the following statuses are supported:<ul><li><strong>- [ ] Todo</strong> - This has a {space} between the brackets. Will toggle to Done.</li><li><strong>- [/] In Progress</strong> - This has a {/} between the brackets. Will toggle to Done.</li><li><strong>- [x] Done</strong> - This has a {x} between the brackets. Will toggle to Todo.</li><li><strong>- [-] Cancelled</strong> - This has a {-} between the brackets. Will toggle to Todo.</li></ul>"
+      "text": "These are the core status types that Tasks supports. They are not yet editable. You can add custom statuses in the section below.",
+      "html": null
+    },
+    "settings": [
+      {
+        "name": "",
+        "description": "",
+        "type": "function",
+        "initialValue": "",
+        "placeholder": "",
+        "settingName": "insertTaskCoreStatusSettings",
+        "featureFlag": "",
+        "notice": null
+      }
+    ]
+  },
+  {
+    "text": "Custom Status Types",
+    "level": "h3",
+    "class": "",
+    "open": true,
+    "notice": {
+      "class": "",
+      "text": "If you want to have the tasks support additional statuses outside of the default ones add them here with the status symbol. ",
+      "html": null
     },
     "settings": [
       {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I am trying to move towards enabling editing of the 'next symbol' for the core/standard statuses (TODO, IN_PROGRESS, DONE, CANCELLED).

As a first step, this replaces the previous HTML list of standard statuses with a new block in settings, that presents them in the same way as the custom ones are shown - but with no delete and edit buttons.

This also now initially shows the status settings blocks as open, for discoverability when it is first released.

## Motivation and Context

See above

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4840096/211145822-0c961afa-d878-4f32-bfd5-925889ea909b.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
