### PR TITLE
fix: Use proper natural sorting order for group names

### DIFF
--- a/src/Query/TaskGroups.ts
+++ b/src/Query/TaskGroups.ts
@@ -93,13 +93,10 @@ export class TaskGroups {
             // Compare two TaskGroup objects, sorting them by the group names at each grouping level.
             const groupNames1 = group1.groups;
             const groupNames2 = group2.groups;
-            // TODO Replace with localeCompare()
             for (let i = 0; i < groupNames1.length; i++) {
-                if (groupNames1[i] < groupNames2[i]) {
-                    return -1;
-                }
-                if (groupNames1[i] > groupNames2[i]) {
-                    return 1;
+                const result = groupNames1[i].localeCompare(groupNames2[i], undefined, { numeric: true });
+                if (result !== 0) {
+                    return result;
                 }
             }
             // identical if we reach here

--- a/tests/TaskGroups.test.ts
+++ b/tests/TaskGroups.test.ts
@@ -142,18 +142,17 @@ describe('Grouping tasks', () => {
 
         const grouping = [new FilenameField().createGrouper()];
         const groups = new TaskGroups(grouping, inputs);
-        // TODO Fix this - the two groups currently are in the wrong order.
         expect(groups.toString()).toMatchInlineSnapshot(`
             "
-            Group names: [[[10 something]]]
-            #### [[10 something]]
-            - [ ] second, as 10 is more than 9
-
-            ---
-
             Group names: [[[9 something]]]
             #### [[9 something]]
             - [ ] first, as 9 is less then 10
+
+            ---
+
+            Group names: [[[10 something]]]
+            #### [[10 something]]
+            - [ ] second, as 10 is more than 9
 
             ---
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

The order of groups created by `group by ...` instructions is now logical for groups that begin with numbers, for example 9 comes before 10.

## Motivation and Context

Fixes #1430

## How has this been tested?

Updating an existing test that showed the wrong behaviour.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [b] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
