### PR TITLE
test: Fix assertions in Task tests & fix tests; thanks SonarLint

### DIFF
--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -169,8 +169,8 @@ describe('parsing', () => {
         expect(task!.description).toEqual('this is a task due #inside_tag #some/tags_with_underscore');
         expect(task!.tags).toEqual(['#inside_tag', '#some/tags_with_underscore']);
         expect(task!.dueDate).not.toBeNull();
-        expect(task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD')));
-        expect(task!.priority == Priority.High);
+        expect(task!.dueDate!.isSame(moment('2021-09-12', 'YYYY-MM-DD'))).toEqual(true);
+        expect(task!.priority).toEqual(Priority.High);
     });
 
     it('supports parsing large number of values', () => {
@@ -186,11 +186,11 @@ describe('parsing', () => {
         // Assert
         expect(task).not.toBeNull();
         expect(task!.description).toEqual('Wobble #tag1 #tag2 #tag3 #tag4 #tag5 #tag6 #tag7 #tag8 #tag9 #tag10');
-        expect(task!.dueDate!.isSame(moment('022-07-02', 'YYYY-MM-DD')));
-        expect(task!.doneDate!.isSame(moment('022-07-02', 'YYYY-MM-DD')));
-        expect(task!.startDate!.isSame(moment('022-07-02', 'YYYY-MM-DD')));
-        expect(task!.scheduledDate!.isSame(moment('022-07-02', 'YYYY-MM-DD')));
-        expect(task!.priority == Priority.High);
+        expect(task!.dueDate!.isSame(moment('2022-07-02', 'YYYY-MM-DD'))).toEqual(true);
+        expect(task!.doneDate!.isSame(moment('2022-07-02', 'YYYY-MM-DD'))).toEqual(true);
+        expect(task!.startDate!.isSame(moment('2022-07-02', 'YYYY-MM-DD'))).toEqual(true);
+        expect(task!.scheduledDate!.isSame(moment('2022-07-02', 'YYYY-MM-DD'))).toEqual(true);
+        expect(task!.priority).toEqual(Priority.High);
         expect(task!.tags).toStrictEqual([
             '#tag1',
             '#tag2',


### PR DESCRIPTION
# Description

- Add some missing assertions in `Task.test.ts`
- And fix the incorrect tests that then failed!

SonarLint in WebStorm reports:

- Assertions should be complete.
- CodeSmell typescript: S2970
- It is very easy to write incomplete assertions when using some test frameworks.

It turns out that 4 of the tests were actually incorrect, but seemed to be passing because they were not asserting on the result.


## Motivation and Context

See above.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Running the tests. They failed :-)

## Screenshots (if appropriate)

## Types of changes

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

n/a

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
