### PR TITLE
fix: imported CANCELLED tasks now toggle to TODO

### DIFF
--- a/docs/reference/status-collections/aura-theme.md
+++ b/docs/reference/status-collections/aura-theme.md
@@ -69,7 +69,7 @@ Tasks' setting pane has a one-click button to add the following information, rep
 | ----- | ----- | ----- | ----- | ----- |
 | `space` | `x` | incomplete | `TODO` | No |
 | `x` | `space` | complete / done | `DONE` | No |
-| `-` | `x` | cancelled | `CANCELLED` | Yes |
+| `-` | `space` | cancelled | `CANCELLED` | Yes |
 | `>` | `x` | deferred | `TODO` | Yes |
 | `/` | `x` | in progress, or half-done | `IN_PROGRESS` | Yes |
 | `!` | `x` | Important | `TODO` | Yes |

--- a/docs/reference/status-collections/ebullientworks-theme.md
+++ b/docs/reference/status-collections/ebullientworks-theme.md
@@ -57,7 +57,7 @@ Tasks' setting pane has a one-click button to add the following information, rep
 | ----- | ----- | ----- | ----- | ----- |
 | `space` | `x` | Unchecked | `TODO` | No |
 | `x` | `space` | Checked | `DONE` | No |
-| `-` | `x` | Cancelled | `CANCELLED` | Yes |
+| `-` | `space` | Cancelled | `CANCELLED` | Yes |
 | `/` | `x` | In Progress | `IN_PROGRESS` | Yes |
 | `>` | `x` | Deferred | `TODO` | Yes |
 | `!` | `x` | Important | `TODO` | Yes |

--- a/docs/reference/status-collections/its-theme.md
+++ b/docs/reference/status-collections/its-theme.md
@@ -89,7 +89,7 @@ Tasks' setting pane has a one-click button to add the following information, rep
 | `space` | `x` | Unchecked | `TODO` | No |
 | `x` | `space` | Regular | `DONE` | No |
 | `X` | `space` | Checked | `DONE` | Yes |
-| `-` | `x` | Dropped | `CANCELLED` | Yes |
+| `-` | `space` | Dropped | `CANCELLED` | Yes |
 | `>` | `x` | Forward | `TODO` | Yes |
 | `D` | `x` | Date | `TODO` | Yes |
 | `?` | `x` | Question | `TODO` | Yes |

--- a/docs/reference/status-collections/minimal-theme.md
+++ b/docs/reference/status-collections/minimal-theme.md
@@ -72,7 +72,7 @@ Tasks' setting pane has a one-click button to add the following information, rep
 | `space` | `x` | to-do | `TODO` | No |
 | `/` | `x` | incomplete | `IN_PROGRESS` | Yes |
 | `x` | `space` | done | `DONE` | No |
-| `-` | `x` | canceled | `CANCELLED` | Yes |
+| `-` | `space` | canceled | `CANCELLED` | Yes |
 | `>` | `x` | forwarded | `TODO` | Yes |
 | `<` | `x` | scheduling | `TODO` | Yes |
 | `?` | `x` | question | `TODO` | Yes |

--- a/docs/reference/status-collections/slrvb-alternate-checkboxes-snippet.md
+++ b/docs/reference/status-collections/slrvb-alternate-checkboxes-snippet.md
@@ -89,7 +89,7 @@ Tasks' setting pane has a one-click button to add the following information, rep
 | `space` | `x` | Unchecked | `TODO` | No |
 | `x` | `space` | Regular | `DONE` | No |
 | `X` | `space` | Checked | `DONE` | Yes |
-| `-` | `x` | Dropped | `CANCELLED` | Yes |
+| `-` | `space` | Dropped | `CANCELLED` | Yes |
 | `>` | `x` | Forward | `TODO` | Yes |
 | `D` | `x` | Date | `TODO` | Yes |
 | `?` | `x` | Question | `TODO` | Yes |

--- a/docs/reference/status-collections/things-theme.md
+++ b/docs/reference/status-collections/things-theme.md
@@ -72,7 +72,7 @@ Tasks' setting pane has a one-click button to add the following information, rep
 | `space` | `x` | to-do | `TODO` | No |
 | `/` | `x` | incomplete | `IN_PROGRESS` | Yes |
 | `x` | `space` | done | `DONE` | No |
-| `-` | `x` | canceled | `CANCELLED` | Yes |
+| `-` | `space` | canceled | `CANCELLED` | Yes |
 | `>` | `x` | forwarded | `TODO` | Yes |
 | `<` | `x` | scheduling | `TODO` | Yes |
 | `?` | `x` | question | `TODO` | Yes |

--- a/src/Config/Themes/AuraThemeCollection.ts
+++ b/src/Config/Themes/AuraThemeCollection.ts
@@ -8,7 +8,7 @@ export function auraSupportedStatuses() {
     const zzz: StatusCollection = [
         [' ', 'incomplete', 'x', 'TODO'],
         ['x', 'complete / done', ' ', 'DONE'],
-        ['-', 'cancelled', 'x', 'CANCELLED'],
+        ['-', 'cancelled', ' ', 'CANCELLED'],
         ['>', 'deferred', 'x', 'TODO'],
         ['/', 'in progress, or half-done', 'x', 'IN_PROGRESS'],
         ['!', 'Important', 'x', 'TODO'],

--- a/src/Config/Themes/EbullientworksThemeCollection.ts
+++ b/src/Config/Themes/EbullientworksThemeCollection.ts
@@ -8,7 +8,7 @@ export function ebullientworksSupportedStatuses() {
     const zzz: StatusCollection = [
         [' ', 'Unchecked', 'x', 'TODO'],
         ['x', 'Checked', ' ', 'DONE'],
-        ['-', 'Cancelled', 'x', 'CANCELLED'],
+        ['-', 'Cancelled', ' ', 'CANCELLED'],
         ['/', 'In Progress', 'x', 'IN_PROGRESS'],
         ['>', 'Deferred', 'x', 'TODO'],
         ['!', 'Important', 'x', 'TODO'],

--- a/src/Config/Themes/ITSThemeCollection.ts
+++ b/src/Config/Themes/ITSThemeCollection.ts
@@ -10,7 +10,7 @@ export function itsSupportedStatuses() {
         [' ', 'Unchecked', 'x', 'TODO'],
         ['x', 'Regular', ' ', 'DONE'],
         ['X', 'Checked', ' ', 'DONE'],
-        ['-', 'Dropped', 'x', 'CANCELLED'],
+        ['-', 'Dropped', ' ', 'CANCELLED'],
         ['>', 'Forward', 'x', 'TODO'],
         ['D', 'Date', 'x', 'TODO'],
         ['?', 'Question', 'x', 'TODO'],

--- a/src/Config/Themes/MinimalThemeCollection.ts
+++ b/src/Config/Themes/MinimalThemeCollection.ts
@@ -10,7 +10,7 @@ export function minimalSupportedStatuses() {
         [' ', 'to-do', 'x', 'TODO'],
         ['/', 'incomplete', 'x', 'IN_PROGRESS'],
         ['x', 'done', ' ', 'DONE'],
-        ['-', 'canceled', 'x', 'CANCELLED'],
+        ['-', 'canceled', ' ', 'CANCELLED'],
         ['>', 'forwarded', 'x', 'TODO'],
         ['<', 'scheduling', 'x', 'TODO'],
         ['?', 'question', 'x', 'TODO'],

--- a/src/Config/Themes/ThingsThemeCollection.ts
+++ b/src/Config/Themes/ThingsThemeCollection.ts
@@ -10,7 +10,7 @@ export function thingsSupportedStatuses() {
         [' ', 'to-do', 'x', 'TODO'],
         ['/', 'incomplete', 'x', 'IN_PROGRESS'],
         ['x', 'done', ' ', 'DONE'],
-        ['-', 'canceled', 'x', 'CANCELLED'],
+        ['-', 'canceled', ' ', 'CANCELLED'],
         ['>', 'forwarded', 'x', 'TODO'],
         ['<', 'scheduling', 'x', 'TODO'],
         // Extras

--- a/tests/DocsSamplesForStatuses.test.Theme_Aura Table.approved.md
+++ b/tests/DocsSamplesForStatuses.test.Theme_Aura Table.approved.md
@@ -4,7 +4,7 @@
 | ----- | ----- | ----- | ----- | ----- |
 | `space` | `x` | incomplete | `TODO` | No |
 | `x` | `space` | complete / done | `DONE` | No |
-| `-` | `x` | cancelled | `CANCELLED` | Yes |
+| `-` | `space` | cancelled | `CANCELLED` | Yes |
 | `>` | `x` | deferred | `TODO` | Yes |
 | `/` | `x` | in progress, or half-done | `IN_PROGRESS` | Yes |
 | `!` | `x` | Important | `TODO` | Yes |

--- a/tests/DocsSamplesForStatuses.test.Theme_Ebullientworks Table.approved.md
+++ b/tests/DocsSamplesForStatuses.test.Theme_Ebullientworks Table.approved.md
@@ -4,7 +4,7 @@
 | ----- | ----- | ----- | ----- | ----- |
 | `space` | `x` | Unchecked | `TODO` | No |
 | `x` | `space` | Checked | `DONE` | No |
-| `-` | `x` | Cancelled | `CANCELLED` | Yes |
+| `-` | `space` | Cancelled | `CANCELLED` | Yes |
 | `/` | `x` | In Progress | `IN_PROGRESS` | Yes |
 | `>` | `x` | Deferred | `TODO` | Yes |
 | `!` | `x` | Important | `TODO` | Yes |

--- a/tests/DocsSamplesForStatuses.test.Theme_ITS Table.approved.md
+++ b/tests/DocsSamplesForStatuses.test.Theme_ITS Table.approved.md
@@ -5,7 +5,7 @@
 | `space` | `x` | Unchecked | `TODO` | No |
 | `x` | `space` | Regular | `DONE` | No |
 | `X` | `space` | Checked | `DONE` | Yes |
-| `-` | `x` | Dropped | `CANCELLED` | Yes |
+| `-` | `space` | Dropped | `CANCELLED` | Yes |
 | `>` | `x` | Forward | `TODO` | Yes |
 | `D` | `x` | Date | `TODO` | Yes |
 | `?` | `x` | Question | `TODO` | Yes |

--- a/tests/DocsSamplesForStatuses.test.Theme_Minimal Table.approved.md
+++ b/tests/DocsSamplesForStatuses.test.Theme_Minimal Table.approved.md
@@ -5,7 +5,7 @@
 | `space` | `x` | to-do | `TODO` | No |
 | `/` | `x` | incomplete | `IN_PROGRESS` | Yes |
 | `x` | `space` | done | `DONE` | No |
-| `-` | `x` | canceled | `CANCELLED` | Yes |
+| `-` | `space` | canceled | `CANCELLED` | Yes |
 | `>` | `x` | forwarded | `TODO` | Yes |
 | `<` | `x` | scheduling | `TODO` | Yes |
 | `?` | `x` | question | `TODO` | Yes |

--- a/tests/DocsSamplesForStatuses.test.Theme_Things Table.approved.md
+++ b/tests/DocsSamplesForStatuses.test.Theme_Things Table.approved.md
@@ -5,7 +5,7 @@
 | `space` | `x` | to-do | `TODO` | No |
 | `/` | `x` | incomplete | `IN_PROGRESS` | Yes |
 | `x` | `space` | done | `DONE` | No |
-| `-` | `x` | canceled | `CANCELLED` | Yes |
+| `-` | `space` | canceled | `CANCELLED` | Yes |
 | `>` | `x` | forwarded | `TODO` | Yes |
 | `<` | `x` | scheduling | `TODO` | Yes |
 | `?` | `x` | question | `TODO` | Yes |

--- a/tests/DocsSamplesForStatuses.test.ts
+++ b/tests/DocsSamplesForStatuses.test.ts
@@ -9,8 +9,9 @@ import * as FilterParser from '../src/Query/FilterParser';
 import { Group } from '../src/Query/Group';
 import { StatusNameField } from '../src/Query/Filter/StatusNameField';
 import { StatusTypeField } from '../src/Query/Filter/StatusTypeField';
-import type { StatusCollection } from '../src/StatusCollection';
+import type { StatusCollection, StatusCollectionEntry } from '../src/StatusCollection';
 import * as Themes from '../src/Config/Themes';
+import { StatusValidator } from '../src/StatusValidator';
 import { TaskBuilder } from './TestingTools/TaskBuilder';
 
 function verifyMarkdown(markdown: string) {
@@ -176,7 +177,13 @@ describe('Theme', () => {
         ['Things', Themes.thingsSupportedStatuses()],
     ];
 
-    describe.each(themes)('%s', (_, statuses) => {
+    describe.each(themes)('%s', (_: string, statuses: StatusCollection) => {
+        it.each(statuses)('Validate status: "%s", "%s", "%s", "%s"', (symbol, name, nextSymbol, type) => {
+            const statusValidator = new StatusValidator();
+            const entry: StatusCollectionEntry = [symbol, name, nextSymbol, type];
+            expect(statusValidator.validateStatusCollectionEntry(entry)).toEqual([]);
+        });
+
         it('Table', () => {
             verifyStatusesAsMarkdownTable(constructStatuses(statuses), true);
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Imported CANCELLED tasks for themes now toggle to TODO instead of DONE.

This makes them consistent with the default CANCELLED status in Tasks.

## Motivation and Context

Fixes #1605

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- By adding tests
- By running the new code inside Obsidian

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
