### PR TITLE
chore: Introduce 'contrib' Conventional Commit prefix for contributing docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,8 +26,9 @@ Changes visible to users:
 - [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
 - [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
 - [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
-- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content)
+- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
 - [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
+- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))
 
 Internal changes:
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Description


It introduces the prefix `contrib: ` custom conventional commit prefix for changes to the [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/) docs.

## Motivation and Context

This is a tiny remaining part of #1705.

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)


## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
