### PR TITLE
test: More custom matchers, for easier Task testing

### DIFF
--- a/tests/CustomMatchers/CustomMatchersForTaskBuilder.ts
+++ b/tests/CustomMatchers/CustomMatchersForTaskBuilder.ts
@@ -1,0 +1,36 @@
+import type { TaskBuilder } from '../TestingTools/TaskBuilder';
+
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toBeIdenticalTo(builder2: TaskBuilder): R;
+        }
+
+        interface Expect {
+            toBeIdenticalTo(builder2: TaskBuilder): any;
+        }
+
+        interface InverseAsymmetricMatchers {
+            toBeIdenticalTo(builder2: TaskBuilder): any;
+        }
+    }
+}
+
+export function toBeIdenticalTo(builder1: TaskBuilder, builder2: TaskBuilder) {
+    const task1 = builder1.build();
+    const task2 = builder2.build();
+    const pass = task1.identicalTo(task2);
+
+    if (pass) {
+        return {
+            message: () => 'Tasks treated as identical, but should be different',
+            pass: true,
+        };
+    }
+    return {
+        message: () => {
+            return 'Tasks should be identical, but are treated as different';
+        },
+        pass: false,
+    };
+}

--- a/tests/CustomMatchers/CustomMatchersForTasks.ts
+++ b/tests/CustomMatchers/CustomMatchersForTasks.ts
@@ -4,23 +4,23 @@ import { fromLine } from '../TestHelpers';
 declare global {
     namespace jest {
         interface Matchers<R> {
-            toToggleLineTo(expectedLines: string[]): R;
+            toToggleTo(expectedLines: string[]): R;
             toToggleWithRecurrenceInUsersOrderTo(expectedLines: string[]): R;
         }
 
         interface Expect {
-            toToggleLineTo(expectedLines: string[]): any;
+            toToggleTo(expectedLines: string[]): any;
             toToggleWithRecurrenceInUsersOrderTo(expectedLines: string[]): any;
         }
 
         interface InverseAsymmetricMatchers {
-            toToggleLineTo(expectedLines: string[]): any;
+            toToggleTo(expectedLines: string[]): any;
             toToggleWithRecurrenceInUsersOrderTo(expectedLines: string[]): any;
         }
     }
 }
 
-export function toToggleLineTo(line: string, expectedLines: string[]) {
+export function toToggleTo(line: string, expectedLines: string[]) {
     const task = fromLine({ line: line });
     const receivedLines = task.toggle().map((t) => t.toFileLineString());
     return toMatchLines(receivedLines, expectedLines);

--- a/tests/CustomMatchers/CustomMatchersForTasks.ts
+++ b/tests/CustomMatchers/CustomMatchersForTasks.ts
@@ -20,7 +20,10 @@ declare global {
 export function toToggleLineTo(line: string, expectedLines: string[]) {
     const task = fromLine({ line: line });
     const receivedLines = task.toggle().map((t) => t.toFileLineString());
+    return toMatchLines(receivedLines, expectedLines);
+}
 
+function toMatchLines(receivedLines: string[], expectedLines: string[]) {
     const matches = receivedLines.join('\n') === expectedLines.join('\n');
     if (!matches) {
         return {

--- a/tests/CustomMatchers/CustomMatchersForTasks.ts
+++ b/tests/CustomMatchers/CustomMatchersForTasks.ts
@@ -5,14 +5,17 @@ declare global {
     namespace jest {
         interface Matchers<R> {
             toToggleLineTo(expectedLines: string[]): R;
+            toToggleWithRecurrenceInUsersOrderTo(expectedLines: string[]): R;
         }
 
         interface Expect {
             toToggleLineTo(expectedLines: string[]): any;
+            toToggleWithRecurrenceInUsersOrderTo(expectedLines: string[]): any;
         }
 
         interface InverseAsymmetricMatchers {
             toToggleLineTo(expectedLines: string[]): any;
+            toToggleWithRecurrenceInUsersOrderTo(expectedLines: string[]): any;
         }
     }
 }
@@ -20,6 +23,12 @@ declare global {
 export function toToggleLineTo(line: string, expectedLines: string[]) {
     const task = fromLine({ line: line });
     const receivedLines = task.toggle().map((t) => t.toFileLineString());
+    return toMatchLines(receivedLines, expectedLines);
+}
+
+export function toToggleWithRecurrenceInUsersOrderTo(line: string, expectedLines: string[]) {
+    const task = fromLine({ line: line });
+    const receivedLines = task.toggleWithRecurrenceInUsersOrder().map((t) => t.toFileLineString());
     return toMatchLines(receivedLines, expectedLines);
 }
 

--- a/tests/CustomMatchers/CustomMatchersForTasks.ts
+++ b/tests/CustomMatchers/CustomMatchersForTasks.ts
@@ -1,0 +1,36 @@
+import { diff } from 'jest-diff';
+import { fromLine } from '../TestHelpers';
+
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toToggleLineTo(expectedLines: string[]): R;
+        }
+
+        interface Expect {
+            toToggleLineTo(expectedLines: string[]): any;
+        }
+
+        interface InverseAsymmetricMatchers {
+            toToggleLineTo(expectedLines: string[]): any;
+        }
+    }
+}
+
+export function toToggleLineTo(line: string, expectedLines: string[]) {
+    const task = fromLine({ line: line });
+    const receivedLines = task.toggle().map((t) => t.toFileLineString());
+
+    const matches = receivedLines.join('\n') === expectedLines.join('\n');
+    if (!matches) {
+        return {
+            message: () => 'unexpected incorrect new task lines:\n' + diff(expectedLines, receivedLines),
+            pass: false,
+        };
+    }
+
+    return {
+        message: () => `new task lines" should not be: "${receivedLines}"`,
+        pass: true,
+    };
+}

--- a/tests/CustomMatchers/jest.custom_matchers.setup.ts
+++ b/tests/CustomMatchers/jest.custom_matchers.setup.ts
@@ -39,9 +39,9 @@ expect.extend({
 // ---------------------------------------------------------------------
 // CustomMatchersForTasks
 // ---------------------------------------------------------------------
-import { toToggleLineTo, toToggleWithRecurrenceInUsersOrderTo } from './CustomMatchersForTasks';
+import { toToggleTo, toToggleWithRecurrenceInUsersOrderTo } from './CustomMatchersForTasks';
 expect.extend({
-    toToggleLineTo,
+    toToggleTo,
     toToggleWithRecurrenceInUsersOrderTo,
 });
 

--- a/tests/CustomMatchers/jest.custom_matchers.setup.ts
+++ b/tests/CustomMatchers/jest.custom_matchers.setup.ts
@@ -10,16 +10,6 @@ import {
     toMatchTaskWithPath,
     toMatchTaskWithStatus,
 } from './CustomMatchersForFilters';
-
-import { toSupportGroupingWithProperty } from './CustomMatchersForGrouping';
-
-import { toBeIdenticalTo } from './CustomMatchersForTaskBuilder';
-expect.extend({
-    toBeIdenticalTo,
-});
-
-import { toMatchTaskDetails } from './CustomMatchersForTaskSerializer';
-
 expect.extend({
     toBeValid,
     toHaveExplanation,
@@ -28,6 +18,28 @@ expect.extend({
     toMatchTaskWithHeading,
     toMatchTaskWithPath,
     toMatchTaskWithStatus,
-    toMatchTaskDetails,
+});
+
+// ---------------------------------------------------------------------
+// CustomMatchersForGrouping
+// ---------------------------------------------------------------------
+import { toSupportGroupingWithProperty } from './CustomMatchersForGrouping';
+expect.extend({
     toSupportGroupingWithProperty,
+});
+
+// ---------------------------------------------------------------------
+// CustomMatchersForTaskBuilder
+// ---------------------------------------------------------------------
+import { toBeIdenticalTo } from './CustomMatchersForTaskBuilder';
+expect.extend({
+    toBeIdenticalTo,
+});
+
+// ---------------------------------------------------------------------
+// CustomMatchersForTaskBuilder
+// ---------------------------------------------------------------------
+import { toMatchTaskDetails } from './CustomMatchersForTaskSerializer';
+expect.extend({
+    toMatchTaskDetails,
 });

--- a/tests/CustomMatchers/jest.custom_matchers.setup.ts
+++ b/tests/CustomMatchers/jest.custom_matchers.setup.ts
@@ -13,6 +13,11 @@ import {
 
 import { toSupportGroupingWithProperty } from './CustomMatchersForGrouping';
 
+import { toBeIdenticalTo } from './CustomMatchersForTaskBuilder';
+expect.extend({
+    toBeIdenticalTo,
+});
+
 import { toMatchTaskDetails } from './CustomMatchersForTaskSerializer';
 
 expect.extend({

--- a/tests/CustomMatchers/jest.custom_matchers.setup.ts
+++ b/tests/CustomMatchers/jest.custom_matchers.setup.ts
@@ -37,6 +37,14 @@ expect.extend({
 });
 
 // ---------------------------------------------------------------------
+// CustomMatchersForTasks
+// ---------------------------------------------------------------------
+import { toToggleLineTo } from './CustomMatchersForTasks';
+expect.extend({
+    toToggleLineTo,
+});
+
+// ---------------------------------------------------------------------
 // CustomMatchersForTaskBuilder
 // ---------------------------------------------------------------------
 import { toMatchTaskDetails } from './CustomMatchersForTaskSerializer';

--- a/tests/CustomMatchers/jest.custom_matchers.setup.ts
+++ b/tests/CustomMatchers/jest.custom_matchers.setup.ts
@@ -39,9 +39,10 @@ expect.extend({
 // ---------------------------------------------------------------------
 // CustomMatchersForTasks
 // ---------------------------------------------------------------------
-import { toToggleLineTo } from './CustomMatchersForTasks';
+import { toToggleLineTo, toToggleWithRecurrenceInUsersOrderTo } from './CustomMatchersForTasks';
 expect.extend({
     toToggleLineTo,
+    toToggleWithRecurrenceInUsersOrderTo,
 });
 
 // ---------------------------------------------------------------------

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1019,7 +1019,15 @@ describe('toggle done', () => {
 });
 
 describe('set correct created date on reccurence task', () => {
+    const today = '2023-03-08';
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date(today));
+    });
+
     afterEach(() => {
+        jest.useRealTimers();
         resetSettings();
     });
 
@@ -1066,8 +1074,6 @@ describe('set correct created date on reccurence task', () => {
 
     it('set created date with enabled setting', () => {
         // Arrange
-        const today = '2023-03-08';
-        const todaySpy = jest.spyOn(Date, 'now').mockReturnValue(moment(today).valueOf());
         const line = '- [ ] this is a task 📅 2021-09-12 🔁 every day';
         updateSettings({ setCreatedDate: true });
 
@@ -1085,15 +1091,10 @@ describe('set correct created date on reccurence task', () => {
         const nextTask: Task = tasks[0];
         expect(nextTask.createdDate).not.toBeNull();
         expect(nextTask!.createdDate!.isSame(moment(today, 'YYYY-MM-DD'))).toStrictEqual(true);
-
-        // cleanup
-        todaySpy.mockClear();
     });
 
     it('set created date with enabled setting when repeated has created date', () => {
         // Arrange
-        const today = '2023-03-08';
-        const todaySpy = jest.spyOn(Date, 'now').mockReturnValue(moment(today).valueOf());
         const line = '- [ ] this is a task ➕ 2021-09-11 📅 2021-09-12 🔁 every day';
         updateSettings({ setCreatedDate: true });
 
@@ -1112,9 +1113,6 @@ describe('set correct created date on reccurence task', () => {
         const nextTask: Task = tasks[0];
         expect(nextTask.createdDate).not.toBeNull();
         expect(nextTask!.createdDate!.isSame(moment(today, 'YYYY-MM-DD'))).toStrictEqual(true);
-
-        // cleanup
-        todaySpy.mockClear();
     });
 });
 

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1171,45 +1171,6 @@ describe('order of recurring tasks', () => {
     });
 });
 
-declare global {
-    namespace jest {
-        interface Matchers<R> {
-            toBeIdenticalTo(builder2: TaskBuilder): R;
-        }
-
-        interface Expect {
-            toBeIdenticalTo(builder2: TaskBuilder): any;
-        }
-
-        interface InverseAsymmetricMatchers {
-            toBeIdenticalTo(builder2: TaskBuilder): any;
-        }
-    }
-}
-
-export function toBeIdenticalTo(builder1: TaskBuilder, builder2: TaskBuilder) {
-    const task1 = builder1.build();
-    const task2 = builder2.build();
-    const pass = task1.identicalTo(task2);
-
-    if (pass) {
-        return {
-            message: () => 'Tasks treated as identical, but should be different',
-            pass: true,
-        };
-    }
-    return {
-        message: () => {
-            return 'Tasks should be identical, but are treated as different';
-        },
-        pass: false,
-    };
-}
-
-expect.extend({
-    toBeIdenticalTo,
-});
-
 describe('identicalTo', () => {
     it('should check status', () => {
         const lhs = new TaskBuilder().status(Status.TODO);

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1018,7 +1018,7 @@ describe('toggle done', () => {
     });
 });
 
-describe('set correct created date on reccurence task', () => {
+describe('created dates on recurring task', () => {
     beforeEach(() => {
         jest.useFakeTimers();
         jest.setSystemTime(new Date('2023-03-08'));
@@ -1029,7 +1029,7 @@ describe('set correct created date on reccurence task', () => {
         resetSettings();
     });
 
-    it('does not set created date with disabled setting', () => {
+    it('should not set created date with disabled setting', () => {
         // Arrange
         const line = '- [ ] this is a task 📅 2021-09-12 🔁 every day';
         updateSettings({ setCreatedDate: false });
@@ -1041,7 +1041,7 @@ describe('set correct created date on reccurence task', () => {
         ]);
     });
 
-    it('does not set created date with disabled setting when repeated has created date', () => {
+    it('should not set created date if setting disabled, even if original has created date', () => {
         // Arrange
         const line = '- [ ] this is a task ➕ 2021-09-11 📅 2021-09-12 🔁 every day';
         updateSettings({ setCreatedDate: false });
@@ -1053,7 +1053,7 @@ describe('set correct created date on reccurence task', () => {
         ]);
     });
 
-    it('set created date with enabled setting', () => {
+    it('should set created date if setting enabled', () => {
         // Arrange
         const line = '- [ ] this is a task 📅 2021-09-12 🔁 every day';
         updateSettings({ setCreatedDate: true });
@@ -1065,7 +1065,7 @@ describe('set correct created date on reccurence task', () => {
         ]);
     });
 
-    it('set created date with enabled setting when repeated has created date', () => {
+    it('should set created date if setting enabled, when original has created date', () => {
         // Arrange
         const line = '- [ ] this is a task ➕ 2021-09-11 📅 2021-09-12 🔁 every day';
         updateSettings({ setCreatedDate: true });

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1090,19 +1090,9 @@ describe('order of recurring tasks', () => {
         resetSettings();
     });
 
-    function togglingInUsersOrderShouldGive(line: string, expectedLines: string[]) {
-        // Arrange
-        const task = fromLine({ line: line });
-
-        // Act
-        const lines = task.toggleWithRecurrenceInUsersOrder().map((t) => t.toFileLineString());
-
-        // Assert
-        expect(lines).toStrictEqual(expectedLines);
-    }
-
     it('should put new task before old, by default', () => {
-        togglingInUsersOrderShouldGive('- [ ] this is a recurring task 🔁 every day', [
+        const line = '- [ ] this is a recurring task 🔁 every day';
+        expect(line).toToggleWithRecurrenceInUsersOrderTo([
             '- [ ] this is a recurring task 🔁 every day',
             '- [x] this is a recurring task 🔁 every day ✅ 2023-05-16',
         ]);
@@ -1111,7 +1101,8 @@ describe('order of recurring tasks', () => {
     it('should honour new-task-before-old setting', () => {
         updateSettings({ recurrenceOnNextLine: false });
 
-        togglingInUsersOrderShouldGive('- [ ] this is a recurring task 🔁 every day', [
+        const line = '- [ ] this is a recurring task 🔁 every day';
+        expect(line).toToggleWithRecurrenceInUsersOrderTo([
             '- [ ] this is a recurring task 🔁 every day',
             '- [x] this is a recurring task 🔁 every day ✅ 2023-05-16',
         ]);
@@ -1120,7 +1111,8 @@ describe('order of recurring tasks', () => {
     it('should honour old-task-before-new setting', () => {
         updateSettings({ recurrenceOnNextLine: true });
 
-        togglingInUsersOrderShouldGive('- [ ] this is a recurring task 🔁 every day', [
+        const line = '- [ ] this is a recurring task 🔁 every day';
+        expect(line).toToggleWithRecurrenceInUsersOrderTo([
             '- [x] this is a recurring task 🔁 every day ✅ 2023-05-16',
             '- [ ] this is a recurring task 🔁 every day',
         ]);

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1037,18 +1037,10 @@ describe('set correct created date on reccurence task', () => {
         updateSettings({ setCreatedDate: false });
 
         // Act
-        const task = fromLine({
-            line,
-        });
-
-        // Assert
-        expect(task).not.toBeNull();
-        expect(task!.createdDate).toBeNull();
-
-        const tasks = task!.toggle();
-        expect(tasks.length).toEqual(2);
-        const nextTask: Task = tasks[0];
-        expect(nextTask.createdDate).toBeNull();
+        expect(line).toToggleLineTo([
+            '- [ ] this is a task 🔁 every day 📅 2021-09-13',
+            '- [x] this is a task 🔁 every day 📅 2021-09-12 ✅ 2023-03-08',
+        ]);
     });
 
     it('does not set created date with disabled setting when repeated has created date', () => {
@@ -1057,19 +1049,10 @@ describe('set correct created date on reccurence task', () => {
         updateSettings({ setCreatedDate: false });
 
         // Act
-        const task = fromLine({
-            line,
-        });
-
-        // Assert
-        expect(task).not.toBeNull();
-        expect(task!.createdDate).not.toBeNull();
-        expect(task!.createdDate!.isSame(moment('2021-09-11', 'YYYY-MM-DD'))).toStrictEqual(true);
-
-        const tasks = task!.toggle();
-        expect(tasks.length).toEqual(2);
-        const nextTask: Task = tasks[0];
-        expect(nextTask.createdDate).toBeNull();
+        expect(line).toToggleLineTo([
+            '- [ ] this is a task 🔁 every day 📅 2021-09-13',
+            '- [x] this is a task 🔁 every day ➕ 2021-09-11 📅 2021-09-12 ✅ 2023-03-08',
+        ]);
     });
 
     it('set created date with enabled setting', () => {
@@ -1078,19 +1061,10 @@ describe('set correct created date on reccurence task', () => {
         updateSettings({ setCreatedDate: true });
 
         // Act
-        const task = fromLine({
-            line,
-        });
-
-        // Assert
-        expect(task).not.toBeNull();
-        expect(task!.createdDate).toBeNull();
-
-        const tasks = task!.toggle();
-        expect(tasks.length).toEqual(2);
-        const nextTask: Task = tasks[0];
-        expect(nextTask.createdDate).not.toBeNull();
-        expect(nextTask!.createdDate!.isSame(moment(today, 'YYYY-MM-DD'))).toStrictEqual(true);
+        expect(line).toToggleLineTo([
+            '- [ ] this is a task 🔁 every day ➕ 2023-03-08 📅 2021-09-13',
+            '- [x] this is a task 🔁 every day 📅 2021-09-12 ✅ 2023-03-08',
+        ]);
     });
 
     it('set created date with enabled setting when repeated has created date', () => {
@@ -1099,20 +1073,10 @@ describe('set correct created date on reccurence task', () => {
         updateSettings({ setCreatedDate: true });
 
         // Act
-        const task = fromLine({
-            line,
-        });
-
-        // Assert
-        expect(task).not.toBeNull();
-        expect(task!.createdDate).not.toBeNull();
-        expect(task!.createdDate!.isSame(moment('2021-09-11', 'YYYY-MM-DD'))).toStrictEqual(true);
-
-        const tasks = task!.toggle();
-        expect(tasks.length).toEqual(2);
-        const nextTask: Task = tasks[0];
-        expect(nextTask.createdDate).not.toBeNull();
-        expect(nextTask!.createdDate!.isSame(moment(today, 'YYYY-MM-DD'))).toStrictEqual(true);
+        expect(line).toToggleLineTo([
+            '- [ ] this is a task 🔁 every day ➕ 2023-03-08 📅 2021-09-13',
+            '- [x] this is a task 🔁 every day ➕ 2021-09-11 📅 2021-09-12 ✅ 2023-03-08',
+        ]);
     });
 });
 

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1019,6 +1019,10 @@ describe('toggle done', () => {
 });
 
 describe('set correct created date on reccurence task', () => {
+    afterEach(() => {
+        resetSettings();
+    });
+
     it('does not set created date with disabled setting', () => {
         // Arrange
         const line = '- [ ] this is a task 📅 2021-09-12 🔁 every day';
@@ -1037,9 +1041,6 @@ describe('set correct created date on reccurence task', () => {
         expect(tasks.length).toEqual(2);
         const nextTask: Task = tasks[0];
         expect(nextTask.createdDate).toBeNull();
-
-        // cleanup
-        resetSettings();
     });
 
     it('does not set created date with disabled setting when repeated has created date', () => {
@@ -1061,9 +1062,6 @@ describe('set correct created date on reccurence task', () => {
         expect(tasks.length).toEqual(2);
         const nextTask: Task = tasks[0];
         expect(nextTask.createdDate).toBeNull();
-
-        // cleanup
-        resetSettings();
     });
 
     it('set created date with enabled setting', () => {
@@ -1089,7 +1087,6 @@ describe('set correct created date on reccurence task', () => {
         expect(nextTask!.createdDate!.isSame(moment(today, 'YYYY-MM-DD'))).toStrictEqual(true);
 
         // cleanup
-        resetSettings();
         todaySpy.mockClear();
     });
 
@@ -1117,7 +1114,6 @@ describe('set correct created date on reccurence task', () => {
         expect(nextTask!.createdDate!.isSame(moment(today, 'YYYY-MM-DD'))).toStrictEqual(true);
 
         // cleanup
-        resetSettings();
         todaySpy.mockClear();
     });
 });

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1019,11 +1019,9 @@ describe('toggle done', () => {
 });
 
 describe('set correct created date on reccurence task', () => {
-    const today = '2023-03-08';
-
     beforeEach(() => {
         jest.useFakeTimers();
-        jest.setSystemTime(new Date(today));
+        jest.setSystemTime(new Date('2023-03-08'));
     });
 
     afterEach(() => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1035,7 +1035,7 @@ describe('created dates on recurring task', () => {
         updateSettings({ setCreatedDate: false });
 
         // Act
-        expect(line).toToggleLineTo([
+        expect(line).toToggleTo([
             '- [ ] this is a task 🔁 every day 📅 2021-09-13',
             '- [x] this is a task 🔁 every day 📅 2021-09-12 ✅ 2023-03-08',
         ]);
@@ -1047,7 +1047,7 @@ describe('created dates on recurring task', () => {
         updateSettings({ setCreatedDate: false });
 
         // Act
-        expect(line).toToggleLineTo([
+        expect(line).toToggleTo([
             '- [ ] this is a task 🔁 every day 📅 2021-09-13',
             '- [x] this is a task 🔁 every day ➕ 2021-09-11 📅 2021-09-12 ✅ 2023-03-08',
         ]);
@@ -1059,7 +1059,7 @@ describe('created dates on recurring task', () => {
         updateSettings({ setCreatedDate: true });
 
         // Act
-        expect(line).toToggleLineTo([
+        expect(line).toToggleTo([
             '- [ ] this is a task 🔁 every day ➕ 2023-03-08 📅 2021-09-13',
             '- [x] this is a task 🔁 every day 📅 2021-09-12 ✅ 2023-03-08',
         ]);
@@ -1071,7 +1071,7 @@ describe('created dates on recurring task', () => {
         updateSettings({ setCreatedDate: true });
 
         // Act
-        expect(line).toToggleLineTo([
+        expect(line).toToggleTo([
             '- [ ] this is a task 🔁 every day ➕ 2023-03-08 📅 2021-09-13',
             '- [x] this is a task 🔁 every day ➕ 2021-09-11 📅 2021-09-12 ✅ 2023-03-08',
         ]);

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1031,7 +1031,7 @@ describe('created dates on recurring task', () => {
 
     it('should not set created date with disabled setting', () => {
         // Arrange
-        const line = '- [ ] this is a task 📅 2021-09-12 🔁 every day';
+        const line = '- [ ] this is a task 🔁 every day 📅 2021-09-12';
         updateSettings({ setCreatedDate: false });
 
         // Act
@@ -1043,7 +1043,7 @@ describe('created dates on recurring task', () => {
 
     it('should not set created date if setting disabled, even if original has created date', () => {
         // Arrange
-        const line = '- [ ] this is a task ➕ 2021-09-11 📅 2021-09-12 🔁 every day';
+        const line = '- [ ] this is a task 🔁 every day ➕ 2021-09-11 📅 2021-09-12';
         updateSettings({ setCreatedDate: false });
 
         // Act
@@ -1055,7 +1055,7 @@ describe('created dates on recurring task', () => {
 
     it('should set created date if setting enabled', () => {
         // Arrange
-        const line = '- [ ] this is a task 📅 2021-09-12 🔁 every day';
+        const line = '- [ ] this is a task 🔁 every day 📅 2021-09-12';
         updateSettings({ setCreatedDate: true });
 
         // Act
@@ -1067,7 +1067,7 @@ describe('created dates on recurring task', () => {
 
     it('should set created date if setting enabled, when original has created date', () => {
         // Arrange
-        const line = '- [ ] this is a task ➕ 2021-09-11 📅 2021-09-12 🔁 every day';
+        const line = '- [ ] this is a task 🔁 every day ➕ 2021-09-11 📅 2021-09-12';
         updateSettings({ setCreatedDate: true });
 
         // Act


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Description

Added some more Jest custom matchers:

- `CustomMatchersForTaskBuilder.ts`
    - `toBeIdenticalTo()`
        - (moved from `tests/Task.test.ts`)
- `CustomMatchersForTasks.ts`
    - `toToggleTo()`
    - `toToggleWithRecurrenceInUsersOrderTo()`
- Removed about 100 lines from `Task.test.ts`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Remove repetition in existing tests
- And make them more expressive

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Running existing and updated tests

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
