### PR TITLE
fix: Improve wording & fix styling in status settings

### DIFF
--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -462,6 +462,7 @@ function createRowForTaskStatus(
     //const taskStatusDiv = containerEl.createEl('div');
 
     const taskStatusPreview = containerEl.createEl('pre');
+    taskStatusPreview.addClass('row-for-status');
     taskStatusPreview.textContent = StatusSettingsHelpers.statusPreviewText(statusType);
 
     const setting = new Setting(containerEl);

--- a/src/Config/settingsConfiguration.json
+++ b/src/Config/settingsConfiguration.json
@@ -5,7 +5,7 @@
     "class": "",
     "open": true,
     "notice": {
-      "class": "",
+      "class": "setting-item-description",
       "text": "These are the core status types that Tasks supports. They are not yet editable. You can add custom statuses in the section below.",
       "html": null
     },
@@ -28,9 +28,9 @@
     "class": "",
     "open": true,
     "notice": {
-      "class": "",
-      "text": "If you want to have the tasks support additional statuses outside of the default ones add them here with the status symbol. ",
-      "html": null
+      "class": "setting-item-description",
+      "text": null,
+      "html": "If you want to have the tasks support additional statuses outside of the default ones add them here with the status symbol.<br><b>Note</b>: Any statuses with the same symbol as any earlier statuses will be ignored.<br>You can confirm the actually loaded statuses by running the 'Create or edit task' command and looking at the Status drop-down."
     },
     "settings": [
       {

--- a/styles.css
+++ b/styles.css
@@ -282,3 +282,8 @@
     border-top: 0px;
     border-bottom: 1px solid var(--background-modifier-border);
 }
+
+.tasks-settings .row-for-status {
+    margin-top: 0px;
+    margin-bottom: 0px;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Improve wording & fix styling in status settings

- Descriptions of 2 status sections - see red arrows in image below
    - Explain how duplicate symbols are (not) handled
    - Improve the styling of these two descriptions
- Remove excessive vertical height in the row for each status
    - See the blue arrows in the image below.

## Motivation and Context

To get it to the stage where I would be comfortable to release it.

## How has this been tested?

By running the plugin locally.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4840096/212394534-205f5d2f-f540-4168-a358-90ab775a2252.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
