### PR TITLE
fix: Enable 'High priority' to be selected easily in Auto Suggest

### DIFF
--- a/docs/Getting Started/Auto-Suggest.md
+++ b/docs/Getting Started/Auto-Suggest.md
@@ -174,10 +174,10 @@ Similarly, you can type some fraction of the word `start` (of whatever length is
 | Searchable Text               | Text that is added         |
 | ----------------------------- | -------------------------- |
 | ⏎                             | \<new line>                |
-| 🔺 highest priority           | 🔺                         |
 | ⏫ high priority              | ⏫                         |
 | 🔼 medium priority            | 🔼                         |
 | 🔽 low priority               | 🔽                         |
+| 🔺 highest priority           | 🔺                         |
 | ⏬️ lowest priority            | ⏬️                         |
 | 🔁 recurring (repeat)         | 🔁                         |
 | every                         | 🔁 every                   |

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -84,10 +84,6 @@ function addTaskPropertySuggestions(
         });
     if (!hasPriority(line)) {
         genericSuggestions.push({
-            displayText: `${symbols.prioritySymbols.Highest} highest priority`,
-            appendText: `${symbols.prioritySymbols.Highest} `,
-        });
-        genericSuggestions.push({
             displayText: `${symbols.prioritySymbols.High} high priority`,
             appendText: `${symbols.prioritySymbols.High} `,
         });
@@ -98,6 +94,10 @@ function addTaskPropertySuggestions(
         genericSuggestions.push({
             displayText: `${symbols.prioritySymbols.Low} low priority`,
             appendText: `${symbols.prioritySymbols.Low} `,
+        });
+        genericSuggestions.push({
+            displayText: `${symbols.prioritySymbols.Highest} highest priority`,
+            appendText: `${symbols.prioritySymbols.Highest} `,
         });
         genericSuggestions.push({
             displayText: `${symbols.prioritySymbols.Lowest} lowest priority`,

--- a/tests/Suggestor/Suggestor.test.auto-complete_with__dataview__symbols_show_all_suggested_text.approved.md
+++ b/tests/Suggestor/Suggestor.test.auto-complete_with__dataview__symbols_show_all_suggested_text.approved.md
@@ -4,10 +4,10 @@
 | due:: due date | due::  |
 | start:: start date | start::  |
 | scheduled:: scheduled date | scheduled::  |
-| priority:: highest highest priority | priority:: highest  |
 | priority:: high high priority | priority:: high  |
 | priority:: medium medium priority | priority:: medium  |
 | priority:: low low priority | priority:: low  |
+| priority:: highest highest priority | priority:: highest  |
 | priority:: lowest lowest priority | priority:: lowest  |
 | repeat:: recurring (repeat) | repeat::  |
 | created:: created today (2022-07-11) | created:: 2022-07-11  |

--- a/tests/Suggestor/Suggestor.test.auto-complete_with__emoji__symbols_show_all_suggested_text.approved.md
+++ b/tests/Suggestor/Suggestor.test.auto-complete_with__emoji__symbols_show_all_suggested_text.approved.md
@@ -4,10 +4,10 @@
 | 📅 due date | 📅  |
 | 🛫 start date | 🛫  |
 | ⏳ scheduled date | ⏳  |
-| 🔺 highest priority | 🔺  |
 | ⏫ high priority | ⏫  |
 | 🔼 medium priority | 🔼  |
 | 🔽 low priority | 🔽  |
+| 🔺 highest priority | 🔺  |
 | ⏬ lowest priority | ⏬  |
 | 🔁 recurring (repeat) | 🔁  |
 | ➕ created today (2022-07-11) | ➕ 2022-07-11  |

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -48,8 +48,8 @@ describe.each([
             { displayText: `${dueDateSymbol} due date`, appendText: `${dueDateSymbol} ` },
             { displayText: `${startDateSymbol} start date`, appendText: `${startDateSymbol} ` },
             { displayText: `${scheduledDateSymbol} scheduled date`, appendText: `${scheduledDateSymbol} ` },
-            { displayText: `${prioritySymbols.Highest} highest priority`, appendText: `${prioritySymbols.Highest} ` },
             { displayText: `${prioritySymbols.High} high priority`, appendText: `${prioritySymbols.High} ` },
+            { displayText: `${prioritySymbols.Medium} medium priority`, appendText: `${prioritySymbols.Medium} ` },
         ]);
     });
 


### PR DESCRIPTION
# Description

Via auto-suggest I keep ending up with tasks of Highest priority accidentally. See #1995 for a write-up.

This PR reverts to the original order of priority items in the auto-suggest menu.

The order of priorities in auto suggestion is now:

1. high
2. medium
3. low
4. highest (new)
5. lowest (new)

Benefits:

- This retains the original order, for people's muscle memory. 
- And it means that the longer names are after the shorter ones, which also makes it possible to type both, 
- And it means that typing parts of names selects the same result as before highest and lowest were added.


## Motivation and Context

Fixes #1943

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

- Via the unit tests
- In Obsidian (both with the default number of suggests (6) and the maximum (12)

## Screenshots (if appropriate)

With 6 suggestions:

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/f376baa0-5336-4420-8741-42f8110e9865)

With 12 suggestions:

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/b86a082e-464c-4357-b90e-b80acecbbb5d)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
