### PR TITLE
fix: Documentation link in Task Format settings now works

### DIFF
--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -65,7 +65,7 @@ export class SettingsTab extends PluginSettingTab {
                 SettingsTab.createFragmentWithHTML(
                     '<p>The format that Tasks uses to read and write tasks.</p>' +
                         '<p><b>Important:</b> Tasks currently only supports one format at a time. Selecting Dataview will currently <b>stop Tasks reading its own emoji signifiers</b>.</p>' +
-                        '<p>See the <a href="https://publish.obsidian.md/tasks/Reference/Formats/About+Formats">documentation</a>.</p>',
+                        '<p>See the <a href="https://publish.obsidian.md/tasks/Reference/Task+Formats/About+Task+Formats">documentation</a>.</p>',
                 ),
             )
             .addDropdown((dropdown) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I accidentally released the Task Formats feature with an out-of-date link to the documentation in the settings.

This fixes that.

Broken link:
https://publish.obsidian.md/tasks/Reference/Formats/About+Formats

Working link:
https://publish.obsidian.md/tasks/Reference/Task+Formats/About+Task+Formats


## How has this been tested?
In a local build.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

N/A

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
