### PR TITLE
fix: Hide UI for status commands

### DIFF
--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -1,5 +1,5 @@
 import { Modal, Setting, TextComponent } from 'obsidian';
-import { StatusConfiguration } from '../Status';
+import { Status, StatusConfiguration } from '../Status';
 import type TasksPlugin from '../main';
 
 export class CustomStatusModal extends Modal {
@@ -81,16 +81,18 @@ export class CustomStatusModal extends Modal {
                 });
             });
 
-        new Setting(settingDiv)
-            .setName('Available as command')
-            .setDesc(
-                'If enabled this status will be available as a command so you can assign a hotkey and toggle the status using it.',
-            )
-            .addToggle((toggle) => {
-                toggle.setValue(this.statusAvailableAsCommand).onChange(async (value) => {
-                    this.statusAvailableAsCommand = value;
+        if (Status.tasksPluginCanCreateCommandsForStatuses()) {
+            new Setting(settingDiv)
+                .setName('Available as command')
+                .setDesc(
+                    'If enabled this status will be available as a command so you can assign a hotkey and toggle the status using it.',
+                )
+                .addToggle((toggle) => {
+                    toggle.setValue(this.statusAvailableAsCommand).onChange(async (value) => {
+                        this.statusAvailableAsCommand = value;
+                    });
                 });
-            });
+        }
 
         const footerEl = contentEl.createDiv();
         const footerButtons = new Setting(footerEl);

--- a/src/Config/StatusSettingsHelpers.ts
+++ b/src/Config/StatusSettingsHelpers.ts
@@ -3,7 +3,7 @@
  * It intentionally does not import any Obsidian types, so that tests can
  * be written for its contents.
  */
-import { StatusConfiguration } from '../Status';
+import { Status, StatusConfiguration } from '../Status';
 
 /**
  * Return a one-line summary of the status, for presentation to users.
@@ -11,7 +11,7 @@ import { StatusConfiguration } from '../Status';
  */
 export function statusPreviewText(status: StatusConfiguration) {
     let commandNotice = '';
-    if (status.availableAsCommand) {
+    if (Status.tasksPluginCanCreateCommandsForStatuses() && status.availableAsCommand) {
         commandNotice = 'Available as a command.';
     }
     return `- [${status.indicator}] ${status.name}, next status is '${status.nextStatusIndicator}'. ${commandNotice}`;

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -117,6 +117,17 @@ export class Status {
     private readonly configuration: StatusConfiguration;
 
     /**
+     * Whether Tasks can yet create 'Toggle Status' commands for statuses
+     *
+     * This is not yet possible, and so some UI features are temporarily hidden.
+     * See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1486
+     * Once that issue is addressed, this method can be removed.
+     */
+    public static tasksPluginCanCreateCommandsForStatuses(): boolean {
+        return false;
+    }
+
+    /**
      * The indicator used between the two square brackets in the markdown task.
      *
      * @type {string}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

The statuses UI provides an 'Available as command' feature, but that facility is not yet implemented in Tasks. (See #1486).

So this PR hides the 'Available as command' bits in the statuses UI.

## Motivation and Context

This fixes #1487.

## How has this been tested?

By running the plugin locally.

### Before

**The list of available statuses:**

![image](https://user-images.githubusercontent.com/4840096/211172538-0bffc9fc-392f-4cbe-b90e-1de98161aa2b.png)

**The modal for editing a status:**

![image](https://user-images.githubusercontent.com/4840096/211172557-8a96df0b-05a8-4415-880d-bae7ce0ddf4b.png)


### After


**The list of available statuses:**

![image](https://user-images.githubusercontent.com/4840096/211188794-2bdfe777-45d3-483b-a0ee-9e40480b186b.png)

**The modal for editing a status:**

![image](https://user-images.githubusercontent.com/4840096/211188805-651f21ab-76c9-4afe-b449-2f3b562e747e.png)

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
