### PR TITLE
refactor: Simplify BacklinkField & add test for #1927

### DIFF
--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -1,7 +1,6 @@
 import type { Task } from '../../Task';
 import type { GrouperFunction } from '../Grouper';
 import { TextField } from './TextField';
-import { HeadingField } from './HeadingField';
 import { FilterOrErrorMessage } from './Filter';
 
 export class BacklinkField extends TextField {
@@ -14,26 +13,7 @@ export class BacklinkField extends TextField {
         if (linkText === null) {
             return 'Unknown Location';
         }
-
-        let filenameComponent = 'Unknown Location';
-
-        if (task.filename !== null) {
-            filenameComponent = task.filename;
-        }
-
-        if (task.precedingHeader === null || task.precedingHeader.length === 0) {
-            return filenameComponent;
-        }
-
-        // Markdown characters in the heading must NOT be escaped.
-        const headingGrouper = new HeadingField().createGrouper().grouper;
-        const headingComponent = headingGrouper(task)[0];
-
-        if (filenameComponent === headingComponent) {
-            return filenameComponent;
-        } else {
-            return `${filenameComponent} > ${headingComponent}`;
-        }
+        return linkText;
     }
 
     createFilterOrErrorMessage(line: string): FilterOrErrorMessage {

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -35,9 +35,12 @@ export class BacklinkField extends TextField {
                 return ['Unknown Location'];
             }
 
+            // Always escape the filename, to prevent any underscores being interpreted as markdown:
             let result = TextField.escapeMarkdownCharacters(filename);
-            // In case backlink is 'file_name > heading', the filename only shall be escaped
+
+            // Only append the heading if it differs from the un-escaped fileanme:
             if (task.precedingHeader && task.precedingHeader !== filename) {
+                // We don't escape the heading, as any markdown inside really are markdown styling
                 result += ' > ' + task.precedingHeader;
             }
             return [result];

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -31,15 +31,16 @@ export class BacklinkField extends TextField {
     public grouper(): GrouperFunction {
         return (task: Task) => {
             const filename = task.filename;
-            if (filename !== null) {
-                const backlink = this.value(task);
-                if (filename !== backlink) {
-                    // In case backlink is 'file_name > heading', the filename only shall be escaped
-                    return [TextField.escapeMarkdownCharacters(filename) + backlink.substring(filename.length)];
-                }
+            if (filename === null) {
+                return ['Unknown Location'];
             }
 
-            return [TextField.escapeMarkdownCharacters(this.value(task))];
+            let result = TextField.escapeMarkdownCharacters(filename);
+            // In case backlink is 'file_name > heading', the filename only shall be escaped
+            if (task.precedingHeader && task.precedingHeader !== filename) {
+                result += ' > ' + task.precedingHeader;
+            }
+            return [result];
         };
     }
 }

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -40,7 +40,7 @@ export class BacklinkField extends TextField {
 
             // Only append the heading if it differs from the un-escaped fileanme:
             if (task.precedingHeader && task.precedingHeader !== filename) {
-                // We don't escape the heading, as any markdown inside really are markdown styling
+                // We don't escape the heading, as any markdown characters in it really are markdown styling:
                 result += ' > ' + task.precedingHeader;
             }
             return [result];

--- a/tests/Query/Filter/BacklinkField.test.ts
+++ b/tests/Query/Filter/BacklinkField.test.ts
@@ -46,7 +46,7 @@ describe('grouping by backlink', () => {
         // If file name and heading are identical, avoid duplication ('c > c')
         ['a/b/c.md', 'c', ['c']],
 
-        // Even if there are underscores in the file name
+        // If file name and heading are identical, avoid duplication, even if there are underscores in the file name
         ['a_b_c.md', 'a_b_c', ['a\\_b\\_c']],
 
         // Underscores in file name component are escaped

--- a/tests/Query/Filter/BacklinkField.test.ts
+++ b/tests/Query/Filter/BacklinkField.test.ts
@@ -38,7 +38,7 @@ describe('grouping by backlink', () => {
         [undefined, 'heading', ['Unknown Location']],
 
         // no heading supplied
-        ['a/b/c.md', undefined, ['c']],
+        ['a/b/c.md', null, ['c']],
 
         // File and heading, nominal case
         ['a/b/c.md', 'heading', ['c > heading']],
@@ -50,13 +50,13 @@ describe('grouping by backlink', () => {
         ['a_b_c.md', 'a_b_c', ['a\\_b\\_c']],
 
         // Underscores in file name component are escaped
-        ['a/b/_c_.md', undefined, ['\\_c\\_']],
+        ['a/b/_c_.md', null, ['\\_c\\_']],
 
         // But underscores in the heading component are not
         ['a/b/_c_.md', 'heading _italic text_', ['\\_c\\_ > heading _italic text_']],
     ])(
         'task "%s" with path "%s" should have groups: %s',
-        (path: string | undefined, heading: string | undefined, groups: string[]) => {
+        (path: string | undefined, heading: string | null, groups: string[]) => {
             // Arrange
             const grouper = new BacklinkField().createGrouper().grouper;
             const t = '- [ ] xyz';

--- a/tests/Query/Filter/BacklinkField.test.ts
+++ b/tests/Query/Filter/BacklinkField.test.ts
@@ -54,7 +54,7 @@ describe('grouping by backlink', () => {
 
         // But underscores in the heading component are not
         ['a/b/_c_.md', 'heading _italic text_', ['\\_c\\_ > heading _italic text_']],
-    ])('task "%s" with path "%s" should have groups: %s', (path: string, heading: string | null, groups: string[]) => {
+    ])('path "%s" & heading "%s" should have groups: %s', (path: string, heading: string | null, groups: string[]) => {
         // Arrange
         const grouper = new BacklinkField().createGrouper().grouper;
         const t = '- [ ] xyz';

--- a/tests/Query/Filter/BacklinkField.test.ts
+++ b/tests/Query/Filter/BacklinkField.test.ts
@@ -35,7 +35,7 @@ describe('grouping by backlink', () => {
 
     it.each([
         // no location supplied
-        [undefined, 'heading', ['Unknown Location']],
+        ['', 'heading', ['Unknown Location']],
 
         // no heading supplied
         ['a/b/c.md', null, ['c']],
@@ -54,15 +54,12 @@ describe('grouping by backlink', () => {
 
         // But underscores in the heading component are not
         ['a/b/_c_.md', 'heading _italic text_', ['\\_c\\_ > heading _italic text_']],
-    ])(
-        'task "%s" with path "%s" should have groups: %s',
-        (path: string | undefined, heading: string | null, groups: string[]) => {
-            // Arrange
-            const grouper = new BacklinkField().createGrouper().grouper;
-            const t = '- [ ] xyz';
+    ])('task "%s" with path "%s" should have groups: %s', (path: string, heading: string | null, groups: string[]) => {
+        // Arrange
+        const grouper = new BacklinkField().createGrouper().grouper;
+        const t = '- [ ] xyz';
 
-            // Assert
-            expect(grouper(fromLine({ line: t, path: path, precedingHeader: heading }))).toEqual(groups);
-        },
-    );
+        // Assert
+        expect(grouper(fromLine({ line: t, path: path, precedingHeader: heading }))).toEqual(groups);
+    });
 });

--- a/tests/Query/Filter/BacklinkField.test.ts
+++ b/tests/Query/Filter/BacklinkField.test.ts
@@ -54,12 +54,15 @@ describe('grouping by backlink', () => {
 
         // But underscores in the heading component are not
         ['a/b/_c_.md', 'heading _italic text_', ['\\_c\\_ > heading _italic text_']],
-    ])('path "%s" & heading "%s" should have groups: %s', (path: string, heading: string | null, groups: string[]) => {
-        // Arrange
-        const grouper = new BacklinkField().createGrouper().grouper;
-        const t = '- [ ] xyz';
+    ])(
+        'path "%s" and heading "%s" should have groups: %s',
+        (path: string, heading: string | null, groups: string[]) => {
+            // Arrange
+            const grouper = new BacklinkField().createGrouper().grouper;
+            const t = '- [ ] xyz';
 
-        // Assert
-        expect(grouper(fromLine({ line: t, path: path, precedingHeader: heading }))).toEqual(groups);
-    });
+            // Assert
+            expect(grouper(fromLine({ line: t, path: path, precedingHeader: heading }))).toEqual(groups);
+        },
+    );
 });

--- a/tests/Query/Filter/BacklinkField.test.ts
+++ b/tests/Query/Filter/BacklinkField.test.ts
@@ -46,6 +46,9 @@ describe('grouping by backlink', () => {
         // If file name and heading are identical, avoid duplication ('c > c')
         ['a/b/c.md', 'c', ['c']],
 
+        // Even if there are underscores in the file name
+        ['a_b_c.md', 'a_b_c', ['a\\_b\\_c']],
+
         // Underscores in file name component are escaped
         ['a/b/_c_.md', undefined, ['\\_c\\_']],
 

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -414,6 +414,82 @@ describe('parsing tags', () => {
     );
 });
 
+describe('backlinks', () => {
+    function shouldGiveLinkText(
+        path: string,
+        heading: string | null,
+        filenameUnique: boolean,
+        expected: string | null,
+    ) {
+        expect(
+            new TaskBuilder()
+                .path(path)
+                .precedingHeader(heading)
+                .build()
+                .getLinkText({ isFilenameUnique: filenameUnique }),
+        ).toEqual(expected);
+    }
+
+    describe('valid and unique paths', () => {
+        it('valid, unique path without heading should use filename as backlink', () => {
+            shouldGiveLinkText('a/b/c.md', null, true, 'c');
+        });
+
+        it('valid, unique path with different heading should use filename and heading as backlink', () => {
+            shouldGiveLinkText('a/b/c.md', 'heading', true, 'c > heading');
+        });
+
+        it('valid, unique path with same heading should use just filename as backlink', () => {
+            shouldGiveLinkText('a/b/c.md', 'c', true, 'c');
+        });
+    });
+
+    describe('valid non-unique paths', () => {
+        it('valid, non-unique path without heading should use full path as backlink', () => {
+            shouldGiveLinkText('a/b/c.md', null, false, '/a/b/c.md');
+        });
+
+        it('valid, non-unique path with different heading should use full path and heading as backlink', () => {
+            shouldGiveLinkText('a/b/c.md', 'heading', false, '/a/b/c.md > heading');
+        });
+
+        it('valid, non-unique path with same heading as file name should use full path and heading as backlink', () => {
+            shouldGiveLinkText('a/b/c.md', 'c', false, '/a/b/c.md > c');
+        });
+
+        it('valid, non-unique path with same heading as path name with initial slash should use just the path as backlink', () => {
+            // This is not a realistic use-case, but is included to show the current behaviour of the code
+            shouldGiveLinkText('a/b/c.md', '/a/b/c.md', false, '/a/b/c.md');
+        });
+    });
+
+    describe('invalid unique paths', () => {
+        // use invalid file extension to generate null filename
+        // This is not a realistic use-case, but is included to show the current behaviour of the code
+
+        it('invalid, unique path without heading should give null for backlink', () => {
+            shouldGiveLinkText('a/b/c.markdown', null, true, null);
+        });
+
+        it('invalid, unique path with heading should give null for backlink', () => {
+            shouldGiveLinkText('a/b/c.markdown', 'heading', true, null);
+        });
+    });
+
+    describe('invalid non-unique paths', () => {
+        // use invalid file extension to generate null filename
+        // This is not a realistic use-case, but is included to show the current behaviour of the code
+
+        it('invalid, non-unique path without heading uses path anyway for backlink', () => {
+            shouldGiveLinkText('a/b/c.markdown', null, false, '/a/b/c.markdown');
+        });
+
+        it('invalid, non-unique path with heading uses path and backlink anyway for backlink', () => {
+            shouldGiveLinkText('a/b/c.markdown', 'heading', false, '/a/b/c.markdown > heading');
+        });
+    });
+});
+
 describe('to string', () => {
     it('retains the indentation', () => {
         const line = '> > > - [ ] Task inside a nested blockquote or callout';

--- a/tests/TestHelpers.ts
+++ b/tests/TestHelpers.ts
@@ -4,7 +4,7 @@ import { TaskLocation } from '../src/TaskLocation';
 export function fromLine({
     line,
     path = '',
-    precedingHeader = '',
+    precedingHeader = null,
 }: {
     line: string;
     path?: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Add a passing test for #1927
- Add extensive tests for `Task.getLinkText()`
- Make the types used for `path` and `heading` in `BacklinkField` tests match those used in `Task`
- Simplify the implementation of `BacklinkField.value()` to re-use `Task.getLinkText()`
    - This previously looked like it wouldn't work as strings like `filename > ` were being generated, but that turned out to be due to the tests using `undefined` where `Task` was using `null`)
- Simplify the implementation of `BacklinkField.grouper()` to remove `substring()` and do simple string joining

## Motivation and Context

In investigating #1927 - and trying to figure out how it actually got fixed by f3c6a41e92b3e39a81f564b4287c3016318fb93b, I spent some time trying to understand how the refactoring in f3c6a41e92b3e39a81f564b4287c3016318fb93b could have changed the behaviour.

Even though the change in behaviour was an improvement, I hadn't spotted the change during reviewing the code, and so I wanted to understand the new code.

What I had misread in the new `BacklinkField` code was this, in the `value()` method:

https://github.com/obsidian-tasks-group/obsidian-tasks/blob/f3c6a41e92b3e39a81f564b4287c3016318fb93b/src/Query/Filter/BacklinkField.ts#L29-L33

It still had the `filenameComponent === headingComponent` code that pre-dated the bug-fix, and from the comment on line 29, I had _thought_ that these lines still had the issue of comparing an escaped string with a non-escaped one.

But they weren't - both were non-escaped strings. And the code in `value()` wasn't relevant to the grouping code anyway!

However, by the time I had got that far, I could see some ways to simplify the `BacklinkField` code.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Adding new tests, and using code coverage to ensure they were thorough
- Running existing tests

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
