### PR TITLE
chore: Add stress_test_obsidian_tasks.py

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/Stress Test/.gitignore
+++ b/resources/sample_vaults/Tasks-Demo/Stress Test/.gitignore
@@ -1,0 +1,1 @@
+tasks-stress-test*

--- a/resources/sample_vaults/Tasks-Demo/Stress Test/Stress Test Readme.md
+++ b/resources/sample_vaults/Tasks-Demo/Stress Test/Stress Test Readme.md
@@ -1,0 +1,22 @@
+# Stress Test Readme
+## Requirements
+
+> [!INFO] Info
+> Needs Python3 to be installed.
+
+## Running the script to create files for stress-testing
+To populate this directory with a large number of files for testing, run:
+
+```bash
+cd obsidian-tasks
+./scripts/stress_test_obsidian_tasks.py
+```
+
+The script will write output files to this directory.
+There are some parameters in the script that you can edit.
+
+The created files are ignored in the `.gitignore`
+
+## Varying behaviour
+
+There are some hard-coded constants in `scripts/stress_test_obsidian_tasks.py` that you can edit to vary the behaviour.

--- a/scripts/stress_test_obsidian_tasks.py
+++ b/scripts/stress_test_obsidian_tasks.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# Generate some files containing tasks, to stress-test the Tasks plugin.
+
+import os.path
+
+files_to_write = 50
+list_items_to_write = 100
+add_task_every_n_lines = 1 # 1 or higher
+
+def file_content(basename: str, file_index: int, number_of_list_items: int) -> str:
+    content = ''
+    content += f'# {basename}\n\n'
+    content += f'## {basename} - level 2\n\n'
+    for i in range(1, number_of_list_items + 1):
+        line_text = f'#task Set {file_index} Task {i} of {number_of_list_items}'
+        if i % add_task_every_n_lines == 0:
+            content += f'- [ ] {line_text}\n'
+        else:
+            content += f'- {line_text}\n'
+    return content
+
+
+def create_files(dir) -> None:
+    if not os.path.isdir(dir):
+        os.mkdir(dir)
+    os.chdir(dir)
+    for i in range(1, files_to_write + 1):
+        basename = f'tasks-stress-test-{i}'
+        filename = f'{basename}.md'
+        with open(filename, 'w') as f:
+            f.write(file_content(basename, i, list_items_to_write))
+
+
+if __name__ == '__main__':
+    # Run from the root of the vault
+    create_files('resources/sample_vaults/Tasks-Demo/Stress Test')
+    print('Done')


### PR DESCRIPTION
# Description

Add `stress_test_obsidian_tasks.py`.

It generates a bunch of files with tasks in `resources/sample_vaults/Tasks-Demo/Stress Test`.

This is useful for quickly generating large numbers of tasks, for testing purposes.

I've been running this on my development machine, but it was useful for a bugfix, so I'm adding it to the vault.

For more info, see the new file `resources/sample_vaults/Tasks-Demo/Stress Test/Stress Test Readme.md`.

## Motivation and Context

To help me explore the root cause of Queries stuck on "Loading Tasks ...": #829

## How has this been tested?

By running it locally and experimenting with the parameters in the script.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4840096/212298650-cb05183d-ecb4-4f7e-9f22-0e6fa44e212d.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Not applicable.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
