### PR TITLE
fix: 'sort by status.name' was treated as 'sort by status' in queries

### DIFF
--- a/src/Query/FilterParser.ts
+++ b/src/Query/FilterParser.ts
@@ -21,6 +21,7 @@ import type { FilterOrErrorMessage } from './Filter/Filter';
 import type { Sorter } from './Sorter';
 
 const fieldCreators = [
+    () => new StatusNameField(), // status.name is before status, to avoid ambiguity
     () => new StatusField(),
     () => new RecurringField(),
     () => new PriorityField(),
@@ -38,7 +39,6 @@ const fieldCreators = [
     () => new FilenameField(),
     () => new UrgencyField(),
     () => new RecurrenceField(),
-    () => new StatusNameField(),
 ];
 
 export function parseFilter(filterString: string): FilterOrErrorMessage | null {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -253,6 +253,11 @@ describe('Query parsing', () => {
             expect(query.error).toBeUndefined();
         });
     });
+
+    it('should parse ambiguous queries correctly', () => {
+        expect(new Query({ source: 'sort by status' }).sorting[0].property).toEqual('status');
+        expect(new Query({ source: 'sort by status.name' }).sorting[0].property).toEqual('status.name');
+    });
 });
 
 describe('Query', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Fix a bug found in manual testing, that 'sort by status.name' was treated as 'sort by status' in queries.

Added an integration test to show the problem.

## Motivation and Context

Bug in unreleased code.

## How has this been tested?

Via integration test, and manual testing in demo vault.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
