### PR TITLE
refactor: Rename indicator to symbol throughout

### DIFF
--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -64,7 +64,7 @@ export const taskFromLine = ({ line, path }: { line: string; path: string }): Ta
     const indentation: string = nonTaskMatch[1];
     const listMarker = nonTaskMatch[2] ?? '-';
     const statusString: string = nonTaskMatch[4] ?? ' ';
-    const status = StatusRegistry.getInstance().byIndicatorOrCreate(statusString);
+    const status = StatusRegistry.getInstance().bySymbolOrCreate(statusString);
 
     let description: string = nonTaskMatch[5];
 

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -78,7 +78,7 @@ export const toggleLine = (line: string, path: string) => {
         if (regexMatch !== null) {
             // Toggle the status of the checklist item.
             const statusString = regexMatch[3];
-            const status = StatusRegistry.getInstance().byIndicator(statusString);
+            const status = StatusRegistry.getInstance().bySymbol(statusString);
             const newStatusString = status.nextStatusSymbol;
             toggledLine = line.replace(TaskRegularExpressions.taskRegex, `$1- [${newStatusString}] $4`);
         } else if (TaskRegularExpressions.listItemRegex.test(line)) {

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -79,7 +79,7 @@ export const toggleLine = (line: string, path: string) => {
             // Toggle the status of the checklist item.
             const statusString = regexMatch[3];
             const status = StatusRegistry.getInstance().byIndicator(statusString);
-            const newStatusString = status.nextStatusIndicator;
+            const newStatusString = status.nextStatusSymbol;
             toggledLine = line.replace(TaskRegularExpressions.taskRegex, `$1- [${newStatusString}] $4`);
         } else if (TaskRegularExpressions.listItemRegex.test(line)) {
             // Convert the list item to a checklist item.

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -53,12 +53,12 @@ export class CustomStatusModal extends Modal {
                 statusSymbolText = text;
                 text.setValue(this.statusSymbol).onChange((v) => {
                     this.statusSymbol = v;
-                    CustomStatusModal.setValid(text, validator.validateIndicator(this.statusConfiguration()));
+                    CustomStatusModal.setValid(text, validator.validateSymbol(this.statusConfiguration()));
                 });
             })
             .then((_setting) => {
                 // Show any error if the initial value loaded is incorrect.
-                CustomStatusModal.setValid(statusSymbolText, validator.validateIndicator(this.statusConfiguration()));
+                CustomStatusModal.setValid(statusSymbolText, validator.validateSymbol(this.statusConfiguration()));
             });
 
         let statusNameText: TextComponent;
@@ -84,13 +84,13 @@ export class CustomStatusModal extends Modal {
                 statusNextSymbolText = text;
                 text.setValue(this.statusNextSymbol).onChange((v) => {
                     this.statusNextSymbol = v;
-                    CustomStatusModal.setValid(text, validator.validateNextIndicator(this.statusConfiguration()));
+                    CustomStatusModal.setValid(text, validator.validateNextSynbol(this.statusConfiguration()));
                 });
             })
             .then((_setting) => {
                 CustomStatusModal.setValid(
                     statusNextSymbolText,
-                    validator.validateNextIndicator(this.statusConfiguration()),
+                    validator.validateNextSynbol(this.statusConfiguration()),
                 );
             });
 

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -84,13 +84,13 @@ export class CustomStatusModal extends Modal {
                 statusNextSymbolText = text;
                 text.setValue(this.statusNextSymbol).onChange((v) => {
                     this.statusNextSymbol = v;
-                    CustomStatusModal.setValid(text, validator.validateNextSynbol(this.statusConfiguration()));
+                    CustomStatusModal.setValid(text, validator.validateNextSymbol(this.statusConfiguration()));
                 });
             })
             .then((_setting) => {
                 CustomStatusModal.setValid(
                     statusNextSymbolText,
-                    validator.validateNextSynbol(this.statusConfiguration()),
+                    validator.validateNextSymbol(this.statusConfiguration()),
                 );
             });
 

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -17,7 +17,7 @@ export class CustomStatusModal extends Modal {
     error: boolean = false;
     constructor(public plugin: TasksPlugin, statusType: StatusConfiguration) {
         super(plugin.app);
-        this.statusSymbol = statusType.indicator;
+        this.statusSymbol = statusType.symbol;
         this.statusName = statusType.name;
         this.statusNextSymbol = statusType.nextStatusIndicator;
         this.statusAvailableAsCommand = statusType.availableAsCommand;

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -19,7 +19,7 @@ export class CustomStatusModal extends Modal {
         super(plugin.app);
         this.statusSymbol = statusType.symbol;
         this.statusName = statusType.name;
-        this.statusNextSymbol = statusType.nextStatusIndicator;
+        this.statusNextSymbol = statusType.nextStatusSymbol;
         this.statusAvailableAsCommand = statusType.availableAsCommand;
         this.type = statusType.type;
     }

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -83,7 +83,7 @@ export const getSettings = (): Settings => {
     // TODO Special case for indicator 'X' or 'x' (just in case)
     settings.statusSettings.customStatusTypes = settings.statusSettings.customStatusTypes.map((s) => {
         const newType = Status.getTypeFromStatusTypeString(s.type);
-        return new StatusConfiguration(s.symbol, s.name, s.nextStatusIndicator, s.availableAsCommand, newType);
+        return new StatusConfiguration(s.symbol, s.name, s.nextStatusSymbol, s.availableAsCommand, newType);
     });
 
     return { ...settings };

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -80,7 +80,7 @@ export const getSettings = (): Settings => {
     }
 
     // In case saves pre-dated StatusConfiguration.type
-    // TODO Special case for indicator 'X' or 'x' (just in case)
+    // TODO Special case for symbol 'X' or 'x' (just in case)
     settings.statusSettings.customStatusTypes = settings.statusSettings.customStatusTypes.map((s) => {
         const newType = Status.getTypeFromStatusTypeString(s.type);
         return new StatusConfiguration(s.symbol, s.name, s.nextStatusSymbol, s.availableAsCommand, newType);

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -83,7 +83,7 @@ export const getSettings = (): Settings => {
     // TODO Special case for indicator 'X' or 'x' (just in case)
     settings.statusSettings.customStatusTypes = settings.statusSettings.customStatusTypes.map((s) => {
         const newType = Status.getTypeFromStatusTypeString(s.type);
-        return new StatusConfiguration(s.indicator, s.name, s.nextStatusIndicator, s.availableAsCommand, newType);
+        return new StatusConfiguration(s.symbol, s.name, s.nextStatusIndicator, s.availableAsCommand, newType);
     });
 
     return { ...settings };

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -83,7 +83,13 @@ export const getSettings = (): Settings => {
     // TODO Special case for symbol 'X' or 'x' (just in case)
     settings.statusSettings.customStatusTypes = settings.statusSettings.customStatusTypes.map((s) => {
         const newType = Status.getTypeFromStatusTypeString(s.type);
-        return new StatusConfiguration(s.symbol, s.name, s.nextStatusSymbol, s.availableAsCommand, newType);
+        return new StatusConfiguration(
+            s.symbol ?? ' ',
+            s.name,
+            s.nextStatusSymbol ?? 'x',
+            s.availableAsCommand,
+            newType,
+        );
     });
 
     return { ...settings };

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -119,7 +119,7 @@ export class StatusSettings {
         supportedStatuses.forEach((importedStatus) => {
             const hasStatus = statusSettings.customStatusTypes.find((element) => {
                 return (
-                    element.indicator == importedStatus[0] &&
+                    element.symbol == importedStatus[0] &&
                     element.name == importedStatus[1] &&
                     element.nextStatusIndicator == importedStatus[2]
                 );

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -121,7 +121,7 @@ export class StatusSettings {
                 return (
                     element.symbol == importedStatus[0] &&
                     element.name == importedStatus[1] &&
-                    element.nextStatusIndicator == importedStatus[2]
+                    element.nextStatusSymbol == importedStatus[2]
                 );
             });
             if (!hasStatus) {

--- a/src/Query/Filter/StatusField.ts
+++ b/src/Query/Filter/StatusField.ts
@@ -55,7 +55,7 @@ export class StatusField extends FilterInstructionsBasedField {
     }
 
     private static oldStatusName(a: Task): string {
-        if (a.status.indicator === ' ') {
+        if (a.status.symbol === ' ') {
             return 'Todo';
         } else {
             return 'Done';

--- a/src/Query/Group.ts
+++ b/src/Query/Group.ts
@@ -194,7 +194,7 @@ export class Group {
         // Backwards-compatibility note: In Tasks 1.22.0 and earlier, the only
         // names used by 'group by status' were 'Todo' and 'Done' - and
         // any character other than a space was considered to be 'Done'.
-        if (task.status.indicator === ' ') {
+        if (task.status.symbol === ' ') {
             return ['Todo'];
         } else {
             return ['Done'];

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -51,7 +51,7 @@ export class Status {
     public readonly configuration: StatusConfiguration;
 
     /**
-     * The indicator used between the two square brackets in the markdown task.
+     * The symbol used between the two square brackets in the markdown task.
      *
      * @type {string}
      * @memberof Status
@@ -145,13 +145,13 @@ export class Status {
     }
 
     /**
-     * Return the StatusType to use for an indicator, if it is not in the StatusRegistry.
-     * The core indicators are recognised.
-     * Other indicators are treated as StatusType.TODO
-     * @param indicator
+     * Return the StatusType to use for a symbol, if it is not in the StatusRegistry.
+     * The core symbols are recognised.
+     * Other symbols are treated as StatusType.TODO
+     * @param symbol
      */
-    static getTypeForUnknownIndicator(indicator: string): StatusType {
-        switch (indicator) {
+    static getTypeForUnknownSymbol(symbol: string): StatusType {
+        switch (symbol) {
             case 'x':
             case 'X':
                 return StatusType.DONE;
@@ -177,27 +177,27 @@ export class Status {
     }
 
     /**
-     * Create a Status representing the given, unknown indicator.
+     * Create a Status representing the given, unknown symbol.
      *
-     * This can be useful when StatusRegistry does not recognise an indicator,
+     * This can be useful when StatusRegistry does not recognise a symbol,
      * and we do not want to expose the user's data to the Status.EMPTY status.
      *
      * The type is set to TODO.
-     * @param unknownIndicator
+     * @param unknownSymbol
      */
-    static createUnknownStatus(unknownIndicator: string) {
-        return new Status(new StatusConfiguration(unknownIndicator, 'Unknown', 'x', false, StatusType.TODO));
+    static createUnknownStatus(unknownSymbol: string) {
+        return new Status(new StatusConfiguration(unknownSymbol, 'Unknown', 'x', false, StatusType.TODO));
     }
 
     /**
      * Helper function for bulk-importing settings from arrays of strings.
      *
-     * @param imported An array of indicator, name, next indicator, status type
+     * @param imported An array of symbol, name, next symbol, status type
      */
     static createFromImportedValue(imported: StatusCollectionEntry) {
-        const indicator = imported[0];
+        const symbol = imported[0];
         const type = Status.getTypeFromStatusTypeString(imported[3]);
-        return new Status(new StatusConfiguration(indicator, imported[1], imported[2], false, type));
+        return new Status(new StatusConfiguration(symbol, imported[1], imported[2], false, type));
     }
 
     /**

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -76,8 +76,8 @@ export class Status {
      * @type {string}
      * @memberof Status
      */
-    public get nextStatusIndicator(): string {
-        return this.configuration.nextStatusIndicator;
+    public get nextStatusSymbol(): string {
+        return this.configuration.nextStatusSymbol;
     }
 
     /**
@@ -219,7 +219,7 @@ export class Status {
         if (Status.tasksPluginCanCreateCommandsForStatuses() && this.availableAsCommand) {
             commandNotice = 'Available as a command.';
         }
-        return `- [${this.symbol}] ${this.name}, next status is '${this.nextStatusIndicator}', type is '${this.configuration.type}'. ${commandNotice}`;
+        return `- [${this.symbol}] ${this.name}, next status is '${this.nextStatusSymbol}', type is '${this.configuration.type}'. ${commandNotice}`;
     }
 
     /**

--- a/src/Status.ts
+++ b/src/Status.ts
@@ -56,8 +56,8 @@ export class Status {
      * @type {string}
      * @memberof Status
      */
-    public get indicator(): string {
-        return this.configuration.indicator;
+    public get symbol(): string {
+        return this.configuration.symbol;
     }
 
     /**
@@ -219,7 +219,7 @@ export class Status {
         if (Status.tasksPluginCanCreateCommandsForStatuses() && this.availableAsCommand) {
             commandNotice = 'Available as a command.';
         }
-        return `- [${this.indicator}] ${this.name}, next status is '${this.nextStatusIndicator}', type is '${this.configuration.type}'. ${commandNotice}`;
+        return `- [${this.symbol}] ${this.name}, next status is '${this.nextStatusIndicator}', type is '${this.configuration.type}'. ${commandNotice}`;
     }
 
     /**

--- a/src/StatusCollection.ts
+++ b/src/StatusCollection.ts
@@ -1,6 +1,6 @@
 /**
  * The type used for a single entry in bulk imports of pre-created sets of statuses, such as for Themes or CSS Snippets.
- * The values are: indicator, name, next indicator, status type (must be one of the values in {@link StatusType}
+ * The values are: symbol, name, next symbol, status type (must be one of the values in {@link StatusType}
  */
 export type StatusCollectionEntry = [string, string, string, string];
 

--- a/src/StatusConfiguration.ts
+++ b/src/StatusConfiguration.ts
@@ -40,7 +40,7 @@ export class StatusConfiguration {
      * @type {string}
      * @memberof Status
      */
-    public readonly nextStatusIndicator: string;
+    public readonly nextStatusSymbol: string;
 
     /**
      * If true then it is registered as a command that the user can map to.
@@ -75,7 +75,7 @@ export class StatusConfiguration {
     ) {
         this.symbol = indicator;
         this.name = name;
-        this.nextStatusIndicator = nextStatusIndicator;
+        this.nextStatusSymbol = nextStatusIndicator;
         this.availableAsCommand = availableAsCommand;
         this.type = type;
     }

--- a/src/StatusConfiguration.ts
+++ b/src/StatusConfiguration.ts
@@ -59,23 +59,23 @@ export class StatusConfiguration {
      * Creates an instance of Status. The registry will be added later in the case
      * of the default statuses.
      *
-     * @param {string} indicator
+     * @param {string} symbol
      * @param {string} name
-     * @param {Status} nextStatusIndicator
+     * @param {Status} nextStatusSymbol
      * @param {boolean} availableAsCommand
      * @param {StatusType} type
      * @memberof Status
      */
     constructor(
-        indicator: string,
+        symbol: string,
         name: string,
-        nextStatusIndicator: string,
+        nextStatusSymbol: string,
         availableAsCommand: boolean,
         type: StatusType = StatusType.TODO, // TODO Remove default value
     ) {
-        this.symbol = indicator;
+        this.symbol = symbol;
         this.name = name;
-        this.nextStatusSymbol = nextStatusIndicator;
+        this.nextStatusSymbol = nextStatusSymbol;
         this.availableAsCommand = availableAsCommand;
         this.type = type;
     }

--- a/src/StatusConfiguration.ts
+++ b/src/StatusConfiguration.ts
@@ -19,12 +19,12 @@ export enum StatusType {
  */
 export class StatusConfiguration {
     /**
-     * The indicator used between the two square brackets in the markdown task.
+     * The character used between the two square brackets in the markdown task.
      *
      * @type {string}
      * @memberof Status
      */
-    public readonly indicator: string;
+    public readonly symbol: string;
 
     /**
      * Returns the name of the status for display purposes.
@@ -73,7 +73,7 @@ export class StatusConfiguration {
         availableAsCommand: boolean,
         type: StatusType = StatusType.TODO, // TODO Remove default value
     ) {
-        this.indicator = indicator;
+        this.symbol = indicator;
         this.name = name;
         this.nextStatusIndicator = nextStatusIndicator;
         this.availableAsCommand = availableAsCommand;

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -69,7 +69,7 @@ export class StatusRegistry {
      * @memberof StatusRegistry
      */
     public add(status: StatusConfiguration | Status): void {
-        if (!this.hasIndicator(status.symbol)) {
+        if (!this.hasSymbol(status.symbol)) {
             if (status instanceof Status) {
                 this._registeredStatuses.push(status);
             } else {
@@ -79,43 +79,43 @@ export class StatusRegistry {
     }
 
     /**
-     * Returns the registered status by the indicator between the
+     * Returns the registered status by the symbol between the
      * square braces in the markdown task.
-     * Returns an EMPTY status if indicator is unknown.
+     * Returns an EMPTY status if symbol is unknown.
      *
-     * @see byIndicatorOrCreate
+     * @see bySymbolOrCreate
      *
-     * @param {string} indicator
+     * @param {string} symbol
      * @return {*}  {Status}
      * @memberof StatusRegistry
      */
-    public byIndicator(indicator: string): Status {
-        if (this.hasIndicator(indicator)) {
-            return this.getIndicator(indicator);
+    public bySymbol(symbol: string): Status {
+        if (this.hasSymbol(symbol)) {
+            return this.getSymbol(symbol);
         }
 
         return Status.EMPTY;
     }
 
     /**
-     * Returns the registered status by the indicator between the
+     * Returns the registered status by the symbol between the
      * square braces in the markdown task.
      *
-     * Creates a usable new Status with this given indicator if indicator is unknown.
-     * Note: An unknown indicator is not added to the registry.
+     * Creates a usable new Status with this given symbol if symbol is unknown.
+     * Note: An unknown symbol is not added to the registry.
      *
-     * @see hasIndicator
+     * @see hasSymbol
      *
-     * @param {string} indicator
+     * @param {string} symbol
      * @return {*}  {Status}
      * @memberof StatusRegistry
      */
-    public byIndicatorOrCreate(indicator: string): Status {
-        if (this.hasIndicator(indicator)) {
-            return this.getIndicator(indicator);
+    public bySymbolOrCreate(symbol: string): Status {
+        if (this.hasSymbol(symbol)) {
+            return this.getSymbol(symbol);
         }
 
-        return Status.createUnknownStatus(indicator);
+        return Status.createUnknownStatus(symbol);
     }
 
     /**
@@ -153,7 +153,7 @@ export class StatusRegistry {
      */
     public getNextStatus(status: Status): Status {
         if (status.nextStatusSymbol !== '') {
-            const nextStatus = this.byIndicator(status.nextStatusSymbol);
+            const nextStatus = this.bySymbol(status.nextStatusSymbol);
             if (nextStatus !== null) {
                 return nextStatus;
             }
@@ -194,7 +194,7 @@ export class StatusRegistry {
         });
 
         const unknownStatuses = allStatuses.filter((s) => {
-            return !this.hasIndicator(s.symbol);
+            return !this.hasSymbol(s.symbol);
         });
 
         // Use a separate StatusRegistry to keep track of duplicates,
@@ -204,13 +204,13 @@ export class StatusRegistry {
 
         const namedUniqueStatuses: Status[] = [];
         unknownStatuses.forEach((s) => {
-            // Check if we have seen this indicator already:
-            if (newStatusRegistry.hasIndicator(s.symbol)) {
+            // Check if we have seen this symbol already:
+            if (newStatusRegistry.hasSymbol(s.symbol)) {
                 return;
             }
 
             // Go ahead and create a suitably-named copy,
-            // including the indicator in the name.
+            // including the symbol in the name.
             const newStatus = StatusRegistry.copyStatusWithNewName(s, `Unknown (${s.symbol})`);
             namedUniqueStatuses.push(newStatus);
             // And add it to our local registry, to prevent duplicates.
@@ -231,29 +231,29 @@ export class StatusRegistry {
     }
 
     /**
-     * Filters the Status types by the indicator and returns the first one found.
+     * Filters the Status types by the symbol and returns the first one found.
      *
      * @private
-     * @param {string} indicatorToFind
+     * @param {string} symbolToFind
      * @return {*}  {Status}
      * @memberof StatusRegistry
      */
-    private getIndicator(indicatorToFind: string): Status {
-        return this._registeredStatuses.filter(({ symbol }) => symbol === indicatorToFind)[0];
+    private getSymbol(symbolToFind: string): Status {
+        return this._registeredStatuses.filter(({ symbol }) => symbol === symbolToFind)[0];
     }
 
     /**
-     * Filters all the Status types by the indicator and returns true if found.
+     * Filters all the Status types by the symbol and returns true if found.
      *
      * @private
-     * @param {string} indicatorToFind
+     * @param {string} symbolToFind
      * @return {*}  {boolean}
      * @memberof StatusRegistry
      */
-    private hasIndicator(indicatorToFind: string): boolean {
+    private hasSymbol(symbolToFind: string): boolean {
         return (
             this._registeredStatuses.find((element) => {
-                return element.symbol === indicatorToFind;
+                return element.symbol === symbolToFind;
             }) !== undefined
         );
     }

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -152,8 +152,8 @@ export class StatusRegistry {
      * @see getNextStatusOrCreate
      */
     public getNextStatus(status: Status): Status {
-        if (status.nextStatusIndicator !== '') {
-            const nextStatus = this.byIndicator(status.nextStatusIndicator);
+        if (status.nextStatusSymbol !== '') {
+            const nextStatus = this.byIndicator(status.nextStatusSymbol);
             if (nextStatus !== null) {
                 return nextStatus;
             }
@@ -176,7 +176,7 @@ export class StatusRegistry {
         }
         // status is configured to advance to a symbol that is not registered.
         // So we go ahead and create it anyway - we just cannot give it a meaningful name.
-        return Status.createUnknownStatus(status.nextStatusIndicator);
+        return Status.createUnknownStatus(status.nextStatusSymbol);
     }
 
     /**
@@ -223,7 +223,7 @@ export class StatusRegistry {
         const statusConfiguration = new StatusConfiguration(
             s.symbol,
             newName,
-            s.nextStatusIndicator,
+            s.nextStatusSymbol,
             s.availableAsCommand,
             s.type,
         );

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -44,7 +44,7 @@ export class StatusRegistry {
      * @memberof StatusRegistry
      */
     public get registeredStatuses(): Status[] {
-        return this._registeredStatuses.filter(({ indicator }) => indicator !== Status.EMPTY.indicator);
+        return this._registeredStatuses.filter(({ symbol }) => symbol !== Status.EMPTY.symbol);
     }
 
     /**
@@ -69,7 +69,7 @@ export class StatusRegistry {
      * @memberof StatusRegistry
      */
     public add(status: StatusConfiguration | Status): void {
-        if (!this.hasIndicator(status.indicator)) {
+        if (!this.hasIndicator(status.symbol)) {
             if (status instanceof Status) {
                 this._registeredStatuses.push(status);
             } else {
@@ -194,7 +194,7 @@ export class StatusRegistry {
         });
 
         const unknownStatuses = allStatuses.filter((s) => {
-            return !this.hasIndicator(s.indicator);
+            return !this.hasIndicator(s.symbol);
         });
 
         // Use a separate StatusRegistry to keep track of duplicates,
@@ -205,13 +205,13 @@ export class StatusRegistry {
         const namedUniqueStatuses: Status[] = [];
         unknownStatuses.forEach((s) => {
             // Check if we have seen this indicator already:
-            if (newStatusRegistry.hasIndicator(s.indicator)) {
+            if (newStatusRegistry.hasIndicator(s.symbol)) {
                 return;
             }
 
             // Go ahead and create a suitably-named copy,
             // including the indicator in the name.
-            const newStatus = StatusRegistry.copyStatusWithNewName(s, `Unknown (${s.indicator})`);
+            const newStatus = StatusRegistry.copyStatusWithNewName(s, `Unknown (${s.symbol})`);
             namedUniqueStatuses.push(newStatus);
             // And add it to our local registry, to prevent duplicates.
             newStatusRegistry.add(newStatus);
@@ -221,7 +221,7 @@ export class StatusRegistry {
 
     private static copyStatusWithNewName(s: Status, newName: string) {
         const statusConfiguration = new StatusConfiguration(
-            s.indicator,
+            s.symbol,
             newName,
             s.nextStatusIndicator,
             s.availableAsCommand,
@@ -239,7 +239,7 @@ export class StatusRegistry {
      * @memberof StatusRegistry
      */
     private getIndicator(indicatorToFind: string): Status {
-        return this._registeredStatuses.filter(({ indicator }) => indicator === indicatorToFind)[0];
+        return this._registeredStatuses.filter(({ symbol }) => symbol === indicatorToFind)[0];
     }
 
     /**
@@ -253,7 +253,7 @@ export class StatusRegistry {
     private hasIndicator(indicatorToFind: string): boolean {
         return (
             this._registeredStatuses.find((element) => {
-                return element.indicator === indicatorToFind;
+                return element.symbol === indicatorToFind;
             }) !== undefined
         );
     }

--- a/src/StatusValidator.ts
+++ b/src/StatusValidator.ts
@@ -20,7 +20,7 @@ export class StatusValidator {
     }
 
     public validateNextIndicator(statusConfiguration: StatusConfiguration): string[] {
-        return StatusValidator.validateOneIndicator(statusConfiguration.nextStatusIndicator, 'Task Next Status Symbol');
+        return StatusValidator.validateOneIndicator(statusConfiguration.nextStatusSymbol, 'Task Next Status Symbol');
     }
 
     public validateName(statusConfiguration: StatusConfiguration) {

--- a/src/StatusValidator.ts
+++ b/src/StatusValidator.ts
@@ -10,17 +10,17 @@ export class StatusValidator {
         // Messages are added in the order fields are shown when editing statuses.
         errors.push(...this.validateSymbol(statusConfiguration));
         errors.push(...this.validateName(statusConfiguration));
-        errors.push(...this.validateNextSynbol(statusConfiguration));
+        errors.push(...this.validateNextSymbol(statusConfiguration));
 
         return errors;
     }
 
     public validateSymbol(statusConfiguration: StatusConfiguration): string[] {
-        return StatusValidator.validateOneSynbol(statusConfiguration.symbol, 'Task Status Symbol');
+        return StatusValidator.validateOneSymbol(statusConfiguration.symbol, 'Task Status Symbol');
     }
 
-    public validateNextSynbol(statusConfiguration: StatusConfiguration): string[] {
-        return StatusValidator.validateOneSynbol(statusConfiguration.nextStatusSymbol, 'Task Next Status Symbol');
+    public validateNextSymbol(statusConfiguration: StatusConfiguration): string[] {
+        return StatusValidator.validateOneSymbol(statusConfiguration.nextStatusSymbol, 'Task Next Status Symbol');
     }
 
     public validateName(statusConfiguration: StatusConfiguration) {
@@ -31,7 +31,7 @@ export class StatusValidator {
         return errors;
     }
 
-    private static validateOneSynbol(symbol: string, symbolName: string): string[] {
+    private static validateOneSymbol(symbol: string, symbolName: string): string[] {
         const errors: string[] = [];
         if (symbol.length === 0) {
             errors.push(`${symbolName} cannot be empty.`);

--- a/src/StatusValidator.ts
+++ b/src/StatusValidator.ts
@@ -8,19 +8,19 @@ export class StatusValidator {
         const errors: string[] = [];
 
         // Messages are added in the order fields are shown when editing statuses.
-        errors.push(...this.validateIndicator(statusConfiguration));
+        errors.push(...this.validateSymbol(statusConfiguration));
         errors.push(...this.validateName(statusConfiguration));
-        errors.push(...this.validateNextIndicator(statusConfiguration));
+        errors.push(...this.validateNextSynbol(statusConfiguration));
 
         return errors;
     }
 
-    public validateIndicator(statusConfiguration: StatusConfiguration): string[] {
-        return StatusValidator.validateOneIndicator(statusConfiguration.symbol, 'Task Status Symbol');
+    public validateSymbol(statusConfiguration: StatusConfiguration): string[] {
+        return StatusValidator.validateOneSynbol(statusConfiguration.symbol, 'Task Status Symbol');
     }
 
-    public validateNextIndicator(statusConfiguration: StatusConfiguration): string[] {
-        return StatusValidator.validateOneIndicator(statusConfiguration.nextStatusSymbol, 'Task Next Status Symbol');
+    public validateNextSynbol(statusConfiguration: StatusConfiguration): string[] {
+        return StatusValidator.validateOneSynbol(statusConfiguration.nextStatusSymbol, 'Task Next Status Symbol');
     }
 
     public validateName(statusConfiguration: StatusConfiguration) {
@@ -31,14 +31,14 @@ export class StatusValidator {
         return errors;
     }
 
-    private static validateOneIndicator(indicator: string, indicatorName: string): string[] {
+    private static validateOneSynbol(symbol: string, symbolName: string): string[] {
         const errors: string[] = [];
-        if (indicator.length === 0) {
-            errors.push(`${indicatorName} cannot be empty.`);
+        if (symbol.length === 0) {
+            errors.push(`${symbolName} cannot be empty.`);
         }
 
-        if (indicator.length > 1) {
-            errors.push(`${indicatorName} ("${indicator}") must be a single character.`);
+        if (symbol.length > 1) {
+            errors.push(`${symbolName} ("${symbol}") must be a single character.`);
         }
         return errors;
     }

--- a/src/StatusValidator.ts
+++ b/src/StatusValidator.ts
@@ -16,7 +16,7 @@ export class StatusValidator {
     }
 
     public validateIndicator(statusConfiguration: StatusConfiguration): string[] {
-        return StatusValidator.validateOneIndicator(statusConfiguration.indicator, 'Task Status Symbol');
+        return StatusValidator.validateOneIndicator(statusConfiguration.symbol, 'Task Status Symbol');
     }
 
     public validateNextIndicator(statusConfiguration: StatusConfiguration): string[] {

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -502,7 +502,7 @@ export class Task {
      * @memberof Task
      */
     public toFileLineString(): string {
-        return `${this.indentation}${this.listMarker} [${this.status.indicator}] ${this.toString()}`;
+        return `${this.indentation}${this.listMarker} [${this.status.symbol}] ${this.toString()}`;
     }
 
     /**

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -264,7 +264,7 @@ export class Task {
 
         // Get the status of the task.
         const statusString = regexMatch[3];
-        const status = StatusRegistry.getInstance().byIndicatorOrCreate(statusString);
+        const status = StatusRegistry.getInstance().bySymbolOrCreate(statusString);
 
         // Match for block link and remove if found. Always expected to be
         // at the end of the line.

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -59,7 +59,7 @@ export async function renderTaskLine(
     li.appendChild(checkbox);
     checkbox.classList.add('task-list-item-checkbox');
     checkbox.type = 'checkbox';
-    if (task.status.indicator !== ' ') {
+    if (task.status.symbol !== ' ') {
         checkbox.checked = true;
         li.classList.add('is-checked');
     }
@@ -82,7 +82,7 @@ export async function renderTaskLine(
     li.prepend(checkbox);
 
     // Set these to be compatible with stock obsidian lists:
-    li.setAttribute('data-task', task.status.indicator.trim()); // Trim to ensure empty attribute for space. Same way as obsidian.
+    li.setAttribute('data-task', task.status.symbol.trim()); // Trim to ensure empty attribute for space. Same way as obsidian.
     li.setAttribute('data-line', renderDetails.listIndex.toString());
     checkbox.setAttribute('data-line', renderDetails.listIndex.toString());
 

--- a/src/TaskModal.ts
+++ b/src/TaskModal.ts
@@ -38,7 +38,7 @@ export class TaskModal extends Modal {
      */
     private getKnownStatusesAndCurrentTaskStatusIfNotKnown() {
         const statusOptions: Status[] = StatusRegistry.getInstance().registeredStatuses;
-        if (StatusRegistry.getInstance().byIndicator(this.task.status.symbol) === Status.EMPTY) {
+        if (StatusRegistry.getInstance().bySymbol(this.task.status.symbol) === Status.EMPTY) {
             statusOptions.push(this.task.status);
         }
         return statusOptions;

--- a/src/TaskModal.ts
+++ b/src/TaskModal.ts
@@ -38,7 +38,7 @@ export class TaskModal extends Modal {
      */
     private getKnownStatusesAndCurrentTaskStatusIfNotKnown() {
         const statusOptions: Status[] = StatusRegistry.getInstance().registeredStatuses;
-        if (StatusRegistry.getInstance().byIndicator(this.task.status.indicator) === Status.EMPTY) {
+        if (StatusRegistry.getInstance().byIndicator(this.task.status.symbol) === Status.EMPTY) {
             statusOptions.push(this.task.status);
         }
         return statusOptions;

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -371,7 +371,7 @@
             <label for="status">Status </label>
             <select bind:value={editableTask.status} id="status-type" class="dropdown">
                 {#each statusOptions as status}
-                    <option value={status}>{status.name} [{status.indicator}]</option>
+                    <option value={status}>{status.name} [{status.symbol}]</option>
                 {/each}
             </select>
         </div>

--- a/tests/DocsSamplesForStatuses.test.ts
+++ b/tests/DocsSamplesForStatuses.test.ts
@@ -57,8 +57,8 @@ class MarkdownTable {
     }
 }
 
-function getPrintableIndicator(indicator: string) {
-    const result = indicator !== ' ' ? indicator : 'space';
+function getPrintableSymbol(symbol: string) {
+    const result = symbol !== ' ' ? symbol : 'space';
     return '`' + result + '`';
 }
 
@@ -72,9 +72,9 @@ function verifyStatusesAsMarkdownTable(statuses: Status[]) {
     ]);
 
     for (const status of statuses) {
-        const statusCharacter = getPrintableIndicator(status.symbol);
-        const nextStatusCharacter = getPrintableIndicator(status.nextStatusSymbol);
-        const type = getPrintableIndicator(status.type);
+        const statusCharacter = getPrintableSymbol(status.symbol);
+        const nextStatusCharacter = getPrintableSymbol(status.nextStatusSymbol);
+        const type = getPrintableSymbol(status.type);
         const needsCustomStyling = status.symbol !== ' ' && status.symbol !== 'x' ? 'Yes' : 'No';
         table.addRow([statusCharacter, status.name, nextStatusCharacter, type, needsCustomStyling]);
     }

--- a/tests/DocsSamplesForStatuses.test.ts
+++ b/tests/DocsSamplesForStatuses.test.ts
@@ -72,10 +72,10 @@ function verifyStatusesAsMarkdownTable(statuses: Status[]) {
     ]);
 
     for (const status of statuses) {
-        const statusCharacter = getPrintableIndicator(status.indicator);
+        const statusCharacter = getPrintableIndicator(status.symbol);
         const nextStatusCharacter = getPrintableIndicator(status.nextStatusIndicator);
         const type = getPrintableIndicator(status.type);
-        const needsCustomStyling = status.indicator !== ' ' && status.indicator !== 'x' ? 'Yes' : 'No';
+        const needsCustomStyling = status.symbol !== ' ' && status.symbol !== 'x' ? 'Yes' : 'No';
         table.addRow([statusCharacter, status.name, nextStatusCharacter, type, needsCustomStyling]);
     }
     table.verify();

--- a/tests/DocsSamplesForStatuses.test.ts
+++ b/tests/DocsSamplesForStatuses.test.ts
@@ -73,7 +73,7 @@ function verifyStatusesAsMarkdownTable(statuses: Status[]) {
 
     for (const status of statuses) {
         const statusCharacter = getPrintableIndicator(status.symbol);
-        const nextStatusCharacter = getPrintableIndicator(status.nextStatusIndicator);
+        const nextStatusCharacter = getPrintableIndicator(status.nextStatusSymbol);
         const type = getPrintableIndicator(status.type);
         const needsCustomStyling = status.symbol !== ' ' && status.symbol !== 'x' ? 'Yes' : 'No';
         table.addRow([statusCharacter, status.name, nextStatusCharacter, type, needsCustomStyling]);

--- a/tests/Status.test.ts
+++ b/tests/Status.test.ts
@@ -46,7 +46,7 @@ describe('Status', () => {
         expect(status).not.toBeNull();
         expect(status!.symbol).toEqual(indicator);
         expect(status!.name).toEqual(name);
-        expect(status!.nextStatusIndicator).toEqual(next);
+        expect(status!.nextStatusSymbol).toEqual(next);
         expect(status!.type).toEqual(StatusType.IN_PROGRESS);
         expect(status!.isCompleted()).toEqual(false);
     });
@@ -64,7 +64,7 @@ describe('Status', () => {
         expect(status).not.toBeNull();
         expect(status!.symbol).toEqual(indicator);
         expect(status!.name).toEqual(name);
-        expect(status!.nextStatusIndicator).toEqual(next);
+        expect(status!.nextStatusSymbol).toEqual(next);
         expect(status!.isCompleted()).toEqual(true);
     });
 
@@ -99,7 +99,7 @@ describe('Status', () => {
         expect(status).not.toBeNull();
         expect(status!.symbol).toEqual(indicator);
         expect(status!.name).toEqual('Unknown');
-        expect(status!.nextStatusIndicator).toEqual('x');
+        expect(status!.nextStatusSymbol).toEqual('x');
         // Even though the type *could* be deduced as IN_PROGRESS, createUnknownStatus() is used when
         // the user has not defined the meaning of a status indicator, so treat everything as TODO.
         expect(status!.type).toEqual(StatusType.TODO);
@@ -111,7 +111,7 @@ describe('Status', () => {
         const status = Status.createFromImportedValue(imported);
         expect(status.symbol).toEqual('/');
         expect(status.name).toEqual('in progress');
-        expect(status.nextStatusIndicator).toEqual('x');
+        expect(status.nextStatusSymbol).toEqual('x');
         expect(status.type).toEqual(StatusType.IN_PROGRESS); // should deduce IN_PROGRESS from indicator '/'
         expect(status.availableAsCommand).toEqual(false);
     });
@@ -121,7 +121,7 @@ describe('Status', () => {
         const status = Status.createFromImportedValue(imported);
         expect(status.symbol).toEqual('P');
         expect(status.name).toEqual('Pro');
-        expect(status.nextStatusIndicator).toEqual('C');
+        expect(status.nextStatusSymbol).toEqual('C');
         expect(status.type).toEqual(StatusType.NON_TASK);
         expect(status.availableAsCommand).toEqual(false);
     });

--- a/tests/Status.test.ts
+++ b/tests/Status.test.ts
@@ -35,47 +35,47 @@ describe('Status', () => {
 
     it('should initialize with valid properties', () => {
         // Arrange
-        const indicator = '/';
+        const symbol = '/';
         const name = 'In Progress';
         const next = 'x';
 
         // Act
-        const status = new Status(new StatusConfiguration(indicator, name, next, false, StatusType.IN_PROGRESS));
+        const status = new Status(new StatusConfiguration(symbol, name, next, false, StatusType.IN_PROGRESS));
 
         // Assert
         expect(status).not.toBeNull();
-        expect(status!.symbol).toEqual(indicator);
+        expect(status!.symbol).toEqual(symbol);
         expect(status!.name).toEqual(name);
         expect(status!.nextStatusSymbol).toEqual(next);
         expect(status!.type).toEqual(StatusType.IN_PROGRESS);
         expect(status!.isCompleted()).toEqual(false);
     });
 
-    it('should be complete when indicator is "x"', () => {
+    it('should be complete when symbol is "x"', () => {
         // Arrange
-        const indicator = 'x';
+        const symbol = 'x';
         const name = 'Done';
         const next = ' ';
 
         // Act
-        const status = new Status(new StatusConfiguration(indicator, name, next, false, StatusType.DONE));
+        const status = new Status(new StatusConfiguration(symbol, name, next, false, StatusType.DONE));
 
         // Assert
         expect(status).not.toBeNull();
-        expect(status!.symbol).toEqual(indicator);
+        expect(status!.symbol).toEqual(symbol);
         expect(status!.name).toEqual(name);
         expect(status!.nextStatusSymbol).toEqual(next);
         expect(status!.isCompleted()).toEqual(true);
     });
 
-    it('should deduce type for unknown indicators', () => {
-        expect(Status.getTypeForUnknownIndicator(' ')).toEqual(StatusType.TODO);
-        expect(Status.getTypeForUnknownIndicator('!')).toEqual(StatusType.TODO); // Unknown character treated as TODO
-        expect(Status.getTypeForUnknownIndicator('x')).toEqual(StatusType.DONE);
-        expect(Status.getTypeForUnknownIndicator('X')).toEqual(StatusType.DONE);
-        expect(Status.getTypeForUnknownIndicator('/')).toEqual(StatusType.IN_PROGRESS);
-        expect(Status.getTypeForUnknownIndicator('-')).toEqual(StatusType.CANCELLED);
-        expect(Status.getTypeForUnknownIndicator('')).toEqual(StatusType.EMPTY);
+    it('should deduce type for unknown symbols', () => {
+        expect(Status.getTypeForUnknownSymbol(' ')).toEqual(StatusType.TODO);
+        expect(Status.getTypeForUnknownSymbol('!')).toEqual(StatusType.TODO); // Unknown character treated as TODO
+        expect(Status.getTypeForUnknownSymbol('x')).toEqual(StatusType.DONE);
+        expect(Status.getTypeForUnknownSymbol('X')).toEqual(StatusType.DONE);
+        expect(Status.getTypeForUnknownSymbol('/')).toEqual(StatusType.IN_PROGRESS);
+        expect(Status.getTypeForUnknownSymbol('-')).toEqual(StatusType.CANCELLED);
+        expect(Status.getTypeForUnknownSymbol('')).toEqual(StatusType.EMPTY);
     });
 
     it('should deduce type from StatusType text', () => {
@@ -90,18 +90,18 @@ describe('Status', () => {
 
     it('should construct a Status for unknown symbol', () => {
         // Arrange
-        const indicator = '/';
+        const symbol = '/';
 
         // Act
-        const status = Status.createUnknownStatus(indicator);
+        const status = Status.createUnknownStatus(symbol);
 
         // Assert
         expect(status).not.toBeNull();
-        expect(status!.symbol).toEqual(indicator);
+        expect(status!.symbol).toEqual(symbol);
         expect(status!.name).toEqual('Unknown');
         expect(status!.nextStatusSymbol).toEqual('x');
         // Even though the type *could* be deduced as IN_PROGRESS, createUnknownStatus() is used when
-        // the user has not defined the meaning of a status indicator, so treat everything as TODO.
+        // the user has not defined the meaning of a status symbol, so treat everything as TODO.
         expect(status!.type).toEqual(StatusType.TODO);
         expect(status!.isCompleted()).toEqual(false);
     });
@@ -112,7 +112,7 @@ describe('Status', () => {
         expect(status.symbol).toEqual('/');
         expect(status.name).toEqual('in progress');
         expect(status.nextStatusSymbol).toEqual('x');
-        expect(status.type).toEqual(StatusType.IN_PROGRESS); // should deduce IN_PROGRESS from indicator '/'
+        expect(status.type).toEqual(StatusType.IN_PROGRESS); // should deduce IN_PROGRESS from symbol '/'
         expect(status.availableAsCommand).toEqual(false);
     });
 

--- a/tests/Status.test.ts
+++ b/tests/Status.test.ts
@@ -44,7 +44,7 @@ describe('Status', () => {
 
         // Assert
         expect(status).not.toBeNull();
-        expect(status!.indicator).toEqual(indicator);
+        expect(status!.symbol).toEqual(indicator);
         expect(status!.name).toEqual(name);
         expect(status!.nextStatusIndicator).toEqual(next);
         expect(status!.type).toEqual(StatusType.IN_PROGRESS);
@@ -62,7 +62,7 @@ describe('Status', () => {
 
         // Assert
         expect(status).not.toBeNull();
-        expect(status!.indicator).toEqual(indicator);
+        expect(status!.symbol).toEqual(indicator);
         expect(status!.name).toEqual(name);
         expect(status!.nextStatusIndicator).toEqual(next);
         expect(status!.isCompleted()).toEqual(true);
@@ -97,7 +97,7 @@ describe('Status', () => {
 
         // Assert
         expect(status).not.toBeNull();
-        expect(status!.indicator).toEqual(indicator);
+        expect(status!.symbol).toEqual(indicator);
         expect(status!.name).toEqual('Unknown');
         expect(status!.nextStatusIndicator).toEqual('x');
         // Even though the type *could* be deduced as IN_PROGRESS, createUnknownStatus() is used when
@@ -109,7 +109,7 @@ describe('Status', () => {
     it('should construct a Status from a core imported value', () => {
         const imported: StatusCollectionEntry = ['/', 'in progress', 'x', 'IN_PROGRESS'];
         const status = Status.createFromImportedValue(imported);
-        expect(status.indicator).toEqual('/');
+        expect(status.symbol).toEqual('/');
         expect(status.name).toEqual('in progress');
         expect(status.nextStatusIndicator).toEqual('x');
         expect(status.type).toEqual(StatusType.IN_PROGRESS); // should deduce IN_PROGRESS from indicator '/'
@@ -119,7 +119,7 @@ describe('Status', () => {
     it('should construct a Status from a custom imported value', () => {
         const imported: StatusCollectionEntry = ['P', 'Pro', 'C', 'NON_TASK'];
         const status = Status.createFromImportedValue(imported);
-        expect(status.indicator).toEqual('P');
+        expect(status.symbol).toEqual('P');
         expect(status.name).toEqual('Pro');
         expect(status.nextStatusIndicator).toEqual('C');
         expect(status.type).toEqual(StatusType.NON_TASK);

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -67,7 +67,7 @@ describe('StatusRegistry', () => {
         // Assert
         expect(result.symbol).toEqual('?');
         expect(result.name).toEqual('Unknown');
-        expect(result.nextStatusIndicator).toEqual('x');
+        expect(result.nextStatusSymbol).toEqual('x');
     });
 
     it('should allow lookup of next status for a status', () => {
@@ -108,7 +108,7 @@ describe('StatusRegistry', () => {
         // Assert
         expect(nextStatus.symbol).toEqual('C');
         expect(nextStatus.name).toEqual('Unknown');
-        expect(nextStatus.nextStatusIndicator).toEqual('x');
+        expect(nextStatus.nextStatusSymbol).toEqual('x');
         expect(nextStatus.type).toEqual(StatusType.TODO);
     });
 

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -24,45 +24,45 @@ describe('StatusRegistry', () => {
         StatusRegistry.getInstance().clearStatuses();
     });
 
-    it('should create a new instance and populate default status indicators', () => {
+    it('should create a new instance and populate default status symbols', () => {
         // Arrange
 
         // Act
         const statusRegistry = new StatusRegistry();
-        const doneStatus = statusRegistry.byIndicator('x');
+        const doneStatus = statusRegistry.bySymbol('x');
 
         // Assert
         expect(statusRegistry).not.toBeNull();
 
         expect(doneStatus.symbol).toEqual(Status.makeDone().symbol);
 
-        expect(statusRegistry.byIndicator('x').symbol).toEqual(Status.makeDone().symbol);
-        expect(statusRegistry.byIndicator('').symbol).toEqual(Status.makeEmpty().symbol);
-        expect(statusRegistry.byIndicator(' ').symbol).toEqual(Status.makeTodo().symbol);
-        expect(statusRegistry.byIndicator('-').symbol).toEqual(Status.makeCancelled().symbol);
-        expect(statusRegistry.byIndicator('/').symbol).toEqual(Status.makeInProgress().symbol);
+        expect(statusRegistry.bySymbol('x').symbol).toEqual(Status.makeDone().symbol);
+        expect(statusRegistry.bySymbol('').symbol).toEqual(Status.makeEmpty().symbol);
+        expect(statusRegistry.bySymbol(' ').symbol).toEqual(Status.makeTodo().symbol);
+        expect(statusRegistry.bySymbol('-').symbol).toEqual(Status.makeCancelled().symbol);
+        expect(statusRegistry.bySymbol('/').symbol).toEqual(Status.makeInProgress().symbol);
 
-        // Detect unrecognised indicator:
-        expect(statusRegistry.byIndicator('?').symbol).toEqual(Status.makeEmpty().symbol);
+        // Detect unrecognised symbol:
+        expect(statusRegistry.bySymbol('?').symbol).toEqual(Status.makeEmpty().symbol);
     });
 
-    it('should return empty status for lookup by unknown indicator with byIndicator()', () => {
+    it('should return empty status for lookup by unknown symbol with bySymbol()', () => {
         // Arrange
         const statusRegistry = new StatusRegistry();
 
         // Act
-        const result = statusRegistry.byIndicator('?');
+        const result = statusRegistry.bySymbol('?');
 
         // Assert
         expect(result).toEqual(Status.EMPTY);
     });
 
-    it('should return Unknown status for lookup by unknown indicator with byIndicatorOrCreate()', () => {
+    it('should return Unknown status for lookup by unknown symbol with bySymbolOrCreate()', () => {
         // Arrange
         const statusRegistry = new StatusRegistry();
 
         // Act
-        const result = statusRegistry.byIndicatorOrCreate('?');
+        const result = statusRegistry.bySymbolOrCreate('?');
 
         // Assert
         expect(result.symbol).toEqual('?');
@@ -119,7 +119,7 @@ describe('StatusRegistry', () => {
         statusRegistry.add(statusConfiguration);
 
         // Assert
-        const status2 = statusRegistry.byIndicator('a');
+        const status2 = statusRegistry.bySymbol('a');
         expect(status2).toStrictEqual(new Status(statusConfiguration));
     });
 
@@ -130,7 +130,7 @@ describe('StatusRegistry', () => {
         statusRegistry.add(status);
 
         // Assert
-        const status2 = statusRegistry.byIndicator('a');
+        const status2 = statusRegistry.bySymbol('a');
         expect(status2).toStrictEqual(status);
     });
 
@@ -158,10 +158,6 @@ describe('StatusRegistry', () => {
             // Assert
             expect(task).not.toBeNull();
             expect(task!.status.symbol).toEqual(Status.makeTodo().symbol);
-
-            // In Tasks, TODO toggles to DONE, for consistency with earlier releases.
-            // const toggledInProgress = task?.toggle()[0];
-            // expect(toggledInProgress?.status.indicator).toEqual(Status.IN_PROGRESS.indicator);
 
             const toggledDone = task?.toggle()[0];
             expect(toggledDone?.status.symbol).toEqual(Status.makeDone().symbol);
@@ -267,9 +263,9 @@ describe('StatusRegistry', () => {
         it('should bulk-add unknown statuses', () => {
             // Arrange
             const registry = new StatusRegistry();
-            expect(registry.byIndicator('!').type).toEqual(StatusType.EMPTY);
-            expect(registry.byIndicator('X').type).toEqual(StatusType.EMPTY);
-            expect(registry.byIndicator('d').type).toEqual(StatusType.EMPTY);
+            expect(registry.bySymbol('!').type).toEqual(StatusType.EMPTY);
+            expect(registry.bySymbol('X').type).toEqual(StatusType.EMPTY);
+            expect(registry.bySymbol('d').type).toEqual(StatusType.EMPTY);
             const tasks = [
                 new TaskBuilder().statusValues('!', 'Unknown', 'X', false, StatusType.TODO).build(),
                 new TaskBuilder().statusValues('X', 'Unknown', '!', false, StatusType.DONE).build(),

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -34,16 +34,16 @@ describe('StatusRegistry', () => {
         // Assert
         expect(statusRegistry).not.toBeNull();
 
-        expect(doneStatus.indicator).toEqual(Status.makeDone().indicator);
+        expect(doneStatus.symbol).toEqual(Status.makeDone().symbol);
 
-        expect(statusRegistry.byIndicator('x').indicator).toEqual(Status.makeDone().indicator);
-        expect(statusRegistry.byIndicator('').indicator).toEqual(Status.makeEmpty().indicator);
-        expect(statusRegistry.byIndicator(' ').indicator).toEqual(Status.makeTodo().indicator);
-        expect(statusRegistry.byIndicator('-').indicator).toEqual(Status.makeCancelled().indicator);
-        expect(statusRegistry.byIndicator('/').indicator).toEqual(Status.makeInProgress().indicator);
+        expect(statusRegistry.byIndicator('x').symbol).toEqual(Status.makeDone().symbol);
+        expect(statusRegistry.byIndicator('').symbol).toEqual(Status.makeEmpty().symbol);
+        expect(statusRegistry.byIndicator(' ').symbol).toEqual(Status.makeTodo().symbol);
+        expect(statusRegistry.byIndicator('-').symbol).toEqual(Status.makeCancelled().symbol);
+        expect(statusRegistry.byIndicator('/').symbol).toEqual(Status.makeInProgress().symbol);
 
         // Detect unrecognised indicator:
-        expect(statusRegistry.byIndicator('?').indicator).toEqual(Status.makeEmpty().indicator);
+        expect(statusRegistry.byIndicator('?').symbol).toEqual(Status.makeEmpty().symbol);
     });
 
     it('should return empty status for lookup by unknown indicator with byIndicator()', () => {
@@ -65,7 +65,7 @@ describe('StatusRegistry', () => {
         const result = statusRegistry.byIndicatorOrCreate('?');
 
         // Assert
-        expect(result.indicator).toEqual('?');
+        expect(result.symbol).toEqual('?');
         expect(result.name).toEqual('Unknown');
         expect(result.nextStatusIndicator).toEqual('x');
     });
@@ -86,10 +86,10 @@ describe('StatusRegistry', () => {
         statusRegistry.add(statusD);
 
         // Assert
-        expect(statusRegistry.getNextStatus(statusA).indicator).toEqual('b');
-        expect(statusRegistry.getNextStatus(statusB).indicator).toEqual('c');
-        expect(statusRegistry.getNextStatus(statusC).indicator).toEqual('d');
-        expect(statusRegistry.getNextStatus(statusD).indicator).toEqual('a');
+        expect(statusRegistry.getNextStatus(statusA).symbol).toEqual('b');
+        expect(statusRegistry.getNextStatus(statusB).symbol).toEqual('c');
+        expect(statusRegistry.getNextStatus(statusC).symbol).toEqual('d');
+        expect(statusRegistry.getNextStatus(statusD).symbol).toEqual('a');
     });
 
     it('should return EMPTY if next status does not exist', () => {
@@ -106,7 +106,7 @@ describe('StatusRegistry', () => {
         const nextStatus = statusRegistry.getNextStatusOrCreate(status);
 
         // Assert
-        expect(nextStatus.indicator).toEqual('C');
+        expect(nextStatus.symbol).toEqual('C');
         expect(nextStatus.name).toEqual('Unknown');
         expect(nextStatus.nextStatusIndicator).toEqual('x');
         expect(nextStatus.type).toEqual(StatusType.TODO);
@@ -157,17 +157,17 @@ describe('StatusRegistry', () => {
 
             // Assert
             expect(task).not.toBeNull();
-            expect(task!.status.indicator).toEqual(Status.makeTodo().indicator);
+            expect(task!.status.symbol).toEqual(Status.makeTodo().symbol);
 
             // In Tasks, TODO toggles to DONE, for consistency with earlier releases.
             // const toggledInProgress = task?.toggle()[0];
             // expect(toggledInProgress?.status.indicator).toEqual(Status.IN_PROGRESS.indicator);
 
             const toggledDone = task?.toggle()[0];
-            expect(toggledDone?.status.indicator).toEqual(Status.makeDone().indicator);
+            expect(toggledDone?.status.symbol).toEqual(Status.makeDone().symbol);
 
             const toggledTodo = toggledDone?.toggle()[0];
-            expect(toggledTodo?.status.indicator).toEqual(Status.makeTodo().indicator);
+            expect(toggledTodo?.status.symbol).toEqual(Status.makeTodo().symbol);
         });
 
         it('should allow task to toggle from cancelled to todo', () => {
@@ -192,10 +192,10 @@ describe('StatusRegistry', () => {
 
             // Assert
             expect(task).not.toBeNull();
-            expect(task!.status.indicator).toEqual(Status.makeCancelled().indicator);
+            expect(task!.status.symbol).toEqual(Status.makeCancelled().symbol);
 
             const toggledTodo = task?.toggle()[0];
-            expect(toggledTodo?.status.indicator).toEqual(Status.makeTodo().indicator);
+            expect(toggledTodo?.status.symbol).toEqual(Status.makeTodo().symbol);
         });
 
         it('should allow task to toggle through custom transitions', () => {
@@ -229,19 +229,19 @@ describe('StatusRegistry', () => {
 
             // Assert
             expect(task).not.toBeNull();
-            expect(task!.status.indicator).toEqual(statusA.indicator);
+            expect(task!.status.symbol).toEqual(statusA.symbol);
 
             const toggledA = task?.toggle()[0];
-            expect(toggledA?.status.indicator).toEqual(statusB.indicator);
+            expect(toggledA?.status.symbol).toEqual(statusB.symbol);
 
             const toggledB = toggledA?.toggle()[0];
-            expect(toggledB?.status.indicator).toEqual(statusC.indicator);
+            expect(toggledB?.status.symbol).toEqual(statusC.symbol);
 
             const toggledC = toggledB?.toggle()[0];
-            expect(toggledC?.status.indicator).toEqual(statusD.indicator);
+            expect(toggledC?.status.symbol).toEqual(statusD.symbol);
 
             const toggledD = toggledC?.toggle()[0];
-            expect(toggledD?.status.indicator).toEqual(statusA.indicator);
+            expect(toggledD?.status.symbol).toEqual(statusA.symbol);
         });
 
         it('should leave task valid if toggling to unknown status', () => {
@@ -253,7 +253,7 @@ describe('StatusRegistry', () => {
             const line = '- [!] this is an important task';
             const task = TestHelpers.fromLine({ line });
             expect(task).not.toBeNull();
-            expect(task!.status.indicator).toEqual(important.indicator);
+            expect(task!.status.symbol).toEqual(important.symbol);
 
             // Act
             const toggled = task?.toggle()[0];
@@ -261,7 +261,7 @@ describe('StatusRegistry', () => {
             // Assert
             // Issue https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1499
             // Ensure that the next status was applied, even though it is an unrecognised status
-            expect(toggled?.status.indicator).toEqual('D');
+            expect(toggled?.status.symbol).toEqual('D');
         });
 
         it('should bulk-add unknown statuses', () => {

--- a/tests/StatusValidator.test.ts
+++ b/tests/StatusValidator.test.ts
@@ -52,29 +52,29 @@ describe('StatusValidator', () => {
             checkValidation(config, ['Task Next Status Symbol ("yyy") must be a single character.']);
         });
 
-        describe('validate indicator', () => {
-            it('valid indicator', () => {
+        describe('validate symbol', () => {
+            it('valid symbol', () => {
                 const config = new StatusConfiguration('X', 'Completed', 'c', false);
-                expect(statusValidator.validateIndicator(config)).toStrictEqual([]);
+                expect(statusValidator.validateSymbol(config)).toStrictEqual([]);
             });
 
-            it('invalid indicator', () => {
+            it('invalid symbol', () => {
                 const config = new StatusConfiguration('XYZ', 'Completed', 'c', false);
-                expect(statusValidator.validateIndicator(config)).toStrictEqual([
+                expect(statusValidator.validateSymbol(config)).toStrictEqual([
                     'Task Status Symbol ("XYZ") must be a single character.',
                 ]);
             });
         });
 
-        describe('validate next indicator', () => {
-            it('valid indicator', () => {
+        describe('validate next symbol', () => {
+            it('valid symbol', () => {
                 const config = new StatusConfiguration('c', 'Completed', 'X', false);
-                expect(statusValidator.validateNextIndicator(config)).toStrictEqual([]);
+                expect(statusValidator.validateNextSynbol(config)).toStrictEqual([]);
             });
 
-            it('invalid next indicator', () => {
+            it('invalid next symbol', () => {
                 const config = new StatusConfiguration('c', 'Completed', 'XYZ', false);
-                expect(statusValidator.validateNextIndicator(config)).toStrictEqual([
+                expect(statusValidator.validateNextSynbol(config)).toStrictEqual([
                     'Task Next Status Symbol ("XYZ") must be a single character.',
                 ]);
             });

--- a/tests/StatusValidator.test.ts
+++ b/tests/StatusValidator.test.ts
@@ -69,12 +69,12 @@ describe('StatusValidator', () => {
         describe('validate next symbol', () => {
             it('valid symbol', () => {
                 const config = new StatusConfiguration('c', 'Completed', 'X', false);
-                expect(statusValidator.validateNextSynbol(config)).toStrictEqual([]);
+                expect(statusValidator.validateNextSymbol(config)).toStrictEqual([]);
             });
 
             it('invalid next symbol', () => {
                 const config = new StatusConfiguration('c', 'Completed', 'XYZ', false);
-                expect(statusValidator.validateNextSynbol(config)).toStrictEqual([
+                expect(statusValidator.validateNextSymbol(config)).toStrictEqual([
                     'Task Next Status Symbol ("XYZ") must be a single character.',
                 ]);
             });

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -111,7 +111,7 @@ describe('parsing', () => {
         const task = fromLine({ line: '- [D] this is a deferred task' });
 
         // Assert
-        expect(task!.status.indicator).toStrictEqual('D');
+        expect(task!.status.symbol).toStrictEqual('D');
     });
 
     it('allows signifier emojis as part of the description', () => {
@@ -501,7 +501,7 @@ describe('toggle done', () => {
         expect(toggled).not.toBeNull();
         expect(toggled!.status).toStrictEqual(Status.DONE);
         expect(toggled!.doneDate).not.toBeNull();
-        expect(toggled!.status.indicator).toStrictEqual('x');
+        expect(toggled!.status.symbol).toStrictEqual('x');
         expect(toggled!.blockLink).toEqual(' ^my-precious');
     });
 
@@ -520,7 +520,7 @@ describe('toggle done', () => {
         // Assert
         expect(toggled).not.toBeNull();
         expect(toggled!.status).toStrictEqual(Status.TODO);
-        expect(toggled!.status.indicator).toStrictEqual(' ');
+        expect(toggled!.status.symbol).toStrictEqual(' ');
         expect(toggled!.doneDate).toBeNull();
     });
 
@@ -874,8 +874,8 @@ describe('toggle done', () => {
             const doneTask: Task = tasks[1];
             const nextTask: Task = tasks[0];
 
-            expect(doneTask.status.indicator).toEqual(doneIndicator ?? 'x');
-            expect(nextTask.status.indicator).toEqual(nextIndicator ?? ' ');
+            expect(doneTask.status.symbol).toEqual(doneIndicator ?? 'x');
+            expect(nextTask.status.symbol).toEqual(nextIndicator ?? ' ');
             expect({
                 nextDue: nextTask.dueDate?.format('YYYY-MM-DD'),
                 nextScheduled: nextTask.scheduledDate?.format('YYYY-MM-DD'),

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -533,8 +533,8 @@ describe('toggle done', () => {
         start?: string;
         today?: string;
         // results:
-        doneSymbol?: string; // the indicator of the completed task
-        nextSymbol?: string; // the indicator of the recurrence
+        doneSymbol?: string; // the symbol of the completed task
+        nextSymbol?: string; // the symbol of the recurrence
         nextDue?: string;
         nextScheduled?: string;
         nextStart?: string;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -527,14 +527,14 @@ describe('toggle done', () => {
     type RecurrenceCase = {
         // inputs:
         interval: string;
-        indicator?: string;
+        symbol?: string;
         due?: string;
         scheduled?: string;
         start?: string;
         today?: string;
         // results:
-        doneIndicator?: string; // the indicator of the completed task
-        nextIndicator?: string; // the indicator of the recurrence
+        doneSymbol?: string; // the indicator of the completed task
+        nextSymbol?: string; // the indicator of the recurrence
         nextDue?: string;
         nextScheduled?: string;
         nextStart?: string;
@@ -802,23 +802,23 @@ describe('toggle done', () => {
         // ==================================
         {
             interval: 'every day',
-            indicator: 'D',
+            symbol: 'D',
             due: '2023-01-19',
-            doneIndicator: 'X',
-            nextIndicator: '!',
+            doneSymbol: 'X',
+            nextSymbol: '!',
             nextDue: '2023-01-20',
         },
         {
             interval: 'every day',
-            indicator: '2',
-            doneIndicator: '3', // 2 toggles to 3
-            nextIndicator: '1', // and the new task should be 1
+            symbol: '2',
+            doneSymbol: '3', // 2 toggles to 3
+            nextSymbol: '1', // and the new task should be 1
         },
         {
             interval: 'every day',
-            indicator: 'a',
-            doneIndicator: 'b', // a toggles to b
-            nextIndicator: 'c', // b says it toggles to c: , but c does not exist: check that it has been chosen anyway
+            symbol: 'a',
+            doneSymbol: 'b', // a toggles to b
+            nextSymbol: 'c', // b says it toggles to c: , but c does not exist: check that it has been chosen anyway
         },
     ];
 
@@ -830,14 +830,14 @@ describe('toggle done', () => {
         ({
             // inputs:
             interval,
-            indicator,
+            symbol,
             due,
             scheduled,
             start,
             today,
             // results:
-            doneIndicator,
-            nextIndicator,
+            doneSymbol,
+            nextSymbol,
             nextDue,
             nextScheduled,
             nextStart,
@@ -851,12 +851,12 @@ describe('toggle done', () => {
                 nextStart !== undefined ||
                 nextDue !== undefined ||
                 nextScheduled !== undefined ||
-                nextIndicator !== undefined ||
-                doneIndicator !== undefined;
+                nextSymbol !== undefined ||
+                doneSymbol !== undefined;
             expect(atLeaseOneExpectationSupplied).toStrictEqual(true);
 
             const line = [
-                `- [${indicator ?? ' '}] I am task`,
+                `- [${symbol ?? ' '}] I am task`,
                 `🔁 ${interval}`,
                 !!scheduled && `⏳ ${scheduled}`,
                 !!due && `📅 ${due}`,
@@ -874,8 +874,8 @@ describe('toggle done', () => {
             const doneTask: Task = tasks[1];
             const nextTask: Task = tasks[0];
 
-            expect(doneTask.status.symbol).toEqual(doneIndicator ?? 'x');
-            expect(nextTask.status.symbol).toEqual(nextIndicator ?? ' ');
+            expect(doneTask.status.symbol).toEqual(doneSymbol ?? 'x');
+            expect(nextTask.status.symbol).toEqual(nextSymbol ?? ' ');
             expect({
                 nextDue: nextTask.dueDate?.format('YYYY-MM-DD'),
                 nextScheduled: nextTask.scheduledDate?.format('YYYY-MM-DD'),

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -92,19 +92,13 @@ export class TaskBuilder {
     }
 
     public statusValues(
-        indicator: string,
+        symbol: string,
         name: string,
-        nextStatusIndicator: string,
+        nextStatusSymbol: string,
         availableAsCommand: boolean,
         type: StatusType,
     ): TaskBuilder {
-        const statusConfiguration = new StatusConfiguration(
-            indicator,
-            name,
-            nextStatusIndicator,
-            availableAsCommand,
-            type,
-        );
+        const statusConfiguration = new StatusConfiguration(symbol, name, nextStatusSymbol, availableAsCommand, type);
         return this.status(new Status(statusConfiguration));
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

There has been a discrepancy in vocabulary between the status code - which talks about `indicator` characters - and the UI and docs - which talk about `symbol` characters.

This PR converts every use of `indicator` in the code and settings to `symbol`.

## Effect in settings for users who tested earlier test builds of custom statuses:

Users will need to recreate their custom statuses - or make a copy of `data.json` and apply some global edits.

I've documented this for testers in:
- https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/1530#discussioncomment-4737556
- https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/1530#discussioncomment-4737663

## Motivation and Context

Fix #1558 - which describes the motivation.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Automated tests
- Manual testing in Obsidian

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- For users who tested the earlier builds, this is a breaking change. But not for anyone who had used previously Tasks releases.

See my notes above on how I've communicated this to the people who kindly tested the new features.

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
