### PR TITLE
refactor: Modularizing task serialization, task deserialization and suggestion building

### DIFF
--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -1,5 +1,7 @@
+import { DEFAULT_SYMBOLS } from '../TaskSerializer/default';
 import { StatusConfiguration } from '../StatusConfiguration';
 import { Status } from '../Status';
+import { DefaultTaskSerializer, type TaskSerializer } from '../TaskSerializer';
 import { DebugSettings } from './DebugSettings';
 import { StatusSettings } from './StatusSettings';
 import { Feature } from './Feature';
@@ -13,9 +15,21 @@ export type HeadingState = {
     [id: string]: boolean;
 };
 
+interface TaskFormat {
+    taskSerializer: TaskSerializer;
+}
+
+const TaskFormatMap = {
+    Default: { taskSerializer: new DefaultTaskSerializer(DEFAULT_SYMBOLS) },
+} as const;
+
+type TaskFormatMap = typeof TaskFormatMap;
+export const taskFormatKeys = Object.keys(TaskFormatMap) as (keyof TaskFormatMap)[];
+
 export interface Settings {
     globalFilter: string;
     removeGlobalFilter: boolean;
+    taskFormat: keyof TaskFormatMap;
     setDoneDate: boolean;
     autoSuggestInEditor: boolean;
     autoSuggestMinMatch: number;
@@ -42,6 +56,7 @@ export interface Settings {
 const defaultSettings: Settings = {
     globalFilter: '',
     removeGlobalFilter: false,
+    taskFormat: 'Default',
     setDoneDate: true,
     autoSuggestInEditor: true,
     autoSuggestMinMatch: 0,
@@ -148,3 +163,16 @@ export const toggleFeature = (internalName: string, enabled: boolean): FeatureFl
     settings.features[internalName] = enabled;
     return settings.features;
 };
+
+/**
+ * Retrieves specified task format. If none provided, returns one specified by settings
+ *
+ * @export
+ * @param name The name of the TaskFormat
+ * @returns TaskFormat
+ */
+export function getTaskFormat(name?: undefined): TaskFormat;
+export function getTaskFormat<T extends keyof TaskFormatMap>(name: T): TaskFormatMap[T];
+export function getTaskFormat(name?: keyof TaskFormatMap): TaskFormat {
+    return TaskFormatMap[name || getSettings().taskFormat];
+}

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -1,7 +1,9 @@
+import { defaultSuggestionBuilderFactory } from '../Suggestor/Suggestor';
 import { DEFAULT_SYMBOLS } from '../TaskSerializer/default';
 import { StatusConfiguration } from '../StatusConfiguration';
 import { Status } from '../Status';
 import { DefaultTaskSerializer, type TaskSerializer } from '../TaskSerializer';
+import type { SuggestionBuilder } from '../Suggestor';
 import { DebugSettings } from './DebugSettings';
 import { StatusSettings } from './StatusSettings';
 import { Feature } from './Feature';
@@ -17,10 +19,14 @@ export type HeadingState = {
 
 interface TaskFormat {
     taskSerializer: TaskSerializer;
+    buildSuggestions?: SuggestionBuilder;
 }
 
 const TaskFormatMap = {
-    Default: { taskSerializer: new DefaultTaskSerializer(DEFAULT_SYMBOLS) },
+    Default: {
+        taskSerializer: new DefaultTaskSerializer(DEFAULT_SYMBOLS),
+        buildSuggestions: defaultSuggestionBuilderFactory(DEFAULT_SYMBOLS),
+    },
 } as const;
 
 type TaskFormatMap = typeof TaskFormatMap;

--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -1,10 +1,9 @@
 import { App, Editor, EditorSuggest, TFile } from 'obsidian';
 import type { EditorPosition, EditorSuggestContext, EditorSuggestTriggerInfo } from 'obsidian';
 
-import type { Settings } from '../Config/Settings';
+import { type Settings, getTaskFormat } from '../Config/Settings';
 import * as task from '../Task';
-import { buildSuggestions } from './Suggestor';
-import type { SuggestInfo } from './Suggestor';
+import type { SuggestInfo } from '.';
 
 export type SuggestInfoWithContext = SuggestInfo & {
     context: EditorSuggestContext;
@@ -38,13 +37,11 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
         const line = context.query;
         const currentCursor = context.editor.getCursor();
 
-        const suggestions: SuggestInfo[] = buildSuggestions(line, currentCursor.ch, this.settings);
+        const suggestions: SuggestInfo[] =
+            getTaskFormat().buildSuggestions?.(line, currentCursor.ch, this.settings) ?? [];
 
         // Add the editor context to all the suggestions
-        const suggestionsWithContext: SuggestInfoWithContext[] = [];
-        for (const suggestion of suggestions) suggestionsWithContext.push({ ...suggestion, context: context });
-
-        return suggestionsWithContext;
+        return suggestions.map((s) => ({ ...s, context }));
     }
 
     renderSuggestion(value: SuggestInfoWithContext, el: HTMLElement) {

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -2,130 +2,120 @@ import type { Settings } from '../Config/Settings';
 import { DateParser } from '../Query/DateParser';
 import { doAutocomplete } from '../DateAbbreviations';
 import { Recurrence } from '../Recurrence';
+import type { DefaultTaskSerializerSymbols } from '../TaskSerializer/default';
+import { TaskRegularExpressions } from '../Task';
+import type { SuggestInfo, SuggestionBuilder } from '.';
 
-import * as task from '../Task';
+export function defaultSuggestionBuilderFactory(symbols: DefaultTaskSerializerSymbols): SuggestionBuilder {
+    const datePrefixCharacters = `${symbols.startDateSymbol}${symbols.scheduledDateSymbol}${symbols.dueDateSymbol}`;
+    /*
+     * Return a list of suggestions, either generic or more fine-grained to the words at the cursor.
+     */
+    return (line: string, cursorPos: number, settings: Settings): SuggestInfo[] => {
+        let suggestions: SuggestInfo[] = [];
 
-const datePrefixCharacters = `${task.startDateSymbol}${task.scheduledDateSymbol}${task.dueDateSymbol}`;
+        // Step 1: add date suggestions if relevant
+        suggestions = suggestions.concat(addDatesSuggestions(line, cursorPos, settings, datePrefixCharacters));
 
-/*
- * A suggestion presented to the user and some metadata about it.
- */
-export type SuggestInfo = {
-    suggestionType?: 'match' | 'default' | 'empty';
-    // What to display to the user
-    displayText: string;
-    // What to append to the note
-    appendText: string;
-    // At what index in the line to do the insertion (if not specified, the cursor location is used)
-    insertAt?: number;
-    // How many characters to skip from the original line (e.g. if replacing existing text)
-    insertSkip?: number;
-};
+        // Step 2: add recurrence suggestions if relevant
+        suggestions = suggestions.concat(addRecurrenceSuggestions(line, cursorPos, settings, symbols.recurrenceSymbol));
 
-/*
- * Return a list of suggestions, either generic or more fine-grained to the words at the cursor.
- */
-export function buildSuggestions(line: string, cursorPos: number, settings: Settings): SuggestInfo[] {
-    let suggestions: SuggestInfo[] = [];
-
-    // Step 1: add date suggestions if relevant
-    suggestions = suggestions.concat(addDatesSuggestions(line, cursorPos, settings));
-
-    // Step 2: add recurrence suggestions if relevant
-    suggestions = suggestions.concat(addRecurrenceSuggestions(line, cursorPos, settings));
-
-    // Step 3: add more general suggestions ('due', 'recurrence' etc)
-    const morePossibleSuggestions = getPossibleComponentSuggestions(line, settings);
-    // We now filter the general suggestions according to the word at the cursor. If there's
-    // something to match, we filter the suggestions accordingly, so the user can get more specific
-    // results according to what she's typing.
-    // If there's no good match, present the suggestions as they are
-    const wordMatch = matchByPosition(line, /([a-zA-Z'_-]*)/g, cursorPos);
-    let addedSuggestions = false;
-    if (wordMatch && wordMatch.length > 0) {
-        const wordUnderCursor = wordMatch[0];
-        if (wordUnderCursor.length >= Math.max(1, settings.autoSuggestMinMatch)) {
-            const filteredSuggestions = morePossibleSuggestions.filter((suggestInfo) =>
-                suggestInfo.displayText.toLowerCase().includes(wordUnderCursor.toLowerCase()),
-            );
-            for (const filtered of filteredSuggestions) {
-                suggestions.push({
-                    suggestionType: 'match',
-                    displayText: filtered.displayText,
-                    appendText: filtered.appendText,
-                    insertAt: wordMatch.index,
-                    insertSkip: wordUnderCursor.length,
-                });
-                addedSuggestions = true;
+        // Step 3: add more general suggestions ('due', 'recurrence' etc)
+        const morePossibleSuggestions = getPossibleComponentSuggestions(line, settings, symbols);
+        // We now filter the general suggestions according to the word at the cursor. If there's
+        // something to match, we filter the suggestions accordingly, so the user can get more specific
+        // results according to what she's typing.
+        // If there's no good match, present the suggestions as they are
+        const wordMatch = matchByPosition(line, /([a-zA-Z'_-]*)/g, cursorPos);
+        let addedSuggestions = false;
+        if (wordMatch && wordMatch.length > 0) {
+            const wordUnderCursor = wordMatch[0];
+            if (wordUnderCursor.length >= Math.max(1, settings.autoSuggestMinMatch)) {
+                const filteredSuggestions = morePossibleSuggestions.filter((suggestInfo) =>
+                    suggestInfo.displayText.toLowerCase().includes(wordUnderCursor.toLowerCase()),
+                );
+                for (const filtered of filteredSuggestions) {
+                    suggestions.push({
+                        suggestionType: 'match',
+                        displayText: filtered.displayText,
+                        appendText: filtered.appendText,
+                        insertAt: wordMatch.index,
+                        insertSkip: wordUnderCursor.length,
+                    });
+                    addedSuggestions = true;
+                }
             }
         }
-    }
-    // That's where we're adding all the suggestions in case there's nothing specific to match
-    // (and we're allowed by the settings to bring back a zero-sized match)
-    if (!addedSuggestions && settings.autoSuggestMinMatch === 0)
-        suggestions = suggestions.concat(morePossibleSuggestions);
+        // That's where we're adding all the suggestions in case there's nothing specific to match
+        // (and we're allowed by the settings to bring back a zero-sized match)
+        if (!addedSuggestions && settings.autoSuggestMinMatch === 0)
+            suggestions = suggestions.concat(morePossibleSuggestions);
 
-    // Unless we have a suggestion that is a match for something the user is currently typing, add
-    // an 'Enter' entry in the beginning of the menu, so an Enter press will move to the next line
-    // rather than insert a suggestion
-    if (suggestions.length > 0 && !suggestions.some((value) => value.suggestionType === 'match')) {
-        // No actual match, only default ones
-        suggestions.unshift({
-            suggestionType: 'empty',
-            displayText: '⏎',
-            appendText: '\n',
-        });
-    }
+        // Unless we have a suggestion that is a match for something the user is currently typing, add
+        // an 'Enter' entry in the beginning of the menu, so an Enter press will move to the next line
+        // rather than insert a suggestion
+        if (suggestions.length > 0 && !suggestions.some((value) => value.suggestionType === 'match')) {
+            // No actual match, only default ones
+            suggestions.unshift({
+                suggestionType: 'empty',
+                displayText: '⏎',
+                appendText: '\n',
+            });
+        }
 
-    // Either way, after all the aggregations above, never suggest more than the max items
-    suggestions = suggestions.slice(0, settings.autoSuggestMaxItems);
+        // Either way, after all the aggregations above, never suggest more than the max items
+        suggestions = suggestions.slice(0, settings.autoSuggestMaxItems);
 
-    return suggestions;
-}
-
-function hasPriority(line: string) {
-    if (Object.values(task.prioritySymbols).some((value) => value.length > 0 && line.includes(value))) return true;
+        return suggestions;
+    };
 }
 
 /*
  * Get suggestions for generic task components, e.g. a priority or a 'due' symbol
  */
-function getPossibleComponentSuggestions(line: string, _settings: Settings): SuggestInfo[] {
+function getPossibleComponentSuggestions(
+    line: string,
+    _settings: Settings,
+    symbols: DefaultTaskSerializerSymbols,
+): SuggestInfo[] {
+    const hasPriority = (line: string) =>
+        Object.values(symbols.prioritySymbols).some((value) => value.length > 0 && line.includes(value));
+
     const suggestions: SuggestInfo[] = [];
 
-    if (!line.includes(task.dueDateSymbol))
+    if (!line.includes(symbols.dueDateSymbol))
         suggestions.push({
-            displayText: `${task.dueDateSymbol} due date`,
-            appendText: `${task.dueDateSymbol} `,
+            displayText: `${symbols.dueDateSymbol} due date`,
+            appendText: `${symbols.dueDateSymbol} `,
         });
-    if (!line.includes(task.startDateSymbol))
+    if (!line.includes(symbols.startDateSymbol))
         suggestions.push({
-            displayText: `${task.startDateSymbol} start date`,
-            appendText: `${task.startDateSymbol} `,
+            displayText: `${symbols.startDateSymbol} start date`,
+            appendText: `${symbols.startDateSymbol} `,
         });
-    if (!line.includes(task.scheduledDateSymbol))
+    if (!line.includes(symbols.scheduledDateSymbol))
         suggestions.push({
-            displayText: `${task.scheduledDateSymbol} scheduled date`,
-            appendText: `${task.scheduledDateSymbol} `,
+            displayText: `${symbols.scheduledDateSymbol} scheduled date`,
+            appendText: `${symbols.scheduledDateSymbol} `,
         });
     if (!hasPriority(line)) {
         suggestions.push({
-            displayText: `${task.prioritySymbols.High} high priority`,
-            appendText: `${task.prioritySymbols.High} `,
+            displayText: `${symbols.prioritySymbols.High} high priority`,
+            appendText: `${symbols.prioritySymbols.High} `,
         });
         suggestions.push({
-            displayText: `${task.prioritySymbols.Medium} medium priority`,
-            appendText: `${task.prioritySymbols.Medium} `,
+            displayText: `${symbols.prioritySymbols.Medium} medium priority`,
+            appendText: `${symbols.prioritySymbols.Medium} `,
         });
         suggestions.push({
-            displayText: `${task.prioritySymbols.Low} low priority`,
-            appendText: `${task.prioritySymbols.Low} `,
+            displayText: `${symbols.prioritySymbols.Low} low priority`,
+            appendText: `${symbols.prioritySymbols.Low} `,
         });
     }
-    if (!line.includes(task.recurrenceSymbol))
+    if (!line.includes(symbols.recurrenceSymbol))
         suggestions.push({
-            displayText: `${task.recurrenceSymbol} recurring (repeat)`,
-            appendText: `${task.recurrenceSymbol} `,
+            displayText: `${symbols.recurrenceSymbol} recurring (repeat)`,
+            appendText: `${symbols.recurrenceSymbol} `,
         });
 
     return suggestions;
@@ -139,7 +129,12 @@ function getPossibleComponentSuggestions(line: string, _settings: Settings): Sug
  * Generic predefined suggestions, in turn, also have two options: either filtered (if the user started typing
  * something where a date is expected) or unfiltered
  */
-function addDatesSuggestions(line: string, cursorPos: number, settings: Settings): SuggestInfo[] {
+function addDatesSuggestions(
+    line: string,
+    cursorPos: number,
+    settings: Settings,
+    datePrefixCharacters: string,
+): SuggestInfo[] {
     const genericSuggestions = [
         'today',
         'tomorrow',
@@ -174,8 +169,8 @@ function addDatesSuggestions(line: string, cursorPos: number, settings: Settings
             // Seems like the text that the user typed can be parsed as a valid date.
             // Present its completed form as a 1st suggestion
             results.push({
-                displayText: `${possibleDate.format(task.TaskRegularExpressions.dateFormat)}`,
-                appendText: `${datePrefix} ${possibleDate.format(task.TaskRegularExpressions.dateFormat)} `,
+                displayText: `${possibleDate.format(TaskRegularExpressions.dateFormat)}`,
+                appendText: `${datePrefix} ${possibleDate.format(TaskRegularExpressions.dateFormat)} `,
                 insertAt: dateMatch.index,
                 insertSkip: dateMatch[0].length,
             });
@@ -203,7 +198,7 @@ function addDatesSuggestions(line: string, cursorPos: number, settings: Settings
         }
         for (const match of genericMatches) {
             const parsedDate = DateParser.parseDate(match, true);
-            const formattedDate = `${parsedDate.format(task.TaskRegularExpressions.dateFormat)}`;
+            const formattedDate = `${parsedDate.format(TaskRegularExpressions.dateFormat)}`;
             results.push({
                 suggestionType: 'match',
                 displayText: `${match} (${formattedDate})`,
@@ -224,7 +219,7 @@ function addDatesSuggestions(line: string, cursorPos: number, settings: Settings
  * Generic predefined suggestions, in turn, also have two options: either filtered (if the user started typing
  * something where a recurrence is expected) or unfiltered
  */
-function addRecurrenceSuggestions(line: string, cursorPos: number, settings: Settings) {
+function addRecurrenceSuggestions(line: string, cursorPos: number, settings: Settings, recurrenceSymbol: string) {
     const genericSuggestions = [
         'every',
         'every day',
@@ -242,7 +237,7 @@ function addRecurrenceSuggestions(line: string, cursorPos: number, settings: Set
     ];
 
     const results: SuggestInfo[] = [];
-    const recurrenceRegex = new RegExp(`(${task.recurrenceSymbol})\\s*([0-9a-zA-Z ]*)`, 'ug');
+    const recurrenceRegex = new RegExp(`(${recurrenceSymbol})\\s*([0-9a-zA-Z ]*)`, 'ug');
     const recurrenceMatch = matchByPosition(line, recurrenceRegex, cursorPos);
     if (recurrenceMatch && recurrenceMatch.length >= 2) {
         const recurrencePrefix = recurrenceMatch[1];

--- a/src/Suggestor/index.ts
+++ b/src/Suggestor/index.ts
@@ -1,0 +1,21 @@
+import type { Settings } from '../Config/Settings';
+
+/*
+ * A suggestion presented to the user and some metadata about it.
+ */
+export type SuggestInfo = {
+    suggestionType?: 'match' | 'default' | 'empty';
+    // What to display to the user
+    displayText: string;
+    // What to append to the note
+    appendText: string;
+    // At what index in the line to do the insertion (if not specified, the cursor location is used)
+    insertAt?: number;
+    // How many characters to skip from the original line (e.g. if replacing existing text)
+    insertSkip?: number;
+};
+
+/*
+ * Return a list of suggestions, either generic or more fine-grained to the words at the cursor.
+ */
+export type SuggestionBuilder = (line: string, cursorPos: number, settings: Settings) => SuggestInfo[];

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -5,7 +5,7 @@ import * as taskModule from './Task';
 import type { LayoutOptions, TaskLayoutComponent } from './TaskLayout';
 import { TaskLayout } from './TaskLayout';
 import { replaceTaskWithTasks } from './File';
-import { getSettings } from './Config/Settings';
+import { getSettings, getTaskFormat } from './Config/Settings';
 
 export type TaskLineRenderDetails = {
     parentUlElement: HTMLElement;
@@ -101,8 +101,9 @@ async function taskToHtml(
 ) {
     let taskAsString = '';
     const taskLayout = new TaskLayout(renderDetails.layoutOptions);
+    const defaultSerializer = getTaskFormat('Default').taskSerializer;
     for (const component of taskLayout.layoutComponents) {
-        let componentString = task.componentToString(taskLayout, component);
+        let componentString = defaultSerializer.componentToString(task, taskLayout, component);
         if (componentString) {
             if (component === 'description') componentString = removeGlobalFilterIfNeeded(componentString);
             taskAsString += componentString;
@@ -168,20 +169,23 @@ function addTooltip({
     element: HTMLElement;
     isFilenameUnique: boolean | undefined;
 }): void {
+    const { recurrenceSymbol, startDateSymbol, scheduledDateSymbol, dueDateSymbol, doneDateSymbol } =
+        getTaskFormat('Default').taskSerializer.symbols;
+
     element.addEventListener('mouseenter', () => {
         const tooltip = element.createDiv();
         tooltip.addClasses(['tooltip', 'mod-right']);
 
         if (task.recurrence) {
             const recurrenceDiv = tooltip.createDiv();
-            recurrenceDiv.setText(`${taskModule.recurrenceSymbol} ${task.recurrence.toText()}`);
+            recurrenceDiv.setText(`${recurrenceSymbol} ${task.recurrence.toText()}`);
         }
 
         if (task.startDate) {
             const startDateDiv = tooltip.createDiv();
             startDateDiv.setText(
                 toTooltipDate({
-                    signifier: taskModule.startDateSymbol,
+                    signifier: startDateSymbol,
                     date: task.startDate,
                 }),
             );
@@ -191,7 +195,7 @@ function addTooltip({
             const scheduledDateDiv = tooltip.createDiv();
             scheduledDateDiv.setText(
                 toTooltipDate({
-                    signifier: taskModule.scheduledDateSymbol,
+                    signifier: scheduledDateSymbol,
                     date: task.scheduledDate,
                 }),
             );
@@ -201,7 +205,7 @@ function addTooltip({
             const dueDateDiv = tooltip.createDiv();
             dueDateDiv.setText(
                 toTooltipDate({
-                    signifier: taskModule.dueDateSymbol,
+                    signifier: dueDateSymbol,
                     date: task.dueDate,
                 }),
             );
@@ -211,7 +215,7 @@ function addTooltip({
             const doneDateDiv = tooltip.createDiv();
             doneDateDiv.setText(
                 toTooltipDate({
-                    signifier: taskModule.doneDateSymbol,
+                    signifier: doneDateSymbol,
                     date: task.doneDate,
                 }),
             );

--- a/src/TaskSerializer/default.ts
+++ b/src/TaskSerializer/default.ts
@@ -1,0 +1,252 @@
+import type { Moment } from 'moment';
+import { TaskLayout } from '../TaskLayout';
+import type { TaskLayoutComponent } from '../TaskLayout';
+import { Recurrence } from '../Recurrence';
+import { Priority, type Task, TaskRegularExpressions } from '../Task';
+import type { TaskDetails, TaskSerializer } from '.';
+
+export interface DefaultTaskSerializerSymbols {
+    readonly prioritySymbols: {
+        High: string;
+        Medium: string;
+        Low: string;
+        None: string;
+    };
+    readonly startDateSymbol: string;
+    readonly scheduledDateSymbol: string;
+    readonly dueDateSymbol: string;
+    readonly doneDateSymbol: string;
+    readonly recurrenceSymbol: string;
+    readonly TaskFormatRegularExpressions: {
+        priorityRegex: RegExp;
+        startDateRegex: RegExp;
+        scheduledDateRegex: RegExp;
+        dueDateRegex: RegExp;
+        doneDateRegex: RegExp;
+        recurrenceRegex: RegExp;
+    };
+}
+
+/**
+ * A symbol map for obsidian-task's default task style.
+ * Uses emoji's to concisely convey meaning
+ */
+export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
+    prioritySymbols: {
+        High: '⏫',
+        Medium: '🔼',
+        Low: '🔽',
+        None: '',
+    },
+    startDateSymbol: '🛫',
+    scheduledDateSymbol: '⏳',
+    dueDateSymbol: '📅',
+    doneDateSymbol: '✅',
+    recurrenceSymbol: '🔁',
+    TaskFormatRegularExpressions: {
+        // The following regex's end with `$` because they will be matched and
+        // removed from the end until none are left.
+        priorityRegex: /([⏫🔼🔽])$/u,
+        startDateRegex: /🛫 *(\d{4}-\d{2}-\d{2})$/u,
+        scheduledDateRegex: /[⏳⌛] *(\d{4}-\d{2}-\d{2})$/u,
+        dueDateRegex: /[📅📆🗓] *(\d{4}-\d{2}-\d{2})$/u,
+        doneDateRegex: /✅ *(\d{4}-\d{2}-\d{2})$/u,
+        recurrenceRegex: /🔁 ?([a-zA-Z0-9, !]+)$/iu,
+    },
+} as const;
+
+export class DefaultTaskSerializer implements TaskSerializer {
+    constructor(public readonly symbols: DefaultTaskSerializerSymbols) {}
+
+    public serialize(task: Task): string {
+        const taskLayout = new TaskLayout(undefined);
+        let taskString = '';
+        for (const component of taskLayout.layoutComponents) {
+            taskString += this.componentToString(task, taskLayout, component);
+        }
+        return taskString;
+    }
+
+    /**
+     * Renders a specific TaskLayoutComponent of the task (its description, priority, etc) as a string.
+     */
+    public componentToString(task: Task, layout: TaskLayout, component: TaskLayoutComponent) {
+        const {
+            prioritySymbols,
+            startDateSymbol,
+            scheduledDateSymbol,
+            doneDateSymbol,
+            recurrenceSymbol,
+            dueDateSymbol,
+        } = this.symbols;
+
+        switch (component) {
+            case 'description':
+                return task.description;
+            case 'priority': {
+                let priority: string = '';
+
+                if (task.priority === Priority.High) {
+                    priority = ' ' + prioritySymbols.High;
+                } else if (task.priority === Priority.Medium) {
+                    priority = ' ' + prioritySymbols.Medium;
+                } else if (task.priority === Priority.Low) {
+                    priority = ' ' + prioritySymbols.Low;
+                }
+                return priority;
+            }
+            case 'startDate':
+                if (!task.startDate) return '';
+                return layout.options.shortMode
+                    ? ' ' + startDateSymbol
+                    : ` ${startDateSymbol} ${task.startDate.format(TaskRegularExpressions.dateFormat)}`;
+            case 'scheduledDate':
+                if (!task.scheduledDate || task.scheduledDateIsInferred) return '';
+                return layout.options.shortMode
+                    ? ' ' + scheduledDateSymbol
+                    : ` ${scheduledDateSymbol} ${task.scheduledDate.format(TaskRegularExpressions.dateFormat)}`;
+            case 'doneDate':
+                if (!task.doneDate) return '';
+                return layout.options.shortMode
+                    ? ' ' + doneDateSymbol
+                    : ` ${doneDateSymbol} ${task.doneDate.format(TaskRegularExpressions.dateFormat)}`;
+            case 'dueDate':
+                if (!task.dueDate) return '';
+                return layout.options.shortMode
+                    ? ' ' + dueDateSymbol
+                    : ` ${dueDateSymbol} ${task.dueDate.format(TaskRegularExpressions.dateFormat)}`;
+            case 'recurrenceRule':
+                if (!task.recurrence) return '';
+                return layout.options.shortMode
+                    ? ' ' + recurrenceSymbol
+                    : ` ${recurrenceSymbol} ${task.recurrence.toText()}`;
+            case 'blockLink':
+                return task.blockLink ?? '';
+            default:
+                throw new Error(`Don't know how to render task component of type '${component}'`);
+        }
+    }
+
+    /**
+     *
+     */
+    public deserialize(line: string): TaskDetails | null {
+        // Keep matching and removing special strings from the end of the
+        // description in any order. The loop should only run once if the
+        // strings are in the expected order after the description.
+        let matched: boolean;
+        let priority: Priority = Priority.None;
+        let startDate: Moment | null = null;
+        let scheduledDate: Moment | null = null;
+        let dueDate: Moment | null = null;
+        let doneDate: Moment | null = null;
+        let recurrenceRule: string = '';
+        let recurrence: Recurrence | null = null;
+        // let tags: any = []; // Tags that are removed from the end while parsing, but we want to add them back for being part of the description.
+        // In the original task description they are possibly mixed with other components
+        // (e.g. #tag1 <due date> #tag2), they do not have to all trail all task components,
+        // but eventually we want to paste them back to the task description at the end
+        let trailingTags = '';
+        // Add a "max runs" failsafe to never end in an endless loop:
+        const maxRuns = 20;
+        let runs = 0;
+        const { prioritySymbols, TaskFormatRegularExpressions } = this.symbols;
+        do {
+            matched = false;
+            const priorityMatch = line.match(TaskFormatRegularExpressions.priorityRegex);
+            if (priorityMatch !== null) {
+                switch (priorityMatch[1]) {
+                    case prioritySymbols.Low:
+                        priority = Priority.Low;
+                        break;
+                    case prioritySymbols.Medium:
+                        priority = Priority.Medium;
+                        break;
+                    case prioritySymbols.High:
+                        priority = Priority.High;
+                        break;
+                }
+
+                line = line.replace(TaskFormatRegularExpressions.priorityRegex, '').trim();
+                matched = true;
+            }
+
+            const doneDateMatch = line.match(TaskFormatRegularExpressions.doneDateRegex);
+            if (doneDateMatch !== null) {
+                doneDate = window.moment(doneDateMatch[1], TaskRegularExpressions.dateFormat);
+                line = line.replace(TaskFormatRegularExpressions.doneDateRegex, '').trim();
+                matched = true;
+            }
+
+            const dueDateMatch = line.match(TaskFormatRegularExpressions.dueDateRegex);
+            if (dueDateMatch !== null) {
+                dueDate = window.moment(dueDateMatch[1], TaskRegularExpressions.dateFormat);
+                line = line.replace(TaskFormatRegularExpressions.dueDateRegex, '').trim();
+                matched = true;
+            }
+
+            const scheduledDateMatch = line.match(TaskFormatRegularExpressions.scheduledDateRegex);
+            if (scheduledDateMatch !== null) {
+                scheduledDate = window.moment(scheduledDateMatch[1], TaskRegularExpressions.dateFormat);
+                line = line.replace(TaskFormatRegularExpressions.scheduledDateRegex, '').trim();
+                matched = true;
+            }
+
+            const startDateMatch = line.match(TaskFormatRegularExpressions.startDateRegex);
+            if (startDateMatch !== null) {
+                startDate = window.moment(startDateMatch[1], TaskRegularExpressions.dateFormat);
+                line = line.replace(TaskFormatRegularExpressions.startDateRegex, '').trim();
+                matched = true;
+            }
+
+            const recurrenceMatch = line.match(TaskFormatRegularExpressions.recurrenceRegex);
+            if (recurrenceMatch !== null) {
+                // Save the recurrence rule, but *do not parse it yet*.
+                // Creating the Recurrence object requires a reference date (e.g. a due date),
+                // and it might appear in the next (earlier in the line) tokens to parse
+                recurrenceRule = recurrenceMatch[1].trim();
+                line = line.replace(TaskFormatRegularExpressions.recurrenceRegex, '').trim();
+                matched = true;
+            }
+
+            // Match tags from the end to allow users to mix the various task components with
+            // tags. These tags will be added back to the description below
+            const tagsMatch = line.match(TaskRegularExpressions.hashTagsFromEnd);
+            if (tagsMatch != null) {
+                line = line.replace(TaskRegularExpressions.hashTagsFromEnd, '').trim();
+                matched = true;
+                const tagName = tagsMatch[0].trim();
+                // Adding to the left because the matching is done right-to-left
+                trailingTags = trailingTags.length > 0 ? [tagName, trailingTags].join(' ') : tagName;
+            }
+
+            runs++;
+        } while (matched && runs <= maxRuns);
+
+        // Now that we have all the task details, parse the recurrence rule if we found any
+        if (recurrenceRule.length > 0) {
+            recurrence = Recurrence.fromText({
+                recurrenceRuleText: recurrenceRule,
+                startDate,
+                scheduledDate,
+                dueDate,
+            });
+        }
+        // Add back any trailing tags to the description. We removed them so we can parse the rest of the
+        // components but now we want them back.
+        // The goal is for a task of them form 'Do something #tag1 (due) tomorrow #tag2 (start) today'
+        // to actually have the description 'Do something #tag1 #tag2'
+        if (trailingTags.length > 0) line += ' ' + trailingTags;
+
+        return {
+            description: line,
+            priority,
+            startDate,
+            scheduledDate,
+            dueDate,
+            doneDate,
+            recurrence,
+            tags: undefined,
+        };
+    }
+}

--- a/src/TaskSerializer/index.ts
+++ b/src/TaskSerializer/index.ts
@@ -1,0 +1,18 @@
+import type { Task } from '../Task';
+
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+
+// A propertity bag of fields that can be parsed by a TaskSerializer
+// All fields are writeable for convenience
+
+export type TaskDetails = Writeable<
+    Pick<Task, 'description' | 'priority' | 'startDate' | 'scheduledDate' | 'dueDate' | 'doneDate' | 'recurrence'> &
+        Partial<Pick<Task, 'tags'>>
+>;
+
+export interface TaskSerializer {
+    deserialize(line: string): TaskDetails | null;
+    serialize(task: Task): string;
+}
+
+export { DefaultTaskSerializer } from './default';

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -2,22 +2,23 @@
     import * as chrono from 'chrono-node';
     import { onMount } from 'svelte';
     import { Recurrence } from '../Recurrence';
-    import { getSettings } from '../Config/Settings';
+    import { getSettings, getTaskFormat } from '../Config/Settings';
     import { Status } from '../Status';
     import { Priority, Task } from '../Task';
-    import {
-        prioritySymbols,
-        recurrenceSymbol,
-        startDateSymbol,
-        scheduledDateSymbol,
-        dueDateSymbol,
-    } from '../Task';
     import { doAutocomplete } from '../DateAbbreviations';
 
     // These exported variables are passed in as props by TaskModal.onOpen():
     export let task: Task;
     export let onSubmit: (updatedTasks: Task[]) => void | Promise<void>;
     export let statusOptions: Status[];
+
+    const {
+        prioritySymbols,
+        recurrenceSymbol,
+        startDateSymbol,
+        scheduledDateSymbol,
+        dueDateSymbol,
+    } = getTaskFormat('Default').taskSerializer.symbols;
 
     let descriptionInput: HTMLInputElement;
     let editableTask: {

--- a/tests/EditorSuggest.test.ts
+++ b/tests/EditorSuggest.test.ts
@@ -3,12 +3,12 @@
  */
 import moment from 'moment';
 import { getSettings, getTaskFormat } from '../src/Config/Settings';
-import { buildSuggestions } from '../src/Suggestor/Suggestor';
 import type { SuggestInfo } from '../src/Suggestor';
 
 window.moment = moment;
 
 describe('auto-complete', () => {
+    const buildSuggestions = getTaskFormat('Default').buildSuggestions;
     it('offers basic completion options for an empty task', () => {
         // Arrange
         const originalSettings = getSettings();

--- a/tests/EditorSuggest.test.ts
+++ b/tests/EditorSuggest.test.ts
@@ -2,11 +2,9 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
-import { getSettings } from '../src/Config/Settings';
+import { getSettings, getTaskFormat } from '../src/Config/Settings';
 import { buildSuggestions } from '../src/Suggestor/Suggestor';
-import type { SuggestInfo } from '../src/Suggestor/Suggestor';
-
-import * as task from '../src/Task';
+import type { SuggestInfo } from '../src/Suggestor';
 
 window.moment = moment;
 
@@ -92,13 +90,15 @@ describe('auto-complete', () => {
         // const todaySpy = jest
         //     .spyOn(Date, 'now')
         //     .mockReturnValue(moment('2022-06-11').valueOf());
+        const { dueDateSymbol, scheduledDateSymbol, startDateSymbol, recurrenceSymbol } =
+            getTaskFormat('Default').taskSerializer.symbols;
 
         const lines = [
             '- [ ] some task',
-            '- [ ] some task 🔁 ',
-            `- [ ] some task ${task.dueDateSymbol} `,
-            `- [ ] some task ${task.scheduledDateSymbol} `,
-            `- [ ] some task ${task.startDateSymbol} `,
+            `- [ ] some task ${recurrenceSymbol} `,
+            `- [ ] some task ${dueDateSymbol} `,
+            `- [ ] some task ${scheduledDateSymbol} `,
+            `- [ ] some task ${startDateSymbol} `,
         ];
         const allSuggestions: string[] = [];
         for (const line of lines) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR is the first of a pair of PRs with the ultimate goal of providing an _option_ to write tasks using a plaintext version of this plugin's task format.

This PR's goal is to pave the way for implementing that plaintext task format, specifically by:

* **Refactor**: Introducing a new abstraction that manages the conversion of `string -> Task` and `Task -> string`. The plugin was updated to leverage this abstraction where appropriate (`src/Task.ts`, `src/Suggestor/EditorSuggestorPopup.ts`)
* **Refactor**: Parameterizing `buildSuggestion` and the "Default Task Format" over the symbols they use. This to facilitate making new task formats and suggestion strategies that are identical to the default, except for the symbols they use (e.g. plaintext symbols).
* **Breaking Change** (?): _Slightly_ reworking how the cursor is repositioned during the `ToggleDone` command. This to make it be agnostic to the task's format. See commit message of [3919033e](https://github.com/obsidian-tasks-group/obsidian-tasks/commit/3919033e1e066b7f049d8acc981fc00bffb58cd3) for more details.

[A draft of the second PR can be seen here](https://github.com/kedestin/obsidian-tasks/pull/1) 

_Note_: I had started working on this [before a similar feature request was marked "won't implement"](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/62#discussioncomment-4832544). Totally understand if that position extends to the work done here, please feel free to close this PR if that's the case.

### Non-goals of this PR

* Expand the scope of the plugin in a way that massively increases the maintenance cost. 
* Changing ***anything*** user-facing about the querying or rendering systems. This PR *does not* change how Tasks are displayed in `task` blocks.
* Changing the **fundamental** representation of a Task in a markdown file: a single-line, checklist item. That is an invariant that is preserved.
* Adding new fields/functionality to `Task`

### Implementation 

The core of this PR is the concept of a `TaskFormat` which encapsulates all of the format specific ways that a `Task` is written to and read from a Markdown File.

https://github.com/obsidian-tasks-group/obsidian-tasks/blob/c1a2b9cfc62f371e5405bcaa90f55abe3e77c020/src/Config/Settings.ts#L20-L23

#### TaskSerializer

A `TaskSerializer` is responsible for: 

* Parsing the `Task` fields that can be inferred from the text after the checkbox.
* Generating the `string` representation of a `Task`.

https://github.com/obsidian-tasks-group/obsidian-tasks/blob/c1a2b9cfc62f371e5405bcaa90f55abe3e77c020/src/TaskSerializer/index.ts#L5-L17

Leveraged by `src/Task.ts` to:

* Parse a `Task`:

https://github.com/obsidian-tasks-group/obsidian-tasks/blob/c1a2b9cfc62f371e5405bcaa90f55abe3e77c020/src/Task.ts#L233-L234

* Convert a `Task` to a `string`:

https://github.com/obsidian-tasks-group/obsidian-tasks/blob/c1a2b9cfc62f371e5405bcaa90f55abe3e77c020/src/Task.ts#L280-L282

#### SuggestionBuilder

A `SuggestionBuilder` is responsible for generating the suggestion list as a user is typing. This abstraction is directly modeled after the existing `buildSuggestions` function.

https://github.com/obsidian-tasks-group/obsidian-tasks/blob/c1a2b9cfc62f371e5405bcaa90f55abe3e77c020/src/Suggestor/index.ts#L18-L21

Leveraged by `src/EditorSuggestorPopUp.ts` to generate suggestions:

https://github.com/obsidian-tasks-group/obsidian-tasks/blob/c1a2b9cfc62f371e5405bcaa90f55abe3e77c020/src/Suggestor/EditorSuggestorPopup.ts#L40-L41

## Motivation and Context

I wanted to use Obsidian for task tracking, but would prefer to keep my files plaintext.

## How has this been tested?

Except for the `ToggleDone` command, this PR changes no user facing behavior and leverages the existing test suite to validate this.

In the case of the `ToggleDone` command, some tests were updated to reflect the changed behavior.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [x] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#updating-documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md#maintaining-the-tests).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
