### PR TITLE
docs: Improve tables of content and version banners

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -3,6 +3,7 @@
   			"style": "dash"
   		   },
   "MD013": false, // Ignore the line length rule.
+  "MD022": false, // Headers should be surrounded by blank lines - disabled so that {: .no_toc } is next to its heading
   "MD025": false, // Allow the title in the front matter and markdown heading one to match.
   "MD033": false, // Allow Inline HTML.
   "MD046": false // Allow fenced code blocks, for syntax hughlighting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,13 @@
 - [Updating documentation](#updating-documentation)
   - [Documentation and branches](#documentation-and-branches)
   - [Adding Tables of Contents to rendered docs](#adding-tables-of-contents-to-rendered-docs)
+  - [Omitting a heading from the page's Table of Contents](#omitting-a-heading-from-the-pages-table-of-contents)
   - [Linking to other pages in the docs](#linking-to-other-pages-in-the-docs)
   - [Screenshots in documentation](#screenshots-in-documentation)
     - [Creating screenshots](#creating-screenshots)
     - [Saving screenshots](#saving-screenshots)
     - [Adding screenshots to the documentation](#adding-screenshots-to-the-documentation)
+  - [Callouts](#callouts)
   - [Version numbers in documentation](#version-numbers-in-documentation)
   - [How the documentation is generated](#how-the-documentation-is-generated)
 - [Updating code](#updating-code)
@@ -155,6 +157,21 @@ The `ACME` note has some tasks - as linked to from any file in a sub-directory o
 ```
 
 With this mechanism, you can preview the embedded images in any decent Markdown editor, including by opening the `obsidian-tasks` directory in Obsidian.
+
+### Callouts
+
+The following callout styles are available. There must be no blank line between the style name and the content.
+
+```text
+{: .warning }
+I will be shown in red
+
+{: .info }
+I will be shown in blue
+
+{: .released }
+I will be shown in green
+```
 
 ### Version numbers in documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ We will help you make this right once you opened the PR.
 Add the following between the H1 and the first H2, to show a table of contents in a page on the published documentation.
 
 ```text
+# Page Heading
 {: .no_toc }
 
 <details open markdown="block">
@@ -86,6 +87,10 @@ Add the following between the H1 and the first H2, to show a table of contents i
 
 ---
 ```
+
+### Omitting a heading from the page's Table of Contents
+
+To omit a heading from the page's table of contents, put a `{: .no_toc }` line immediately after the heading.
 
 ### Linking to other pages in the docs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,8 +167,12 @@ This placeholder is usually used after a section heading:
 Introduced in Tasks X.Y.Z.
 ```
 
-- `> X (Y and Z) was introduced in Tasks X.Y.Z`
-  - This placeholder is used when you need to tag a sub-part of something, for example a list.
+This placeholder is used when you need to tag a sub-part of something, for example a list:
+
+```text
+{: .released }
+X (Y and Z) was introduced in Tasks X.Y.Z.
+```
 
 ### How the documentation is generated
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,8 +160,13 @@ version upon release.
 There are 2 styles of placeholders used through the documentation, Please pick the one that
 fits your text better. (If in doubt, take a look at the existing version tags for other features.)
 
-- `> Introduced in Tasks X.Y.Z`
-  - This placeholder is usually used after a section heading.
+This placeholder is usually used after a section heading:
+
+```text
+{: .released }
+Introduced in Tasks X.Y.Z.
+```
+
 - `> X (Y and Z) was introduced in Tasks X.Y.Z`
   - This placeholder is used when you need to tag a sub-part of something, for example a list.
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,3 +35,6 @@ callouts:
   info:
     title: Information
     color: blue
+  released:
+    title: Released
+    color: green

--- a/docs/advanced/styling.md
+++ b/docs/advanced/styling.md
@@ -22,5 +22,6 @@ following styles are available.
 | task-list-item-checkbox        | This is applied to the INPUT element for the task.                                                              |
 | tasks-group-heading            | This is applied to H4, H5 and H6 group headings                                                                 |
 
-> `tasks-group-heading` was introduced in Tasks 1.6.0.<br>
-> `plugin-tasks-query-explanation` was introduced in Tasks 1.19.0.
+{: .released }
+`tasks-group-heading` was introduced in Tasks 1.6.0.<br>
+`plugin-tasks-query-explanation` was introduced in Tasks 1.19.0.

--- a/docs/advanced/urgency.md
+++ b/docs/advanced/urgency.md
@@ -6,7 +6,6 @@ parent: Advanced
 ---
 
 # Urgency
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/getting-started/auto-suggest.md
+++ b/docs/getting-started/auto-suggest.md
@@ -7,7 +7,6 @@ has_toc: false
 ---
 
 # Intelligent Auto-Suggest
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/getting-started/auto-suggest.md
+++ b/docs/getting-started/auto-suggest.md
@@ -23,7 +23,8 @@ has_toc: false
 
 ## Introduction
 
-> Introduced in Tasks 1.9.0.
+{: .released }
+Introduced in Tasks 1.9.0.
 
 The [Priorities]({{ site.baseurl }}{% link getting-started/priority.md %}), [Dates]({{ site.baseurl }}{% link getting-started/dates.md %}) and [Recurring Tasks]({{ site.baseurl }}{% link getting-started/recurring-tasks.md %}) pages show various emojis and special phrases that the Tasks plugin recognises, when searching for tasks.
 

--- a/docs/getting-started/create-or-edit-task.md
+++ b/docs/getting-started/create-or-edit-task.md
@@ -35,7 +35,8 @@ Use the command 'Tasks: Create or edit task' to launch the modal.
 
 ## Keyboard shortcuts
 
-> Introduced in Tasks 1.17.0.
+{: .released }
+Introduced in Tasks 1.17.0.
 
 All the fields of the form have "access keys", that is, keyboard shortcuts. The access keys are displayed as the underlined letters in the labels.
 
@@ -44,7 +45,8 @@ All the fields of the form have "access keys", that is, keyboard shortcuts. The 
 
 ### Turning off keyboard shortcuts
 
-> Introduced in Tasks 1.17.0.
+{: .released }
+Introduced in Tasks 1.17.0.
 
 If the access keys (keyboard shortcuts) for any field conflicts with system keyboard shortcuts or interferes with assistive technology functionality that is important for you, you may want to turn them off in the Tasks plugin's settings:
 
@@ -89,7 +91,8 @@ Note that relative dates will be always interpreted as being in the future, beca
 
 ### Date abbreviations
 
-> Introduced in Tasks 1.8.0.
+{: .released }
+Introduced in Tasks 1.8.0.
 
 The modal also has a few abbreviations of its own, to speed up entering of common values in the date fields.
 

--- a/docs/getting-started/create-or-edit-task.md
+++ b/docs/getting-started/create-or-edit-task.md
@@ -87,7 +87,8 @@ There is a lot of flexibility here. For example:
 
 Note that relative dates will be always interpreted as being in the future, because that is usually what you want. You can change this behavior by unchecking "Only future dates" if you want to enter an overdue task or experiment with the way how relative dates in the past would be interpreted in queries.
 
-> `Only future dates` was introduced in Tasks 1.15.0.
+{: .released }
+`Only future dates` was introduced in Tasks 1.15.0.
 
 ### Date abbreviations
 

--- a/docs/getting-started/create-or-edit-task.md
+++ b/docs/getting-started/create-or-edit-task.md
@@ -7,7 +7,6 @@ has_toc: false
 ---
 
 # 'Create or edit Task' Modal
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/getting-started/dates.md
+++ b/docs/getting-started/dates.md
@@ -64,7 +64,8 @@ Scheduled dates use an hourglass emoji instead of a calendar emoji.
 
 See [Use Filename as Default Date]({{ site.baseurl }}{% link getting-started/use-filename-as-default-date.md %}) for how to optionally make Tasks use any dates in file names as the scheduled date for all undated tasks in that file.
 
-> 'Use Filename as Default Date' was introduced in Tasks 1.18.0.
+{: .released }
+'Use Filename as Default Date' was introduced in Tasks 1.18.0.
 
 ---
 

--- a/docs/getting-started/dates.md
+++ b/docs/getting-started/dates.md
@@ -6,7 +6,6 @@ parent: Getting Started
 ---
 
 # Dates
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/getting-started/global-filter.md
+++ b/docs/getting-started/global-filter.md
@@ -7,7 +7,6 @@ has_toc: false
 ---
 
 # Global Filter
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -5,6 +5,8 @@ nav_order: 3
 has_children: true
 ---
 
+# Getting Started
+
 {: .no_toc }
 
 <details open markdown="block">
@@ -17,8 +19,6 @@ has_children: true
 </details>
 
 ---
-
-# Getting Started
 
 ## Finding tasks in your vault
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -6,7 +6,6 @@ has_children: true
 ---
 
 # Getting Started
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -109,7 +109,8 @@ Warning
 {: .label .label-yellow}
 Tasks can read tasks that are in **numbered lists**.
 
-> Reading tasks inside numbered lists was introduced in Tasks 1.20.0.
+{: .released }
+Reading tasks inside numbered lists was introduced in Tasks 1.20.0.
 
 For example:
 
@@ -131,7 +132,8 @@ Warning
 {: .label .label-yellow}
 Tasks can read tasks that are inside **blockquotes** or [Obsidian's built-in callouts](https://help.obsidian.md/How+to/Use+callouts).
 
-> Reading tasks inside callouts and blockquotes was introduced in Tasks 1.11.1
+{: .released }
+Reading tasks inside callouts and blockquotes was introduced in Tasks 1.11.1
 
 However, under the following very specific circumstance, Tasks cannot add or remove completion dates or make the next copy of a recurring task:
 

--- a/docs/getting-started/priority.md
+++ b/docs/getting-started/priority.md
@@ -7,7 +7,6 @@ has_toc: false
 ---
 
 # Priority
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/getting-started/recurring-tasks.md
+++ b/docs/getting-started/recurring-tasks.md
@@ -7,7 +7,6 @@ has_toc: false
 ---
 
 # Recurring Tasks (Repetition)
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/getting-started/statuses.md
+++ b/docs/getting-started/statuses.md
@@ -36,7 +36,8 @@ The convention in markdown is:
 
 ## Tasks core task statuses
 
-- `> Introduced in Tasks X.Y.Z`
+{: .released }
+Introduced in Tasks X.Y.Z
 
 Tasks supports custom task statuses.
 

--- a/docs/getting-started/statuses.md
+++ b/docs/getting-started/statuses.md
@@ -7,7 +7,6 @@ has_toc: false
 ---
 
 # Statuses
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/getting-started/use-filename-as-default-date.md
+++ b/docs/getting-started/use-filename-as-default-date.md
@@ -23,7 +23,8 @@ has_toc: false
 
 ## Automatic scheduled date
 
-> Introduced in Tasks 1.18.0.
+{: .released }
+Introduced in Tasks 1.18.0.
 
 You can automatically set a scheduled date for tasks based on the name of their files. This feature can be enabled in the
 settings, via the option `Use filename as Scheduled date for undated tasks`. Changing this requires a restart of Obsidian.

--- a/docs/getting-started/use-filename-as-default-date.md
+++ b/docs/getting-started/use-filename-as-default-date.md
@@ -7,7 +7,6 @@ has_toc: false
 ---
 
 # Use Filename as Default Date
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/how-to/find-tasks-for-coming-7-days.md
+++ b/docs/how-to/find-tasks-for-coming-7-days.md
@@ -6,7 +6,6 @@ parent: How Tos
 ---
 
 # Find all tasks for the coming 7 days
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/how-to/find-tasks-with-invalid-data.md
+++ b/docs/how-to/find-tasks-with-invalid-data.md
@@ -6,7 +6,6 @@ parent: How Tos
 ---
 
 # Find tasks with potentially invalid data
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/how-to/get-tasks-in-current-file.md
+++ b/docs/how-to/get-tasks-in-current-file.md
@@ -6,7 +6,6 @@ parent: How Tos
 ---
 
 # How to get all tasks in the current file
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -6,7 +6,6 @@ has_children: true
 ---
 
 # How Tos
-
 {: .no_toc }
 
 These How-to guides take you through the steps required to solve real-world problems with Tasks.

--- a/docs/how-to/set-up-custom-statuses.md
+++ b/docs/how-to/set-up-custom-statuses.md
@@ -6,7 +6,6 @@ parent: How Tos
 ---
 
 # Set up custom statuses
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/how-to/set-up-custom-statuses.md
+++ b/docs/how-to/set-up-custom-statuses.md
@@ -40,7 +40,8 @@ As installed, the Tasks plugin supports just two statuses for your tasks:
 
 Many users would like to represent other statuses, such as Cancelled, Delegated, Blocked and many more.
 
-> Custom statuses were introduced in Tasks X.Y.Z
+{: .released }
+Custom statuses were introduced in Tasks X.Y.Z
 
 Tasks now allows you to add custom statuses to your settings, to give you powerful control over what happens next when you click on the task's checkbox.
 

--- a/docs/how-to/style-backlinks.md
+++ b/docs/how-to/style-backlinks.md
@@ -6,7 +6,6 @@ parent: How Tos
 ---
 
 # How to style backlinks
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/how-to/style-custom-statuses.md
+++ b/docs/how-to/style-custom-statuses.md
@@ -6,7 +6,6 @@ parent: How Tos
 ---
 
 # Style custom statuses
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,6 @@ nav_order: 1
 ---
 
 # Introduction
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/other-plugins/dataview.md
+++ b/docs/other-plugins/dataview.md
@@ -29,7 +29,8 @@ please see its [documentation](https://blacksmithgu.github.io/obsidian-dataview/
 
 ## Automatic Task Completion
 
-> Introduced in Dataview 0.5.42
+{: .released }
+Introduced in Dataview 0.5.42
 
 If you use the "Set Done Date on every completed task" option in Tasks, you can configure Dataview so that clicking a task's checkbox from a Dataview query result will add or remove the `✅ YYYY-MM-DD` completion date just like clicking the checkbox in a Task query result or using the command `Tasks: Toggle Done`.
 

--- a/docs/other-plugins/dataview.md
+++ b/docs/other-plugins/dataview.md
@@ -7,7 +7,6 @@ has_toc: false
 ---
 
 # Combining Dataview and Tasks
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/queries/combining-filters.md
+++ b/docs/queries/combining-filters.md
@@ -22,7 +22,8 @@ parent: Queries
 
 ## Summary
 
-> Introduced in Tasks 1.9.0.
+{: .released }
+Introduced in Tasks 1.9.0.
 
 The [individual filters]({{ site.baseurl }}{% link queries/filters.md %}) provided by Tasks can be combined together in powerful ways, by wrapping each of them in `(` and `)`,
 and then joining them with boolean operators such as `AND`, `OR` and `NOT`.

--- a/docs/queries/combining-filters.md
+++ b/docs/queries/combining-filters.md
@@ -6,7 +6,6 @@ parent: Queries
 ---
 
 # Combining Filters
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/queries/explaining-queries.md
+++ b/docs/queries/explaining-queries.md
@@ -7,7 +7,6 @@ has_toc: false
 ---
 
 # Explaining Queries
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/queries/explaining-queries.md
+++ b/docs/queries/explaining-queries.md
@@ -23,7 +23,8 @@ has_toc: false
 
 ## Overview: the 'explain' instruction
 
-> Introduced in Tasks 1.19.0.
+{: .released }
+Introduced in Tasks 1.19.0.
 
 The `explain` instruction adds some extra output at the start of the search results, when tasks blocks are viewed in Live Preview and Reading modes.
 

--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -6,7 +6,6 @@ parent: Queries
 ---
 
 # Filters
-
 {: .no_toc }
 
 <details open markdown="block">
@@ -262,7 +261,6 @@ The available priorities are (from high to low):
 For more information, see [Priorities]({{ site.baseurl }}{% link getting-started/priority.md %}) .
 
 #### Examples
-
 {: .no_toc }
 
     ```tasks
@@ -322,7 +320,6 @@ Introduced in Tasks 1.6.0.
 `regex matches` and `regex does not match` were introduced in Tasks 1.13.0.
 
 #### Tag Query Examples
-
 {: .no_toc }
 
 - `tags include #todo`

--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -41,7 +41,8 @@ When the day changes, relative dates like `due today` are re-evaluated so that t
 
 ### Finding Tasks with Invalid Dates
 
-> Validation of dates was introduced in Tasks 1.16.0.
+{: .released }
+Validation of dates was introduced in Tasks 1.16.0.
 
 It is possible to accidentally use a non-existent date on a task signifier, such as `📅 2022-02-30`. February has at most 29 days.
 
@@ -91,7 +92,8 @@ In the following examples, we describe the `heading` filter, but these comments 
 
 ## Matching multiple filters
 
-> Boolean combinations were introduced in Tasks 1.9.0
+{: .released }
+Boolean combinations were introduced in Tasks 1.9.0
 
 Each line of a query has to match in order for a task to be listed.
 In other words, lines are considered to have an 'AND' operator between them.
@@ -122,8 +124,9 @@ For full details of combining filters with boolean operators, see [Combining Fil
 - `done (before|after|on) <date>`
 - `done date is invalid`
 
-> `no done date` and `has done date` were introduced in Tasks 1.7.0.<br>
-> `done date is invalid` was introduced in Tasks 1.16.0.
+{: .released }
+`no done date` and `has done date` were introduced in Tasks 1.7.0.<br>
+`done date is invalid` was introduced in Tasks 1.16.0.
 
 ### Due Date
 
@@ -132,8 +135,9 @@ For full details of combining filters with boolean operators, see [Combining Fil
 - `due (before|after|on) <date>`
 - `due date is invalid`
 
-> `has due date` was introduced in Tasks 1.6.0.<br>
-> `due date is invalid` was introduced in Tasks 1.16.0.
+{: .released }
+`has due date` was introduced in Tasks 1.6.0.<br>
+`due date is invalid` was introduced in Tasks 1.16.0.
 
 ### Scheduled Date
 
@@ -142,8 +146,9 @@ For full details of combining filters with boolean operators, see [Combining Fil
 - `scheduled (before|after|on) <date>`
 - `scheduled date is invalid`
 
-> `has scheduled date` was introduced in Tasks 1.6.0.<br>
-> `scheduled date is invalid` was introduced in Tasks 1.16.0.
+{: .released }
+`has scheduled date` was introduced in Tasks 1.6.0.<br>
+`scheduled date is invalid` was introduced in Tasks 1.16.0.
 
 ### Start Date
 
@@ -152,8 +157,9 @@ For full details of combining filters with boolean operators, see [Combining Fil
 - `starts (before|after|on) <date>`
 - `start date is invalid`
 
-> `has start date` was Introduced in Tasks 1.6.0.<br>
-> `start date is invalid` was introduced in Tasks 1.16.0.
+{: .released }
+`has start date` was Introduced in Tasks 1.6.0.<br>
+`start date is invalid` was introduced in Tasks 1.16.0.
 
 When filtering queries by [start date]({{ site.baseurl }}{% link getting-started/dates.md %}#-start),
 the result will include tasks without a start date.
@@ -179,7 +185,8 @@ because the tasks starts before tomorrow. Only one of the dates needs to match.
 - `has happens date`
   - Return tasks where _any_ of start date, scheduled date, _or_ due date are set.
 
-> `no happens date` and `has happens date` were introduced in Tasks 1.7.0.
+{: .released }
+`no happens date` and `has happens date` were introduced in Tasks 1.7.0.
 
 ## Filters for Task Statuses
 
@@ -196,7 +203,8 @@ because the tasks starts before tomorrow. Only one of the dates needs to match.
   - Does regular expression match (case-sensitive by default).
   - Essential reading: [Regular Expression Searches]({{ site.baseurl }}{% link queries/regular-expressions.md %}).
 
-> `status.name` text searching was introduced in Tasks X.Y.Z.
+{: .released }
+`status.name` text searching was introduced in Tasks X.Y.Z.
 
 For more information, including adding your own customised statuses, see [Statuses]({{ site.baseurl }}{% link getting-started/statuses.md %}).
 
@@ -222,7 +230,8 @@ As well as the date-related searches above, these filters search other propertie
   - Does regular expression match (case-sensitive by default).
   - Essential reading: [Regular Expression Searches]({{ site.baseurl }}{% link queries/regular-expressions.md %}).
 
-> `regex matches` and `regex does not match` were introduced in Tasks 1.12.0.
+{: .released }
+`regex matches` and `regex does not match` were introduced in Tasks 1.12.0.
 
 For precise searches, it may help to know that `description`:
 
@@ -282,7 +291,8 @@ For more information, see [Priorities]({{ site.baseurl }}{% link getting-started
   - Does regular expression match (case-sensitive by default).
   - Essential reading: [Regular Expression Searches]({{ site.baseurl }}{% link queries/regular-expressions.md %}).
 
-> `recurrence` text searching was introduced in Tasks 1.22.0.
+{: .released }
+`recurrence` text searching was introduced in Tasks 1.22.0.
 
 ### Sub-Items
 
@@ -308,7 +318,8 @@ Introduced in Tasks 1.6.0.
   - This enables tag searches that avoid sub-tags, by putting a `$` character at the end of the regular expression. See examples below.
   - If searching for sub-tags, remember to escape the slashes in regular expressions: `\/`
 
-> `regex matches` and `regex does not match` were introduced in Tasks 1.13.0.
+{: .released }
+`regex matches` and `regex does not match` were introduced in Tasks 1.13.0.
 
 #### Tag Query Examples
 
@@ -334,7 +345,8 @@ Note that the path includes the `.md` extension.
   - Does regular expression match (case-sensitive by default).
   - Essential reading: [Regular Expression Searches]({{ site.baseurl }}{% link queries/regular-expressions.md %}).
 
-> `regex matches` and `regex does not match` were introduced in Tasks 1.12.0.
+{: .released }
+`regex matches` and `regex does not match` were introduced in Tasks 1.12.0.
 
 ### File Name
 
@@ -362,4 +374,5 @@ Note that the file name includes the `.md` extension.
   - `regex does not match` will match a task that does not have a preceding heading in its file.
   - Essential reading: [Regular Expression Searches]({{ site.baseurl }}{% link queries/regular-expressions.md %}).
 
-> `regex matches` and `regex does not match` were introduced in Tasks 1.12.0.
+{: .released }
+`regex matches` and `regex does not match` were introduced in Tasks 1.12.0.

--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -291,7 +291,8 @@ For more information, see [Priorities]({{ site.baseurl }}{% link getting-started
 
 ### Tags
 
-> Introduced in Tasks 1.6.0.
+{: .released }
+Introduced in Tasks 1.6.0.
 
 - `tags (include|do not include) <tag>` _or_
 - `tag (includes|does not include) <tag>`
@@ -337,7 +338,8 @@ Note that the path includes the `.md` extension.
 
 ### File Name
 
-> Introduced in Tasks 1.13.0.
+{: .released }
+Introduced in Tasks 1.13.0.
 
 Note that the file name includes the `.md` extension.
 

--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -323,6 +323,8 @@ Introduced in Tasks 1.6.0.
 
 #### Tag Query Examples
 
+{: .no_toc }
+
 - `tags include #todo`
 - `tags do not include #todo`
 - `tag regex matches /#t$/`

--- a/docs/queries/grouping.md
+++ b/docs/queries/grouping.md
@@ -6,7 +6,6 @@ parent: Queries
 ---
 
 # Grouping
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/queries/grouping.md
+++ b/docs/queries/grouping.md
@@ -29,11 +29,11 @@ By default, Tasks displays tasks in a single list.
 
 To divide the matching tasks up with headings, you can add `group by` lines to the query.
 
-### Available grouping properties
+## Available grouping properties
 
-You can group by the following properties:
+You can group by the following properties.
 
-File locations:
+### File locations
 
 1. `path` (the path to the file that contains the task, that is, the folder and the filename)
 1. `root` (the top-level folder of the file that contains the task, that is, the first directory in the path, which will be `/` for files in root of the vault)
@@ -44,12 +44,12 @@ File locations:
 {: .released }
 `root` grouping option was introduced in Tasks 1.11.0.
 
-File contents:
+### File contents
 
 1. `backlink` (the text that would be shown in the task's backlink, combining the task's file name and heading, but with no link added)
 1. `heading` (the heading preceding the task, or `(No heading)` if there are no headings in the file)
 
-Task date properties:
+### Task date properties
 
 1. `start`
    - The start date of the task, including the week-day, or `No start date`.
@@ -65,7 +65,7 @@ Task date properties:
 {: .released }
 `happens` grouping option was introduced in Tasks 1.11.0.
 
-Task properties - other:
+### Other task properties
 
 1. `status` (Done or Todo, which is capitalized for visibility in the headings)
     - Note that the Done group is displayed before the Todo group,
@@ -89,7 +89,7 @@ Task properties - other:
 `tags` grouping option was introduced in Tasks 1.10.0.<br>
 `priority`, `recurring` and `recurrence` grouping options were introduced in Tasks 1.11.0.
 
-### Multiple groups
+## Multiple groups
 
 You can add multiple `group by` query options, each on an extra line.
 This will create nested groups.

--- a/docs/queries/grouping.md
+++ b/docs/queries/grouping.md
@@ -22,7 +22,8 @@ parent: Queries
 
 ## Basics
 
-> Introduced in Tasks 1.6.0.
+{: .released }
+Introduced in Tasks 1.6.0.
 
 By default, Tasks displays tasks in a single list.
 

--- a/docs/queries/grouping.md
+++ b/docs/queries/grouping.md
@@ -41,7 +41,8 @@ File locations:
 1. `filename` (the link to the file that contains the task, without the `.md` extension)
     - Note that tasks from different notes with the same file name will be grouped together in the same group.
 
-> `root` grouping option was introduced in Tasks 1.11.0.
+{: .released }
+`root` grouping option was introduced in Tasks 1.11.0.
 
 File contents:
 
@@ -61,7 +62,8 @@ Task date properties:
 1. `happens`
     - The earliest of start date, scheduled date, and due date, including the week-day, or `No happens date` if none of those are set.
 
-> `happens` grouping option was introduced in Tasks 1.11.0.
+{: .released }
+`happens` grouping option was introduced in Tasks 1.11.0.
 
 Task properties - other:
 
@@ -82,11 +84,10 @@ Task properties - other:
 1. `tags`
     - The tags of the tasks or `(No tags)`. If the task has multiple tags, it will show up under every tag.
 
-> `start`, `scheduled`, `due` and `done` grouping options were introduced in Tasks 1.7.0.
->
-> `tags` grouping option was introduced in Tasks 1.10.0.
->
-> `priority`, `recurring` and `recurrence` grouping options were introduced in Tasks 1.11.0.
+{: .released }
+`start`, `scheduled`, `due` and `done` grouping options were introduced in Tasks 1.7.0.<br>
+`tags` grouping option was introduced in Tasks 1.10.0.<br>
+`priority`, `recurring` and `recurrence` grouping options were introduced in Tasks 1.11.0.
 
 ### Multiple groups
 

--- a/docs/queries/index.md
+++ b/docs/queries/index.md
@@ -6,7 +6,6 @@ has_children: true
 ---
 
 # Queries
-
 {: .no_toc }
 
 You can list tasks from your entire vault by querying them using a `tasks` code block. You can edit the tasks from the query results by clicking on the little pencil icon next to them.

--- a/docs/queries/layout.md
+++ b/docs/queries/layout.md
@@ -36,12 +36,14 @@ The following elements exist:
 - `recurrence rule`
 - `task count`
 
-> `urgency` was introduced in Tasks 1.14.0.
+{: .released }
+`urgency` was introduced in Tasks 1.14.0.
 
 All of these elements except `urgency` are shown by default, so you will use the command `hide`
 if you do not want to show any of them, or the command `show` to show the urgency score.
 
-> The `show` commands were introduced in Tasks 1.14.0.
+{: .released }
+The `show` commands were introduced in Tasks 1.14.0.
 
 Example:
 

--- a/docs/queries/layout.md
+++ b/docs/queries/layout.md
@@ -6,7 +6,6 @@ parent: Queries
 ---
 
 # Layout commands
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/queries/regular-expressions.md
+++ b/docs/queries/regular-expressions.md
@@ -23,7 +23,8 @@ has_toc: false
 
 ## Introduction
 
-> Introduced in Tasks 1.12.0.
+{: .released }
+Introduced in Tasks 1.12.0.
 
 [Regular expression](https://en.wikipedia.org/wiki/Regular_expression)  ("regex") searches are a powerful alternative to the simple `includes` and  `does not include` searches.
 

--- a/docs/queries/regular-expressions.md
+++ b/docs/queries/regular-expressions.md
@@ -7,7 +7,6 @@ has_toc: false
 ---
 
 # Regular Expressions
-
 {: .no_toc }
 
 <details open markdown="block">

--- a/docs/queries/sorting.md
+++ b/docs/queries/sorting.md
@@ -26,11 +26,11 @@ By default Tasks sorts tasks by [a calculated score we call "urgency"]({{ site.b
 
 To sort the results of a query different from the default, you must add at least one `sort by` line to the query.
 
-### Available sorting properties
+## Available sorting properties
 
-You can sort tasks by the following properties:
+You can sort tasks by the following properties.
 
-File locations:
+### File locations
 
 1. `path` (the path to the file that contains the task)
 1. `filename` (the filename of the file that contains the task, with its extension)
@@ -39,14 +39,14 @@ File locations:
 {: .released }
 `sort by filename` was introduced in Tasks 1.21.0.
 
-File contents:
+### File contents
 
 1. `sort by heading` (the heading preceding the task; files with empty headings sort before other tasks)
 
 {: .released }
 `sort by heading` was introduced in Tasks 1.21.0.
 
-Task date properties:
+### Task date properties
 
 1. `start` (the date when the task starts)
 1. `scheduled` (the date when the task is scheduled)
@@ -57,7 +57,7 @@ Task date properties:
 {: .released }
 `sort by happens` was introduced in Tasks 1.21.0.
 
-Task properties - other:
+### Other task properties
 
 1. `description` (the description of the task)
 1. `status` (done or todo)

--- a/docs/queries/sorting.md
+++ b/docs/queries/sorting.md
@@ -36,13 +36,15 @@ File locations:
 1. `filename` (the filename of the file that contains the task, with its extension)
     - Note that tasks from different notes with the same file name will be sorter.
 
-> `sort by filename` was introduced in Tasks 1.21.0.
+{: .released }
+`sort by filename` was introduced in Tasks 1.21.0.
 
 File contents:
 
 1. `sort by heading` (the heading preceding the task; files with empty headings sort before other tasks)
 
-> `sort by heading` was introduced in Tasks 1.21.0.
+{: .released }
+`sort by heading` was introduced in Tasks 1.21.0.
 
 Task date properties:
 
@@ -52,7 +54,8 @@ Task date properties:
 1. `done` (the date when the task was done)
 1. `happens` (the earliest of start date, scheduled date, and due date)
 
-> `sort by happens` was introduced in Tasks 1.21.0.
+{: .released }
+`sort by happens` was introduced in Tasks 1.21.0.
 
 Task properties - other:
 

--- a/docs/queries/sorting.md
+++ b/docs/queries/sorting.md
@@ -101,7 +101,8 @@ For example, when you `sort by done reverse` and your query results contain task
 
 ## Tag sorting
 
-> Introduced in Tasks 1.6.0.
+{: .released }
+Introduced in Tasks 1.6.0.
 
 If you want to sort by tags, by default it will sort by the first tag found in the description. If you want to sort by a tag that comes after that then you can specify the index at the end of the query. All tasks should have the same amount of tags for optimal sorting and the tags in the same order. The index starts from 1 which is also the default.
 

--- a/docs/queries/sorting.md
+++ b/docs/queries/sorting.md
@@ -6,7 +6,6 @@ parent: Queries
 ---
 
 # Sorting
-
 {: .no_toc }
 
 <details open markdown="block">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

In writing the docs for custom statuses, I found out a few things about the Just the Docs Jekyll theme that this project uses, that improve the docs.

- Tables of contents on pages no longer all have a single `1.` with everything else nested inside.
- The 'Introduced in version blah' banners are now in a nice callout.
- CONTRIBUTING updated to record how these things are done
- Also refined the heading levels in a few pages

## Motivation and Context

To make the docs more pleasing to read and easier to navigate.

## How has this been tested?

Viewing the docs locally.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4840096/211669469-7cbcaebf-7bf3-414a-9da9-aea843bd01e1.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
