### PR TITLE
feat: Add support for either Dataview OR Tasks emoji task formats

### DIFF
--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -1,5 +1,5 @@
 import { makeDefaultSuggestionBuilder } from '../Suggestor/Suggestor';
-import { DEFAULT_SYMBOLS } from '../TaskSerializer/DefaultTaskSerializer';
+import { DEFAULT_SYMBOLS, PLAINTEXT_SYMBOLS } from '../TaskSerializer/DefaultTaskSerializer';
 import { StatusConfiguration } from '../StatusConfiguration';
 import { Status } from '../Status';
 import { DefaultTaskSerializer, type TaskSerializer } from '../TaskSerializer';
@@ -37,6 +37,11 @@ export const TASK_FORMATS = {
         displayName: 'Default',
         taskSerializer: new DefaultTaskSerializer(DEFAULT_SYMBOLS),
         buildSuggestions: makeDefaultSuggestionBuilder(DEFAULT_SYMBOLS),
+    },
+    tasksPluginPlaintext: {
+        displayName: 'Default (Plaintext)',
+        taskSerializer: new DefaultTaskSerializer(PLAINTEXT_SYMBOLS),
+        buildSuggestions: makeDefaultSuggestionBuilder(PLAINTEXT_SYMBOLS),
     },
 } as const;
 

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -1,5 +1,5 @@
 import { makeDefaultSuggestionBuilder } from '../Suggestor/Suggestor';
-import { DEFAULT_SYMBOLS, PLAINTEXT_SYMBOLS } from '../TaskSerializer/DefaultTaskSerializer';
+import { DATAVIEW_SYMBOLS, DEFAULT_SYMBOLS } from '../TaskSerializer/DefaultTaskSerializer';
 import { StatusConfiguration } from '../StatusConfiguration';
 import { Status } from '../Status';
 import { DefaultTaskSerializer, type TaskSerializer } from '../TaskSerializer';
@@ -38,10 +38,10 @@ export const TASK_FORMATS = {
         taskSerializer: new DefaultTaskSerializer(DEFAULT_SYMBOLS),
         buildSuggestions: makeDefaultSuggestionBuilder(DEFAULT_SYMBOLS),
     },
-    tasksPluginPlaintext: {
-        displayName: 'Default (Plaintext)',
-        taskSerializer: new DefaultTaskSerializer(PLAINTEXT_SYMBOLS),
-        buildSuggestions: makeDefaultSuggestionBuilder(PLAINTEXT_SYMBOLS),
+    dataview: {
+        displayName: 'Dataview',
+        taskSerializer: new DefaultTaskSerializer(DATAVIEW_SYMBOLS),
+        buildSuggestions: makeDefaultSuggestionBuilder(DATAVIEW_SYMBOLS),
     },
 } as const;
 

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -1,9 +1,11 @@
 import { makeDefaultSuggestionBuilder } from '../Suggestor/Suggestor';
-import { DATAVIEW_SYMBOLS, DEFAULT_SYMBOLS } from '../TaskSerializer/DefaultTaskSerializer';
+import { DEFAULT_SYMBOLS } from '../TaskSerializer/DefaultTaskSerializer';
+import { DATAVIEW_SYMBOLS } from '../TaskSerializer/DataviewTaskSerializer';
 import { StatusConfiguration } from '../StatusConfiguration';
 import { Status } from '../Status';
 import { DefaultTaskSerializer, type TaskSerializer } from '../TaskSerializer';
 import type { SuggestionBuilder } from '../Suggestor';
+import { DataviewTaskSerializer } from '../TaskSerializer/DataviewTaskSerializer';
 import { DebugSettings } from './DebugSettings';
 import { StatusSettings } from './StatusSettings';
 import { Feature } from './Feature';
@@ -40,7 +42,7 @@ export const TASK_FORMATS = {
     },
     dataview: {
         displayName: 'Dataview',
-        taskSerializer: new DefaultTaskSerializer(DATAVIEW_SYMBOLS),
+        taskSerializer: new DataviewTaskSerializer(),
         buildSuggestions: makeDefaultSuggestionBuilder(DATAVIEW_SYMBOLS),
     },
 } as const;

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -5,7 +5,7 @@ import { StatusRegistry } from '../StatusRegistry';
 import { Status } from '../Status';
 import type { StatusCollection } from '../StatusCollection';
 import * as Themes from './Themes';
-import type { HeadingState } from './Settings';
+import { type HeadingState, TASK_FORMATS } from './Settings';
 import { getSettings, isFeatureEnabled, updateGeneralSetting, updateSettings } from './Settings';
 import { GlobalFilter } from './GlobalFilter';
 import { StatusSettings } from './StatusSettings';
@@ -54,6 +54,23 @@ export class SettingsTab extends PluginSettingTab {
             cls: 'tasks-setting-important',
             text: 'Changing any settings requires a restart of obsidian.',
         });
+
+        // ---------------------------------------------------------------------------
+        containerEl.createEl('h4', { text: 'Task Format Settings' });
+        // ---------------------------------------------------------------------------
+
+        new Setting(containerEl)
+            .setName('Task Format')
+            .setDesc('Format used to write tasks.')
+            .addDropdown((dropdown) => {
+                for (const key of Object.keys(TASK_FORMATS) as (keyof TASK_FORMATS)[]) {
+                    dropdown.addOption(key, TASK_FORMATS[key].displayName);
+                }
+
+                dropdown.setValue(getSettings().taskFormat).onChange(async (value) => {
+                    updateSettings({ taskFormat: value as keyof TASK_FORMATS });
+                });
+            });
 
         // ---------------------------------------------------------------------------
         containerEl.createEl('h4', { text: 'Global filter Settings' });

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -61,7 +61,7 @@ export class SettingsTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Task Format')
-            .setDesc('Format used to write tasks.')
+            .setDesc('The format that Tasks uses to read and write tasks.')
             .addDropdown((dropdown) => {
                 for (const key of Object.keys(TASK_FORMATS) as (keyof TASK_FORMATS)[]) {
                     dropdown.addOption(key, TASK_FORMATS[key].displayName);

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -69,6 +69,7 @@ export class SettingsTab extends PluginSettingTab {
 
                 dropdown.setValue(getSettings().taskFormat).onChange(async (value) => {
                     updateSettings({ taskFormat: value as keyof TASK_FORMATS });
+                    await this.plugin.saveSettings();
                 });
             });
 

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -7,7 +7,7 @@ import { TaskRegularExpressions } from '../Task';
 import type { SuggestInfo, SuggestionBuilder } from '.';
 
 export function makeDefaultSuggestionBuilder(symbols: DefaultTaskSerializerSymbols): SuggestionBuilder {
-    const datePrefixCharacters = `${symbols.startDateSymbol}${symbols.scheduledDateSymbol}${symbols.dueDateSymbol}`;
+    const datePrefixRegex = [symbols.startDateSymbol, symbols.scheduledDateSymbol, symbols.dueDateSymbol].join('|');
     /*
      * Return a list of suggestions, either generic or more fine-grained to the words at the cursor.
      */
@@ -15,7 +15,7 @@ export function makeDefaultSuggestionBuilder(symbols: DefaultTaskSerializerSymbo
         let suggestions: SuggestInfo[] = [];
 
         // Step 1: add date suggestions if relevant
-        suggestions = suggestions.concat(addDatesSuggestions(line, cursorPos, settings, datePrefixCharacters));
+        suggestions = suggestions.concat(addDatesSuggestions(line, cursorPos, settings, datePrefixRegex));
 
         // Step 2: add recurrence suggestions if relevant
         suggestions = suggestions.concat(addRecurrenceSuggestions(line, cursorPos, settings, symbols.recurrenceSymbol));
@@ -141,7 +141,7 @@ function addDatesSuggestions(
     line: string,
     cursorPos: number,
     settings: Settings,
-    datePrefixCharacters: string,
+    datePrefixRegex: string,
 ): SuggestInfo[] {
     const genericSuggestions = [
         'today',
@@ -159,7 +159,7 @@ function addDatesSuggestions(
     ];
 
     const results: SuggestInfo[] = [];
-    const dateRegex = new RegExp(`([${datePrefixCharacters}])\\s*([0-9a-zA-Z ]*)`, 'ug');
+    const dateRegex = new RegExp(`(${datePrefixRegex})\\s*([0-9a-zA-Z ]*)`, 'ug');
     const dateMatch = matchByPosition(line, dateRegex, cursorPos);
     if (dateMatch && dateMatch.length >= 2) {
         const datePrefix = dateMatch[1];

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -1,0 +1,39 @@
+import { DefaultTaskSerializer, type DefaultTaskSerializerSymbols } from './DefaultTaskSerializer';
+
+/**
+ * A symbol map that corresponds to a task format that strives to be compatible with
+ *   [Dataview]{@link https://github.com/blacksmithgu/obsidian-dataview}
+ */
+export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
+    prioritySymbols: {
+        High: 'priority:: high',
+        Medium: 'priority:: medium',
+        Low: 'priority:: low',
+        None: '',
+    },
+    startDateSymbol: 'start::',
+    createdDateSymbol: 'created::',
+    scheduledDateSymbol: 'scheduled::',
+    dueDateSymbol: 'due::',
+    doneDateSymbol: 'completion::',
+    recurrenceSymbol: 'repeat::',
+    TaskFormatRegularExpressions: {
+        priorityRegex: /(priority:: *(?:high|medium|low))/,
+        startDateRegex: /start:: *(\d{4}-\d{2}-\d{2})$/,
+        createdDateRegex: /created:: *(\d{4}-\d{2}-\d{2})$/,
+        scheduledDateRegex: /scheduled:: *(\d{4}-\d{2}-\d{2})$/,
+        dueDateRegex: /due:: *(\d{4}-\d{2}-\d{2})$/,
+        doneDateRegex: /completion:: *(\d{4}-\d{2}-\d{2})$/,
+        recurrenceRegex: /repeat:: ?([a-zA-Z0-9, !]+)$/i,
+    },
+} as const;
+
+/**
+ * A {@link TaskSerializer} that that reads and writes tasks compatible with
+ *   [Dataview]{@link https://github.com/blacksmithgu/obsidian-dataview}
+ */
+export class DataviewTaskSerializer extends DefaultTaskSerializer {
+    constructor() {
+        super(DATAVIEW_SYMBOLS);
+    }
+}

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -1,7 +1,7 @@
 import type { TaskLayout, TaskLayoutComponent } from '../TaskLayout';
 import type { Task } from '../Task';
-import { DefaultTaskSerializer, type DefaultTaskSerializerSymbols } from './DefaultTaskSerializer';
 import { Priority } from '../Task';
+import { DefaultTaskSerializer } from './DefaultTaskSerializer';
 
 /**
  * Takes a regex of the form 'key:: value' and turns it into a regex that can parse
@@ -57,7 +57,7 @@ function toInlineFieldRegex(innerFieldRegex: RegExp): RegExp {
  * A symbol map that corresponds to a task format that strives to be compatible with
  *   [Dataview]{@link https://github.com/blacksmithgu/obsidian-dataview}
  */
-export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
+export const DATAVIEW_SYMBOLS = {
     prioritySymbols: {
         High: 'priority:: high',
         Medium: 'priority:: medium',

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -1,6 +1,7 @@
 import type { TaskLayout, TaskLayoutComponent } from '../TaskLayout';
 import type { Task } from '../Task';
 import { DefaultTaskSerializer, type DefaultTaskSerializerSymbols } from './DefaultTaskSerializer';
+import { Priority } from '../Task';
 
 /**
  * Takes a regex of the form 'key:: value' and turns it into a regex that can parse
@@ -70,7 +71,7 @@ export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
     doneDateSymbol: 'completion::',
     recurrenceSymbol: 'repeat::',
     TaskFormatRegularExpressions: {
-        priorityRegex: toInlineFieldRegex(/(priority:: *(?:high|medium|low))/),
+        priorityRegex: toInlineFieldRegex(/priority:: *(high|medium|low)/),
         startDateRegex: toInlineFieldRegex(/start:: *(\d{4}-\d{2}-\d{2})/),
         createdDateRegex: toInlineFieldRegex(/created:: *(\d{4}-\d{2}-\d{2})/),
         scheduledDateRegex: toInlineFieldRegex(/scheduled:: *(\d{4}-\d{2}-\d{2})/),
@@ -87,6 +88,19 @@ export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
 export class DataviewTaskSerializer extends DefaultTaskSerializer {
     constructor() {
         super(DATAVIEW_SYMBOLS);
+    }
+
+    protected parsePriority(p: string): Priority {
+        switch (p) {
+            case 'high':
+                return Priority.High;
+            case 'medium':
+                return Priority.Medium;
+            case 'low':
+                return Priority.Low;
+            default:
+                return Priority.None;
+        }
     }
 
     public componentToString(task: Task, layout: TaskLayout, component: TaskLayoutComponent) {

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -1,3 +1,5 @@
+import type { TaskLayout, TaskLayoutComponent } from '../TaskLayout';
+import type { Task } from '../Task';
 import { DefaultTaskSerializer, type DefaultTaskSerializerSymbols } from './DefaultTaskSerializer';
 
 /**
@@ -85,5 +87,12 @@ export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
 export class DataviewTaskSerializer extends DefaultTaskSerializer {
     constructor() {
         super(DATAVIEW_SYMBOLS);
+    }
+
+    public componentToString(task: Task, layout: TaskLayout, component: TaskLayoutComponent) {
+        const stringComponent = super.componentToString(task, layout, component);
+        const notInlineFieldComponents: TaskLayoutComponent[] = ['blockLink', 'description'];
+        const shouldMakeInlineField = stringComponent !== '' && !notInlineFieldComponents.includes(component);
+        return shouldMakeInlineField ? ` [${stringComponent.trim()}]` : stringComponent;
     }
 }

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -149,6 +149,28 @@ export class DefaultTaskSerializer implements TaskSerializer {
         }
     }
 
+    /**
+     * Given the string captured in the first capture group of
+     *    {@link DefaultTaskSerializerSymbols.TaskFormatRegularExpressions.priorityRegex},
+     *    returns the corresponding Priority level.
+     *
+     * @param p String captured by priorityRegex
+     * @returns Corresponding priority if parsing was successful, otherwise {@link Priority.None}
+     */
+    protected parsePriority(p: string): Priority {
+        const { prioritySymbols } = this.symbols;
+        switch (p) {
+            case prioritySymbols.Low:
+                return Priority.Low;
+            case prioritySymbols.Medium:
+                return Priority.Medium;
+            case prioritySymbols.High:
+                return Priority.High;
+            default:
+                return Priority.None;
+        }
+    }
+
     /* Parse TaskDetails from the textual description of a {@link Task}
      *
      * @param line The string to parse
@@ -156,7 +178,7 @@ export class DefaultTaskSerializer implements TaskSerializer {
      * @return {TaskDetails}
      */
     public deserialize(line: string): TaskDetails {
-        const { prioritySymbols, TaskFormatRegularExpressions } = this.symbols;
+        const { TaskFormatRegularExpressions } = this.symbols;
 
         // Keep matching and removing special strings from the end of the
         // description in any order. The loop should only run once if the
@@ -182,18 +204,7 @@ export class DefaultTaskSerializer implements TaskSerializer {
             matched = false;
             const priorityMatch = line.match(TaskFormatRegularExpressions.priorityRegex);
             if (priorityMatch !== null) {
-                switch (priorityMatch[1]) {
-                    case prioritySymbols.Low:
-                        priority = Priority.Low;
-                        break;
-                    case prioritySymbols.Medium:
-                        priority = Priority.Medium;
-                        break;
-                    case prioritySymbols.High:
-                        priority = Priority.High;
-                        break;
-                }
-
+                priority = this.parsePriority(priorityMatch[1]);
                 line = line.replace(TaskFormatRegularExpressions.priorityRegex, '').trim();
                 matched = true;
             }

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -81,7 +81,7 @@ export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
     scheduledDateSymbol: 'scheduled::',
     dueDateSymbol: 'due::',
     doneDateSymbol: 'completion::',
-    recurrenceSymbol: 'recur::',
+    recurrenceSymbol: 'repeat::',
     TaskFormatRegularExpressions: {
         priorityRegex: /(?<=\s|^)(P(-|!|!!))(?=\s|$)/u,
         startDateRegex: /start:: *(\d{4}-\d{2}-\d{2})$/,
@@ -89,7 +89,7 @@ export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
         scheduledDateRegex: /scheduled:: *(\d{4}-\d{2}-\d{2})$/,
         dueDateRegex: /due:: *(\d{4}-\d{2}-\d{2})$/,
         doneDateRegex: /completion:: *(\d{4}-\d{2}-\d{2})$/,
-        recurrenceRegex: /recur:: ?([a-zA-Z0-9, !]+)$/i,
+        recurrenceRegex: /repeat:: ?([a-zA-Z0-9, !]+)$/i,
     },
 } as const;
 

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -65,34 +65,6 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
     },
 } as const;
 
-/**
- * A symbol map that corresponds to a task format that strives to be compatible with
- *   [Dataview]{@link https://github.com/blacksmithgu/obsidian-dataview}
- */
-export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
-    prioritySymbols: {
-        High: 'priority:: high',
-        Medium: 'priority:: medium',
-        Low: 'priority:: low',
-        None: '',
-    },
-    startDateSymbol: 'start::',
-    createdDateSymbol: 'created::',
-    scheduledDateSymbol: 'scheduled::',
-    dueDateSymbol: 'due::',
-    doneDateSymbol: 'completion::',
-    recurrenceSymbol: 'repeat::',
-    TaskFormatRegularExpressions: {
-        priorityRegex: /(priority:: *(?:high|medium|low))/,
-        startDateRegex: /start:: *(\d{4}-\d{2}-\d{2})$/,
-        createdDateRegex: /created:: *(\d{4}-\d{2}-\d{2})$/,
-        scheduledDateRegex: /scheduled:: *(\d{4}-\d{2}-\d{2})$/,
-        dueDateRegex: /due:: *(\d{4}-\d{2}-\d{2})$/,
-        doneDateRegex: /completion:: *(\d{4}-\d{2}-\d{2})$/,
-        recurrenceRegex: /repeat:: ?([a-zA-Z0-9, !]+)$/i,
-    },
-} as const;
-
 export class DefaultTaskSerializer implements TaskSerializer {
     constructor(public readonly symbols: DefaultTaskSerializerSymbols) {}
 

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -65,6 +65,33 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
     },
 } as const;
 
+/**
+ * A symbol map for a plaintext version of obsidian-task's default task style.
+ */
+export const PLAINTEXT_SYMBOLS: DefaultTaskSerializerSymbols = {
+    prioritySymbols: {
+        High: 'P!!',
+        Medium: 'P!',
+        Low: 'P-',
+        None: '',
+    },
+    startDateSymbol: 'start::',
+    createdDateSymbol: 'created::',
+    scheduledDateSymbol: 'scheduled::',
+    dueDateSymbol: 'due::',
+    doneDateSymbol: 'done::',
+    recurrenceSymbol: 'recur::',
+    TaskFormatRegularExpressions: {
+        priorityRegex: /(?<=\s|^)(P(-|!|!!))(?=\s|$)/u,
+        startDateRegex: /start:: *(\d{4}-\d{2}-\d{2})$/,
+        createdDateRegex: /created:: *(\d{4}-\d{2}-\d{2})$/,
+        scheduledDateRegex: /scheduled:: *(\d{4}-\d{2}-\d{2})$/,
+        dueDateRegex: /due:: *(\d{4}-\d{2}-\d{2})$/,
+        doneDateRegex: /done:: *(\d{4}-\d{2}-\d{2})$/,
+        recurrenceRegex: /recur:: ?([a-zA-Z0-9, !]+)$/i,
+    },
+} as const;
+
 export class DefaultTaskSerializer implements TaskSerializer {
     constructor(public readonly symbols: DefaultTaskSerializerSymbols) {}
 

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -80,7 +80,7 @@ export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
     createdDateSymbol: 'created::',
     scheduledDateSymbol: 'scheduled::',
     dueDateSymbol: 'due::',
-    doneDateSymbol: 'done::',
+    doneDateSymbol: 'completion::',
     recurrenceSymbol: 'recur::',
     TaskFormatRegularExpressions: {
         priorityRegex: /(?<=\s|^)(P(-|!|!!))(?=\s|$)/u,
@@ -88,7 +88,7 @@ export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
         createdDateRegex: /created:: *(\d{4}-\d{2}-\d{2})$/,
         scheduledDateRegex: /scheduled:: *(\d{4}-\d{2}-\d{2})$/,
         dueDateRegex: /due:: *(\d{4}-\d{2}-\d{2})$/,
-        doneDateRegex: /done:: *(\d{4}-\d{2}-\d{2})$/,
+        doneDateRegex: /completion:: *(\d{4}-\d{2}-\d{2})$/,
         recurrenceRegex: /recur:: ?([a-zA-Z0-9, !]+)$/i,
     },
 } as const;

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -71,9 +71,9 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
  */
 export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
     prioritySymbols: {
-        High: 'P!!',
-        Medium: 'P!',
-        Low: 'P-',
+        High: 'priority:: high',
+        Medium: 'priority:: medium',
+        Low: 'priority:: low',
         None: '',
     },
     startDateSymbol: 'start::',
@@ -83,7 +83,7 @@ export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
     doneDateSymbol: 'completion::',
     recurrenceSymbol: 'repeat::',
     TaskFormatRegularExpressions: {
-        priorityRegex: /(?<=\s|^)(P(-|!|!!))(?=\s|$)/u,
+        priorityRegex: /(priority:: *(?:high|medium|low))/,
         startDateRegex: /start:: *(\d{4}-\d{2}-\d{2})$/,
         createdDateRegex: /created:: *(\d{4}-\d{2}-\d{2})$/,
         scheduledDateRegex: /scheduled:: *(\d{4}-\d{2}-\d{2})$/,

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -66,9 +66,10 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
 } as const;
 
 /**
- * A symbol map for a plaintext version of obsidian-task's default task style.
+ * A symbol map that corresponds to a task format that strives to be compatible with
+ *   [Dataview]{@link https://github.com/blacksmithgu/obsidian-dataview}
  */
-export const PLAINTEXT_SYMBOLS: DefaultTaskSerializerSymbols = {
+export const DATAVIEW_SYMBOLS: DefaultTaskSerializerSymbols = {
     prioritySymbols: {
         High: 'P!!',
         Medium: 'P!',

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -6,7 +6,7 @@ import * as chrono from 'chrono-node';
 import { getSettings } from '../../src/Config/Settings';
 import type { SuggestInfo } from '../../src/Suggestor';
 import { makeDefaultSuggestionBuilder } from '../../src/Suggestor/Suggestor';
-import { DEFAULT_SYMBOLS } from '../../src/TaskSerializer/DefaultTaskSerializer';
+import { DEFAULT_SYMBOLS, PLAINTEXT_SYMBOLS } from '../../src/TaskSerializer/DefaultTaskSerializer';
 
 window.moment = moment;
 
@@ -17,7 +17,10 @@ jest.spyOn(chrono, 'parseDate').mockImplementation(
     (text, _, options) => chrono.en.casual.parseDate(text, mockDate, options)!,
 );
 
-describe.each([{ name: 'emoji', symbols: DEFAULT_SYMBOLS }])("auto-complete with '$name' symbols", ({ symbols }) => {
+describe.each([
+    { name: 'emoji', symbols: DEFAULT_SYMBOLS },
+    { name: 'plaintext', symbols: PLAINTEXT_SYMBOLS },
+])("auto-complete with '$name' symbols", ({ symbols }) => {
     const buildSuggestions = makeDefaultSuggestionBuilder(symbols);
     const {
         dueDateSymbol,

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -6,7 +6,7 @@ import * as chrono from 'chrono-node';
 import { getSettings } from '../../src/Config/Settings';
 import type { SuggestInfo } from '../../src/Suggestor';
 import { makeDefaultSuggestionBuilder } from '../../src/Suggestor/Suggestor';
-import { DEFAULT_SYMBOLS, PLAINTEXT_SYMBOLS } from '../../src/TaskSerializer/DefaultTaskSerializer';
+import { DATAVIEW_SYMBOLS, DEFAULT_SYMBOLS } from '../../src/TaskSerializer/DefaultTaskSerializer';
 
 window.moment = moment;
 
@@ -19,7 +19,7 @@ jest.spyOn(chrono, 'parseDate').mockImplementation(
 
 describe.each([
     { name: 'emoji', symbols: DEFAULT_SYMBOLS },
-    { name: 'plaintext', symbols: PLAINTEXT_SYMBOLS },
+    { name: 'dataview', symbols: DATAVIEW_SYMBOLS },
 ])("auto-complete with '$name' symbols", ({ symbols }) => {
     const buildSuggestions = makeDefaultSuggestionBuilder(symbols);
     const {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -6,7 +6,8 @@ import * as chrono from 'chrono-node';
 import { getSettings } from '../../src/Config/Settings';
 import type { SuggestInfo } from '../../src/Suggestor';
 import { makeDefaultSuggestionBuilder } from '../../src/Suggestor/Suggestor';
-import { DATAVIEW_SYMBOLS, DEFAULT_SYMBOLS } from '../../src/TaskSerializer/DefaultTaskSerializer';
+import { DEFAULT_SYMBOLS } from '../../src/TaskSerializer/DefaultTaskSerializer';
+import { DATAVIEW_SYMBOLS } from '../../src/TaskSerializer/DataviewTaskSerializer';
 
 window.moment = moment;
 

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -52,21 +52,21 @@ describe('DataviewTaskSerializer', () => {
 
         it('should parse a task with multiple fields and tags', () => {
             const taskDetails = deserialize(
-                'Wobble [priority::high] #tag1 [completion::2022-07-02] #tag2  [due::2022-07-02] #tag3 [scheduled::2022-07-02] #tag4 [start::2022-07-02] #tag5  [repeat::every day]  #tag6 #tag7 #tag8 #tag9 #tag10',
+                'Wobble [priority::high] #tag1 [completion:: 2024-09-04] #tag2  [due::2025-10-05] #tag3 [scheduled::2022-07-02] #tag4 [start::2023-08-03] #tag5  [repeat::every day]  #tag6 #tag7 #tag8 #tag9 #tag10',
             );
 
             expect(taskDetails).toMatchTaskDetails({
                 description: 'Wobble #tag1 #tag2 #tag3 #tag4 #tag5 #tag6 #tag7 #tag8 #tag9 #tag10',
-                dueDate: moment('2022-07-02', 'YYYY-MM-DD'),
-                doneDate: moment('2022-07-02', 'YYYY-MM-DD'),
-                startDate: moment('2022-07-02', 'YYYY-MM-DD'),
+                dueDate: moment('2025-10-05', 'YYYY-MM-DD'),
+                doneDate: moment('2024-09-04', 'YYYY-MM-DD'),
+                startDate: moment('2023-08-03', 'YYYY-MM-DD'),
                 scheduledDate: moment('2022-07-02', 'YYYY-MM-DD'),
                 priority: Priority.High,
                 recurrence: new RecurrenceBuilder()
                     .rule('every day')
-                    .dueDate('2022-07-02')
+                    .dueDate('2025-10-05')
                     .scheduledDate('2022-07-02')
-                    .startDate('2022-07-02')
+                    .startDate('2023-08-03')
                     .build(),
                 tags: ['#tag1', '#tag2', '#tag3', '#tag4', '#tag5', '#tag6', '#tag7', '#tag8', '#tag9', '#tag10'],
             });
@@ -250,17 +250,17 @@ describe('DataviewTaskSerializer', () => {
         it('should serialize a task with multiple fields and tags', () => {
             const task = new TaskBuilder()
                 .description('Wobble')
-                .dueDate('2022-07-02')
-                .doneDate('2022-07-02')
-                .startDate('2022-07-02')
+                .dueDate('2025-10-05')
+                .doneDate('2024-09-04')
+                .startDate('2023-08-03')
                 .scheduledDate('2022-07-02')
                 .priority(Priority.High)
                 .recurrence(
                     new RecurrenceBuilder()
                         .rule('every day')
-                        .dueDate('2022-07-02')
+                        .dueDate('2025-10-05')
+                        .startDate('2023-08-03')
                         .scheduledDate('2022-07-02')
-                        .startDate('2022-07-02')
                         .build(),
                 )
                 // TaskBuilder appends tasks to the description automatically
@@ -269,7 +269,7 @@ describe('DataviewTaskSerializer', () => {
 
             const serialized = serialize(task);
             expect(serialized).toEqual(
-                'Wobble #tag1 #tag2 #tag3 #tag4 #tag5 #tag6 #tag7 #tag8 #tag9 #tag10 [priority:: high] [repeat:: every day] [start:: 2022-07-02] [scheduled:: 2022-07-02] [due:: 2022-07-02] [completion:: 2022-07-02]',
+                'Wobble #tag1 #tag2 #tag3 #tag4 #tag5 #tag6 #tag7 #tag8 #tag9 #tag10 [priority:: high] [repeat:: every day] [start:: 2023-08-03] [scheduled:: 2022-07-02] [due:: 2025-10-05] [completion:: 2024-09-04]',
             );
         });
     });

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -50,6 +50,28 @@ describe('DataviewTaskSerializer', () => {
             });
         });
 
+        it('should parse a task with multiple fields and tags', () => {
+            const taskDetails = deserialize(
+                'Wobble [priority::high] #tag1 [completion::2022-07-02] #tag2  [due::2022-07-02] #tag3 [scheduled::2022-07-02] #tag4 [start::2022-07-02] #tag5  [repeat::every day]  #tag6 #tag7 #tag8 #tag9 #tag10',
+            );
+
+            expect(taskDetails).toMatchTaskDetails({
+                description: 'Wobble #tag1 #tag2 #tag3 #tag4 #tag5 #tag6 #tag7 #tag8 #tag9 #tag10',
+                dueDate: moment('2022-07-02', 'YYYY-MM-DD'),
+                doneDate: moment('2022-07-02', 'YYYY-MM-DD'),
+                startDate: moment('2022-07-02', 'YYYY-MM-DD'),
+                scheduledDate: moment('2022-07-02', 'YYYY-MM-DD'),
+                priority: Priority.High,
+                recurrence: new RecurrenceBuilder()
+                    .rule('every day')
+                    .dueDate('2022-07-02')
+                    .scheduledDate('2022-07-02')
+                    .startDate('2022-07-02')
+                    .build(),
+                tags: ['#tag1', '#tag2', '#tag3', '#tag4', '#tag5', '#tag6', '#tag7', '#tag8', '#tag9', '#tag10'],
+            });
+        });
+
         describe('whitespace within an inline field', () => {
             type OnlyStringKeys<T> = { [K in keyof T as K]: T[K] extends string ? T[K] : never };
             type DataviewFieldsWithoutPriority = OnlyStringKeys<typeof DATAVIEW_SYMBOLS>[keyof OnlyStringKeys<

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -53,6 +53,38 @@ describe('DataviewTaskSerializer', () => {
             const taskDetails = deserialize(description);
             expect(taskDetails).toMatchTaskDetails({ tags: ['#hello', '#world', '#task'], description });
         });
+
+        it('should recognize inline fields surrounded by square brackets', () => {
+            const taskDetails = deserialize('Some task that is [due::2021-08-22] [priority:: high]');
+            expect(taskDetails).toMatchTaskDetails({
+                priority: Priority.High,
+                dueDate: moment('2021-08-22', 'YYYY-MM-DD'),
+                description: 'Some task that is',
+            });
+        });
+
+        it('should recognize inline fields surrounded by parens', () => {
+            const taskDetails = deserialize('Some task that is (due::2021-08-22) (priority:: high)');
+            expect(taskDetails).toMatchTaskDetails({
+                priority: Priority.High,
+                dueDate: moment('2021-08-22', 'YYYY-MM-DD'),
+                description: 'Some task that is',
+            });
+        });
+
+        it('should not recognize inline fields with mismatched surrounding pair', () => {
+            const taskDetails = deserialize('Some task that is [due::2021-08-22) (priority:: high]');
+            expect(taskDetails).toMatchTaskDetails({
+                description: 'Some task that is [due::2021-08-22) (priority:: high]',
+            });
+        });
+
+        it('should not recognize unbracketed fields', () => {
+            const taskDetails = deserialize('Some task - due value not found by dataview - due:: 2021-08-22');
+            expect(taskDetails).toMatchTaskDetails({
+                description: 'Some task - due value not found by dataview - due:: 2021-08-22',
+            });
+        });
     });
 
     describe('serialize', () => {

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -234,5 +234,31 @@ describe('DataviewTaskSerializer', () => {
             const serialized = serialize(task);
             expect(serialized).toEqual(' #hello #world #task');
         });
+
+        it('should serialize a task with multiple fields and tags', () => {
+            const task = new TaskBuilder()
+                .description('Wobble')
+                .dueDate('2022-07-02')
+                .doneDate('2022-07-02')
+                .startDate('2022-07-02')
+                .scheduledDate('2022-07-02')
+                .priority(Priority.High)
+                .recurrence(
+                    new RecurrenceBuilder()
+                        .rule('every day')
+                        .dueDate('2022-07-02')
+                        .scheduledDate('2022-07-02')
+                        .startDate('2022-07-02')
+                        .build(),
+                )
+                // TaskBuilder appends tasks to the description automatically
+                .tags(['#tag1', '#tag2', '#tag3', '#tag4', '#tag5', '#tag6', '#tag7', '#tag8', '#tag9', '#tag10'])
+                .build();
+
+            const serialized = serialize(task);
+            expect(serialized).toEqual(
+                'Wobble #tag1 #tag2 #tag3 #tag4 #tag5 #tag6 #tag7 #tag8 #tag9 #tag10 [priority:: high] [repeat:: every day] [start:: 2022-07-02] [scheduled:: 2022-07-02] [due:: 2022-07-02] [completion:: 2022-07-02]',
+            );
+        });
     });
 });

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -191,6 +191,18 @@ describe('DataviewTaskSerializer', () => {
                 description: 'Some task - due value not found by dataview - due:: 2021-08-22',
             });
         });
+
+        // This is one major behavior difference between Dataview and Tasks
+        // This task is marked as skipped until tasks has support for parsing fields arbitrarily
+        // within a task line
+        it.skip('should recognize inline fields arbitrarily positioned in the string', () => {
+            const taskDetails = deserialize('Some task that is [due::2021-08-02] and is [priority::high]');
+            expect(taskDetails).toMatchTaskDetails({
+                description: 'Some task that is [due::2021-08-02] and is [priority::high]',
+                dueDate: moment('2021-08-02', 'YYYY-MM-DD'),
+                priority: Priority.High,
+            });
+        });
     });
 
     describe('serialize', () => {

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+import moment from 'moment';
+import { Priority } from '../../src/Task';
+import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { DATAVIEW_SYMBOLS, DataviewTaskSerializer } from '../../src/TaskSerializer/DataviewTaskSerializer';
+
+jest.mock('obsidian');
+window.moment = moment;
+
+describe('DataviewTaskSerializer', () => {
+    const taskSerializer = new DataviewTaskSerializer();
+    const serialize = taskSerializer.serialize.bind(taskSerializer);
+    const deserialize = taskSerializer.deserialize.bind(taskSerializer);
+
+    const dateFields = ['startDate', 'dueDate', 'doneDate', 'createdDate', 'scheduledDate'] as const;
+
+    describe('deserialize', () => {
+        it('should parse an empty string', () => {
+            const taskDetails = deserialize('');
+            expect(taskDetails).toMatchTaskDetails({});
+        });
+
+        it.each(dateFields)('should parse a %s', (field) => {
+            const symbol = DATAVIEW_SYMBOLS[`${field}Symbol`];
+            const taskDetails = deserialize(`[${symbol} 2021-06-20]`);
+            expect(taskDetails).toMatchTaskDetails({ [field]: moment('2021-06-20', 'YYYY-MM-DD') });
+        });
+
+        it('should parse a priority', () => {
+            const priorities = ['High', 'Medium', 'Low'] as const;
+            for (const p of priorities) {
+                const prioritySymbol = DATAVIEW_SYMBOLS.prioritySymbols[p];
+                const priority = Priority[p];
+
+                const taskDetails = deserialize(`[${prioritySymbol}]`);
+
+                expect(taskDetails).toMatchTaskDetails({ priority });
+            }
+        });
+
+        it('should parse a recurrence', () => {
+            const taskDetails = deserialize('[repeat:: every day]');
+            expect(taskDetails).toMatchTaskDetails({
+                recurrence: new RecurrenceBuilder().rule('every day').build(),
+            });
+        });
+
+        it('should parse tags', () => {
+            const description = ' #hello #world #task';
+            const taskDetails = deserialize(description);
+            expect(taskDetails).toMatchTaskDetails({ tags: ['#hello', '#world', '#task'], description });
+        });
+    });
+
+    describe('serialize', () => {
+        it('should serialize an "Empty" Task as the empty string', () => {
+            const serialized = serialize(new TaskBuilder().description('').build());
+            expect(serialized).toEqual('');
+        });
+
+        it.each(dateFields)('should serialize a %s', (dateField) => {
+            const serialized = serialize(new TaskBuilder()[dateField]('2021-06-20').description('').build());
+            const symbol = DATAVIEW_SYMBOLS[`${dateField}Symbol`];
+            expect(serialized).toEqual(` [${symbol} 2021-06-20]`);
+        });
+
+        it('should serialize a High, Medium and Low priority', () => {
+            const priorities = ['High', 'Medium', 'Low'] as const;
+            for (const p of priorities) {
+                const task = new TaskBuilder().priority(Priority[p]).description('').build();
+                const serialized = serialize(task);
+                expect(serialized).toEqual(` [${DATAVIEW_SYMBOLS.prioritySymbols[p]}]`);
+            }
+        });
+
+        it('should serialize a None priority', () => {
+            const task = new TaskBuilder().priority(Priority.None).description('').build();
+            const serialized = serialize(task);
+            expect(serialized).toEqual('');
+        });
+
+        it('should serialize a recurrence', () => {
+            const task = new TaskBuilder()
+                .recurrence(new RecurrenceBuilder().rule('every day').build())
+                .description('')
+                .build();
+            const serialized = serialize(task);
+            expect(serialized).toEqual(' [repeat:: every day]');
+        });
+
+        it('should serialize tags', () => {
+            const task = new TaskBuilder().description('').tags(['#hello', '#world', '#task']).build();
+            const serialized = serialize(task);
+            expect(serialized).toEqual(' #hello #world #task');
+        });
+    });
+});

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -6,6 +6,8 @@ import { Priority } from '../../src/Task';
 import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { DATAVIEW_SYMBOLS, DataviewTaskSerializer } from '../../src/TaskSerializer/DataviewTaskSerializer';
+import type { Task } from '../../src/Task';
+import type { TaskDetails } from '../../src/TaskSerializer';
 
 jest.mock('obsidian');
 window.moment = moment;
@@ -45,6 +47,88 @@ describe('DataviewTaskSerializer', () => {
             const taskDetails = deserialize('[repeat:: every day]');
             expect(taskDetails).toMatchTaskDetails({
                 recurrence: new RecurrenceBuilder().rule('every day').build(),
+            });
+        });
+
+        describe('whitespace within an inline field', () => {
+            type OnlyStringKeys<T> = { [K in keyof T as K]: T[K] extends string ? T[K] : never };
+            type DataviewFieldsWithoutPriority = OnlyStringKeys<typeof DATAVIEW_SYMBOLS>[keyof OnlyStringKeys<
+                typeof DATAVIEW_SYMBOLS
+            >];
+
+            type FieldWhitespaceTest = {
+                field: keyof Task;
+                input: {
+                    symbol: DataviewFieldsWithoutPriority | 'priority::';
+                    value: string;
+                };
+                expected: Partial<TaskDetails>;
+            };
+
+            describe.each([
+                ...dateFields.map((dateField) => ({
+                    field: dateField,
+                    input: { symbol: DATAVIEW_SYMBOLS[`${dateField}Symbol`], value: '2021-06-20' },
+                    expected: { [dateField]: moment('2021-06-20', 'YYYY-MM-DD') },
+                })),
+                {
+                    field: 'recurrence',
+                    input: { symbol: 'repeat::', value: 'every day' },
+                    expected: { recurrence: new RecurrenceBuilder().rule('every day').build() },
+                },
+                {
+                    field: 'priority',
+                    input: { symbol: 'priority::', value: 'high' },
+                    expected: { priority: Priority.High },
+                },
+            ] as FieldWhitespaceTest[])('$field', ({ input, expected }) => {
+                const { symbol, value } = input;
+
+                it('should parse with no extraneous whitespace', () => {
+                    const taskDetails = deserialize(`[${symbol}${value}]`);
+                    expect(taskDetails).toMatchTaskDetails(expected);
+                });
+
+                it('should parse with whitespace after ::', () => {
+                    // Single space
+                    let taskDetails = deserialize(`[${symbol} ${value}]`);
+                    expect(taskDetails).toMatchTaskDetails(expected);
+
+                    // Many spaces
+                    taskDetails = deserialize(`[${symbol}               ${value}]`);
+                    expect(taskDetails).toMatchTaskDetails(expected);
+                });
+
+                it('should parse with whitespace near brackets', () => {
+                    // Single space after opening
+                    let taskDetails = deserialize(`[ ${symbol}${value}]`);
+                    expect(taskDetails).toMatchTaskDetails(expected);
+
+                    // Many spaces after opening
+                    taskDetails = deserialize(`[      ${symbol}${value}]`);
+                    expect(taskDetails).toMatchTaskDetails(expected);
+
+                    // Single space before closing
+                    taskDetails = deserialize(`[${symbol}${value} ]`);
+                    expect(taskDetails).toMatchTaskDetails(expected);
+
+                    // Single space before closing
+                    taskDetails = deserialize(`[${symbol}${value}     ]`);
+                    expect(taskDetails).toMatchTaskDetails(expected);
+
+                    // Single space surrounding
+                    taskDetails = deserialize(`[ ${symbol}${value} ]`);
+                    expect(taskDetails).toMatchTaskDetails(expected);
+
+                    // Many spaces surrounding
+                    taskDetails = deserialize(`[     ${symbol}${value}     ]`);
+                    expect(taskDetails).toMatchTaskDetails(expected);
+                });
+
+                it('should parse with whitespace near brackets and after ::', () => {
+                    const taskDetails = deserialize(`[     ${symbol}     ${value}     ]`);
+                    expect(taskDetails).toMatchTaskDetails(expected);
+                });
             });
         });
 

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -7,9 +7,9 @@ import type { Settings } from '../../src/Config/Settings';
 import { DefaultTaskSerializer } from '../../src/TaskSerializer';
 import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
 import {
+    DATAVIEW_SYMBOLS,
     DEFAULT_SYMBOLS,
     type DefaultTaskSerializerSymbols,
-    PLAINTEXT_SYMBOLS,
 } from '../../src/TaskSerializer/DefaultTaskSerializer';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 
@@ -23,7 +23,7 @@ type DefaultTaskSerializeSymbolMap = readonly {
 // A map that facilitates parameterizing the tests over symbols
 const symbolMap: DefaultTaskSerializeSymbolMap = [
     { taskFormat: 'tasksPluginEmoji', symbols: DEFAULT_SYMBOLS },
-    { taskFormat: 'tasksPluginPlaintext', symbols: PLAINTEXT_SYMBOLS },
+    { taskFormat: 'dataview', symbols: DATAVIEW_SYMBOLS },
 ];
 
 describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ symbols }) => {

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -6,7 +6,11 @@ import { Priority } from '../../src/Task';
 import type { Settings } from '../../src/Config/Settings';
 import { DefaultTaskSerializer } from '../../src/TaskSerializer';
 import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
-import { DEFAULT_SYMBOLS, type DefaultTaskSerializerSymbols } from '../../src/TaskSerializer/DefaultTaskSerializer';
+import {
+    DEFAULT_SYMBOLS,
+    type DefaultTaskSerializerSymbols,
+    PLAINTEXT_SYMBOLS,
+} from '../../src/TaskSerializer/DefaultTaskSerializer';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 
 jest.mock('obsidian');
@@ -17,7 +21,10 @@ type DefaultTaskSerializeSymbolMap = readonly {
     symbols: DefaultTaskSerializerSymbols;
 }[];
 // A map that facilitates parameterizing the tests over symbols
-const symbolMap: DefaultTaskSerializeSymbolMap = [{ taskFormat: 'tasksPluginEmoji', symbols: DEFAULT_SYMBOLS }];
+const symbolMap: DefaultTaskSerializeSymbolMap = [
+    { taskFormat: 'tasksPluginEmoji', symbols: DEFAULT_SYMBOLS },
+    { taskFormat: 'tasksPluginPlaintext', symbols: PLAINTEXT_SYMBOLS },
+];
 
 describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ symbols }) => {
     const taskSerializer = new DefaultTaskSerializer(symbols);

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -6,12 +6,9 @@ import { Priority } from '../../src/Task';
 import type { Settings } from '../../src/Config/Settings';
 import { DefaultTaskSerializer } from '../../src/TaskSerializer';
 import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
-import {
-    DATAVIEW_SYMBOLS,
-    DEFAULT_SYMBOLS,
-    type DefaultTaskSerializerSymbols,
-} from '../../src/TaskSerializer/DefaultTaskSerializer';
+import { DEFAULT_SYMBOLS, type DefaultTaskSerializerSymbols } from '../../src/TaskSerializer/DefaultTaskSerializer';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { DATAVIEW_SYMBOLS } from '../../src/TaskSerializer/DataviewTaskSerializer';
 
 jest.mock('obsidian');
 window.moment = moment;

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -8,7 +8,6 @@ import { DefaultTaskSerializer } from '../../src/TaskSerializer';
 import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
 import { DEFAULT_SYMBOLS, type DefaultTaskSerializerSymbols } from '../../src/TaskSerializer/DefaultTaskSerializer';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
-import { DATAVIEW_SYMBOLS } from '../../src/TaskSerializer/DataviewTaskSerializer';
 
 jest.mock('obsidian');
 window.moment = moment;
@@ -18,10 +17,7 @@ type DefaultTaskSerializeSymbolMap = readonly {
     symbols: DefaultTaskSerializerSymbols;
 }[];
 // A map that facilitates parameterizing the tests over symbols
-const symbolMap: DefaultTaskSerializeSymbolMap = [
-    { taskFormat: 'tasksPluginEmoji', symbols: DEFAULT_SYMBOLS },
-    { taskFormat: 'dataview', symbols: DATAVIEW_SYMBOLS },
-];
+const symbolMap: DefaultTaskSerializeSymbolMap = [{ taskFormat: 'tasksPluginEmoji', symbols: DEFAULT_SYMBOLS }];
 
 describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ symbols }) => {
     const taskSerializer = new DefaultTaskSerializer(symbols);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR builds on work intiated in #1703, and adds a task format that is fully plaintext. Specifically, this PR adds a task format that strives to be compatible with Dataview's task format. Addresses #373 

<!--- Describe your changes in detail -->

## Motivation and Context

I wanted to use this plugin to manage my tasks in Obsidian, but wanted to keep my notes in plaintext. 

## How has this been tested?

Some existing tests could be reused (specifically `tests/Suggestor/Suggestor.test.ts`).
Added unit tests in `tests/TaskSerializer/DataviewTaskSerializer.test.ts`

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
