### PR TITLE
fix: Status changes now applied immediately!

### DIFF
--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -1,6 +1,7 @@
 import { Notice, PluginSettingTab, Setting, debounce } from 'obsidian';
 import { Status, StatusConfiguration } from 'Status';
 import type TasksPlugin from '../main';
+import { StatusRegistry } from '../StatusRegistry';
 import type { HeadingState } from './Settings';
 import { getSettings, isFeatureEnabled, updateGeneralSetting, updateSettings } from './Settings';
 import { StatusSettings } from './StatusSettings';
@@ -528,6 +529,10 @@ async function updateAndSaveStatusSettings(statusTypes: StatusSettings, settings
     updateSettings({
         statusSettings: statusTypes,
     });
+
+    // Update the active statuses.
+    // This saves the user from having to restart Obsidian in order to apply the changed status(es).
+    StatusSettings.applyToStatusRegistry(statusTypes, StatusRegistry.getInstance());
 
     await settings.saveSettings(true);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Status changes are now applied immediately.

Users no longer need to restart Obsidian to test out edits to custom statuses.



## Motivation and Context

This has been driving me nuts!

## How has this been tested?

Manually

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
