### PR TITLE
fix: 'group by filename' links now work on filenames with underscores

### DIFF
--- a/src/Query/Group.ts
+++ b/src/Query/Group.ts
@@ -156,7 +156,7 @@ export class Group {
         if (filename === null) {
             return ['Unknown Location'];
         }
-        return ['[[' + Group.escapeMarkdownCharacters(filename) + ']]'];
+        return ['[[' + filename + ']]'];
     }
 
     private static groupByRoot(task: Task): string[] {

--- a/tests/Group.test.ts
+++ b/tests/Group.test.ts
@@ -194,22 +194,22 @@ describe('Grouping tasks', () => {
         // Assert
         expect(groups.toString()).toMatchInlineSnapshot(`
             "
-            Group names: [folder\\_a/folder\\_b/,[[file\\_c]]]
+            Group names: [folder\\_a/folder\\_b/,[[file_c]]]
             #### folder\\_a/folder\\_b/
-            ##### [[file\\_c]]
+            ##### [[file_c]]
             - [ ] Task 3 - but path is 1st, alphabetically
 
             ---
 
-            Group names: [folder\\_b/folder\\_c/,[[file\\_c]]]
+            Group names: [folder\\_b/folder\\_c/,[[file_c]]]
             #### folder\\_b/folder\\_c/
-            ##### [[file\\_c]]
+            ##### [[file_c]]
             - [ ] Task 1 - but path is 2nd, alphabetically
 
             ---
 
-            Group names: [folder\\_b/folder\\_c/,[[file\\_d]]]
-            ##### [[file\\_d]]
+            Group names: [folder\\_b/folder\\_c/,[[file_d]]]
+            ##### [[file_d]]
             - [ ] Task 2 - but path is 2nd, alphabetically
 
             ---
@@ -307,7 +307,7 @@ describe('Group names', () => {
         {
             groupBy: 'filename',
             taskLine: '- [ ] a',
-            expectedGroupNames: ['[[\\_c\\_]]'], // underscores in file names are escaped
+            expectedGroupNames: ['[[_c_]]'], // underscores in links shall not be escaped
             path: 'a/b/_c_.md',
         },
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

## Motivation and Context

Fixes #1708 

In #1426 the filename was changed to a link. The former needed the characters to be escaped. The latter doesn't. This fixes this.

## How has this been tested?

Unit tests modified accordingly.

Also tested on my local vault with a test file manually.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
