### PR TITLE
fix: No longer accept 'status-name' and similar instead of 'status.name'

### DIFF
--- a/src/Query/Filter/StatusNameField.ts
+++ b/src/Query/Filter/StatusNameField.ts
@@ -13,6 +13,11 @@ export class StatusNameField extends TextField {
         return 'status.name';
     }
 
+    protected fieldPattern(): string {
+        // Guard against accidental allowing of strings like 'status-name'
+        return 'status\\.name';
+    }
+
     value(task: Task): string {
         return task.status.name;
     }

--- a/tests/Query/Filter/StatusNameField.test.ts
+++ b/tests/Query/Filter/StatusNameField.test.ts
@@ -29,4 +29,13 @@ describe('status.name', () => {
         expect(filter).toMatchTaskFromLine('- [ ] Xxx');
         expect(filter).not.toMatchTaskFromLine('- [x] Xxx');
     });
+
+    it('status-name is not valid', () => {
+        // Arrange
+        const filter = new StatusNameField().createFilterOrErrorMessage('status-name includes todo');
+
+        // Assert
+        // Check that the '.' in status.name is interpreted exactly as a dot.
+        expect(filter).not.toBeValid();
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I realised that the parsing of `status.name` as a new field would accidentally match any character where the `.` is.

This makes the parsing stricter, to avoid accidentally ending up having to support mis-spellings in user vaults for ever more.

## Motivation and Context

Make parsing more accurate. This is a not-yet-released feature.

## How has this been tested?

Add and running tests.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
