### PR TITLE
fix: Speed up drawing of Tasks blocks after 2.0.0 release

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -149,6 +149,22 @@ Completing a task by clicking its checkbox from a `tasks` query block _will_ wor
 Warning
 {: .label .label-yellow}
 
+Tasks cannot read tasks that are in **Obsidian Canvas cards**.
+
+---
+
+Warning
+{: .label .label-yellow}
+
+Tasks does not display Tasks query blocks that are in **Obsidian Canvas cards**.
+
+We are tracking this in [issue #1732](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1732).
+
+---
+
+Warning
+{: .label .label-yellow}
+
 Tasks cannot read tasks that are **inside code blocks**, such as the ones used by the **Admonitions plugin**. Use Obsidian's built-in callouts instead.
 
 ---

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -25,18 +25,15 @@ export class QueryRenderer {
     public addQueryRenderChild = this._addQueryRenderChild.bind(this);
 
     private async _addQueryRenderChild(source: string, element: HTMLElement, context: MarkdownPostProcessorContext) {
-        const child = new QueryRenderChild({
-            app: this.app,
-            events: this.events,
-            container: element,
-            source,
-            filePath: context.sourcePath,
-        });
-
-        context.addChild(child);
-
-        child.load();
-        child.onload();
+        context.addChild(
+            new QueryRenderChild({
+                app: this.app,
+                events: this.events,
+                container: element,
+                source,
+                filePath: context.sourcePath,
+            }),
+        );
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Revert:

- #1733

This fixes #1800:

- #1800 

But unfortunately reopens:

- #1732

The fix for #1732 caused Tasks to start rendering every Tasks block twice, every time any tasks changed, instead of the usual once.

After a note with tasks query blocks in was closed, its blocks would still be redrawn once every time a task was edited, so in a session where lots of query blocks were opened and then closed, Tasks ended up chewing up more and more resources.

Also document that:

- Tasks cannot read task lines in Canvas cards
- Tasks cannot render task query blocks in Canvas cards

## Motivation and Context

As above.


## How has this been tested?

To satisfy myself that I going to be reverted the cause of the regression:

- Via git bisect, in my local build
- Via downloading many different post-1.25.0 builds and systematically testing their behaviour.
- Doing the above repeatedly to make sure I didn't record an incorrect result.

To test, after reverting:

- And then reverting the #1732 - and confirming that doing so did get back the previous behaviour
- Running a local build of the reverted edit for 24 hours in my personal vault, to confirm that the performance really had improved.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
