### PR TITLE
fix: Make NON_TASK statuses match 'done'

### DIFF
--- a/docs/getting-started/statuses.md
+++ b/docs/getting-started/statuses.md
@@ -48,7 +48,7 @@ The tasks shown are purely examples for context. The `~` column is just an arbit
 | Operation | TODO | IN_PROGRESS | DONE | CANCELLED | NON_TASK |
 | ----- | ----- | ----- | ----- | ----- | ----- |
 | Example Task | `- [ ] demo` | `- [/] demo` | `- [x] demo` | `- [-] demo` | `- [~] demo` |
-| Matches `done` | no | no | YES | YES | no |
+| Matches `done` | no | no | YES | YES | YES |
 | Matches `not done` | YES | YES | no | no | no |
 | Matches `status.name includes todo` | YES | no | no | no | no |
 | Matches `status.type is TODO` | YES | no | no | no | no |

--- a/docs/queries/filters.md
+++ b/docs/queries/filters.md
@@ -191,9 +191,8 @@ because the tasks starts before tomorrow. Only one of the dates needs to match.
 
 ### Status
 
-- `done` - matches tasks status types `DONE` and `CANCELLED`
+- `done` - matches tasks status types `DONE`, `CANCELLED` and `NON_TASK`
 - `not done` - matches status types with type `TODO` and `IN_PROGRESS`
-- Note: tasks with status type `NON_TASK` match neither filter.
 
 {: .info }
 > Prior to Tasks X.Y.Z, there was no concept of task status type, and so only the status symbol was used:

--- a/src/Query/Filter/StatusField.ts
+++ b/src/Query/Filter/StatusField.ts
@@ -15,10 +15,13 @@ export class StatusField extends FilterInstructionsBasedField {
         //   StatusType.CANCELLED counts as done
         //   StatusType.TODO counts as not done
         //   StatusType.IN_PROGRESS counts as not done
-        //   StatusType.NON_TASK does not match either
+        //   StatusType.NON_TASK counts as done
         this._filters.add(
             'done',
-            (task: Task) => task.status.type === StatusType.DONE || task.status.type === StatusType.CANCELLED,
+            (task: Task) =>
+                task.status.type === StatusType.DONE ||
+                task.status.type === StatusType.CANCELLED ||
+                task.status.type === StatusType.NON_TASK,
         );
         this._filters.add(
             'not done',

--- a/tests/DocsSamplesForStatuses.test.Status_Transitions status-types.approved.md
+++ b/tests/DocsSamplesForStatuses.test.Status_Transitions status-types.approved.md
@@ -3,7 +3,7 @@
 | Operation | TODO | IN_PROGRESS | DONE | CANCELLED | NON_TASK |
 | ----- | ----- | ----- | ----- | ----- | ----- |
 | Example Task | `- [ ] demo` | `- [/] demo` | `- [x] demo` | `- [-] demo` | `- [~] demo` |
-| Matches `done` | no | no | YES | YES | no |
+| Matches `done` | no | no | YES | YES | YES |
 | Matches `not done` | YES | YES | no | no | no |
 | Matches `status.name includes todo` | YES | no | no | no | no |
 | Matches `status.type is TODO` | YES | no | no | no | no |

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -27,6 +27,7 @@ describe('status', () => {
         expect(filter).not.toMatchTaskWithStatus(Status.makeInProgress().configuration);
         expect(filter).toMatchTaskWithStatus(Status.makeCancelled().configuration);
         expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('!', 'Todo', 'x', true, StatusType.TODO)); // 'done' checks type.
+        expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));
     });
 
     it('not done', () => {
@@ -42,6 +43,7 @@ describe('status', () => {
         expect(filter).toMatchTaskWithStatus(Status.makeInProgress().configuration);
         expect(filter).not.toMatchTaskWithStatus(Status.makeCancelled().configuration);
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('!', 'Todo', 'x', true, StatusType.TODO)); // 'not done' type.
+        expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));
     });
 });
 

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -27,7 +27,7 @@ describe('status', () => {
         expect(filter).not.toMatchTaskWithStatus(Status.makeInProgress().configuration);
         expect(filter).toMatchTaskWithStatus(Status.makeCancelled().configuration);
         expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('!', 'Todo', 'x', true, StatusType.TODO)); // 'done' checks type.
-        expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));
+        expect(filter).toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));
     });
 
     it('not done', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

If the user has set up any statuses with type `NON_TASK`, tasks in this status will now match `done` filters.

This makes the current code behave more like previous releases.

## Motivation and Context

Fixes #1562

## How has this been tested?

- Unit tests
- Manual testing

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
