### PR TITLE
feat: Add ability to edit core statuses

### DIFF
--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -15,13 +15,15 @@ export class CustomStatusModal extends Modal {
 
     saved: boolean = false;
     error: boolean = false;
-    constructor(public plugin: TasksPlugin, statusType: StatusConfiguration) {
+    private symbolMayBeEdited: boolean;
+    constructor(public plugin: TasksPlugin, statusType: StatusConfiguration, symbolMayBeEdited: boolean) {
         super(plugin.app);
         this.statusSymbol = statusType.symbol;
         this.statusName = statusType.name;
         this.statusNextSymbol = statusType.nextStatusSymbol;
         this.statusAvailableAsCommand = statusType.availableAsCommand;
         this.type = statusType.type;
+        this.symbolMayBeEdited = symbolMayBeEdited;
     }
 
     /**
@@ -48,7 +50,7 @@ export class CustomStatusModal extends Modal {
         let statusSymbolText: TextComponent;
         new Setting(settingDiv)
             .setName('Task Status Symbol')
-            .setDesc('This is the character between the square braces.')
+            .setDesc('This is the character between the square braces. (It can only be edited for Custom statuses.)')
             .addText((text) => {
                 statusSymbolText = text;
                 text.setValue(this.statusSymbol).onChange((v) => {
@@ -56,6 +58,7 @@ export class CustomStatusModal extends Modal {
                     CustomStatusModal.setValid(text, validator.validateSymbol(this.statusConfiguration()));
                 });
             })
+            .setDisabled(!this.symbolMayBeEdited)
             .then((_setting) => {
                 // Show any error if the initial value loaded is incorrect.
                 CustomStatusModal.setValid(statusSymbolText, validator.validateSymbol(this.statusConfiguration()));

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -15,15 +15,15 @@ export class CustomStatusModal extends Modal {
 
     saved: boolean = false;
     error: boolean = false;
-    private symbolMayBeEdited: boolean;
-    constructor(public plugin: TasksPlugin, statusType: StatusConfiguration, symbolMayBeEdited: boolean) {
+    private isCoreStatus: boolean;
+    constructor(public plugin: TasksPlugin, statusType: StatusConfiguration, isCoreStatus: boolean) {
         super(plugin.app);
         this.statusSymbol = statusType.symbol;
         this.statusName = statusType.name;
         this.statusNextSymbol = statusType.nextStatusSymbol;
         this.statusAvailableAsCommand = statusType.availableAsCommand;
         this.type = statusType.type;
-        this.symbolMayBeEdited = symbolMayBeEdited;
+        this.isCoreStatus = isCoreStatus;
     }
 
     /**
@@ -58,7 +58,7 @@ export class CustomStatusModal extends Modal {
                     CustomStatusModal.setValid(text, validator.validateSymbol(this.statusConfiguration()));
                 });
             })
-            .setDisabled(!this.symbolMayBeEdited)
+            .setDisabled(this.isCoreStatus)
             .then((_setting) => {
                 // Show any error if the initial value loaded is incorrect.
                 CustomStatusModal.setValid(statusSymbolText, validator.validateSymbol(this.statusConfiguration()));

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -81,9 +81,9 @@ export const getSettings = (): Settings => {
 
     // In case saves pre-dated StatusConfiguration.type
     // TODO Special case for symbol 'X' or 'x' (just in case)
-    settings.statusSettings.customStatusTypes = settings.statusSettings.customStatusTypes.map((s) => {
+    settings.statusSettings.customStatusTypes.forEach((s, index, array) => {
         const newType = Status.getTypeFromStatusTypeString(s.type);
-        return new StatusConfiguration(
+        array[index] = new StatusConfiguration(
             s.symbol ?? ' ',
             s.name,
             s.nextStatusSymbol ?? 'x',

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -379,9 +379,7 @@ export class SettingsTab extends PluginSettingTab {
                 statusSettings,
                 settings,
                 settings.plugin,
-                false, // deletable
-                true, // editable
-                false, // symbolMayBeEdited
+                true, // isCoreStatus
             );
         });
     }
@@ -405,9 +403,7 @@ export class SettingsTab extends PluginSettingTab {
                 statusSettings,
                 settings,
                 settings.plugin,
-                true, // deletable
-                true, // editable
-                true, // symbolMayBeEdited
+                false, // isCoreStatus
             );
         });
 
@@ -499,9 +495,7 @@ export class SettingsTab extends PluginSettingTab {
  * @param statusSettings - All the status types already in the user's settings, EXCEPT the standard ones.
  * @param settings
  * @param plugin
- * @param deletable - whether the delete button wil be shown
- * @param editable - whether the edit button wil be shown
- * @param symbolMayBeEdited - whether the status symbol may be edited
+ * @param isCoreStatus - whether the status is a core status
  */
 function createRowForTaskStatus(
     containerEl: HTMLElement,
@@ -510,9 +504,7 @@ function createRowForTaskStatus(
     statusSettings: StatusSettings,
     settings: SettingsTab,
     plugin: TasksPlugin,
-    deletable: boolean,
-    editable: boolean,
-    symbolMayBeEdited: boolean,
+    isCoreStatus: boolean,
 ) {
     //const taskStatusDiv = containerEl.createEl('div');
 
@@ -524,7 +516,7 @@ function createRowForTaskStatus(
 
     setting.infoEl.replaceWith(taskStatusPreview);
 
-    if (deletable) {
+    if (!isCoreStatus) {
         setting.addExtraButton((extra) => {
             extra
                 .setIcon('cross')
@@ -537,26 +529,24 @@ function createRowForTaskStatus(
         });
     }
 
-    if (editable) {
-        setting.addExtraButton((extra) => {
-            extra
-                .setIcon('pencil')
-                .setTooltip('Edit')
-                .onClick(async () => {
-                    const modal = new CustomStatusModal(plugin, statusType, symbolMayBeEdited);
+    setting.addExtraButton((extra) => {
+        extra
+            .setIcon('pencil')
+            .setTooltip('Edit')
+            .onClick(async () => {
+                const modal = new CustomStatusModal(plugin, statusType, isCoreStatus);
 
-                    modal.onClose = async () => {
-                        if (modal.saved) {
-                            if (StatusSettings.replaceStatus(statuses, statusType, modal.statusConfiguration())) {
-                                await updateAndSaveStatusSettings(statusSettings, settings);
-                            }
+                modal.onClose = async () => {
+                    if (modal.saved) {
+                        if (StatusSettings.replaceStatus(statuses, statusType, modal.statusConfiguration())) {
+                            await updateAndSaveStatusSettings(statusSettings, settings);
                         }
-                    };
+                    }
+                };
 
-                    modal.open();
-                });
-        });
-    }
+                modal.open();
+            });
+    });
 
     setting.infoEl.remove();
 }

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -479,7 +479,7 @@ export class SettingsTab extends PluginSettingTab {
                 .setButtonText('Delete All Custom Status Types')
                 .setWarning()
                 .onClick(async () => {
-                    StatusSettings.deleteAllCustomStatues(statusSettings);
+                    StatusSettings.deleteAllCustomStatuses(statusSettings);
                     await updateAndSaveStatusSettings(statusSettings, settings);
                 });
         });

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -368,16 +368,20 @@ export class SettingsTab extends PluginSettingTab {
      * @memberof SettingsTab
      */
     insertTaskCoreStatusSettings(containerEl: HTMLElement, settings: SettingsTab) {
-        // TODO Make these statuses editable
-        const coreStatuses: StatusSettings = new StatusSettings();
-        StatusSettings.addStatus(coreStatuses.customStatusTypes, Status.makeTodo().configuration);
-        StatusSettings.addStatus(coreStatuses.customStatusTypes, Status.makeInProgress().configuration);
-        StatusSettings.addStatus(coreStatuses.customStatusTypes, Status.makeDone().configuration);
-        StatusSettings.addStatus(coreStatuses.customStatusTypes, Status.makeCancelled().configuration);
+        const { statusSettings } = getSettings();
 
-        /* -------------------- One row per status in the settings -------------------- */
-        coreStatuses.customStatusTypes.forEach((status_type) => {
-            createRowForTaskStatus(containerEl, status_type, coreStatuses, settings, settings.plugin, false, false);
+        /* -------------------- One row per core status in the settings -------------------- */
+        statusSettings.coreStatusTypes.forEach((status_type) => {
+            createRowForTaskStatus(
+                containerEl,
+                status_type,
+                statusSettings.coreStatusTypes,
+                statusSettings,
+                settings,
+                settings.plugin,
+                false,
+                true,
+            );
         });
     }
 
@@ -391,9 +395,18 @@ export class SettingsTab extends PluginSettingTab {
     insertCustomTaskStatusSettings(containerEl: HTMLElement, settings: SettingsTab) {
         const { statusSettings } = getSettings();
 
-        /* -------------------- One row per status in the settings -------------------- */
+        /* -------------------- One row per custom status in the settings -------------------- */
         statusSettings.customStatusTypes.forEach((status_type) => {
-            createRowForTaskStatus(containerEl, status_type, statusSettings, settings, settings.plugin, true, true);
+            createRowForTaskStatus(
+                containerEl,
+                status_type,
+                statusSettings.customStatusTypes,
+                statusSettings,
+                settings,
+                settings.plugin,
+                true,
+                true,
+            );
         });
 
         containerEl.createEl('div');
@@ -480,6 +493,7 @@ export class SettingsTab extends PluginSettingTab {
  * Create the row to see and modify settings for a single task status type.
  * @param containerEl
  * @param statusType - The status type to be edited.
+ * @param statuses - The list of statuses that statusType is stored in.
  * @param statusSettings - All the status types already in the user's settings, EXCEPT the standard ones.
  * @param settings
  * @param plugin
@@ -489,6 +503,7 @@ export class SettingsTab extends PluginSettingTab {
 function createRowForTaskStatus(
     containerEl: HTMLElement,
     statusType: StatusConfiguration,
+    statuses: StatusConfiguration[],
     statusSettings: StatusSettings,
     settings: SettingsTab,
     plugin: TasksPlugin,
@@ -511,7 +526,7 @@ function createRowForTaskStatus(
                 .setIcon('cross')
                 .setTooltip('Delete')
                 .onClick(async () => {
-                    if (StatusSettings.deleteStatus(statusSettings.customStatusTypes, statusType)) {
+                    if (StatusSettings.deleteStatus(statuses, statusType)) {
                         await updateAndSaveStatusSettings(statusSettings, settings);
                     }
                 });
@@ -528,13 +543,7 @@ function createRowForTaskStatus(
 
                     modal.onClose = async () => {
                         if (modal.saved) {
-                            if (
-                                StatusSettings.replaceStatus(
-                                    statusSettings.customStatusTypes,
-                                    statusType,
-                                    modal.statusConfiguration(),
-                                )
-                            ) {
+                            if (StatusSettings.replaceStatus(statuses, statusType, modal.statusConfiguration())) {
                                 await updateAndSaveStatusSettings(statusSettings, settings);
                             }
                         }

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -379,8 +379,9 @@ export class SettingsTab extends PluginSettingTab {
                 statusSettings,
                 settings,
                 settings.plugin,
-                false,
-                true,
+                false, // deletable
+                true, // editable
+                false, // symbolMayBeEdited
             );
         });
     }
@@ -404,8 +405,9 @@ export class SettingsTab extends PluginSettingTab {
                 statusSettings,
                 settings,
                 settings.plugin,
-                true,
-                true,
+                true, // deletable
+                true, // editable
+                true, // symbolMayBeEdited
             );
         });
 
@@ -499,6 +501,7 @@ export class SettingsTab extends PluginSettingTab {
  * @param plugin
  * @param deletable - whether the delete button wil be shown
  * @param editable - whether the edit button wil be shown
+ * @param symbolMayBeEdited - whether the status symbol may be edited
  */
 function createRowForTaskStatus(
     containerEl: HTMLElement,
@@ -509,6 +512,7 @@ function createRowForTaskStatus(
     plugin: TasksPlugin,
     deletable: boolean,
     editable: boolean,
+    symbolMayBeEdited: boolean,
 ) {
     //const taskStatusDiv = containerEl.createEl('div');
 
@@ -539,7 +543,7 @@ function createRowForTaskStatus(
                 .setIcon('pencil')
                 .setTooltip('Edit')
                 .onClick(async () => {
-                    const modal = new CustomStatusModal(plugin, statusType);
+                    const modal = new CustomStatusModal(plugin, statusType, symbolMayBeEdited);
 
                     modal.onClose = async () => {
                         if (modal.saved) {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -511,7 +511,7 @@ function createRowForTaskStatus(
                 .setIcon('cross')
                 .setTooltip('Delete')
                 .onClick(async () => {
-                    if (StatusSettings.deleteCustomStatus(statusSettings, statusType)) {
+                    if (StatusSettings.deleteStatus(statusSettings.customStatusTypes, statusType)) {
                         await updateAndSaveStatusSettings(statusSettings, settings);
                     }
                 });

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -529,8 +529,8 @@ function createRowForTaskStatus(
                     modal.onClose = async () => {
                         if (modal.saved) {
                             if (
-                                StatusSettings.replaceCustomStatus(
-                                    statusSettings,
+                                StatusSettings.replaceStatus(
+                                    statusSettings.customStatusTypes,
                                     statusType,
                                     modal.statusConfiguration(),
                                 )

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -18,7 +18,7 @@ export class SettingsTab extends PluginSettingTab {
     // then be rendered instead of a normal checkbox or text box.
     customFunctions: { [K: string]: Function } = {
         insertTaskCoreStatusSettings: this.insertTaskCoreStatusSettings.bind(this),
-        insertTaskStatusSettings: this.insertTaskStatusSettings.bind(this),
+        insertCustomTaskStatusSettings: this.insertCustomTaskStatusSettings.bind(this),
     };
 
     private readonly plugin: TasksPlugin;
@@ -388,7 +388,7 @@ export class SettingsTab extends PluginSettingTab {
      * @param {SettingsTab} settings
      * @memberof SettingsTab
      */
-    insertTaskStatusSettings(containerEl: HTMLElement, settings: SettingsTab) {
+    insertCustomTaskStatusSettings(containerEl: HTMLElement, settings: SettingsTab) {
         const { statusSettings } = getSettings();
 
         /* -------------------- One row per status in the settings -------------------- */

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -370,10 +370,10 @@ export class SettingsTab extends PluginSettingTab {
     insertTaskCoreStatusSettings(containerEl: HTMLElement, settings: SettingsTab) {
         // TODO Make these statuses editable
         const coreStatuses: StatusSettings = new StatusSettings();
-        StatusSettings.addCustomStatus(coreStatuses, Status.makeTodo().configuration);
-        StatusSettings.addCustomStatus(coreStatuses, Status.makeInProgress().configuration);
-        StatusSettings.addCustomStatus(coreStatuses, Status.makeDone().configuration);
-        StatusSettings.addCustomStatus(coreStatuses, Status.makeCancelled().configuration);
+        StatusSettings.addStatus(coreStatuses.customStatusTypes, Status.makeTodo().configuration);
+        StatusSettings.addStatus(coreStatuses.customStatusTypes, Status.makeInProgress().configuration);
+        StatusSettings.addStatus(coreStatuses.customStatusTypes, Status.makeDone().configuration);
+        StatusSettings.addStatus(coreStatuses.customStatusTypes, Status.makeCancelled().configuration);
 
         /* -------------------- One row per status in the settings -------------------- */
         coreStatuses.customStatusTypes.forEach((status_type) => {
@@ -404,8 +404,8 @@ export class SettingsTab extends PluginSettingTab {
                 .setButtonText('Add New Task Status')
                 .setCta()
                 .onClick(async () => {
-                    StatusSettings.addCustomStatus(
-                        statusSettings,
+                    StatusSettings.addStatus(
+                        statusSettings.customStatusTypes,
                         new StatusConfiguration('', '', '', false, StatusType.TODO),
                     );
                     await updateAndSaveStatusSettings(statusSettings, settings);
@@ -455,7 +455,7 @@ export class SettingsTab extends PluginSettingTab {
                         return;
                     }
                     unknownStatuses.forEach((s) => {
-                        StatusSettings.addCustomStatus(statusSettings, s);
+                        StatusSettings.addStatus(statusSettings.customStatusTypes, s);
                     });
                     await updateAndSaveStatusSettings(statusSettings, settings);
                 });

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -23,11 +23,11 @@ export class StatusSettings {
      *
      * - Currently, duplicates are allowed.
      * - Allows empty StatusConfiguration objects - where every string is empty
-     * @param statusSettings
+     * @param statuses
      * @param newStatus
      */
-    public static addCustomStatus(statusSettings: StatusSettings, newStatus: StatusConfiguration) {
-        statusSettings.customStatusTypes.push(newStatus);
+    public static addStatus(statuses: StatusConfiguration[], newStatus: StatusConfiguration) {
+        statuses.push(newStatus);
     }
 
     /**
@@ -125,7 +125,10 @@ export class StatusSettings {
                 );
             });
             if (!hasStatus) {
-                StatusSettings.addCustomStatus(statusSettings, Status.createFromImportedValue(importedStatus));
+                StatusSettings.addStatus(
+                    statusSettings.customStatusTypes,
+                    Status.createFromImportedValue(importedStatus),
+                );
             } else {
                 notices.push(`The status ${importedStatus[1]} (${importedStatus[0]}) is already added.`);
             }

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -12,9 +12,16 @@ import type { StatusCollection } from '../StatusCollection';
  */
 export class StatusSettings {
     constructor() {
+        this.coreStatusTypes = [
+            Status.makeTodo().configuration,
+            Status.makeInProgress().configuration,
+            Status.makeDone().configuration,
+            Status.makeCancelled().configuration,
+        ]; // Do not modify directly: use the static mutation methods in this class.
         this.customStatusTypes = []; // Do not modify directly: use the static mutation methods in this class.
     }
-    customStatusTypes: StatusConfiguration[];
+    readonly coreStatusTypes: StatusConfiguration[]; // TODO - need to handle if this was not present in settings read from disk
+    readonly customStatusTypes: StatusConfiguration[];
 
     /**
      * Add a new custom status.
@@ -142,8 +149,10 @@ export class StatusSettings {
      * @param statusRegistry
      */
     public static applyToStatusRegistry(statusSettings: StatusSettings, statusRegistry: StatusRegistry) {
-        // Reset the registry as this may also come from a settings add/delete.
-        statusRegistry.resetToDefaultStatuses();
+        statusRegistry.clearStatuses();
+        statusSettings.coreStatusTypes.forEach((statusType) => {
+            statusRegistry.add(statusType);
+        });
         statusSettings.customStatusTypes.forEach((statusType) => {
             statusRegistry.add(statusType);
         });

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -70,20 +70,20 @@ export class StatusSettings {
     }
 
     /**
-     * Delete the given custom status.
+     * Delete the given status.
      * Returns true if deleted, and false if not.
      *
      * This is static so that it can be called from modal onClick() call-backs.
      *
-     * @param statusSettings
+     * @param statuses
      * @param status
      */
-    public static deleteCustomStatus(statusSettings: StatusSettings, status: StatusConfiguration) {
-        const index = this.findStatusIndex(status, statusSettings.customStatusTypes);
+    public static deleteStatus(statuses: StatusConfiguration[], status: StatusConfiguration) {
+        const index = this.findStatusIndex(status, statuses);
         if (index <= -1) {
             return false;
         }
-        statusSettings.customStatusTypes.splice(index, 1);
+        statuses.splice(index, 1);
         return true;
     }
 

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -47,7 +47,7 @@ export class StatusSettings {
         originalStatus: StatusConfiguration,
         newStatus: StatusConfiguration,
     ): boolean {
-        const index = this.findStatusIndex(originalStatus, statusSettings);
+        const index = this.findStatusIndex(originalStatus, statusSettings.customStatusTypes);
         if (index <= -1) {
             return false;
         }
@@ -59,12 +59,12 @@ export class StatusSettings {
      * This is a workaround for the fact that statusSettings.customStatusTypes.indexOf(statusConfiguration)
      * stopped finding identical statuses since the addition of StatusConfiguration.type.
      * @param statusConfiguration
-     * @param statusSettings
+     * @param statuses
      * @private
      */
-    private static findStatusIndex(statusConfiguration: StatusConfiguration, statusSettings: StatusSettings) {
+    private static findStatusIndex(statusConfiguration: StatusConfiguration, statuses: StatusConfiguration[]) {
         const originalStatusAsStatus = new Status(statusConfiguration);
-        return statusSettings.customStatusTypes.findIndex((s) => {
+        return statuses.findIndex((s) => {
             return new Status(s).previewText() == originalStatusAsStatus.previewText();
         });
     }
@@ -79,7 +79,7 @@ export class StatusSettings {
      * @param status
      */
     public static deleteCustomStatus(statusSettings: StatusSettings, status: StatusConfiguration) {
-        const index = this.findStatusIndex(status, statusSettings);
+        const index = this.findStatusIndex(status, statusSettings.customStatusTypes);
         if (index <= -1) {
             return false;
         }

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -140,7 +140,7 @@ export class StatusSettings {
      */
     public static applyToStatusRegistry(statusSettings: StatusSettings, statusRegistry: StatusRegistry) {
         // Reset the registry as this may also come from a settings add/delete.
-        statusRegistry.clearStatuses();
+        statusRegistry.resetToDefaultStatuses();
         statusSettings.customStatusTypes.forEach((statusType) => {
             statusRegistry.add(statusType);
         });

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -101,7 +101,7 @@ export class StatusSettings {
      *
      * @param statusSettings
      */
-    public static deleteAllCustomStatues(statusSettings: StatusSettings) {
+    public static deleteAllCustomStatuses(statusSettings: StatusSettings) {
         statusSettings.customStatusTypes.splice(0);
     }
 

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -38,20 +38,20 @@ export class StatusSettings {
      *
      * - Does not currently check whether the status character is the same
      * - If the status character is different, does not check whether the new one is already used in another status
-     * @param statusSettings
+     * @param statuses
      * @param originalStatus
      * @param newStatus
      */
-    public static replaceCustomStatus(
-        statusSettings: StatusSettings,
+    public static replaceStatus(
+        statuses: StatusConfiguration[],
         originalStatus: StatusConfiguration,
         newStatus: StatusConfiguration,
     ): boolean {
-        const index = this.findStatusIndex(originalStatus, statusSettings.customStatusTypes);
+        const index = this.findStatusIndex(originalStatus, statuses);
         if (index <= -1) {
             return false;
         }
-        statusSettings.customStatusTypes.splice(index, 1, newStatus);
+        statuses.splice(index, 1, newStatus);
         return true;
     }
 

--- a/src/Config/settingsConfiguration.json
+++ b/src/Config/settingsConfiguration.json
@@ -39,7 +39,7 @@
         "type": "function",
         "initialValue": "",
         "placeholder": "",
-        "settingName": "insertTaskStatusSettings",
+        "settingName": "insertCustomTaskStatusSettings",
         "featureFlag": "",
         "notice": null
       }

--- a/src/Config/settingsConfiguration.json
+++ b/src/Config/settingsConfiguration.json
@@ -6,7 +6,7 @@
     "open": true,
     "notice": {
       "class": "setting-item-description",
-      "text": "These are the core status types that Tasks supports. They are not yet editable. You can add custom statuses in the section below.",
+      "text": "These are the core status types that Tasks supports. You can add custom statuses in the section below.",
       "html": null
     },
     "settings": [

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -134,11 +134,11 @@ export class StatusRegistry {
     }
 
     /**
-     * Resets the array os Status types to be empty.
+     * Resets the array of Status types to the default statuses.
      *
      * @memberof StatusRegistry
      */
-    public clearStatuses(): void {
+    public resetToDefaultStatuses(): void {
         this._registeredStatuses = [];
         this.addDefaultStatusTypes();
     }

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -265,13 +265,7 @@ export class StatusRegistry {
      * @memberof StatusRegistry
      */
     private addDefaultStatusTypes(): void {
-        const defaultStatuses = [
-            Status.makeTodo(),
-            Status.makeInProgress(),
-            Status.makeDone(),
-            Status.makeCancelled(),
-            Status.makeEmpty(),
-        ];
+        const defaultStatuses = [Status.makeTodo(), Status.makeInProgress(), Status.makeDone(), Status.makeCancelled()];
 
         defaultStatuses.forEach((status) => {
             this.add(status);

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -139,8 +139,15 @@ export class StatusRegistry {
      * @memberof StatusRegistry
      */
     public resetToDefaultStatuses(): void {
-        this._registeredStatuses = [];
+        this.clearStatuses();
         this.addDefaultStatusTypes();
+    }
+
+    /**
+     * Clears the array of Status types to be empty.
+     */
+    public clearStatuses(): void {
+        this._registeredStatuses = [];
     }
 
     /**

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -171,7 +171,7 @@ describe('ToggleDone', () => {
 
         // Arrange
         const statusRegistry = StatusRegistry.getInstance();
-        statusRegistry.clearStatuses();
+        statusRegistry.resetToDefaultStatuses();
         statusRegistry.add(new Status(new StatusConfiguration('P', 'Pro', 'C', false)));
         statusRegistry.add(new Status(new StatusConfiguration('C', 'Con', 'P', false)));
 

--- a/tests/Config/StatusSettings.test.StatusSettings_verify default status settings.approved.json
+++ b/tests/Config/StatusSettings.test.StatusSettings_verify default status settings.approved.json
@@ -1,3 +1,33 @@
 {
+  "coreStatusTypes": [
+    {
+      "symbol": " ",
+      "name": "Todo",
+      "nextStatusSymbol": "x",
+      "availableAsCommand": true,
+      "type": "TODO"
+    },
+    {
+      "symbol": "/",
+      "name": "In Progress",
+      "nextStatusSymbol": "x",
+      "availableAsCommand": true,
+      "type": "IN_PROGRESS"
+    },
+    {
+      "symbol": "x",
+      "name": "Done",
+      "nextStatusSymbol": " ",
+      "availableAsCommand": true,
+      "type": "DONE"
+    },
+    {
+      "symbol": "-",
+      "name": "Cancelled",
+      "nextStatusSymbol": " ",
+      "availableAsCommand": true,
+      "type": "CANCELLED"
+    }
+  ],
   "customStatusTypes": []
 }

--- a/tests/Config/StatusSettings.test.ts
+++ b/tests/Config/StatusSettings.test.ts
@@ -15,9 +15,9 @@ describe('StatusSettings', () => {
         const pro = new StatusConfiguration('P', 'Pro', 'C', false);
         const imp = new StatusConfiguration('!', 'Important', 'x', false);
         const con = new StatusConfiguration('C', 'Con', 'P', false);
-        StatusSettings.addCustomStatus(settings, pro);
-        StatusSettings.addCustomStatus(settings, imp);
-        StatusSettings.addCustomStatus(settings, con);
+        StatusSettings.addStatus(settings.customStatusTypes, pro);
+        StatusSettings.addStatus(settings.customStatusTypes, imp);
+        StatusSettings.addStatus(settings.customStatusTypes, con);
         return { pro, imp, con };
     }
 
@@ -28,7 +28,7 @@ describe('StatusSettings', () => {
 
         // Act
         const newStatus = new StatusConfiguration('!', 'Important', 'x', false);
-        StatusSettings.addCustomStatus(settings, newStatus);
+        StatusSettings.addStatus(settings.customStatusTypes, newStatus);
 
         // Assert
         expect(settings.customStatusTypes.length).toEqual(1);

--- a/tests/Config/StatusSettings.test.ts
+++ b/tests/Config/StatusSettings.test.ts
@@ -98,7 +98,7 @@ describe('StatusSettings', () => {
         expect(settings.customStatusTypes.length).toEqual(3);
 
         // Act
-        StatusSettings.deleteAllCustomStatues(settings);
+        StatusSettings.deleteAllCustomStatuses(settings);
 
         // Assert
         expect(settings.customStatusTypes.length).toEqual(0);

--- a/tests/Config/StatusSettings.test.ts
+++ b/tests/Config/StatusSettings.test.ts
@@ -44,7 +44,7 @@ describe('StatusSettings', () => {
 
         // Act
         const newImp = new StatusConfiguration('!', 'ReallyImportant', 'X', true);
-        StatusSettings.replaceCustomStatus(settings, imp, newImp);
+        StatusSettings.replaceStatus(settings.customStatusTypes, imp, newImp);
 
         // Assert
         expect(settings.customStatusTypes.length).toEqual(3);

--- a/tests/Config/StatusSettings.test.ts
+++ b/tests/Config/StatusSettings.test.ts
@@ -78,7 +78,7 @@ describe('StatusSettings', () => {
         expect(settings.customStatusTypes.length).toEqual(3);
 
         // Act
-        const result = StatusSettings.deleteCustomStatus(settings, imp);
+        const result = StatusSettings.deleteStatus(settings.customStatusTypes, imp);
 
         // Assert
         expect(result).toEqual(true);
@@ -87,7 +87,7 @@ describe('StatusSettings', () => {
         expect(settings.customStatusTypes[1]).toStrictEqual(con);
 
         // Delete a second time. It should now report that nothing was deleted.
-        const result2 = StatusSettings.deleteCustomStatus(settings, imp);
+        const result2 = StatusSettings.deleteStatus(settings.customStatusTypes, imp);
         expect(result2).toEqual(false);
     });
 

--- a/tests/Config/StatusSettings.test.ts
+++ b/tests/Config/StatusSettings.test.ts
@@ -8,6 +8,7 @@ import type { StatusCollection } from '../../src/StatusCollection';
 describe('StatusSettings', () => {
     it('verify default status settings', () => {
         const defaultStatusSettings = new StatusSettings();
+        // This captures the default contents of both core and custom statuses
         verifyAsJson(defaultStatusSettings);
     });
 
@@ -24,6 +25,7 @@ describe('StatusSettings', () => {
     it('should add a status', () => {
         // Arrange
         const settings = new StatusSettings();
+        expect(settings.coreStatusTypes.length).toEqual(4);
         expect(settings.customStatusTypes.length).toEqual(0);
 
         // Act

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -17,11 +17,11 @@ describe('StatusRegistry', () => {
     // The global StatusRegistry is used by the code that toggles tasks.
     // Where possible, tests should create their own StatusRegistry to act on.
     beforeEach(() => {
-        StatusRegistry.getInstance().clearStatuses();
+        StatusRegistry.getInstance().resetToDefaultStatuses();
     });
 
     afterEach(() => {
-        StatusRegistry.getInstance().clearStatuses();
+        StatusRegistry.getInstance().resetToDefaultStatuses();
     });
 
     it('should create a new instance and populate default status symbols', () => {
@@ -73,7 +73,7 @@ describe('StatusRegistry', () => {
     it('should allow lookup of next status for a status', () => {
         // Arrange
         const statusRegistry = new StatusRegistry();
-        statusRegistry.clearStatuses();
+        statusRegistry.resetToDefaultStatuses();
         const statusA = new Status(new StatusConfiguration('a', 'A', 'b', false));
         const statusB = new Status(new StatusConfiguration('b', 'B', 'c', false));
         const statusC = new Status(new StatusConfiguration('c', 'C', 'd', false));

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -46,6 +46,18 @@ describe('StatusRegistry', () => {
         expect(statusRegistry.bySymbol('?').symbol).toEqual(Status.makeEmpty().symbol);
     });
 
+    it('should clear the statuses', () => {
+        // Arrange
+        const statusRegistry = new StatusRegistry();
+        expect(statusRegistry.registeredStatuses.length).toEqual(4);
+
+        // Act
+        statusRegistry.clearStatuses();
+
+        // Assert
+        expect(statusRegistry.registeredStatuses.length).toEqual(0);
+    });
+
     it('should return empty status for lookup by unknown symbol with bySymbol()', () => {
         // Arrange
         const statusRegistry = new StatusRegistry();

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -482,7 +482,7 @@ describe('toggle done', () => {
     });
 
     afterAll(() => {
-        StatusRegistry.getInstance().clearStatuses();
+        StatusRegistry.getInstance().resetToDefaultStatuses();
     });
 
     it('retains the block link', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This adds the ability to edit core statuses.

It's best understood by reviewing the individual commits, but basically:

- `StatusSettings`
    - now has another array which it currently calls `coreStatusTypes` and is initialised to the 4 standard statuses.
    - its 2 arrays are now readonly, because the callbacks on the status Edit and Delete buttons hold on to the appropriate status list from `StatusSettings`.
    - many of its static methods had to be updated to pass in the appropriate list of statuses - core or custom.
- `StatusRegistry` needed a way to delete the 4 default statuses it previously always imposed.
- `CustomStatusModal` only allows the symbol to be modified for custom statuses, not core ones.

## Motivation and Context

Some users want to be able to make `space` -> `/` -> `x`, and this makes that possible.

## How has this been tested?

- Lots of manual testing
- Updating and adding of automated tests

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4840096/213926738-d1581993-575e-4cd3-b337-ea4fd9e4fd05.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
