### PR TITLE
refactor: Simplify grouping code in Field.ts

### DIFF
--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -265,16 +265,6 @@ export abstract class Field {
     }
 
     /**
-     * Parse a 'group by' line and return a {@link Grouper} object.
-     *
-     * Returns null line does not match this field or is invalid,
-     * or this field does not support grouping.
-     */
-    public parseGroupLine(line: string): Grouper | null {
-        return this.createGrouperFromLine(line);
-    }
-
-    /**
      * Parse the line, and return either a {@link Grouper} object or null.
      *
      * This default implementation works for all fields that support

--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -275,28 +275,7 @@ export abstract class Field {
             return null;
         }
 
-        if (!this.canCreateGrouperForLine(line)) {
-            return null;
-        }
-
         return this.createGrouperFromLine(line);
-    }
-
-    /**
-     * Returns true if the class can parse the given 'group by' instruction line.
-     *
-     * Current implementation simply checks whether the class does support grouping,
-     * and whether the line matches this.grouperRegExp().
-     * @param line - A line from a ```tasks``` block.
-     *
-     * @see {@link createGrouperFromLine}
-     */
-    public canCreateGrouperForLine(line: string): boolean {
-        if (!this.supportsGrouping()) {
-            return false;
-        }
-
-        return Field.lineMatchesFilter(this.grouperRegExp(), line);
     }
 
     /**
@@ -309,8 +288,6 @@ export abstract class Field {
      * this method.
      *
      * @param line - A 'group by' line from a ```tasks``` block.
-     *
-     * @see {@link canCreateGrouperForLine}
      */
     public createGrouperFromLine(line: string): Grouper | null {
         if (!this.supportsGrouping()) {

--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -271,10 +271,6 @@ export abstract class Field {
      * or this field does not support grouping.
      */
     public parseGroupLine(line: string): Grouper | null {
-        if (!this.supportsGrouping()) {
-            return null;
-        }
-
         return this.createGrouperFromLine(line);
     }
 

--- a/src/Query/FilterParser.ts
+++ b/src/Query/FilterParser.ts
@@ -101,7 +101,7 @@ export function parseGrouper(line: string): Grouper | null {
     // See if any of the fields can parse the line.
     for (const creator of fieldCreators) {
         const field = creator();
-        const grouper = field.parseGroupLine(line);
+        const grouper = field.createGrouperFromLine(line);
         if (grouper) {
             return grouper;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This applies some simplifications to the grouping code in the `Field` class.

These simplifications were spotted by @ilandikov when we were pairing recently, and I showed a diagram of the method calls in the grouping code.

Removed methods:

- `parseGroupLine`: Call `createGrouperFromLine` instead
- `canCreateGrouperForLine`: Call `createGrouperFromLine` instead

## Motivation and Context

Remove clutter.

## How has this been tested?

By running existing tests.

## Screenshots (if appropriate)

### Before

Here is a canvas diagram of the call hierarchy in `Field` **before** this PR:

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/49e0b2f9-0184-45c5-9892-7fbc056aebad)

### After

Here is a canvas diagram of the call hierarchy in `Field` **after** this PR:

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/e799e4dc-1c20-429a-8295-a48b5deb8ace)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
