### PR TITLE
docs: Fix some issues in the recurrence docs

### DIFF
--- a/docs/getting-started/recurring-tasks.md
+++ b/docs/getting-started/recurring-tasks.md
@@ -88,7 +88,11 @@ You can validate that tasks understands your rule by using the `Tasks: Create or
 
 ---
 
-## Repeating a Task Based on the Original Due Date or the Completion Date
+## Make Overdue Recurring Tasks Skip to Next Future Date: use `when done`
+
+Use `when done` at the end of your recurrence rule. For details, see below.
+
+### Repeating a Task Based on the Original Due Date or the Completion Date
 
 When you create a recurring task, you can decide whether the next occurrence should be based on the original dates or the date when you completed the task.
 The default behavior results in newly created tasks having dates relative to the original task rather than "today".

--- a/docs/getting-started/recurring-tasks.md
+++ b/docs/getting-started/recurring-tasks.md
@@ -50,7 +50,9 @@ The next Sunday after 25 April 2021 is on 2 May.
 Important
 {: .label .label-yellow }
 
-A recurring task should have a due date. The due date and the recurrence rule must appear after the task's description.
+A recurring task should have at least one of start, scheduled and due dates. The date(s) and the recurrence rule must appear after the task's description.
+
+(Technically, you _can_ add a recurrence rule to a task without any dates, but it is not clear that the behaviour is very useful.)
 
 <hr />
 Important

--- a/docs/getting-started/recurring-tasks.md
+++ b/docs/getting-started/recurring-tasks.md
@@ -266,7 +266,7 @@ Examples of possible recurrence rules (mix and match as desired; these should be
 - `🔁 every 6 months on the 2nd Wednesday`
 - `🔁 every January on the 15th`
 - `🔁 every February on the last`
-- `🔁 every April and December on the 1st and 24th` (meaning every _April 1st_ and _December 24th_)
+- `🔁 every April and December on the 1st and 24th` (meaning every _April 1st_, _April 24th_, _December 1st_ and _December 24th_)
 - `🔁 every year`
 
 ---


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

- Update incorrect docs in recurrence. Due date is not mandatory.
    - Fixes #1651.
- Try to make 'when done' much more visible in recurrence docs
    - This gets requested as a new feature reasonably often, so this attempts to make it visible in the table of contents.
    - Fixes #1642.
- Fix 'every April and December on the 1st and 24th' docs
    - Fixes #611
    - I spent ridiculous amounts of time trying to actually write a test to prove the behaviour. But I did confirm manually that the behaviour is still what I logged #611.


## Motivation and Context

- Trying to make docs better for users
- Trying to reduce support overhead of feature requests for the existing `when done`

## How has this been tested?

- Viewing the generated docs locally

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
