### PR TITLE
fix: 'sort by status.type' now puts most actionable tasks first

### DIFF
--- a/docs/queries/sorting.md
+++ b/docs/queries/sorting.md
@@ -59,10 +59,11 @@ You can sort tasks by the following properties.
 ### Task statuses
 
 1. `status` (done or todo)
-1. `status.name` (Done, Todo, Cancelled, In Progress, Unknown etc - sorted alphabetically)
+1. `status.name` (Done, Todo, Cancelled, In Progress, Unknown, My very important custom status, etc - sorted alphabetically)
+1. `status.type` (Sorted in the order `IN_PROGRESS`, `TODO`, `DONE`, `CANCELLED` then `NON_TASK`)
 
 {: .released }
-`sort by status.name` was introduced in Tasks X.Y.Z.
+`sort by status.name` and `sort by status.type` were introduced in Tasks X.Y.Z.
 
 For more information, including adding your own customised statuses, see [Statuses]({{ site.baseurl }}{% link getting-started/statuses.md %}).
 

--- a/src/Query/Filter/StatusTypeField.ts
+++ b/src/Query/Filter/StatusTypeField.ts
@@ -91,7 +91,9 @@ export class StatusTypeField extends Field {
 
     comparator(): Comparator {
         return (a: Task, b: Task) => {
-            return this.value(a).localeCompare(this.value(b), undefined, { numeric: true });
+            const keyA = StatusTypeField.groupName(a);
+            const keyB = StatusTypeField.groupName(b);
+            return keyA.localeCompare(keyB, undefined, { numeric: true });
         };
     }
 
@@ -105,29 +107,33 @@ export class StatusTypeField extends Field {
 
     public grouper(): GrouperFunction {
         return (task: Task) => {
-            let prefix: string;
-            // Add a numeric prefix to sort in to a meaningful order for users
-            switch (task.status.type) {
-                case StatusType.IN_PROGRESS:
-                    prefix = '1';
-                    break;
-                case StatusType.TODO:
-                    prefix = '2';
-                    break;
-                case StatusType.DONE:
-                    prefix = '3';
-                    break;
-                case StatusType.CANCELLED:
-                    prefix = '4';
-                    break;
-                case StatusType.NON_TASK:
-                    prefix = '5';
-                    break;
-                case StatusType.EMPTY:
-                    prefix = '6';
-                    break;
-            }
-            return [prefix + ' ' + task.status.type];
+            return [StatusTypeField.groupName(task)];
         };
+    }
+
+    private static groupName(task: Task) {
+        let prefix: string;
+        // Add a numeric prefix to sort in to a meaningful order for users
+        switch (task.status.type) {
+            case StatusType.IN_PROGRESS:
+                prefix = '1';
+                break;
+            case StatusType.TODO:
+                prefix = '2';
+                break;
+            case StatusType.DONE:
+                prefix = '3';
+                break;
+            case StatusType.CANCELLED:
+                prefix = '4';
+                break;
+            case StatusType.NON_TASK:
+                prefix = '5';
+                break;
+            case StatusType.EMPTY:
+                prefix = '6';
+                break;
+        }
+        return prefix + ' ' + task.status.type;
     }
 }

--- a/tests/Query/Filter/StatusTypeField.test.ts
+++ b/tests/Query/Filter/StatusTypeField.test.ts
@@ -18,13 +18,16 @@ expect.extend({
 });
 
 // Abbreviated names so that the markdown text is aligned
-const todoTask = TestHelpers.fromLine({ line: '- [ ] Xxx' });
-const inprTask = TestHelpers.fromLine({ line: '- [/] Xxx' });
-const doneTask = TestHelpers.fromLine({ line: '- [x] Xxx' });
-const cancTask = TestHelpers.fromLine({ line: '- [-] Xxx' });
-const unknTask = TestHelpers.fromLine({ line: '- [%] Xxx' });
-const non_Task = new TaskBuilder().statusValues('^', 'non-task', 'x', false, StatusType.NON_TASK).build();
-const emptTask = new TaskBuilder().status(Status.makeEmpty()).build();
+const todoTask = TestHelpers.fromLine({ line: '- [ ] Todo' });
+const inprTask = TestHelpers.fromLine({ line: '- [/] In progress' });
+const doneTask = TestHelpers.fromLine({ line: '- [x] Done' });
+const cancTask = TestHelpers.fromLine({ line: '- [-] Cancelled' });
+const unknTask = TestHelpers.fromLine({ line: '- [%] Unknown' });
+const non_Task = new TaskBuilder()
+    .statusValues('^', 'non-task', 'x', false, StatusType.NON_TASK)
+    .description('Non-task')
+    .build();
+const emptTask = new TaskBuilder().status(Status.makeEmpty()).description('Empty task').build();
 
 describe('status.name', () => {
     it('value', () => {
@@ -115,15 +118,15 @@ describe('sorting by status.name', () => {
         expectTaskComparesEqual(sorter, cancTask, cancTask);
         expectTaskComparesEqual(sorter, todoTask, unknTask); // Unknown treated as TODO
 
-        // Alphabetical order by status name
-        expectTaskComparesBefore(sorter, cancTask, doneTask);
-        expectTaskComparesBefore(sorter, doneTask, inprTask);
-        expectTaskComparesBefore(sorter, inprTask, non_Task);
-        expectTaskComparesBefore(sorter, non_Task, todoTask);
+        // Most actionable type first..
+        expectTaskComparesBefore(sorter, inprTask, todoTask);
+        expectTaskComparesBefore(sorter, todoTask, doneTask);
+        expectTaskComparesBefore(sorter, doneTask, cancTask);
+        expectTaskComparesBefore(sorter, cancTask, non_Task);
 
         // Users won't see empty tasks, but test them anyway
         expectTaskComparesBefore(sorter, doneTask, emptTask);
-        expectTaskComparesBefore(sorter, emptTask, inprTask);
+        expectTaskComparesAfter(sorter, emptTask, inprTask);
     });
 
     it('sort by status.name reverse', () => {
@@ -134,15 +137,15 @@ describe('sorting by status.name', () => {
         expectTaskComparesEqual(sorter, cancTask, cancTask);
         expectTaskComparesEqual(sorter, todoTask, unknTask); // Unknown treated as TODO
 
-        // Reverse of Alphabetical order by status name
-        expectTaskComparesAfter(sorter, cancTask, doneTask);
-        expectTaskComparesAfter(sorter, doneTask, inprTask);
-        expectTaskComparesAfter(sorter, inprTask, non_Task);
-        expectTaskComparesAfter(sorter, non_Task, todoTask);
+        // Reverse of  order by status name
+        expectTaskComparesAfter(sorter, inprTask, todoTask);
+        expectTaskComparesAfter(sorter, todoTask, doneTask);
+        expectTaskComparesAfter(sorter, doneTask, cancTask);
+        expectTaskComparesAfter(sorter, cancTask, non_Task);
 
         // Users won't see empty tasks, but test them anyway
         expectTaskComparesAfter(sorter, doneTask, emptTask);
-        expectTaskComparesAfter(sorter, emptTask, inprTask);
+        expectTaskComparesBefore(sorter, emptTask, inprTask);
     });
 });
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Description

`sort by status.type` now puts most actionable tasks first.
It now sorts in the same order that `group by status.type` sorts in.

## Motivation and Context

It's more useful this way.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Automated tests
- Manual testing

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
