### PR TITLE
refactor: More logical order of default settings values

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
@@ -1,8 +1,8 @@
 {
   "globalFilter": "#task",
   "removeGlobalFilter": true,
-  "setCreatedDate": false,
   "taskFormat": "tasksPluginEmoji",
+  "setCreatedDate": false,
   "setDoneDate": true,
   "autoSuggestInEditor": true,
   "autoSuggestMinMatch": 0,

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
@@ -1,6 +1,8 @@
 {
   "globalFilter": "#task",
   "removeGlobalFilter": true,
+  "setCreatedDate": false,
+  "taskFormat": "tasksPluginEmoji",
   "setDoneDate": true,
   "autoSuggestInEditor": true,
   "autoSuggestMinMatch": 0,

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -36,8 +36,8 @@ export type TASK_FORMATS = typeof TASK_FORMATS; // For convenience to make some 
 export interface Settings {
     globalFilter: string;
     removeGlobalFilter: boolean;
-    setCreatedDate: boolean;
     taskFormat: keyof TASK_FORMATS;
+    setCreatedDate: boolean;
     setDoneDate: boolean;
     autoSuggestInEditor: boolean;
     autoSuggestMinMatch: number;
@@ -64,8 +64,8 @@ export interface Settings {
 const defaultSettings: Settings = {
     globalFilter: '',
     removeGlobalFilter: false,
-    setCreatedDate: false,
     taskFormat: 'tasksPluginEmoji',
+    setCreatedDate: false,
     setDoneDate: true,
     autoSuggestInEditor: true,
     autoSuggestMinMatch: 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Put setCreatedDate next to setDoneDate in the order in the default settings values.

This is so they appear in a logical order in data.json.

(The previous order was random, due to the order that two unrelated pull requests were merged recently.)

## Motivation and Context

It's a tiny cosmetic change, but will help me with version-control in multiple vaults.

## How has this been tested?

Manually.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
