### PR TITLE
fix: Remove verbose console debug output

### DIFF
--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -144,15 +144,5 @@ export class StatusSettings {
         statusSettings.customStatusTypes.forEach((statusType) => {
             statusRegistry.add(statusType);
         });
-
-        console.debug('Custom statuses read from settings:');
-        console.debug(statusSettings.customStatusTypes);
-
-        console.debug('All statuses registered in Tasks StatusRegistry (including the core ones):');
-        const registeredStatusTypes: StatusConfiguration[] = [];
-        statusRegistry.registeredStatuses.forEach((s) => {
-            registeredStatusTypes.push(s.configuration);
-        });
-        console.debug(registeredStatusTypes);
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Description

Remove verbose debug output from StatusSettings.applyToStatusRegistry()

## Motivation and Context

It's no longer needed, and clutter for users.

## How has this been tested?

Now warnings in WebStorm.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
