### PR TITLE
fix: Prevent exception if toggling in unsaved file in Reading mode

### DIFF
--- a/src/File.ts
+++ b/src/File.ts
@@ -192,11 +192,20 @@ export function findLineNumberOfTaskToToggle(
     listItemsCache: ListItemCache[] | MockListItemCache[],
     errorLoggingFunction: ErrorLoggingFunction,
 ) {
+    const fileLinesCount = fileLines.length;
     const { globalFilter } = getSettings();
     let taskLineNumber: number | undefined;
     let sectionIndex = 0;
     for (const listItemCache of listItemsCache) {
-        if (listItemCache.position.start.line < originalTask.taskLocation.sectionStart) {
+        const listItemLineNumber = listItemCache.position.start.line;
+        if (listItemLineNumber >= fileLinesCount) {
+            // One or more lines has been deleted since the cache was populated,
+            // so there is at least one list item in the cache that is beyoned
+            // the end of the actual file on disk.
+            return undefined;
+        }
+
+        if (listItemLineNumber < originalTask.taskLocation.sectionStart) {
             continue;
         }
 
@@ -204,11 +213,11 @@ export function findLineNumberOfTaskToToggle(
             continue;
         }
 
-        const line = fileLines[listItemCache.position.start.line];
+        const line = fileLines[listItemLineNumber];
         if (line.includes(globalFilter)) {
             if (sectionIndex === originalTask.taskLocation.sectionIndex) {
                 if (line === originalTask.originalMarkdown) {
-                    taskLineNumber = listItemCache.position.start.line;
+                    taskLineNumber = listItemLineNumber;
                 } else {
                     errorLoggingFunction(
                         `Tasks: Unable to find task in file ${originalTask.taskLocation.path}.

--- a/src/File.ts
+++ b/src/File.ts
@@ -200,7 +200,7 @@ export function findLineNumberOfTaskToToggle(
         const listItemLineNumber = listItemCache.position.start.line;
         if (listItemLineNumber >= fileLinesCount) {
             // One or more lines has been deleted since the cache was populated,
-            // so there is at least one list item in the cache that is beyoned
+            // so there is at least one list item in the cache that is beyond
             // the end of the actual file on disk.
             return undefined;
         }

--- a/tests/File.test.replaceTaskWithTasks_issue 1680 - Cannot read properties of undefined correct behaviour.approved.txt
+++ b/tests/File.test.replaceTaskWithTasks_issue 1680 - Cannot read properties of undefined correct behaviour.approved.txt
@@ -1,0 +1,1 @@
+Could not find line for task

--- a/tests/File.test.replaceTaskWithTasks_issue 1680 - Cannot read properties of undefined current incorrect behaviour.approved.txt
+++ b/tests/File.test.replaceTaskWithTasks_issue 1680 - Cannot read properties of undefined current incorrect behaviour.approved.txt
@@ -1,0 +1,1 @@
+Could not find line for task

--- a/tests/File.test.ts
+++ b/tests/File.test.ts
@@ -55,7 +55,15 @@ function testFindLineNumberOfTaskToToggle(
     );
 
     // Assert
-    verify(errorString ? errorString : 'Success. Line found OK. No error reported.');
+    let descriptionOfOutcome = '';
+    if (errorString !== undefined) {
+        descriptionOfOutcome = errorString;
+    } else if (result === undefined) {
+        descriptionOfOutcome = 'Could not find line for task';
+    } else {
+        descriptionOfOutcome = 'Success. Line found OK. No error reported.';
+    }
+    verify(descriptionOfOutcome);
 
     if (expectedLineNumber !== undefined) {
         expect(result).not.toBeUndefined();
@@ -93,6 +101,26 @@ describe('replaceTaskWithTasks', () => {
             // It is recognised as an incorrect line, and so line number is returned as undefined.
             const expectedLineNumber = undefined;
             // const actualIncorrectLineFound = '- [ ] #task task1a';
+            testFindLineNumberOfTaskToToggle(jsonFileName, taskLineToToggle, expectedLineNumber);
+        });
+    });
+
+    // --------------------------------------------------------------------------------
+    // Issue 1680
+    describe('issue 1680 - Cannot read properties of undefined', () => {
+        const jsonFileName = '1680_task_line_number_past_end_of_file.json';
+        const taskLineToToggle = '- [ ] #task Section 2/Task 2';
+
+        it.failing('correct behaviour', () => {
+            // An incorrect line is currently found, so this test fails, due to bug 1680
+            const expectedLineNumber = 9;
+            testFindLineNumberOfTaskToToggle(jsonFileName, taskLineToToggle, expectedLineNumber);
+        });
+
+        it('current incorrect behaviour', () => {
+            // An incorrect line is currently found, due to bug 688.
+            // It is recognised as an incorrect line, and so line number is returned as undefined.
+            const expectedLineNumber = undefined;
             testFindLineNumberOfTaskToToggle(jsonFileName, taskLineToToggle, expectedLineNumber);
         });
     });

--- a/tests/__test_data__/MockDataForTogglingTasks/1680_task_line_number_past_end_of_file.json
+++ b/tests/__test_data__/MockDataForTogglingTasks/1680_task_line_number_past_end_of_file.json
@@ -1,0 +1,91 @@
+{
+  "taskData": {
+    "originalMarkdown": "- [ ] #task Section 2/Task 2",
+    "taskLocation": {
+      "path": "Manual Testing/Task Toggling Scenarios/1680 - Reading Mode line numbers not updated on editing.md",
+      "lineNumber": 14,
+      "sectionStart": 13,
+      "sectionIndex": 1,
+      "precedingHeader": null
+    }
+  },
+  "fileData": {
+    "fileLines": [
+      "## Test Data",
+      "",
+      "### Tasks Section 1",
+      "- [ ] #task Section 1/Task 1",
+      "- [ ] #task Section 1/Task 2",
+      "",
+      "### Tasks Section 2",
+      "",
+      "- [ ] #task Section 2/Task 1",
+      "- [ ] #task Section 2/Task 2",
+      ""
+    ]
+  },
+  "cacheData": {
+    "listItemsCache": [
+      {
+        "position": {
+          "start": {
+            "line": 8,
+            "col": 0,
+            "offset": 39
+          },
+          "end": {
+            "line": 8,
+            "col": 28,
+            "offset": 67
+          }
+        },
+        "task": " "
+      },
+      {
+        "position": {
+          "start": {
+            "line": 9,
+            "col": 0,
+            "offset": 68
+          },
+          "end": {
+            "line": 9,
+            "col": 28,
+            "offset": 96
+          }
+        },
+        "task": " "
+      },
+      {
+        "position": {
+          "start": {
+            "line": 13,
+            "col": 0,
+            "offset": 119
+          },
+          "end": {
+            "line": 13,
+            "col": 28,
+            "offset": 147
+          }
+        },
+        "task": " "
+      },
+      {
+        "position": {
+          "start": {
+            "line": 14,
+            "col": 0,
+            "offset": 148
+          },
+          "end": {
+            "line": 14,
+            "col": 28,
+            "offset": 176
+          }
+        },
+        "task": " "
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Description

This prevents an exception if toggling in unsaved file in Reading mode.

See the comment https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1680#issuecomment-1457826313.

If lines had been deleted from a file, and it was not yet saved when user then toggled a line near the end of the file in Reading mode, there could be an access of a non-existent line number.

The resultant output was:

```text
plugin:obsidian-tasks-plugin:17605 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'includes')
    at eval (plugin:obsidian-tasks-plugin:17605:14)
    at Generator.next (<anonymous>)
    at fulfilled (plugin:obsidian-tasks-plugin:173:24)
```

## Motivation and Context

Another step in fixing outlier conditions in toggling tasks in Reading view

## How has this been tested?

By adding a test which showed the problem behaviour, before the fix was applied.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
