### PR TITLE
feat: Teach DateParser to read date ranges

### DIFF
--- a/src/Query/DateParser.ts
+++ b/src/Query/DateParser.ts
@@ -15,7 +15,7 @@ export class DateParser {
 
     /**
      * Parse a line and extract a pair of dates, returned in a tuple
-     * @param input - any pair of dates, separate by a hyphen '17 August 2013 - 19 August 2013',
+     * @param input - any pair of dates, separate by one or more spaces '17 August 2013 19 August 2013',
      *                or a single date
      */
     public static parseDateRange(input: string): [moment.Moment, moment.Moment] {
@@ -24,7 +24,7 @@ export class DateParser {
         });
 
         const start = result[0].start;
-        const end = result[0].end ? result[0].end : start;
+        const end = result[1] && result[1].start ? result[1].start : start;
         return [window.moment(start.date()), window.moment(end.date())];
     }
 }

--- a/src/Query/DateParser.ts
+++ b/src/Query/DateParser.ts
@@ -1,4 +1,5 @@
 import * as chrono from 'chrono-node';
+import type moment from 'moment';
 
 export class DateParser {
     public static parseDate(input: string, forwardDate: boolean = false): moment.Moment {
@@ -12,13 +13,18 @@ export class DateParser {
             .startOf('day');
     }
 
-    public static parseDateRange(input: string) {
+    /**
+     * Parse a line and extract a pair of dates, returned in a tuple
+     * @param input - any pair of dates, separate by a hyphen '17 August 2013 - 19 August 2013',
+     *                or a single date
+     */
+    public static parseDateRange(input: string): [moment.Moment, moment.Moment] {
         const result = chrono.parse(input, undefined, {
             forwardDate: true,
         });
 
         const start = result[0].start;
-        const end = result[0].end;
-        return [window.moment(start.date()), window.moment(end!.date())];
+        const end = result[0].end ? result[0].end : start;
+        return [window.moment(start.date()), window.moment(end.date())];
     }
 }

--- a/src/Query/DateParser.ts
+++ b/src/Query/DateParser.ts
@@ -1,5 +1,5 @@
 import * as chrono from 'chrono-node';
-import type moment from 'moment';
+import moment from 'moment';
 
 export class DateParser {
     public static parseDate(input: string, forwardDate: boolean = false): moment.Moment {
@@ -17,11 +17,16 @@ export class DateParser {
      * Parse a line and extract a pair of dates, returned in a tuple, sorted by date.
      * @param input - any pair of dates, separate by one or more spaces '17 August 2013 19 August 2013',
      *                or a single date.
+     * @return - A Tuple of dates. If both input dates are invalid, then both ouput dates will be invalid.
      */
     public static parseDateRange(input: string): [moment.Moment, moment.Moment] {
         const result = chrono.parse(input, undefined, {
             forwardDate: true,
         });
+
+        if (result.length === 0) {
+            return [moment.invalid(), moment.invalid()];
+        }
 
         const startDate = result[0].start;
         const endDate = result[1] && result[1].start ? result[1].start : startDate;

--- a/src/Query/DateParser.ts
+++ b/src/Query/DateParser.ts
@@ -14,17 +14,22 @@ export class DateParser {
     }
 
     /**
-     * Parse a line and extract a pair of dates, returned in a tuple
+     * Parse a line and extract a pair of dates, returned in a tuple, sorted by date.
      * @param input - any pair of dates, separate by one or more spaces '17 August 2013 19 August 2013',
-     *                or a single date
+     *                or a single date.
      */
     public static parseDateRange(input: string): [moment.Moment, moment.Moment] {
         const result = chrono.parse(input, undefined, {
             forwardDate: true,
         });
 
-        const start = result[0].start;
-        const end = result[1] && result[1].start ? result[1].start : start;
-        return [window.moment(start.date()), window.moment(end.date())];
+        const startDate = result[0].start;
+        const endDate = result[1] && result[1].start ? result[1].start : startDate;
+        const start = window.moment(startDate.date());
+        const end = window.moment(endDate.date());
+        if (end.isBefore(start)) {
+            return [end, start];
+        }
+        return [start, end];
     }
 }

--- a/src/Query/DateParser.ts
+++ b/src/Query/DateParser.ts
@@ -11,4 +11,14 @@ export class DateParser {
             )
             .startOf('day');
     }
+
+    public static parseDateRange(input: string) {
+        const result = chrono.parse(input, undefined, {
+            forwardDate: true,
+        });
+
+        const start = result[0].start;
+        const end = result[0].end;
+        return [window.moment(start.date()), window.moment(end!.date())];
+    }
 }

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -25,9 +25,9 @@ describe('DateParser - single dates', () => {
 });
 
 describe('DateParser - date ranges', () => {
-    it('should parse date range from chrono docs - with hyphen', () => {
+    it('should parse date range from chrono docs - but without hyphen', () => {
         // Arrange
-        const input = '17 August 2013 - 19 August 2013';
+        const input = '17 August 2013 19 August 2013';
 
         // Act
         const result = DateParser.parseDateRange(input);
@@ -62,7 +62,7 @@ describe('DateParser - date ranges', () => {
         expect(window.moment(end!.date()).format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-19');
     });
 
-    it('should parse date range without hyphen and multiple spaces', () => {
+    it('should parse single date as date range', () => {
         // Arrange
         const input = '2019-12-28';
 

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -2,34 +2,23 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
-
-window.moment = moment;
-
 import { DateParser } from '../../src/Query/DateParser';
 import { TaskRegularExpressions } from '../../src/Task';
 
+window.moment = moment;
+
+function testParsingeSingleDate(input: string, result: string) {
+    const moment = DateParser.parseDate(input);
+    expect(moment.format(TaskRegularExpressions.dateFormat)).toEqual(result);
+}
+
 describe('DateParser', () => {
     it('should parse a valid fixed date correctly', () => {
-        // Arrange
         const input = '2021-03-17';
-
-        // Act
-        const moment = DateParser.parseDate(input);
-
-        // Assert
-        expect(moment.isValid()).toEqual(true);
-        expect(moment.format(TaskRegularExpressions.dateFormat)).toEqual(input);
+        testParsingeSingleDate(input, input);
     });
 
     it('should recognise an invalid date correctly', () => {
-        // Arrange
-        const input = '2021-13-17';
-
-        // Act
-        const moment = DateParser.parseDate(input);
-
-        // Assert
-        expect(moment.isValid()).toEqual(false);
-        expect(moment.format(TaskRegularExpressions.dateFormat)).toEqual('Invalid date');
+        testParsingeSingleDate('2021-13-17', 'Invalid date');
     });
 });

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -30,19 +30,16 @@ describe('DateParser - date ranges', () => {
         const input = '17 August 2013 - 19 August 2013';
 
         // Act
-        const result = chrono.parse(input, undefined, {
-            forwardDate: true,
-        });
+        const result = DateParser.parseDateRange(input);
 
         // Assert
-        expect(result.length).toEqual(1);
-        const start = result[0].start;
+        const start = result[0];
         expect(start).toBeDefined();
-        expect(window.moment(start.date()).format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-17');
+        expect(start.format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-17');
 
-        const end = result[0].end;
+        const end = result[1];
         expect(end).toBeDefined();
-        expect(window.moment(end!.date()).format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-19');
+        expect(end.format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-19');
     });
 
     it('should parse date range without hyphen and multiple spaces', () => {

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -18,12 +18,12 @@ function testParsingDateRange(input: string, expectedStart: string, expectedEnd:
 
     // Assert
     const start = result[0];
-    expect(start).toBeDefined();
-    expect(start.format(TaskRegularExpressions.dateFormat)).toEqual(expectedStart);
-
     const end = result[1];
+    expect(start).toBeDefined();
     expect(end).toBeDefined();
-    expect(end.format(TaskRegularExpressions.dateFormat)).toEqual(expectedEnd);
+    const startFmt = start.format(TaskRegularExpressions.dateFormat);
+    const endFmt = end.format(TaskRegularExpressions.dateFormat);
+    expect([startFmt, endFmt]).toStrictEqual([expectedStart, expectedEnd]);
 }
 
 describe('DateParser - single dates', () => {
@@ -45,6 +45,10 @@ describe('DateParser - date ranges', () => {
 
     it('should parse date range with  multiple spaces', () => {
         testParsingDateRange('2013-08-17   2014-08-19', '2013-08-17', '2014-08-19');
+    });
+
+    it('should parse date range with end before start', () => {
+        testParsingDateRange('2017-08-17 2014-08-19', '2014-08-19', '2017-08-17');
     });
 
     it('should parse single date as date range', () => {

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -56,4 +56,16 @@ describe('DateParser - date ranges', () => {
         const input = '2019-12-28';
         testParsingDateRange(input, input, input);
     });
+
+    it('should ignore invalid start date when parsing range', () => {
+        testParsingDateRange('2013-99-29 2014-08-19', '2014-08-19', '2014-08-19');
+    });
+
+    it('should ignore invalid end date when parsing range', () => {
+        testParsingDateRange('2014-08-19 2015-99-29', '2014-08-19', '2014-08-19');
+    });
+
+    it('should return 2 invalid dates when both dates are invalid', () => {
+        testParsingDateRange('2015-99-29 2015-99-29', 'Invalid date', 'Invalid date');
+    });
 });

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -12,6 +12,20 @@ function testParsingeSingleDate(input: string, result: string) {
     expect(moment.format(TaskRegularExpressions.dateFormat)).toEqual(result);
 }
 
+function testParsingDateRange(input: string, expectedStart: string, expectedEnd: string) {
+    // Act
+    const result = DateParser.parseDateRange(input);
+
+    // Assert
+    const start = result[0];
+    expect(start).toBeDefined();
+    expect(start.format(TaskRegularExpressions.dateFormat)).toEqual(expectedStart);
+
+    const end = result[1];
+    expect(end).toBeDefined();
+    expect(end.format(TaskRegularExpressions.dateFormat)).toEqual(expectedEnd);
+}
+
 describe('DateParser - single dates', () => {
     it('should parse a valid fixed date correctly', () => {
         const input = '2021-03-17';
@@ -26,52 +40,16 @@ describe('DateParser - single dates', () => {
 describe('DateParser - date ranges', () => {
     it('should parse date range from natural dates', () => {
         // Arrange
-        const input = '17 August 2013 19 August 2013';
-
-        // Act
-        const result = DateParser.parseDateRange(input);
-
-        // Assert
-        const start = result[0];
-        expect(start).toBeDefined();
-        expect(start.format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-17');
-
-        const end = result[1];
-        expect(end).toBeDefined();
-        expect(end.format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-19');
+        testParsingDateRange('17 August 2013 19 August 2013', '2013-08-17', '2013-08-19');
     });
 
     it('should parse date range with  multiple spaces', () => {
-        // Arrange
-        const input = '2013-08-17   2014-08-19';
-
-        // Act
-        const result = DateParser.parseDateRange(input);
-
-        // Assert
-        const start = result[0];
-        expect(start).toBeDefined();
-        expect(start.format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-17');
-
-        const end = result[1];
-        expect(end).toBeDefined();
-        expect(end.format(TaskRegularExpressions.dateFormat)).toEqual('2014-08-19');
+        testParsingDateRange('2013-08-17   2014-08-19', '2013-08-17', '2014-08-19');
     });
 
     it('should parse single date as date range', () => {
         // Arrange
         const input = '2019-12-28';
-
-        // Act
-        const result = DateParser.parseDateRange(input);
-
-        // Assert
-        const start = result[0];
-        expect(start).toBeDefined();
-        expect(start.format(TaskRegularExpressions.dateFormat)).toEqual(input);
-
-        const end = result[1];
-        expect(end).toBeDefined();
-        expect(end.format(TaskRegularExpressions.dateFormat)).toEqual(input);
+        testParsingDateRange(input, input, input);
     });
 });

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -61,4 +61,21 @@ describe('DateParser - date ranges', () => {
         expect(end).toBeDefined();
         expect(window.moment(end!.date()).format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-19');
     });
+
+    it('should parse date range without hyphen and multiple spaces', () => {
+        // Arrange
+        const input = '2019-12-28';
+
+        // Act
+        const result = DateParser.parseDateRange(input);
+
+        // Assert
+        const start = result[0];
+        expect(start).toBeDefined();
+        expect(start.format(TaskRegularExpressions.dateFormat)).toEqual(input);
+
+        const end = result[1];
+        expect(end).toBeDefined();
+        expect(end.format(TaskRegularExpressions.dateFormat)).toEqual(input);
+    });
 });

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -25,7 +25,7 @@ describe('DateParser - single dates', () => {
 });
 
 describe('DateParser - date ranges', () => {
-    it('should parse date range from chrono docs', () => {
+    it('should parse date range from chrono docs - with hyphen', () => {
         // Arrange
         const input = '17 August 2013 - 19 August 2013';
 
@@ -43,7 +43,25 @@ describe('DateParser - date ranges', () => {
         const end = result[0].end;
         expect(end).toBeDefined();
         expect(window.moment(end!.date()).format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-19');
+    });
 
-        console.log(result);
+    it('should parse date range without hyphen', () => {
+        // Arrange
+        const input = '17 August 2013 19 August 2013';
+
+        // Act
+        const result = chrono.parse(input, undefined, {
+            forwardDate: true,
+        });
+
+        // Assert
+        expect(result.length).toEqual(2);
+        const start = result[0].start;
+        expect(start).toBeDefined();
+        expect(window.moment(start.date()).format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-17');
+
+        const end = result[1].start;
+        expect(end).toBeDefined();
+        expect(window.moment(end!.date()).format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-19');
     });
 });

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+import moment from 'moment';
+
+window.moment = moment;
+
+import { DateParser } from '../../src/Query/DateParser';
+import { TaskRegularExpressions } from '../../src/Task';
+
+describe('DateParser', () => {
+    it('should parse a valid fixed date correctly', () => {
+        // Arrange
+        const input = '2021-03-17';
+
+        // Act
+        const moment = DateParser.parseDate(input);
+
+        // Assert
+        expect(moment.isValid()).toEqual(true);
+        expect(moment.format(TaskRegularExpressions.dateFormat)).toEqual(input);
+    });
+
+    it('should recognise an invalid date correctly', () => {
+        // Arrange
+        const input = '2021-13-17';
+
+        // Act
+        const moment = DateParser.parseDate(input);
+
+        // Assert
+        expect(moment.isValid()).toEqual(false);
+        expect(moment.format(TaskRegularExpressions.dateFormat)).toEqual('Invalid date');
+    });
+});

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
-import * as chrono from 'chrono-node';
 import { DateParser } from '../../src/Query/DateParser';
 import { TaskRegularExpressions } from '../../src/Task';
 
@@ -42,24 +41,21 @@ describe('DateParser - date ranges', () => {
         expect(end.format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-19');
     });
 
-    it('should parse date range without hyphen and multiple spaces', () => {
+    it('should parse date range with  multiple spaces', () => {
         // Arrange
-        const input = '2013-08-17   2013-08-19';
+        const input = '2013-08-17   2014-08-19';
 
         // Act
-        const result = chrono.parse(input, undefined, {
-            forwardDate: true,
-        });
+        const result = DateParser.parseDateRange(input);
 
         // Assert
-        expect(result.length).toEqual(2);
-        const start = result[0].start;
+        const start = result[0];
         expect(start).toBeDefined();
-        expect(window.moment(start.date()).format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-17');
+        expect(start.format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-17');
 
-        const end = result[1].start;
+        const end = result[1];
         expect(end).toBeDefined();
-        expect(window.moment(end!.date()).format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-19');
+        expect(end.format(TaskRegularExpressions.dateFormat)).toEqual('2014-08-19');
     });
 
     it('should parse single date as date range', () => {

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -45,9 +45,9 @@ describe('DateParser - date ranges', () => {
         expect(window.moment(end!.date()).format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-19');
     });
 
-    it('should parse date range without hyphen', () => {
+    it('should parse date range without hyphen and multiple spaces', () => {
         // Arrange
-        const input = '17 August 2013 19 August 2013';
+        const input = '2013-08-17   2013-08-19';
 
         // Act
         const result = chrono.parse(input, undefined, {

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -24,7 +24,7 @@ describe('DateParser - single dates', () => {
 });
 
 describe('DateParser - date ranges', () => {
-    it('should parse date range from chrono docs - but without hyphen', () => {
+    it('should parse date range from natural dates', () => {
         // Arrange
         const input = '17 August 2013 19 August 2013';
 

--- a/tests/Query/DateParser.test.ts
+++ b/tests/Query/DateParser.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
+import * as chrono from 'chrono-node';
 import { DateParser } from '../../src/Query/DateParser';
 import { TaskRegularExpressions } from '../../src/Task';
 
@@ -12,7 +13,7 @@ function testParsingeSingleDate(input: string, result: string) {
     expect(moment.format(TaskRegularExpressions.dateFormat)).toEqual(result);
 }
 
-describe('DateParser', () => {
+describe('DateParser - single dates', () => {
     it('should parse a valid fixed date correctly', () => {
         const input = '2021-03-17';
         testParsingeSingleDate(input, input);
@@ -20,5 +21,29 @@ describe('DateParser', () => {
 
     it('should recognise an invalid date correctly', () => {
         testParsingeSingleDate('2021-13-17', 'Invalid date');
+    });
+});
+
+describe('DateParser - date ranges', () => {
+    it('should parse date range from chrono docs', () => {
+        // Arrange
+        const input = '17 August 2013 - 19 August 2013';
+
+        // Act
+        const result = chrono.parse(input, undefined, {
+            forwardDate: true,
+        });
+
+        // Assert
+        expect(result.length).toEqual(1);
+        const start = result[0].start;
+        expect(start).toBeDefined();
+        expect(window.moment(start.date()).format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-17');
+
+        const end = result[0].end;
+        expect(end).toBeDefined();
+        expect(window.moment(end!.date()).format(TaskRegularExpressions.dateFormat)).toEqual('2013-08-19');
+
+        console.log(result);
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add `DateParser.parseDateRange()` to parse filters with two dates.

## Motivation and Context

This is a step on the way to implementing #1613.


## How has this been tested?

By TDD.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

This is a new feature in code, not yet visible to users.

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

All changes done by pairing with @ilandikov 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
