### PR TITLE
Fix edit status error validation

### DIFF
--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -38,36 +38,48 @@ export class CustomStatusModal extends Modal {
         //const title = this.title ?? '...';
 
         let statusSymbolText: TextComponent;
-        // TODO Figure out how to show any error in status symbol if the initial value loaded is incorrect.
         new Setting(settingDiv)
             .setName('Task Status Symbol')
             .setDesc('This is the character between the square braces.')
             .addText((text) => {
                 statusSymbolText = text;
-                statusSymbolText.setValue(this.statusSymbol).onChange((v) => {
+                text.setValue(this.statusSymbol).onChange((v) => {
                     this.statusSymbol = v;
                     CustomStatusModal.setValid(text, this.statusConfiguration().validateIndicator());
                 });
+            })
+            .then((_setting) => {
+                CustomStatusModal.setValid(statusSymbolText, this.statusConfiguration().validateIndicator());
             });
 
+        let statusNameText: TextComponent;
         new Setting(settingDiv)
             .setName('Task Status Name')
             .setDesc('This is the friendly name of the task status.')
             .addText((text) => {
+                statusNameText = text;
                 text.setValue(this.statusName).onChange((v) => {
                     this.statusName = v;
                     CustomStatusModal.setValid(text, this.statusConfiguration().validateName());
                 });
+            })
+            .then((_setting) => {
+                CustomStatusModal.setValid(statusNameText, this.statusConfiguration().validateName());
             });
 
+        let statusNextSymbolText: TextComponent;
         new Setting(settingDiv)
             .setName('Task Next Status Symbol')
             .setDesc('When clicked on this is the symbol that should be used next.')
             .addText((text) => {
+                statusNextSymbolText = text;
                 text.setValue(this.statusNextSymbol).onChange((v) => {
                     this.statusNextSymbol = v;
                     CustomStatusModal.setValid(text, this.statusConfiguration().validateNextIndicator());
                 });
+            })
+            .then((_setting) => {
+                CustomStatusModal.setValid(statusNextSymbolText, this.statusConfiguration().validateNextIndicator());
             });
 
         if (Status.tasksPluginCanCreateCommandsForStatuses()) {

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -2,6 +2,15 @@ import { Modal, Setting, TextComponent } from 'obsidian';
 import { Status, StatusConfiguration } from '../Status';
 import type TasksPlugin from '../main';
 
+const isInvalidClass = 'is-invalid';
+const hasInvalidMessage = 'has-invalid-message';
+
+const unsetAlignItems = 'unset-align-items';
+const dotUnsetAlignItems = '.' + unsetAlignItems;
+
+const invalidFeedback = 'invalid-feedback';
+const dotInvalidFeedback = '.' + 'invalid-feedback';
+
 export class CustomStatusModal extends Modal {
     statusSymbol: string;
     statusName: string;
@@ -138,25 +147,25 @@ export class CustomStatusModal extends Modal {
     }
 
     static setValidationError(textInput: TextComponent, message?: string) {
-        textInput.inputEl.addClass('is-invalid');
+        textInput.inputEl.addClass(isInvalidClass);
         if (message) {
-            textInput.inputEl.parentElement?.addClasses(['has-invalid-message', 'unset-align-items']);
-            textInput.inputEl.parentElement?.parentElement?.addClass('.unset-align-items');
-            let mDiv = textInput.inputEl.parentElement?.querySelector('.invalid-feedback') as HTMLDivElement;
+            textInput.inputEl.parentElement?.addClasses([hasInvalidMessage, unsetAlignItems]);
+            textInput.inputEl.parentElement?.parentElement?.addClass(dotUnsetAlignItems);
+            let mDiv = textInput.inputEl.parentElement?.querySelector(dotInvalidFeedback) as HTMLDivElement;
 
             if (!mDiv) {
-                mDiv = createDiv({ cls: 'invalid-feedback' });
+                mDiv = createDiv({ cls: invalidFeedback });
             }
             mDiv.innerText = message;
             mDiv.insertAfter(textInput.inputEl);
         }
     }
     static removeValidationError(textInput: TextComponent) {
-        textInput.inputEl.removeClass('is-invalid');
-        textInput.inputEl.parentElement?.removeClasses(['has-invalid-message', 'unset-align-items']);
-        textInput.inputEl.parentElement?.parentElement?.removeClass('.unset-align-items');
+        textInput.inputEl.removeClass(isInvalidClass);
+        textInput.inputEl.parentElement?.removeClasses([hasInvalidMessage, unsetAlignItems]);
+        textInput.inputEl.parentElement?.parentElement?.removeClass(dotUnsetAlignItems);
 
-        const invalidFeedback = textInput.inputEl.parentElement?.querySelector('.invalid-feedback');
+        const invalidFeedback = textInput.inputEl.parentElement?.querySelector(dotInvalidFeedback);
         if (invalidFeedback) {
             textInput.inputEl.parentElement?.removeChild(invalidFeedback);
         }

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -37,60 +37,51 @@ export class CustomStatusModal extends Modal {
         const settingDiv = contentEl.createDiv();
         //const title = this.title ?? '...';
 
-        {
-            let statusSymbolText: TextComponent;
-            new Setting(settingDiv)
-                .setName('Task Status Symbol')
-                .setDesc('This is the character between the square braces.')
-                .addText((text) => {
-                    statusSymbolText = text;
-                    text.setValue(this.statusSymbol).onChange((v) => {
-                        this.statusSymbol = v;
-                        CustomStatusModal.setValid(text, this.statusConfiguration().validateIndicator());
-                    });
-                })
-                .then((_setting) => {
-                    // Show any error if the initial value loaded is incorrect.
-                    CustomStatusModal.setValid(statusSymbolText, this.statusConfiguration().validateIndicator());
+        let statusSymbolText: TextComponent;
+        new Setting(settingDiv)
+            .setName('Task Status Symbol')
+            .setDesc('This is the character between the square braces.')
+            .addText((text) => {
+                statusSymbolText = text;
+                text.setValue(this.statusSymbol).onChange((v) => {
+                    this.statusSymbol = v;
+                    CustomStatusModal.setValid(text, this.statusConfiguration().validateIndicator());
                 });
-        }
+            })
+            .then((_setting) => {
+                // Show any error if the initial value loaded is incorrect.
+                CustomStatusModal.setValid(statusSymbolText, this.statusConfiguration().validateIndicator());
+            });
 
-        {
-            let statusNameText: TextComponent;
-            new Setting(settingDiv)
-                .setName('Task Status Name')
-                .setDesc('This is the friendly name of the task status.')
-                .addText((text) => {
-                    statusNameText = text;
-                    text.setValue(this.statusName).onChange((v) => {
-                        this.statusName = v;
-                        CustomStatusModal.setValid(text, this.statusConfiguration().validateName());
-                    });
-                })
-                .then((_setting) => {
-                    CustomStatusModal.setValid(statusNameText, this.statusConfiguration().validateName());
+        let statusNameText: TextComponent;
+        new Setting(settingDiv)
+            .setName('Task Status Name')
+            .setDesc('This is the friendly name of the task status.')
+            .addText((text) => {
+                statusNameText = text;
+                text.setValue(this.statusName).onChange((v) => {
+                    this.statusName = v;
+                    CustomStatusModal.setValid(text, this.statusConfiguration().validateName());
                 });
-        }
+            })
+            .then((_setting) => {
+                CustomStatusModal.setValid(statusNameText, this.statusConfiguration().validateName());
+            });
 
-        {
-            let statusNextSymbolText: TextComponent;
-            new Setting(settingDiv)
-                .setName('Task Next Status Symbol')
-                .setDesc('When clicked on this is the symbol that should be used next.')
-                .addText((text) => {
-                    statusNextSymbolText = text;
-                    text.setValue(this.statusNextSymbol).onChange((v) => {
-                        this.statusNextSymbol = v;
-                        CustomStatusModal.setValid(text, this.statusConfiguration().validateNextIndicator());
-                    });
-                })
-                .then((_setting) => {
-                    CustomStatusModal.setValid(
-                        statusNextSymbolText,
-                        this.statusConfiguration().validateNextIndicator(),
-                    );
+        let statusNextSymbolText: TextComponent;
+        new Setting(settingDiv)
+            .setName('Task Next Status Symbol')
+            .setDesc('When clicked on this is the symbol that should be used next.')
+            .addText((text) => {
+                statusNextSymbolText = text;
+                text.setValue(this.statusNextSymbol).onChange((v) => {
+                    this.statusNextSymbol = v;
+                    CustomStatusModal.setValid(text, this.statusConfiguration().validateNextIndicator());
                 });
-        }
+            })
+            .then((_setting) => {
+                CustomStatusModal.setValid(statusNextSymbolText, this.statusConfiguration().validateNextIndicator());
+            });
 
         if (Status.tasksPluginCanCreateCommandsForStatuses()) {
             new Setting(settingDiv)

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -1,4 +1,4 @@
-import { Modal, Setting, TextComponent } from 'obsidian';
+import { Modal, Notice, Setting, TextComponent } from 'obsidian';
 import { Status, StatusConfiguration } from '../Status';
 import type TasksPlugin from '../main';
 
@@ -44,21 +44,6 @@ export class CustomStatusModal extends Modal {
             .addText((text) => {
                 statusSymbolText = text;
                 statusSymbolText.setValue(this.statusSymbol).onChange((v) => {
-                    if (!v.length) {
-                        CustomStatusModal.setValidationError(text, 'Task status type cannot be empty.');
-                        return;
-                    }
-
-                    if (v.includes(' ')) {
-                        CustomStatusModal.setValidationError(text, 'Task status type cannot include spaces.');
-                        return;
-                    }
-
-                    if (v.length > 1) {
-                        CustomStatusModal.setValidationError(text, 'Task status must be a single character.');
-                        return;
-                    }
-                    CustomStatusModal.removeValidationError(text);
                     this.statusSymbol = v;
                 });
             });
@@ -100,17 +85,13 @@ export class CustomStatusModal extends Modal {
             b.setTooltip('Save')
                 .setIcon('checkmark')
                 .onClick(async () => {
-                    // let error = false;
-                    // if (!this.statusSymbol.length) {
-                    //     SettingsModal.setValidationError(this.statusSymbol, 'Task status type cannot be empty.');
-                    //     error = true;
-                    //     return;
-                    // }
-
-                    // if (error) {
-                    //     new Notice('Fix errors before saving.');
-                    //     return;
-                    // }
+                    const { valid, errors } = this.statusConfiguration().validate();
+                    if (!valid) {
+                        const message = errors.join('\n') + '\n\n' + 'Fix errors before saving.';
+                        // console.debug(message);
+                        new Notice(message);
+                        return;
+                    }
                     this.saved = true;
                     this.close();
                 });

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -38,6 +38,7 @@ export class CustomStatusModal extends Modal {
         //const title = this.title ?? '...';
 
         let statusSymbolText: TextComponent;
+        // TODO Figure out how to show any error in status symbol if the initial value loaded is incorrect.
         new Setting(settingDiv)
             .setName('Task Status Symbol')
             .setDesc('This is the character between the square braces.')
@@ -45,6 +46,7 @@ export class CustomStatusModal extends Modal {
                 statusSymbolText = text;
                 statusSymbolText.setValue(this.statusSymbol).onChange((v) => {
                     this.statusSymbol = v;
+                    CustomStatusModal.setValid(text, this.statusConfiguration().validateIndicator());
                 });
             });
 
@@ -54,6 +56,7 @@ export class CustomStatusModal extends Modal {
             .addText((text) => {
                 text.setValue(this.statusName).onChange((v) => {
                     this.statusName = v;
+                    CustomStatusModal.setValid(text, this.statusConfiguration().validateName());
                 });
             });
 
@@ -63,6 +66,7 @@ export class CustomStatusModal extends Modal {
             .addText((text) => {
                 text.setValue(this.statusNextSymbol).onChange((v) => {
                     this.statusNextSymbol = v;
+                    CustomStatusModal.setValid(text, this.statusConfiguration().validateNextIndicator());
                 });
             });
 
@@ -85,8 +89,8 @@ export class CustomStatusModal extends Modal {
             b.setTooltip('Save')
                 .setIcon('checkmark')
                 .onClick(async () => {
-                    const { valid, errors } = this.statusConfiguration().validate();
-                    if (!valid) {
+                    const errors = this.statusConfiguration().validate();
+                    if (errors.length > 0) {
                         const message = errors.join('\n') + '\n\n' + 'Fix errors before saving.';
                         // console.debug(message);
                         new Notice(message);
@@ -118,28 +122,20 @@ export class CustomStatusModal extends Modal {
         this.display();
     }
 
-    static setValidationError(textInput: TextComponent, message?: string) {
+    static setValidationError(textInput: TextComponent) {
         textInput.inputEl.addClass('is-invalid');
-        if (message) {
-            textInput.inputEl.parentElement?.addClasses(['has-invalid-message', 'unset-align-items']);
-            textInput.inputEl.parentElement?.parentElement?.addClass('.unset-align-items');
-            let mDiv = textInput.inputEl.parentElement?.querySelector('.invalid-feedback') as HTMLDivElement;
-
-            if (!mDiv) {
-                mDiv = createDiv({ cls: 'invalid-feedback' });
-            }
-            mDiv.innerText = message;
-            mDiv.insertAfter(textInput.inputEl);
-        }
     }
+
     static removeValidationError(textInput: TextComponent) {
         textInput.inputEl.removeClass('is-invalid');
-        textInput.inputEl.parentElement?.removeClasses(['has-invalid-message', 'unset-align-items']);
-        textInput.inputEl.parentElement?.parentElement?.removeClass('.unset-align-items');
+    }
 
-        const invalidFeedback = textInput.inputEl.parentElement?.querySelector('.invalid-feedback');
-        if (invalidFeedback) {
-            textInput.inputEl.parentElement?.removeChild(invalidFeedback);
+    private static setValid(text: TextComponent, messages: string[]) {
+        const valid = messages.length === 0;
+        if (valid) {
+            CustomStatusModal.removeValidationError(text);
+        } else {
+            CustomStatusModal.setValidationError(text);
         }
     }
 }

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -37,50 +37,60 @@ export class CustomStatusModal extends Modal {
         const settingDiv = contentEl.createDiv();
         //const title = this.title ?? '...';
 
-        let statusSymbolText: TextComponent;
-        new Setting(settingDiv)
-            .setName('Task Status Symbol')
-            .setDesc('This is the character between the square braces.')
-            .addText((text) => {
-                statusSymbolText = text;
-                text.setValue(this.statusSymbol).onChange((v) => {
-                    this.statusSymbol = v;
-                    CustomStatusModal.setValid(text, this.statusConfiguration().validateIndicator());
+        {
+            let statusSymbolText: TextComponent;
+            new Setting(settingDiv)
+                .setName('Task Status Symbol')
+                .setDesc('This is the character between the square braces.')
+                .addText((text) => {
+                    statusSymbolText = text;
+                    text.setValue(this.statusSymbol).onChange((v) => {
+                        this.statusSymbol = v;
+                        CustomStatusModal.setValid(text, this.statusConfiguration().validateIndicator());
+                    });
+                })
+                .then((_setting) => {
+                    // Show any error if the initial value loaded is incorrect.
+                    CustomStatusModal.setValid(statusSymbolText, this.statusConfiguration().validateIndicator());
                 });
-            })
-            .then((_setting) => {
-                CustomStatusModal.setValid(statusSymbolText, this.statusConfiguration().validateIndicator());
-            });
+        }
 
-        let statusNameText: TextComponent;
-        new Setting(settingDiv)
-            .setName('Task Status Name')
-            .setDesc('This is the friendly name of the task status.')
-            .addText((text) => {
-                statusNameText = text;
-                text.setValue(this.statusName).onChange((v) => {
-                    this.statusName = v;
-                    CustomStatusModal.setValid(text, this.statusConfiguration().validateName());
+        {
+            let statusNameText: TextComponent;
+            new Setting(settingDiv)
+                .setName('Task Status Name')
+                .setDesc('This is the friendly name of the task status.')
+                .addText((text) => {
+                    statusNameText = text;
+                    text.setValue(this.statusName).onChange((v) => {
+                        this.statusName = v;
+                        CustomStatusModal.setValid(text, this.statusConfiguration().validateName());
+                    });
+                })
+                .then((_setting) => {
+                    CustomStatusModal.setValid(statusNameText, this.statusConfiguration().validateName());
                 });
-            })
-            .then((_setting) => {
-                CustomStatusModal.setValid(statusNameText, this.statusConfiguration().validateName());
-            });
+        }
 
-        let statusNextSymbolText: TextComponent;
-        new Setting(settingDiv)
-            .setName('Task Next Status Symbol')
-            .setDesc('When clicked on this is the symbol that should be used next.')
-            .addText((text) => {
-                statusNextSymbolText = text;
-                text.setValue(this.statusNextSymbol).onChange((v) => {
-                    this.statusNextSymbol = v;
-                    CustomStatusModal.setValid(text, this.statusConfiguration().validateNextIndicator());
+        {
+            let statusNextSymbolText: TextComponent;
+            new Setting(settingDiv)
+                .setName('Task Next Status Symbol')
+                .setDesc('When clicked on this is the symbol that should be used next.')
+                .addText((text) => {
+                    statusNextSymbolText = text;
+                    text.setValue(this.statusNextSymbol).onChange((v) => {
+                        this.statusNextSymbol = v;
+                        CustomStatusModal.setValid(text, this.statusConfiguration().validateNextIndicator());
+                    });
+                })
+                .then((_setting) => {
+                    CustomStatusModal.setValid(
+                        statusNextSymbolText,
+                        this.statusConfiguration().validateNextIndicator(),
+                    );
                 });
-            })
-            .then((_setting) => {
-                CustomStatusModal.setValid(statusNextSymbolText, this.statusConfiguration().validateNextIndicator());
-            });
+        }
 
         if (Status.tasksPluginCanCreateCommandsForStatuses()) {
             new Setting(settingDiv)

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -2,15 +2,6 @@ import { Modal, Setting, TextComponent } from 'obsidian';
 import { Status, StatusConfiguration } from '../Status';
 import type TasksPlugin from '../main';
 
-const isInvalidClass = 'is-invalid';
-const hasInvalidMessage = 'has-invalid-message';
-
-const unsetAlignItems = 'unset-align-items';
-const dotUnsetAlignItems = '.' + unsetAlignItems;
-
-const invalidFeedback = 'invalid-feedback';
-const dotInvalidFeedback = '.' + 'invalid-feedback';
-
 export class CustomStatusModal extends Modal {
     statusSymbol: string;
     statusName: string;
@@ -147,25 +138,25 @@ export class CustomStatusModal extends Modal {
     }
 
     static setValidationError(textInput: TextComponent, message?: string) {
-        textInput.inputEl.addClass(isInvalidClass);
+        textInput.inputEl.addClass('is-invalid');
         if (message) {
-            textInput.inputEl.parentElement?.addClasses([hasInvalidMessage, unsetAlignItems]);
-            textInput.inputEl.parentElement?.parentElement?.addClass(dotUnsetAlignItems);
-            let mDiv = textInput.inputEl.parentElement?.querySelector(dotInvalidFeedback) as HTMLDivElement;
+            textInput.inputEl.parentElement?.addClasses(['has-invalid-message', 'unset-align-items']);
+            textInput.inputEl.parentElement?.parentElement?.addClass('.unset-align-items');
+            let mDiv = textInput.inputEl.parentElement?.querySelector('.invalid-feedback') as HTMLDivElement;
 
             if (!mDiv) {
-                mDiv = createDiv({ cls: invalidFeedback });
+                mDiv = createDiv({ cls: 'invalid-feedback' });
             }
             mDiv.innerText = message;
             mDiv.insertAfter(textInput.inputEl);
         }
     }
     static removeValidationError(textInput: TextComponent) {
-        textInput.inputEl.removeClass(isInvalidClass);
-        textInput.inputEl.parentElement?.removeClasses([hasInvalidMessage, unsetAlignItems]);
-        textInput.inputEl.parentElement?.parentElement?.removeClass(dotUnsetAlignItems);
+        textInput.inputEl.removeClass('is-invalid');
+        textInput.inputEl.parentElement?.removeClasses(['has-invalid-message', 'unset-align-items']);
+        textInput.inputEl.parentElement?.parentElement?.removeClass('.unset-align-items');
 
-        const invalidFeedback = textInput.inputEl.parentElement?.querySelector(dotInvalidFeedback);
+        const invalidFeedback = textInput.inputEl.parentElement?.querySelector('.invalid-feedback');
         if (invalidFeedback) {
             textInput.inputEl.parentElement?.removeChild(invalidFeedback);
         }

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -145,11 +145,11 @@ export class CustomStatusModal extends Modal {
     }
 
     static setValidationError(textInput: TextComponent) {
-        textInput.inputEl.addClass('is-invalid');
+        textInput.inputEl.addClass('tasks-settings-is-invalid');
     }
 
     static removeValidationError(textInput: TextComponent) {
-        textInput.inputEl.removeClass('is-invalid');
+        textInput.inputEl.removeClass('tasks-settings-is-invalid');
     }
 
     private static setValid(text: TextComponent, messages: string[]) {

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -63,7 +63,7 @@ export class StatusConfiguration {
 
         // Messages are added in the order fields are shown when editing statuses.
         errors.push(...this.validateIndicator());
-        StatusConfiguration.validateName(this.name, errors);
+        errors.push(...this.validateName());
         errors.push(...this.validateNextIndicator());
 
         return errors;
@@ -81,10 +81,12 @@ export class StatusConfiguration {
         return errors;
     }
 
-    private static validateName(name: string, errors: string[]) {
-        if (name.length === 0) {
+    public validateName() {
+        const errors: string[] = [];
+        if (this.name.length === 0) {
             errors.push('Name cannot be empty.');
         }
+        return errors;
     }
 
     private static validateOneIndicator(indicator: string, errors: string[], indicatorName: string) {

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -58,7 +58,7 @@ export class StatusConfiguration {
     /**
      * Determine whether the date in this object is valid, and return error message(s) for display if not.
      */
-    public validate(): { valid: boolean; errors: string[] } {
+    public validate(): string[] {
         const errors: string[] = [];
 
         // Messages are added in the order fields are shown when editing statuses.
@@ -66,8 +66,7 @@ export class StatusConfiguration {
         StatusConfiguration.validateName(this.name, errors);
         StatusConfiguration.validateOneIndicator(this.nextStatusIndicator, errors, 'Next symbol');
 
-        const valid = errors.length === 0;
-        return { valid, errors };
+        return errors;
     }
 
     public validateIndicator(): string[] {

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -62,22 +62,22 @@ export class StatusConfiguration {
         const errors: string[] = [];
 
         // Messages are added in the order fields are shown when editing statuses.
-        StatusConfiguration.validateOneIndicator(this.indicator, errors, 'Symbol');
+        errors.push(...this.validateIndicator());
         StatusConfiguration.validateName(this.name, errors);
-        StatusConfiguration.validateOneIndicator(this.nextStatusIndicator, errors, 'Next symbol');
+        errors.push(...this.validateNextIndicator());
 
         return errors;
     }
 
     public validateIndicator(): string[] {
         const errors: string[] = [];
-        StatusConfiguration.validateOneIndicator(this.indicator, errors, 'Symbol'); // TODO Remove duplicate string
+        StatusConfiguration.validateOneIndicator(this.indicator, errors, 'Symbol');
         return errors;
     }
 
     public validateNextIndicator(): string[] {
         const errors: string[] = [];
-        StatusConfiguration.validateOneIndicator(this.nextStatusIndicator, errors, 'Next symbol'); // TODO Remove duplicate string
+        StatusConfiguration.validateOneIndicator(this.nextStatusIndicator, errors, 'Next symbol');
         return errors;
     }
 

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -60,10 +60,20 @@ export class StatusConfiguration {
      */
     public validate(): { valid: boolean; errors: string[] } {
         const errors: string[] = [];
+
+        // Messages are added in the order fields are shown when editing statuses.
         StatusConfiguration.validateIndicator(this.indicator, errors, 'Symbol');
+        StatusConfiguration.validateName(this.name, errors);
         StatusConfiguration.validateIndicator(this.nextStatusIndicator, errors, 'Next symbol');
+
         const valid = errors.length === 0;
         return { valid, errors };
+    }
+
+    private static validateName(name: string, errors: string[]) {
+        if (name.length === 0) {
+            errors.push('Name cannot be empty.');
+        }
     }
 
     private static validateIndicator(indicator: string, errors: string[], indicatorName: string) {

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -67,6 +67,10 @@ export class StatusConfiguration {
     }
 
     private static validateIndicator(indicator: string, errors: string[], indicatorName: string) {
+        if (indicator.length === 0) {
+            errors.push(`${indicatorName} cannot be empty.`);
+        }
+
         if (indicator.length > 1) {
             errors.push(`${indicatorName} ("${indicator}") must be a single character.`);
         }

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -70,15 +70,11 @@ export class StatusConfiguration {
     }
 
     public validateIndicator(): string[] {
-        const errors: string[] = [];
-        StatusConfiguration.validateOneIndicator(this.indicator, errors, 'Symbol');
-        return errors;
+        return StatusConfiguration.validateOneIndicator(this.indicator, 'Symbol');
     }
 
     public validateNextIndicator(): string[] {
-        const errors: string[] = [];
-        StatusConfiguration.validateOneIndicator(this.nextStatusIndicator, errors, 'Next symbol');
-        return errors;
+        return StatusConfiguration.validateOneIndicator(this.nextStatusIndicator, 'Next symbol');
     }
 
     public validateName() {
@@ -89,7 +85,8 @@ export class StatusConfiguration {
         return errors;
     }
 
-    private static validateOneIndicator(indicator: string, errors: string[], indicatorName: string) {
+    private static validateOneIndicator(indicator: string, indicatorName: string): string[] {
+        const errors: string[] = [];
         if (indicator.length === 0) {
             errors.push(`${indicatorName} cannot be empty.`);
         }
@@ -97,6 +94,7 @@ export class StatusConfiguration {
         if (indicator.length > 1) {
             errors.push(`${indicatorName} ("${indicator}") must be a single character.`);
         }
+        return errors;
     }
 }
 

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -70,17 +70,17 @@ export class StatusConfiguration {
     }
 
     public validateIndicator(): string[] {
-        return StatusConfiguration.validateOneIndicator(this.indicator, 'Symbol');
+        return StatusConfiguration.validateOneIndicator(this.indicator, 'Task Status Symbol');
     }
 
     public validateNextIndicator(): string[] {
-        return StatusConfiguration.validateOneIndicator(this.nextStatusIndicator, 'Next symbol');
+        return StatusConfiguration.validateOneIndicator(this.nextStatusIndicator, 'Task Next Status Symbol');
     }
 
     public validateName() {
         const errors: string[] = [];
         if (this.name.length === 0) {
-            errors.push('Name cannot be empty.');
+            errors.push('Task Status Name cannot be empty.');
         }
         return errors;
     }

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -62,12 +62,24 @@ export class StatusConfiguration {
         const errors: string[] = [];
 
         // Messages are added in the order fields are shown when editing statuses.
-        StatusConfiguration.validateIndicator(this.indicator, errors, 'Symbol');
+        StatusConfiguration.validateOneIndicator(this.indicator, errors, 'Symbol');
         StatusConfiguration.validateName(this.name, errors);
-        StatusConfiguration.validateIndicator(this.nextStatusIndicator, errors, 'Next symbol');
+        StatusConfiguration.validateOneIndicator(this.nextStatusIndicator, errors, 'Next symbol');
 
         const valid = errors.length === 0;
         return { valid, errors };
+    }
+
+    public validateIndicator(): string[] {
+        const errors: string[] = [];
+        StatusConfiguration.validateOneIndicator(this.indicator, errors, 'Symbol'); // TODO Remove duplicate string
+        return errors;
+    }
+
+    public validateNextIndicator(): string[] {
+        const errors: string[] = [];
+        StatusConfiguration.validateOneIndicator(this.nextStatusIndicator, errors, 'Next symbol'); // TODO Remove duplicate string
+        return errors;
     }
 
     private static validateName(name: string, errors: string[]) {
@@ -76,7 +88,7 @@ export class StatusConfiguration {
         }
     }
 
-    private static validateIndicator(indicator: string, errors: string[], indicatorName: string) {
+    private static validateOneIndicator(indicator: string, errors: string[], indicatorName: string) {
         if (indicator.length === 0) {
             errors.push(`${indicatorName} cannot be empty.`);
         }

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -60,11 +60,16 @@ export class StatusConfiguration {
      */
     public validate(): { valid: boolean; errors: string[] } {
         const errors: string[] = [];
-        if (this.indicator.length > 1) {
-            errors.push('Symbol ("xxx") must be a single character.');
-        }
+        StatusConfiguration.validateIndicator(this.indicator, errors, 'Symbol');
+        StatusConfiguration.validateIndicator(this.nextStatusIndicator, errors, 'Next symbol');
         const valid = errors.length === 0;
         return { valid, errors };
+    }
+
+    private static validateIndicator(indicator: string, errors: string[], indicatorName: string) {
+        if (indicator.length > 1) {
+            errors.push(`${indicatorName} ("${indicator}") must be a single character.`);
+        }
     }
 }
 

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -54,6 +54,18 @@ export class StatusConfiguration {
         this.nextStatusIndicator = nextStatusIndicator;
         this.availableAsCommand = availableAsCommand;
     }
+
+    /**
+     * Determine whether the date in this object is valid, and return error message(s) for display if not.
+     */
+    public validate(): { valid: boolean; errors: string[] } {
+        const errors: string[] = [];
+        if (this.indicator.length > 1) {
+            errors.push('Symbol ("xxx") must be a single character.');
+        }
+        const valid = errors.length === 0;
+        return { valid, errors };
+    }
 }
 
 /**

--- a/styles.css
+++ b/styles.css
@@ -212,9 +212,9 @@
  *------------------------------------------------------------------------**/
 
 .is-invalid {
-    /*color: red;*/
-    border-color: red !important;
-    /*font-weight: bold;*/
+    /* Dark red text on pale background*/
+    color: var(--text-error) !important;
+    background-color: rgba(var(--background-modifier-error-rgb), 0.2) !important;
 }
 
 

--- a/styles.css
+++ b/styles.css
@@ -211,6 +211,12 @@
  **                            SETTINGS
  *------------------------------------------------------------------------**/
 
+.is-invalid {
+    /*color: red;*/
+    border-color: red !important;
+    /*font-weight: bold;*/
+}
+
 
  .tasks-settings .additional {
     margin: 6px 12px;

--- a/styles.css
+++ b/styles.css
@@ -211,7 +211,7 @@
  **                            SETTINGS
  *------------------------------------------------------------------------**/
 
-.is-invalid {
+.tasks-settings-is-invalid {
     /* Dark red text on pale background*/
     color: var(--text-error) !important;
     background-color: rgba(var(--background-modifier-error-rgb), 0.2) !important;

--- a/tests/Status.test.ts
+++ b/tests/Status.test.ts
@@ -24,9 +24,21 @@ describe('StatusConfiguration', () => {
             checkValidation(config, true, []);
         });
 
+        // Check Symbol
+        it('should detect empty symbol', () => {
+            const config = new StatusConfiguration('', 'Completed', ' ', false);
+            checkValidation(config, false, ['Symbol cannot be empty.']);
+        });
+
         it('should detect too-long symbol', () => {
             const config = new StatusConfiguration('yyy', 'Completed', ' ', false);
             checkValidation(config, false, ['Symbol ("yyy") must be a single character.']);
+        });
+
+        // Check Next symbol
+        it('should detect next empty symbol', () => {
+            const config = new StatusConfiguration('X', 'Completed', '', false);
+            checkValidation(config, false, ['Next symbol cannot be empty.']);
         });
 
         it('should detect too-long next symbol', () => {

--- a/tests/Status.test.ts
+++ b/tests/Status.test.ts
@@ -7,6 +7,30 @@ import { Status, StatusConfiguration } from '../src/Status';
 jest.mock('obsidian');
 window.moment = moment;
 
+describe('StatusConfiguration', () => {
+    function checkValidation(
+        statusConfiguration: StatusConfiguration,
+        expectedValid: boolean,
+        expectedMessages: string[],
+    ) {
+        const { valid, errors } = statusConfiguration.validate();
+        expect(valid).toEqual(expectedValid);
+        expect(errors).toEqual(expectedMessages);
+    }
+
+    describe('validation', () => {
+        it('should handle valid input correctly', () => {
+            const config = new StatusConfiguration('X', 'Completed', ' ', false);
+            checkValidation(config, true, []);
+        });
+
+        it('should detect too-long symbol', () => {
+            const config = new StatusConfiguration('xxx', 'Completed', ' ', false);
+            checkValidation(config, false, ['Symbol ("xxx") must be a single character.']);
+        });
+    });
+});
+
 describe('Status', () => {
     it('should initialize with valid properties', () => {
         // Arrange

--- a/tests/Status.test.ts
+++ b/tests/Status.test.ts
@@ -51,6 +51,32 @@ describe('StatusConfiguration', () => {
             const config = new StatusConfiguration('X', 'Completed', 'yyy', false);
             checkValidation(config, false, ['Next symbol ("yyy") must be a single character.']);
         });
+
+        describe('validate indicator', () => {
+            it('valid indicator', () => {
+                const config = new StatusConfiguration('X', 'Completed', 'c', false);
+                expect(config.validateIndicator()).toStrictEqual([]);
+            });
+
+            it('invalid indicator', () => {
+                const config = new StatusConfiguration('XYZ', 'Completed', 'c', false);
+                expect(config.validateIndicator()).toStrictEqual(['Symbol ("XYZ") must be a single character.']);
+            });
+        });
+
+        describe('validate next indicator', () => {
+            it('valid indicator', () => {
+                const config = new StatusConfiguration('c', 'Completed', 'X', false);
+                expect(config.validateNextIndicator()).toStrictEqual([]);
+            });
+
+            it('invalid next indicator', () => {
+                const config = new StatusConfiguration('c', 'Completed', 'XYZ', false);
+                expect(config.validateNextIndicator()).toStrictEqual([
+                    'Next symbol ("XYZ") must be a single character.',
+                ]);
+            });
+        });
     });
 });
 

--- a/tests/Status.test.ts
+++ b/tests/Status.test.ts
@@ -25,8 +25,13 @@ describe('StatusConfiguration', () => {
         });
 
         it('should detect too-long symbol', () => {
-            const config = new StatusConfiguration('xxx', 'Completed', ' ', false);
-            checkValidation(config, false, ['Symbol ("xxx") must be a single character.']);
+            const config = new StatusConfiguration('yyy', 'Completed', ' ', false);
+            checkValidation(config, false, ['Symbol ("yyy") must be a single character.']);
+        });
+
+        it('should detect too-long next symbol', () => {
+            const config = new StatusConfiguration('X', 'Completed', 'yyy', false);
+            checkValidation(config, false, ['Next symbol ("yyy") must be a single character.']);
         });
     });
 });

--- a/tests/Status.test.ts
+++ b/tests/Status.test.ts
@@ -24,6 +24,12 @@ describe('StatusConfiguration', () => {
             checkValidation(config, true, []);
         });
 
+        // Check status name
+        it('should detect empty name', () => {
+            const config = new StatusConfiguration('X', '', ' ', false);
+            checkValidation(config, false, ['Name cannot be empty.']);
+        });
+
         // Check Symbol
         it('should detect empty symbol', () => {
             const config = new StatusConfiguration('', 'Completed', ' ', false);

--- a/tests/Status.test.ts
+++ b/tests/Status.test.ts
@@ -22,38 +22,38 @@ describe('StatusConfiguration', () => {
         it('should handle totally invalid input correctly', () => {
             const config = new StatusConfiguration('Xxx', '', '', false);
             checkValidation(config, [
-                'Symbol ("Xxx") must be a single character.',
-                'Name cannot be empty.',
-                'Next symbol cannot be empty.',
+                'Task Status Symbol ("Xxx") must be a single character.',
+                'Task Status Name cannot be empty.',
+                'Task Next Status Symbol cannot be empty.',
             ]);
         });
 
         // Check status name
         it('should detect empty name', () => {
             const config = new StatusConfiguration('X', '', ' ', false);
-            checkValidation(config, ['Name cannot be empty.']);
+            checkValidation(config, ['Task Status Name cannot be empty.']);
         });
 
         // Check Symbol
         it('should detect empty symbol', () => {
             const config = new StatusConfiguration('', 'Completed', ' ', false);
-            checkValidation(config, ['Symbol cannot be empty.']);
+            checkValidation(config, ['Task Status Symbol cannot be empty.']);
         });
 
         it('should detect too-long symbol', () => {
             const config = new StatusConfiguration('yyy', 'Completed', ' ', false);
-            checkValidation(config, ['Symbol ("yyy") must be a single character.']);
+            checkValidation(config, ['Task Status Symbol ("yyy") must be a single character.']);
         });
 
         // Check Next symbol
         it('should detect next empty symbol', () => {
             const config = new StatusConfiguration('X', 'Completed', '', false);
-            checkValidation(config, ['Next symbol cannot be empty.']);
+            checkValidation(config, ['Task Next Status Symbol cannot be empty.']);
         });
 
         it('should detect too-long next symbol', () => {
             const config = new StatusConfiguration('X', 'Completed', 'yyy', false);
-            checkValidation(config, ['Next symbol ("yyy") must be a single character.']);
+            checkValidation(config, ['Task Next Status Symbol ("yyy") must be a single character.']);
         });
 
         describe('validate indicator', () => {
@@ -64,7 +64,9 @@ describe('StatusConfiguration', () => {
 
             it('invalid indicator', () => {
                 const config = new StatusConfiguration('XYZ', 'Completed', 'c', false);
-                expect(config.validateIndicator()).toStrictEqual(['Symbol ("XYZ") must be a single character.']);
+                expect(config.validateIndicator()).toStrictEqual([
+                    'Task Status Symbol ("XYZ") must be a single character.',
+                ]);
             });
         });
 
@@ -77,7 +79,7 @@ describe('StatusConfiguration', () => {
             it('invalid next indicator', () => {
                 const config = new StatusConfiguration('c', 'Completed', 'XYZ', false);
                 expect(config.validateNextIndicator()).toStrictEqual([
-                    'Next symbol ("XYZ") must be a single character.',
+                    'Task Next Status Symbol ("XYZ") must be a single character.',
                 ]);
             });
         });

--- a/tests/Status.test.ts
+++ b/tests/Status.test.ts
@@ -8,25 +8,20 @@ jest.mock('obsidian');
 window.moment = moment;
 
 describe('StatusConfiguration', () => {
-    function checkValidation(
-        statusConfiguration: StatusConfiguration,
-        expectedValid: boolean,
-        expectedMessages: string[],
-    ) {
-        const { valid, errors } = statusConfiguration.validate();
-        expect(valid).toEqual(expectedValid);
+    function checkValidation(statusConfiguration: StatusConfiguration, expectedMessages: string[]) {
+        const errors = statusConfiguration.validate();
         expect(errors).toEqual(expectedMessages);
     }
 
     describe('validation', () => {
         it('should handle valid input correctly', () => {
             const config = new StatusConfiguration('X', 'Completed', ' ', false);
-            checkValidation(config, true, []);
+            checkValidation(config, []);
         });
 
         it('should handle totally invalid input correctly', () => {
             const config = new StatusConfiguration('Xxx', '', '', false);
-            checkValidation(config, false, [
+            checkValidation(config, [
                 'Symbol ("Xxx") must be a single character.',
                 'Name cannot be empty.',
                 'Next symbol cannot be empty.',
@@ -36,29 +31,29 @@ describe('StatusConfiguration', () => {
         // Check status name
         it('should detect empty name', () => {
             const config = new StatusConfiguration('X', '', ' ', false);
-            checkValidation(config, false, ['Name cannot be empty.']);
+            checkValidation(config, ['Name cannot be empty.']);
         });
 
         // Check Symbol
         it('should detect empty symbol', () => {
             const config = new StatusConfiguration('', 'Completed', ' ', false);
-            checkValidation(config, false, ['Symbol cannot be empty.']);
+            checkValidation(config, ['Symbol cannot be empty.']);
         });
 
         it('should detect too-long symbol', () => {
             const config = new StatusConfiguration('yyy', 'Completed', ' ', false);
-            checkValidation(config, false, ['Symbol ("yyy") must be a single character.']);
+            checkValidation(config, ['Symbol ("yyy") must be a single character.']);
         });
 
         // Check Next symbol
         it('should detect next empty symbol', () => {
             const config = new StatusConfiguration('X', 'Completed', '', false);
-            checkValidation(config, false, ['Next symbol cannot be empty.']);
+            checkValidation(config, ['Next symbol cannot be empty.']);
         });
 
         it('should detect too-long next symbol', () => {
             const config = new StatusConfiguration('X', 'Completed', 'yyy', false);
-            checkValidation(config, false, ['Next symbol ("yyy") must be a single character.']);
+            checkValidation(config, ['Next symbol ("yyy") must be a single character.']);
         });
 
         describe('validate indicator', () => {

--- a/tests/Status.test.ts
+++ b/tests/Status.test.ts
@@ -24,6 +24,15 @@ describe('StatusConfiguration', () => {
             checkValidation(config, true, []);
         });
 
+        it('should handle totally invalid input correctly', () => {
+            const config = new StatusConfiguration('Xxx', '', '', false);
+            checkValidation(config, false, [
+                'Symbol ("Xxx") must be a single character.',
+                'Name cannot be empty.',
+                'Next symbol cannot be empty.',
+            ]);
+        });
+
         // Check status name
         it('should detect empty name', () => {
             const config = new StatusConfiguration('X', '', ' ', false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Essential fix for first release of custom statuses feature.

Fixes problem that if the status symbol was invalid, the modal removed the status symbol text field.
I was unable to prevent this, so now, colouring is used to indicate if there is an error.

Summary of changes:

- `StatusConfiguration` class now provides methods for validating individual fields and the whole object
- `CustomStatusModal` now:
    - uses the above validating code to highlight any incorrect values in red as the user edits the status
    - and when user clicks the checkbox, any errors are displayed in a notice.

Thanks to @Fevol for help with the red colours to show errors.

## Motivation and Context

Fixes #1498

## How has this been tested?

- Unit tests added for the actual validation messages for the status
- Extensive manual testing of the behaviour of the edit dialog

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4840096/212378235-dc3f1093-0bac-4600-b2fb-23bec7ca7d5a.png)

![image](https://user-images.githubusercontent.com/4840096/212378267-cd06e563-744e-4826-a7e9-4a81105a4901.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
