### PR TITLE
Fix reading stale file data when replacing task

### DIFF
--- a/src/File.ts
+++ b/src/File.ts
@@ -139,7 +139,7 @@ const tryRepetitive = async ({
                 } else {
                     console.error(
                         `Tasks: Unable to find task in file ${originalTask.path}.\n` +
-                            `Expected task: ${originalTask.toFileLineString()}. Found task line: ${line}.`,
+                        `Expected task:\n${originalTask.toFileLineString()}.\nFound task:\n${line}.`,
                     );
                     return;
                 }

--- a/src/File.ts
+++ b/src/File.ts
@@ -2,7 +2,7 @@ import { MarkdownView, MetadataCache, TFile, Vault, Workspace } from 'obsidian';
 import type { ListItemCache } from 'obsidian';
 
 import { getSettings } from './Config/Settings';
-import { Task } from './Task';
+import type { Task } from './Task';
 
 let metadataCache: MetadataCache | undefined;
 let vault: Vault | undefined;
@@ -10,7 +10,7 @@ let workspace: Workspace | undefined;
 
 /** the two lists below must be maintained together. */
 const supportedFileExtensions = ['md'];
-const supportedViewTypes      = [MarkdownView];
+const supportedViewTypes = [MarkdownView];
 
 export const initializeFile = ({
     metadataCache: newMetadataCache,
@@ -127,7 +127,7 @@ const tryRepetitive = async ({
 
     // before reading the file, save all open views which may contain dirty data not yet saved to filesys.
     // TODO: future opt is save only if some dirty bit is set.
-    const promises : Promise<void>[] = [];
+    const promises: Promise<void>[] = [];
     workspace.iterateAllLeaves((leaf) => {
         supportedViewTypes.forEach((viewType) => {
             if (leaf.view instanceof viewType && leaf.view.file.path === file.path) {
@@ -160,7 +160,7 @@ const tryRepetitive = async ({
                 } else {
                     console.error(
                         `Tasks: Unable to find task in file ${originalTask.path}.\n` +
-                        `Expected task:\n${originalTask.toFileLineString()}.\nFound task:\n${line}.`,
+                            `Expected task:\n${originalTask.toFileLineString()}.\nFound task:\n${line}.`,
                     );
                     return;
                 }

--- a/src/File.ts
+++ b/src/File.ts
@@ -134,16 +134,7 @@ const tryRepetitive = async ({
         const line = fileLines[listItemCache.position.start.line];
         if (line.includes(globalFilter)) {
             if (sectionIndex === originalTask.sectionIndex) {
-                const dateFromFileName = new Lazy(() => DateFallback.fromPath(originalTask.path));
-                const taskFromLine = Task.fromLine({
-                    line,
-                    path: originalTask.path,
-                    precedingHeader: originalTask.precedingHeader,
-                    sectionStart: originalTask.sectionStart,
-                    sectionIndex: originalTask.sectionIndex,
-                    fallbackDate: dateFromFileName.value,
-                });
-                if (taskFromLine?.identicalTo(originalTask) === true) {
+                if (line === originalTask.originalMarkdown) {
                     listItem = listItemCache;
                 } else {
                     console.error(

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ export default class TasksPlugin extends Plugin {
         initializeFile({
             metadataCache: this.app.metadataCache,
             vault: this.app.vault,
+            workspace: this.app.workspace,
         });
 
         // Load configured status types.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

1. Use `.originalMarkdown` in guard when replace task (discussed with @claremacrae already)
2. Adjust formatting of guard print when replace task
3. Fix reading stale file data when replacing task

Here, "stale file data" is defined as "not in sync with what the user is seeing on the screen", aka, "not in sync with the MarkdownView of the file that they have edited".

what happens is before reading the file, all open views that view the file that the task is contained in are forced to save.

**please note I am not in favour of this as a solution and am very open to alternatives. I open this PR for discussion**

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To fix repro case discussed recently in #984 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Locally in my vault with the specific repro case and seeing it no longer repro.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [X] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [X] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [X] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [X] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
