### PR TITLE
docs: Remove leftover Jekyll {% raw %} and {% endraw %} text from new docs

### DIFF
--- a/docs/Advanced/Daily Agenda.md
+++ b/docs/Advanced/Daily Agenda.md
@@ -7,7 +7,7 @@ publish: true
 <span class="related-pages">#plugin/calendar #plugin/periodic-notes</span>
 
 Using the default `Daily-notes` plugin, **templates** with syntax like
-{% raw %}`{{date+14d:YYYY-MM-DD}}`{% endraw %} won't load dates properly. Nevertheless, **Liam Cain**,
+`{{date+14d:YYYY-MM-DD}}` won't load dates properly. Nevertheless, **Liam Cain**,
 author of both the [Calendar Plugin](https://github.com/liamcain/obsidian-calendar-plugin)
 and [Periodic Notes Plugin](https://github.com/liamcain/obsidian-periodic-notes), has
 written code to create new daily notes (using both plugins) using the `date+Xd` format.
@@ -17,10 +17,10 @@ make sure new notes are created via one of these two plugins, and not `Daily-not
 - **Calendar Plugin**: Just tap the day on the Calendar UI and a new daily note will be created
 - **Periodic Notes Plugin**: Install, migrate from `Daily-notes` if needed, and tap the new `Open Today` ribbon on the left-side dock. Below is an example if today was August 14, 2021.
 
-| | Daily Notes | Calendar | Periodic Notes |
-|-|-------------|----------|----------------|
-| template syntax | `due on {% raw %}{{date+14d:YYYY-MM-DD}}{% endraw %}` | `due on {% raw %}{{date+14d:YYYY-MM-DD}}{% endraw %}` | `due on {% raw %}{{date+14d:YYYY-MM-DD}}{% endraw %}` |
-| output | `due on {% raw %}{{date+14d:YYYY-MM-DD}}{% endraw %}` | `due on 2021-08-28` | `due on 2021-08-28` |
+|                 | Daily Notes                      | Calendar                         | Periodic Notes                   |
+| --------------- | -------------------------------- | -------------------------------- | -------------------------------- |
+| template syntax | `due on {{date+14d:YYYY-MM-DD}}` | `due on {{date+14d:YYYY-MM-DD}}` | `due on {{date+14d:YYYY-MM-DD}}` |
+| output          | `due on {{date+14d:YYYY-MM-DD}}` | `due on 2021-08-28`              | `due on 2021-08-28`              |
 
 ## Example Daily Agenda **template**
 
@@ -28,20 +28,20 @@ make sure new notes are created via one of these two plugins, and not `Daily-not
     ### Overdue
     ```tasks
     not done
-    due before {% raw %}{{date:YYYY-MM-DD}}{% endraw %}
+    due before {{date:YYYY-MM-DD}}
     ```
 
     ### Due today
     ```tasks
     not done
-    due on {% raw %}{{date:YYYY-MM-DD}}{% endraw %}
+    due on {{date:YYYY-MM-DD}}
     ```
 
     ### Due in the next two weeks
     ```tasks
     not done
-    due after {% raw %}{{date:YYYY-MM-DD}}{% endraw %}
-    due before {% raw %}{{date+14d:YYYY-MM-DD}}{% endraw %}
+    due after {{date:YYYY-MM-DD}}
+    due before {{date+14d:YYYY-MM-DD}}
     ```
 
     ### No due date
@@ -52,5 +52,5 @@ make sure new notes are created via one of these two plugins, and not `Daily-not
 
     ### Done today
     ```tasks
-    done on {% raw %}{{date:YYYY-MM-DD}}{% endraw %}
+    done on {{date:YYYY-MM-DD}}
     ```

--- a/docs/Advanced/Quickadd.md
+++ b/docs/Advanced/Quickadd.md
@@ -12,7 +12,7 @@ Additional to the official command to create a task, you can use a quickadd comm
 For example:
 
 ```markdown
-{% raw %}#task {{VALUE:task name}} ⏰ {{VDATE:reminder date and time,YYYY-MM-DD HH:mm}} {{VALUE:⏫,🔼,🔽, }} 🔁 {{VALUE:recurrence}} 🛫 {{VDATE:start date,YYYY-MM-DD}} ⏳ {{VDATE:scheduled date,YYYY-MM-DD}} 📅 {{VDATE:due date,YYYY-MM-DD}}{% endraw %}
+#task {{VALUE:task name}} ⏰ {{VDATE:reminder date and time,YYYY-MM-DD HH:mm}} {{VALUE:⏫,🔼,🔽, }} 🔁 {{VALUE:recurrence}} 🛫 {{VDATE:start date,YYYY-MM-DD}} ⏳ {{VDATE:scheduled date,YYYY-MM-DD}} 📅 {{VDATE:due date,YYYY-MM-DD}}
 ```
 
 You can remove/leave some fields to make different types of tasks. And each one can have its own command.
@@ -21,7 +21,7 @@ You can remove/leave some fields to make different types of tasks. And each one 
 
 Task with due date only:
 
-`{% raw %}#task {{VALUE:task name}} 📅 {{VDATE:due date,YYYY-MM-DD}}{% endraw %}`
+`#task {{VALUE:task name}} 📅 {{VDATE:due date,YYYY-MM-DD}}`
 
 <video controls width="100%">
     <source src="https://user-images.githubusercontent.com/38974541/143467768-cf183171-296c-4229-81ca-a8f820b7a66e.mov" />
@@ -31,7 +31,7 @@ Task with due date only:
 
 Task with priority and reminder date and due date:
 
-`{% raw %}#task {{VALUE:task name}} ⏰ {{VDATE:reminder date and time,YYYY-MM-DD HH:mm}} {{VALUE:⏫,🔼,🔽, }} 📅 {{VDATE:due date,YYYY-MM-DD}}{% endraw %}`
+`#task {{VALUE:task name}} ⏰ {{VDATE:reminder date and time,YYYY-MM-DD HH:mm}} {{VALUE:⏫,🔼,🔽, }} 📅 {{VDATE:due date,YYYY-MM-DD}}`
 
 <video controls width="100%">
     <source src="https://user-images.githubusercontent.com/38974541/143468599-ae598f7d-cc84-4fc9-8293-eae72cf81f8a.mov" />
@@ -41,7 +41,7 @@ Task with priority and reminder date and due date:
 
 Task with recurrence and scheduled date and start date:
 
-`{% raw %}#task {{VALUE:task name}} 🔁 {{VALUE:recurrence}} 🛫 {{VDATE:start date,YYYY-MM-DD}} ⏳ {{VDATE:scheduled date,YYYY-MM-DD}}{% endraw %}`
+`#task {{VALUE:task name}} 🔁 {{VALUE:recurrence}} 🛫 {{VDATE:start date,YYYY-MM-DD}} ⏳ {{VDATE:scheduled date,YYYY-MM-DD}}`
 
 <video controls width="100%">
     <source src="https://user-images.githubusercontent.com/38974541/143468440-c83b5f91-c923-4f30-9c52-7c69e64978c9.mov" />
@@ -61,5 +61,5 @@ Then you can give them the same name, this way you'll write the date only once a
 Here is the format for the current example:
 
 ```markdown
-{% raw %}#task {{VALUE:task name}} ⏰ {{VDATE:same date,YYYY-MM-DD}} {{VDATE:time,HH:mm}} 📅 {{VDATE:same date,YYYY-MM-DD}}{% endraw %}
+#task {{VALUE:task name}} ⏰ {{VDATE:same date,YYYY-MM-DD}} {{VDATE:time,HH:mm}} 📅 {{VDATE:same date,YYYY-MM-DD}}
 ```


### PR DESCRIPTION

# Description

<!--- Describe your changes in detail -->

Remove some leftover text from the old Jekyll-basde docs that I had not realised was being rendered by Obsidian:


- `{% raw %}`
- `{% endraw %}`




## Motivation and Context

Fixes #1902

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

By publishing the new pages and confirming the display is now correct.

## Screenshots (if appropriate)

Before: 


<img width="679" alt="image" src="https://user-images.githubusercontent.com/4840096/233681245-4415c58f-3192-45f4-b98c-6294e6eaed5b.png">


After:

<img width="666" alt="image" src="https://user-images.githubusercontent.com/4840096/233681440-8b4460af-481c-48c4-b628-91ef2ecbba61.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
