### PR TITLE
fix: Prevent rare overwrite of wrong line in Reading mode & results blocks

### DIFF
--- a/src/File.ts
+++ b/src/File.ts
@@ -2,7 +2,10 @@ import { MetadataCache, TFile, Vault } from 'obsidian';
 import type { ListItemCache } from 'obsidian';
 
 import { getSettings } from './Config/Settings';
-import type { Task } from './Task';
+import { Task } from './Task';
+
+import { DateFallback } from './DateFallback';
+import { Lazy } from './lib/Lazy';
 
 let metadataCache: MetadataCache | undefined;
 let vault: Vault | undefined;
@@ -24,6 +27,10 @@ export const initializeFile = ({
  * If you pass more than one replacement task, all subsequent tasks in the same
  * section must be re-rendered, as their section indexes change. Assuming that
  * this is done faster than user interaction in practice.
+ *
+ * In addition, this function is meant to be called with reasonable confidence
+ * that the {@code originalTask} is unmodified and at the exact same section and
+ * sectionIdx in the source file it was originally found in. It will fail otherwise.
  */
 export const replaceTaskWithTasks = async ({
     originalTask,
@@ -125,10 +132,20 @@ const tryRepetitive = async ({
         }
 
         const line = fileLines[listItemCache.position.start.line];
-
         if (line.includes(globalFilter)) {
             if (sectionIndex === originalTask.sectionIndex) {
-                listItem = listItemCache;
+                const dateFromFileName = new Lazy(() => DateFallback.fromPath(originalTask.path));
+                const taskFromLine = Task.fromLine({
+                    line,
+                    path: originalTask.path,
+                    precedingHeader: originalTask.precedingHeader,
+                    sectionStart: originalTask.sectionStart,
+                    sectionIndex: originalTask.sectionIndex,
+                    fallbackDate: dateFromFileName.value,
+                });
+                if (taskFromLine?.identicalTo(originalTask) === true) {
+                    listItem = listItemCache;
+                }
                 break;
             }
 

--- a/src/File.ts
+++ b/src/File.ts
@@ -145,6 +145,12 @@ const tryRepetitive = async ({
                 });
                 if (taskFromLine?.identicalTo(originalTask) === true) {
                     listItem = listItemCache;
+                } else {
+                    console.error(
+                        `Tasks: Unable to find task in file ${originalTask.path}.\n` +
+                            `Expected task: ${originalTask.toFileLineString()}. Found task line: ${line}.`,
+                    );
+                    return;
                 }
                 break;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

In essence, when a task is toggled by the Tasks plugin, the code reads the file that contains the task to find the line to update.

Under certain circumstances (listed below) it may find and update the wrong line, overwriting a different task.

This change makes Tasks check, **when in Reading mode and in Tasks results blocks**,  that the line it is about to overwrite actually contains the expected text. If it does not, the toggling action will halt, and a message will be written to the console.

Note: **This change does not affect Live Preview**. That is planned to be addressed in a separate pull request.

---

All of the detail needed should be in the commit messages.

Update: The key bit is:

> Currently, the unique identifier (UID) for tasks
> are a source file, a section, and an index into
> the array of global-filter-matching tasks within
> that section.
> 
> This diff does not change how tasks are uniquely
> identified.
> 
> However, it does implement a guard when overwriting a
> task in some file to ensure the line that is being
> overwritten has similar content to the line that
> was used to create the Task in the first place.
> 
> The world "similar" is used since the line is
> permitted to have different content, so long as that
> line represents a Task with identical data as per
> the definition of Task.identicalTo

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As an interim fix to #688 so that the users' data is not overwritten.

Some additional notes:
- should fix very occasional accidental overwriting of the wrong line when toggling a task - suspected to maybe be caused by file being synced whilst the task is being completed...
- may fix #1659, but need more info on repro case from reporter...
- once the checkbox is clicked and this guard is "hit", the checkbox cannot be clicked again. This wasn't intentional but it happens...
- also fixes (disables incorrect data overwrite) inline markdown blocks that reference a header of a note.
ex)
```
## Category1 
- [ ] task1

![[#Category 2]]

## Category 2
- [ ] task2
```

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Locally and within my personal vault.

I've tested the fix for the particular issue plus normal usage.

## Screenshots (if appropriate)

https://user-images.githubusercontent.com/38915815/218746728-2e63cf32-1053-41e2-9dd4-4216b9c9991a.mov


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [X] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms


<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [X] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [X] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
