### PR TITLE
docs: Add info and warnings about custom status feature

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,3 +32,6 @@ callouts:
   warning:
     title: Warning
     color: red
+  info:
+    title: Information
+    color: blue

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,3 +27,8 @@ gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into t
 
 # Build settings
 remote_theme: pmarsceill/just-the-docs
+
+callouts:
+  warning:
+    title: Warning
+    color: red

--- a/docs/getting-started/statuses.md
+++ b/docs/getting-started/statuses.md
@@ -40,7 +40,7 @@ The convention in markdown is:
 
 Tasks supports custom task statuses.
 
-This table shows the statues provided by default:
+This table shows the statuses provided by default:
 
 <!-- placeholder to force blank line before table --> <!-- include: DocsSamplesForStatuses.test.DefaultStatuses_core-statuses.approved.md -->
 
@@ -61,11 +61,29 @@ The Tasks settings shows the core statuses:
 
 Note that `Todo` is followed by `Done`, in order to preserve compatibility with earlier Tasks releases.
 
-It will soon be possible to edit these custom statues, and enable `Todo` -> `In Progress` -> `Done`.
+{: .info }
+These core statuses are currently read-only.
+It will soon be possible to edit these custom statuses, and enable `Todo` -> `In Progress` -> `Done`.
 
 ---
 
 ## Custom task statuses
+
+### First choose your styling scheme
+
+First, decide which CSS Snippet or Theme you wish to use, to style your checkboxes.
+
+{: .info }
+We will later enhance this documentation with a more thorough list of available CSS Snippets and Themes that style task checkboxes.
+
+### Editing custom statuses
+
+Your choice of styling facility will determine which letters and characters you wish to you in your custom statuses.
+
+Then see [How to set up your custom statuses]({{ site.baseurl }}{% link how-to/set-up-custom-statuses.md %}) for how to set up your custom statuses.
+
+{: .warning }
+Remember to set up your chosen CSS Snippet or Theme before setting up the custom statues.
 
 ### Minimal supported statuses
 
@@ -123,6 +141,29 @@ It will soon be possible to edit these custom statues, and enable `Todo` -> `In 
 | `c` | Choice | `x` | Yes |
 
 <!-- placeholder to force blank line after table --> <!-- endInclude -->
+
+## Using Statuses
+
+### Editing your tasks
+
+The [‘Create or edit Task’ Modal]({{ site.baseurl }}{% link getting-started/create-or-edit-task.md %}#status-and-done-on) allows you to change the status of a task.
+
+### Related commands
+
+{: .info }
+There are not yet any new commands for applying custom statuses.
+We are tracking this in [issue #1486](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1486) .
+
+### Related searches
+
+{: .info }
+There are not yet any new specific searches for applying custom statuses.
+We envisage adding search filters for `status.name` and `status.symbol` initially.
+
+## Related pages
+
+- [How to set up your custom statuses]({{ site.baseurl }}{% link how-to/set-up-custom-statuses.md %}).
+- [How to style custom statuses]({{ site.baseurl }}{% link how-to/style-custom-statuses.md %}).
 
 ---
 

--- a/docs/how-to/set-up-custom-statuses.md
+++ b/docs/how-to/set-up-custom-statuses.md
@@ -97,6 +97,12 @@ Suppose that you wanted to create a set of 3 statuses that cycle between each ot
 1. Repeat for the other two statuses and you should see:
     - ![After adding the other two new statuses](../images/settings-custom-statuses-important-loop-added.png)
 
+{: .warning }
+At the moment the error-checking in the status edit modal is not quite working, and if there is an invalid value such as an empty status symbol, the field can disappear completely. If this happens, the workaround is to close the modal, and click on the pencil to re-open it. We are tracking this as [issue #1498](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1498).
+
+{: .warning }
+Tasks currently allows creation of more than one status with the same symbol. It silently ignores any duplicate symbols: only the first will be used. If in doubt, examine the available statuses in the status dropdown in the [‘Create or edit Task’ Modal]({{ site.baseurl }}{% link getting-started/create-or-edit-task.md %}).
+
 ## Test the new statuses
 
 The status changes are applied immediately. You do not need to restart Obsidian.


### PR DESCRIPTION
# Description

- Enable callouts mechanism in the docs
- Add some info and warnings about many aspects of the custom statuses feature (and its documentation)

## Motivation and Context

Part of #1497

## How has this been tested?

By viewing the docs locally.

## Screenshots (if appropriate)

Some example callouts added:

![image](https://user-images.githubusercontent.com/4840096/211553508-39542b2d-1a69-4edc-a6be-0bf0156c28b7.png)

![image](https://user-images.githubusercontent.com/4840096/211553431-05f3604c-d147-47b4-ac62-a30e23b8f44e.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
