### PR TITLE
refactor: Simplify sorting code in Field.ts

### DIFF
--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -132,20 +132,6 @@ export abstract class Field {
     }
 
     /**
-     * Parse a 'sort by' line and return a {@link Sorter} object.
-     *
-     * Returns null line does not match this field or is invalid,
-     * or this field does not support sorting.
-     */
-    public parseSortLine(line: string): Sorter | null {
-        if (!this.supportsSorting()) {
-            return null;
-        }
-
-        return this.createSorterFromLine(line);
-    }
-
-    /**
      * Parse the line, and return either a {@link Sorter} object or null.
      *
      * This default implementation works for all fields that support

--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -142,28 +142,7 @@ export abstract class Field {
             return null;
         }
 
-        if (!this.canCreateSorterForLine(line)) {
-            return null;
-        }
-
         return this.createSorterFromLine(line);
-    }
-
-    /**
-     * Returns true if the class can parse the given 'sort by' instruction line.
-     *
-     * Current implementation simply checks whether the class does support sorting,
-     * and whether the line matches this.sorterRegExp().
-     * @param line - A line from a ```tasks``` block.
-     *
-     * @see {@link createSorterFromLine}
-     */
-    public canCreateSorterForLine(line: string): boolean {
-        if (!this.supportsSorting()) {
-            return false;
-        }
-
-        return Field.lineMatchesFilter(this.sorterRegExp(), line);
     }
 
     /**
@@ -176,8 +155,6 @@ export abstract class Field {
      * this method.
      *
      * @param line - A 'sort by' line from a ```tasks``` block.
-     *
-     * @see {@link canCreateSorterForLine}
      */
     public createSorterFromLine(line: string): Sorter | null {
         if (!this.supportsSorting()) {

--- a/src/Query/FilterParser.ts
+++ b/src/Query/FilterParser.ts
@@ -81,7 +81,7 @@ export function parseSorter(sorterString: string): Sorter | null {
     // See if any of the fields can parse the line.
     for (const creator of fieldCreators) {
         const field = creator();
-        const sorter = field.parseSortLine(sorterString);
+        const sorter = field.createSorterFromLine(sorterString);
         if (sorter) {
             return sorter;
         }

--- a/tests/Query/Filter/Field.test.ts
+++ b/tests/Query/Filter/Field.test.ts
@@ -63,8 +63,7 @@ describe('sorting - base class usability and implementation', () => {
 
         it('should fail to parse a "valid" line', () => {
             const line = 'sort by unsupported';
-            expect(unsupported.createSorterFromLine(line)).toBeNull();
-            const sorting = unsupported.parseSortLine(line);
+            const sorting = unsupported.createSorterFromLine(line);
             expect(sorting).toBeNull();
         });
     });
@@ -82,16 +81,14 @@ describe('sorting - base class usability and implementation', () => {
 
         it('should parse a valid line', () => {
             const line = 'sort by description-length';
-            expect(supported.createSorterFromLine(line)).not.toBeNull();
-            const sorting = supported.parseSortLine(line);
+            const sorting = supported.createSorterFromLine(line);
             expect(sorting).not.toBeNull();
             expect(sorting?.property).toEqual('description-length');
         });
 
         it('should fail to parse a invalid line', () => {
             const line = 'sort by jsdajhasdfa';
-            expect(supported.createSorterFromLine(line)).toBeNull();
-            const sorting = supported.parseSortLine(line);
+            const sorting = supported.createSorterFromLine(line);
             expect(sorting).toBeNull();
         });
 

--- a/tests/Query/Filter/Field.test.ts
+++ b/tests/Query/Filter/Field.test.ts
@@ -62,7 +62,6 @@ describe('sorting - base class usability and implementation', () => {
         });
 
         it('should fail to parse a "valid" line', () => {
-            // expect(unsupported.parseSortLine('sort by unsupported')).toThrow(Error);
             const line = 'sort by unsupported';
             expect(unsupported.createSorterFromLine(line)).toBeNull();
             const sorting = unsupported.parseSortLine(line);
@@ -97,7 +96,7 @@ describe('sorting - base class usability and implementation', () => {
         });
 
         it('should compare two tasks', () => {
-            const sorting = supported.parseSortLine('sort by description-length');
+            const sorting = supported.createSorterFromLine('sort by description-length');
             const a = new TaskBuilder().description('short description').build();
             const b = new TaskBuilder().description('very looooooooong description').build();
             expectTaskComparesBefore(sorting!, a, b);

--- a/tests/Query/Filter/Field.test.ts
+++ b/tests/Query/Filter/Field.test.ts
@@ -64,7 +64,6 @@ describe('sorting - base class usability and implementation', () => {
         it('should fail to parse a "valid" line', () => {
             // expect(unsupported.parseSortLine('sort by unsupported')).toThrow(Error);
             const line = 'sort by unsupported';
-            expect(unsupported.canCreateSorterForLine(line)).toBe(false);
             expect(unsupported.createSorterFromLine(line)).toBeNull();
             const sorting = unsupported.parseSortLine(line);
             expect(sorting).toBeNull();
@@ -84,7 +83,6 @@ describe('sorting - base class usability and implementation', () => {
 
         it('should parse a valid line', () => {
             const line = 'sort by description-length';
-            expect(supported.canCreateSorterForLine(line)).toBe(true);
             expect(supported.createSorterFromLine(line)).not.toBeNull();
             const sorting = supported.parseSortLine(line);
             expect(sorting).not.toBeNull();
@@ -93,7 +91,6 @@ describe('sorting - base class usability and implementation', () => {
 
         it('should fail to parse a invalid line', () => {
             const line = 'sort by jsdajhasdfa';
-            expect(supported.canCreateSorterForLine(line)).toBe(false);
             expect(supported.createSorterFromLine(line)).toBeNull();
             const sorting = supported.parseSortLine(line);
             expect(sorting).toBeNull();

--- a/tests/Query/Filter/RecurringField.test.ts
+++ b/tests/Query/Filter/RecurringField.test.ts
@@ -60,7 +60,7 @@ describe('sorting by recurring', () => {
 
     it('parses sort by recurrence', () => {
         const field = new RecurringField();
-        expect(field.parseSortLine('sort by recurring')).not.toBeNull();
+        expect(field.createSorterFromLine('sort by recurring')).not.toBeNull();
     });
 
     it('sort by due', () => {

--- a/tests/Query/Filter/TagsField.test.ts
+++ b/tests/Query/Filter/TagsField.test.ts
@@ -362,20 +362,20 @@ describe('Sort by tags', () => {
         });
 
         it('should parse a valid line with default tag number', () => {
-            const sorter = tagsField.parseSortLine('sort by tag');
+            const sorter = tagsField.createSorterFromLine('sort by tag');
             expect(sorter?.property).toEqual('tag');
             expect(sorter?.comparator(tag_a, tag_b)).toBeLessThan(0);
             expectTaskComparesBefore(sorter!, tag_a, tag_b);
         });
 
         it('should parse a valid line with a non-default tag number', () => {
-            const sorter = tagsField.parseSortLine('sort by tag 2');
+            const sorter = tagsField.createSorterFromLine('sort by tag 2');
             expect(sorter?.property).toEqual('tag');
             expectTaskComparesBefore(sorter!, tags_a_b, tags_a_c);
         });
 
         it('should parse a valid line with reverse and a non-default tag number', () => {
-            const sorter = tagsField.parseSortLine('sort by tag reverse 2');
+            const sorter = tagsField.createSorterFromLine('sort by tag reverse 2');
             expect(sorter?.property).toEqual('tag');
             expectTaskComparesAfter(sorter!, tags_a_b, tags_a_c);
         });
@@ -417,7 +417,10 @@ describe('Sort by tags', () => {
 
         // Act / Assert
         expect(
-            Sort.by([new TagsField().parseSortLine('sort by tag 1')!], [t1, t3, t5, t7, t6, t4, t2, t8, t9, t10]),
+            Sort.by(
+                [new TagsField().createSorterFromLine('sort by tag 1')!],
+                [t1, t3, t5, t7, t6, t4, t2, t8, t9, t10],
+            ),
         ).toEqual(expectedOrder);
     });
 
@@ -438,7 +441,7 @@ describe('Sort by tags', () => {
         // Act / Assert
         expect(
             Sort.by(
-                [new TagsField().parseSortLine('sort by tag reverse 1')!],
+                [new TagsField().createSorterFromLine('sort by tag reverse 1')!],
                 [t1, t3, t5, t7, t6, t4, t2, t8, t9, t10],
             ),
         ).toEqual(expectedOrder);
@@ -451,7 +454,9 @@ describe('Sort by tags', () => {
         const t4 = fromLine({ line: '- [ ] a #iii #ddd' });
         const t5 = fromLine({ line: '- [ ] a #hhh #eee' });
         const expectedOrder = [t1, t2, t3, t4, t5];
-        expect(Sort.by([new TagsField().parseSortLine('sort by tag 2')!], [t4, t3, t2, t1, t5])).toEqual(expectedOrder);
+        expect(Sort.by([new TagsField().createSorterFromLine('sort by tag 2')!], [t4, t3, t2, t1, t5])).toEqual(
+            expectedOrder,
+        );
     });
 
     it('should sort correctly reversed by second tag with no global filter', () => {
@@ -461,7 +466,7 @@ describe('Sort by tags', () => {
         const t4 = fromLine({ line: '- [ ] a #iii #ddd' });
         const t5 = fromLine({ line: '- [ ] a #hhh #eee' });
         const expectedOrder = [t5, t4, t3, t2, t1];
-        expect(Sort.by([new TagsField().parseSortLine('sort by tag reverse 2')!], [t4, t3, t2, t1, t5])).toEqual(
+        expect(Sort.by([new TagsField().createSorterFromLine('sort by tag reverse 2')!], [t4, t3, t2, t1, t5])).toEqual(
             expectedOrder,
         );
     });
@@ -489,7 +494,7 @@ describe('Sort by tags', () => {
         // Act
         expect(
             Sort.by(
-                [new TagsField().parseSortLine('sort by tag 1')!],
+                [new TagsField().createSorterFromLine('sort by tag 1')!],
                 [t1, t12, t3, t13, t5, t7, t6, t4, t2, t8, t9, t10, t11],
             ),
         ).toEqual(expectedOrder);
@@ -521,7 +526,7 @@ describe('Sort by tags', () => {
         // Act
         expect(
             Sort.by(
-                [new TagsField().parseSortLine('sort by tag reverse 1')!],
+                [new TagsField().createSorterFromLine('sort by tag reverse 1')!],
                 [t1, t12, t3, t13, t5, t7, t6, t4, t2, t8, t9, t10, t11],
             ),
         ).toEqual(expectedOrder);
@@ -545,7 +550,10 @@ describe('Sort by tags', () => {
         const expectedOrder = [t1, t2, t3, t4, t5, t6, t7, t8];
 
         // Act
-        const result = Sort.by([new TagsField().parseSortLine('sort by tag 2')!], [t4, t7, t5, t2, t3, t1, t8, t6]);
+        const result = Sort.by(
+            [new TagsField().createSorterFromLine('sort by tag 2')!],
+            [t4, t7, t5, t2, t3, t1, t8, t6],
+        );
 
         // Assert
         expect(result).toEqual(expectedOrder);
@@ -570,7 +578,7 @@ describe('Sort by tags', () => {
 
         // Act
         const result = Sort.by(
-            [new TagsField().parseSortLine('sort by tag reverse 2')!],
+            [new TagsField().createSorterFromLine('sort by tag reverse 2')!],
             [t4, t7, t5, t2, t3, t1, t8, t6],
         );
 
@@ -608,8 +616,8 @@ describe('Sort by tags', () => {
         expect(
             Sort.by(
                 [
-                    new TagsField().parseSortLine('sort by tag 2')!, // tag 2 - ascending
-                    new TagsField().parseSortLine('sort by tag 1')!, // tag 1 - ascending
+                    new TagsField().createSorterFromLine('sort by tag 2')!, // tag 2 - ascending
+                    new TagsField().createSorterFromLine('sort by tag 1')!, // tag 1 - ascending
                     new DescriptionField().createNormalSorter(), // then description - ascending
                 ],
                 input,

--- a/tests/Query/Filter/TagsField.test.ts
+++ b/tests/Query/Filter/TagsField.test.ts
@@ -395,8 +395,7 @@ describe('Sort by tags', () => {
 
         it('should fail to parse a invalid line', () => {
             const line = 'sort by jsdajhasdfa';
-            expect(tagsField.createSorterFromLine(line)).toBeNull();
-            const sorting = tagsField.parseSortLine(line);
+            const sorting = tagsField.createSorterFromLine(line);
             expect(sorting).toBeNull();
         });
     });

--- a/tests/Query/Filter/TagsField.test.ts
+++ b/tests/Query/Filter/TagsField.test.ts
@@ -345,17 +345,6 @@ describe('Sort by tags', () => {
             expect(tagsField.supportsSorting()).toEqual(true);
         });
 
-        it('should report whether it can parse lines', () => {
-            // Valid sort by tag lines:
-            expect(tagsField.canCreateSorterForLine('sort by tag')).toBe(true);
-            expect(tagsField.canCreateSorterForLine('sort by tag 2')).toBe(true);
-            expect(tagsField.canCreateSorterForLine('sort by tag reverse')).toBe(true);
-            expect(tagsField.canCreateSorterForLine('sort by tag reverse 3')).toBe(true);
-
-            // Invalid lines:
-            expect(tagsField.canCreateSorterForLine('sort by description')).toBe(false);
-        });
-
         const tag_a = new TaskBuilder().tags(['#a']).build();
         const tag_b = new TaskBuilder().tags(['#b']).build();
         const tags_a_b = new TaskBuilder().tags(['#a', '#b']).build();
@@ -406,7 +395,6 @@ describe('Sort by tags', () => {
 
         it('should fail to parse a invalid line', () => {
             const line = 'sort by jsdajhasdfa';
-            expect(tagsField.canCreateSorterForLine(line)).toBe(false);
             expect(tagsField.createSorterFromLine(line)).toBeNull();
             const sorting = tagsField.parseSortLine(line);
             expect(sorting).toBeNull();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This applies some simplifications to the **sorting** code in the `Field` class.

The simplifications mentioned in #1976, that were spotted by @ilandikov when we were pairing recently, apply equally to the sorting code (since the grouping code was a copy of the sorting code).

Removed methods:

- `parseSortLine`:
    - Call `createSorterFromLine` instead
- `canCreateSorterForLine`:
    - Call `createSorterFromLine` instead

## Motivation and Context

Remove clutter.

## How has this been tested?

By running existing tests.

## Screenshots (if appropriate)

See the images in #1976 for what the same change looks like when done for the grouping methods.

In those diagrams, `s/Group/Sort/g` to understand this change,


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
