### PR TITLE
Fixes query-related fields not having a "hidden" class

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/.obsidian/snippets/tasks-plugin-smoke-test-query-styling.css
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/snippets/tasks-plugin-smoke-test-query-styling.css
@@ -8,6 +8,6 @@
     background-color: aqua;
 }
 
-ul.contains-task-list.tasks-layout-hide-priority {
+ul.contains-task-list.tasks-layout-hide-priority.tasks-layout-hide-backlinks.tasks-layout-hide-urgency.tasks-layout-hide-edit-button {
     color: red;
 }

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Styling of Queries.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Styling of Queries.md
@@ -36,6 +36,9 @@ short mode
 ```tasks
 path includes Styling of Queries
 hide priority
+hide backlinks
+hide urgency
+hide edit button
 ```
 
 - [ ] 6. Open the Obsidian settings of the Demo vault and under Appearance | CSS Snippets, turn **off** `tasks-plugin-smoke-test-query-styling`.

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -1,5 +1,6 @@
 /**
  * Various rendering options for a query.
+ * See applyOptions below when adding options here.
  */
 export class LayoutOptions {
     hideTaskCount: boolean = false;
@@ -84,6 +85,11 @@ export class TaskLayout {
                 return taskComponents;
             }
         };
+        const markHiddenQueryComponent = (hidden: boolean, hiddenComponentName: string) => {
+            if (hidden) {
+                this.specificClasses.push(`tasks-layout-hide-${hiddenComponentName}`);
+            }
+        };
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
         let newComponents = this.layoutComponents;
@@ -94,6 +100,14 @@ export class TaskLayout {
         newComponents = removeIf(newComponents, layoutOptions.hideScheduledDate, 'scheduledDate');
         newComponents = removeIf(newComponents, layoutOptions.hideDueDate, 'dueDate');
         newComponents = removeIf(newComponents, layoutOptions.hideDoneDate, 'doneDate');
+        // The following components are handled in QueryRenderer.ts and thus are not part of the same flow that
+        // hides TaskLayoutComponent items. However, we still want to have 'tasks-layout-hide' items for them
+        // (see https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1866).
+        // This can benefit from some refactoring, i.e. render these components in a similar flow rather than
+        // separately.
+        markHiddenQueryComponent(layoutOptions.hideUrgency, 'urgency');
+        markHiddenQueryComponent(layoutOptions.hideBacklinks, 'backlinks');
+        markHiddenQueryComponent(layoutOptions.hideEditButton, 'edit-button');
         if (layoutOptions.shortMode) this.specificClasses.push('tasks-layout-short-mode');
         return newComponents;
     }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

Fixes the bug linked below, caused by the code that treats query fields (in contrast to task fields) not using the same flow.

<!--- Describe your changes in detail -->

## Motivation and Context

https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1866

## How has this been tested?

1. Checked using the Obsidian Developer Console.
2. Added the relevant classes to the smoke tests in the test vault.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
