### PR TITLE
feat: Clarify theme buttons in status settings

### DIFF
--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -427,20 +427,20 @@ export class SettingsTab extends PluginSettingTab {
         /* -------------------- Add all Status types supported by ... buttons -------------------- */
         type NamedTheme = [string, StatusCollection];
         const themes: NamedTheme[] = [
-            ['Minimal Theme', Themes.minimalSupportedStatuses()],
-            ['ITS Theme', Themes.itsSupportedStatuses()],
-            ['Things Theme', Themes.thingsSupportedStatuses()],
-            ['Aura Theme (Dark mode only)', Themes.auraSupportedStatuses()],
+            // Light and Dark themes - alphabetical order
             ['Ebullientworks Theme', Themes.ebullientworksSupportedStatuses()],
+            ['ITS Theme & SlRvb Checkboxes', Themes.itsSupportedStatuses()],
+            ['Minimal Theme', Themes.minimalSupportedStatuses()],
+            ['Things Theme', Themes.thingsSupportedStatuses()],
+            // Dark only themes - alphabetical order
+            ['Aura Theme (Dark mode only)', Themes.auraSupportedStatuses()],
         ];
         for (const [name, collection] of themes) {
             const addStatusesSupportedByThisTheme = new Setting(containerEl).addButton((button) => {
-                button
-                    .setButtonText('Add all Status types supported by ' + name)
-                    .setCta()
-                    .onClick(async () => {
-                        await addCustomStatesToSettings(collection, statusSettings, settings);
-                    });
+                const label = `${name}: Add ${collection.length} supported Statuses`;
+                button.setButtonText(label).onClick(async () => {
+                    await addCustomStatesToSettings(collection, statusSettings, settings);
+                });
             });
             addStatusesSupportedByThisTheme.infoEl.remove();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

A few small changes that make the buttons much easier to read

- The 'Add all Status types...' buttons are no longer calls-to-action - so now just plain colour
- The text at the right side is aligned, making the remainder easier to read
- The number of supported statuses in each is now displayed
- The name 'SlRvb Checkboxes' is now shown...
- Remove use of 'Status **types**' - which I missed out by mistake before the 1.23.0 release
- The order is better:
    - Sorted by name, for things that work on dark and light
    - Then sorted by name for dark-only

## Motivation and Context

With the addition of more themes, the intensity of all the theme buttons was making my eyes hurt!

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

In the demo vault.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4840096/215355057-6c08dc75-e89e-4520-b46c-cf000a32ba7b.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
