### PR TITLE
docs: Add 'Find tasks with potentially invalid data'

### DIFF
--- a/docs/how-to/find-tasks-with-invalid-data.md
+++ b/docs/how-to/find-tasks-with-invalid-data.md
@@ -1,0 +1,99 @@
+---
+layout: default
+title: Find tasks with invalid data
+nav_order: 3
+parent: How Tos
+---
+
+# Find tasks with potentially invalid data
+
+{: .no_toc }
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Motivation
+
+For performance reasons, Tasks is stricter in reading data from markdown lines that some users expect.
+
+As a precaution, it can be useful to check the data in your vault periodically, to see if there any tasks with seemingly valid data that is not found by Tasks.
+
+## Find tasks with potentially missed emoji signifiers
+
+### Example emoji problem
+
+In the following task, there is unrecognised text after the due and done dates.
+
+```text
+ - [x] check 📅 2022-12-29 ✅ 2023-01-09 > appointment 19.1.
+```
+
+Tasks sees as an un-dated task with the text description:
+
+`check 📅 2022-12-29 ✅ 2023-01-09 > appointment 19.1.`
+
+### Finding unread emojis
+
+The following tasks block lists any tasks that have emoji in the description, which usually means data that has not been interpreted by Tasks. This is typically because there is some text other than emoji signifiers and tags at the end of the line.
+
+````text
+```tasks
+# These description instructions need to be all on one line:
+(description includes ⏫ ) OR (description includes 🔼 ) OR (description includes 🔽 ) OR (description includes 📅 ) OR (description includes ⏳ ) OR (description includes 🛫 ) OR (description includes ✅ ) OR (description includes 🔁 )
+
+# Optionally, uncomment this line and exclude your templates location
+# path does not include _templates
+
+group by path
+```
+````
+
+The errors can be fixed by editing the Task and moving any text that appears after the unparsed values to earlier in the line.
+
+## Find tasks with invalid dates
+
+### Example date problem
+
+This task has an illegal due date:
+
+```text
+- [ ] Do stuff 📅  2023-12-32
+```
+
+### Finding problem dates
+
+The following tasks block lists any tasks with invalid dates, meaning data that has potentially not been interpreted by Tasks.
+
+````text
+```tasks
+(done date is invalid) OR (due date is invalid) OR (scheduled date is invalid) OR (start date is invalid)
+
+# Optionally, uncomment this line and exclude your templates location
+# path does not include _templates
+
+group by path
+```
+````
+
+Errors with invalid dates are not easily fixed using the [‘Create or edit Task’ Modal]({{ site.baseurl }}{% link getting-started/create-or-edit-task.md %}), as it shows any invalid dates with placeholder text, instead of showing the original values.
+
+So to fix any found tasks, use the backlink to navigate to the original line and fix the error there.
+
+## Invalid recurrence rules
+
+There is not currently a way to find any tasks with invalid recurrence rules.
+
+## More Information
+
+Relevant documentation sections:
+
+- [Limitations and warnings parsing tasks]({{ site.baseurl }}{% link getting-started/index.md %}#limitations-and-warnings)
+- [Finding Tasks with Invalid Dates]({{ site.baseurl }}{% link queries/filters.md %}#finding-tasks-with-invalid-dates).

--- a/docs/how-to/get-tasks-in-current-file.md
+++ b/docs/how-to/get-tasks-in-current-file.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: How to get tasks in current file
-nav_order: 3
+nav_order: 4
 parent: How Tos
 ---
 

--- a/docs/how-to/show-tasks-in-calendar.md
+++ b/docs/how-to/show-tasks-in-calendar.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Show tasks in a calendar
-nav_order: 5
+nav_order: 6
 parent: How Tos
 ---
 

--- a/docs/how-to/style-backlinks.md
+++ b/docs/how-to/style-backlinks.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: How to style backlinks
-nav_order: 4
+nav_order: 5
 parent: How Tos
 ---
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Write up the searches I use in my main vault to find any tasks with accidentally missed tasks emoji date or invalid dates.

(I pushed this change to main by mistake -  😢 - I wanted it to show up in the releases changelog, so reverted the push and then created a branch to make this PR)

## Motivation and Context

To help the user in #1505.

## How has this been tested?

By running the searches in the sample vault.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
