### PR TITLE
test: Normalize timezone for tests to UTC

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,4 +16,5 @@ module.exports = {
     // A list of paths to modules that run some code to configure or
     // set up the testing framework before each test.
     setupFilesAfterEnv: ['<rootDir>/tests/CustomMatchers/jest.custom_matchers.setup.ts'],
+    globalSetup: "./tests/global-setup.js"
 };

--- a/tests/global-setup.js
+++ b/tests/global-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+    process.env.TZ = 'UTC';
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR fixes an issue where the tests in `tests/Query/Filter/ReferenceDocs/FilterReference/DateFieldReference.test.ts` will fail if run in a timezone with a negative offset relative to UTC (i.e. if run on a machine in North America).

## Background

`DateFieldReference.test.ts` mocks the current date by setting it to `new Date('2023-04-19')` which corresponds to "'Wed, 19 Apr 2023 00:00:00 GMT'"

https://github.com/obsidian-tasks-group/obsidian-tasks/blob/88a519fa475b7ee672d3cfbf8aa64efe78b44a4b/tests/Query/Filter/ReferenceDocs/FilterReference/DateFieldReference.test.ts#L12-L15


The tests run in that file expect that the date is Wednesday April 19th 2023 as well 

https://github.com/obsidian-tasks-group/obsidian-tasks/blob/88a519fa475b7ee672d3cfbf8aa64efe78b44a4b/tests/Query/Filter/ReferenceDocs/FilterReference/DateFieldReference.test.explain_date_reference_last-this-next-weekday.approved.explanation.text#L1-L7

This is an issue when your timezone is at a negative offset relative to GMT. Tasks is timezone aware and will format "Wed, 19 Apr 2023 00:00:00 GMT'" as some instant in time on Tuesday the 18th of April.

## Motivation and Context

Needed to resolve a conflict for another PR but tests were failing

## How has this been tested?

The tests that were failing pass now

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
