### PR TITLE
test: add custom matcher to test group sort order

### DIFF
--- a/tests/CustomMatchers/CustomMatchersForGrouping.ts
+++ b/tests/CustomMatchers/CustomMatchersForGrouping.ts
@@ -1,7 +1,5 @@
-import { TaskGroups } from '../../src/Query/TaskGroups';
+import type { TaskGroups } from '../../src/Query/TaskGroups';
 import type { Field } from '../../src/Query/Filter/Field';
-import type { Task } from '../../src/Task';
-import type { Grouper } from '../../src/Query/Grouper';
 
 declare global {
     namespace jest {
@@ -45,11 +43,7 @@ export function toSupportGroupingWithProperty(field: Field, property: string) {
     };
 }
 
-export function expectGroupHeadingsToBe(grouper: Grouper, tasks: Task[], expectedGroupHeadings: string[]) {
-    tasks.sort(() => Math.random() - 0.5);
-
-    // Act
-    const groups = new TaskGroups([grouper], tasks);
+export function expectGroupHeadingsToBe(groups: TaskGroups, expectedGroupHeadings: string[]) {
     const groupHeadings: string[] = [];
     groups.groups.forEach((taskGroup) => {
         taskGroup.groupHeadings.forEach((heading) => {
@@ -57,6 +51,5 @@ export function expectGroupHeadingsToBe(grouper: Grouper, tasks: Task[], expecte
         });
     });
 
-    // Assert
     expect(groupHeadings).toEqual(expectedGroupHeadings);
 }

--- a/tests/CustomMatchers/CustomMatchersForGrouping.ts
+++ b/tests/CustomMatchers/CustomMatchersForGrouping.ts
@@ -1,5 +1,7 @@
 import { diff } from 'jest-diff';
-import type { TaskGroups } from '../../src/Query/TaskGroups';
+import type { Grouper } from 'Query/Grouper';
+import type { Task } from 'Task';
+import { TaskGroups } from '../../src/Query/TaskGroups';
 import type { Field } from '../../src/Query/Filter/Field';
 
 declare global {
@@ -46,9 +48,12 @@ export function toSupportGroupingWithProperty(field: Field, property: string) {
 }
 
 export function groupHeadingsToBe(
-    { groups }: { groups: TaskGroups },
+    { grouper, tasks }: { grouper: Grouper; tasks: Task[] },
     expectedGroupHeadings: string[],
 ): jest.CustomMatcherResult {
+    tasks.sort(() => Math.random() - 0.5);
+    const groups = new TaskGroups([grouper], tasks);
+
     const groupHeadings: string[] = [];
     groups.groups.forEach((taskGroup) => {
         taskGroup.groupHeadings.forEach((heading) => {

--- a/tests/CustomMatchers/CustomMatchersForGrouping.ts
+++ b/tests/CustomMatchers/CustomMatchersForGrouping.ts
@@ -45,7 +45,10 @@ export function toSupportGroupingWithProperty(field: Field, property: string) {
     };
 }
 
-export function groupHeadingsToBe(groups: TaskGroups, expectedGroupHeadings: string[]): jest.CustomMatcherResult {
+export function groupHeadingsToBe(
+    { groups }: { groups: TaskGroups },
+    expectedGroupHeadings: string[],
+): jest.CustomMatcherResult {
     const groupHeadings: string[] = [];
     groups.groups.forEach((taskGroup) => {
         taskGroup.groupHeadings.forEach((heading) => {

--- a/tests/CustomMatchers/CustomMatchersForGrouping.ts
+++ b/tests/CustomMatchers/CustomMatchersForGrouping.ts
@@ -1,4 +1,7 @@
+import { TaskGroups } from '../../src/Query/TaskGroups';
 import type { Field } from '../../src/Query/Filter/Field';
+import type { Task } from '../../src/Task';
+import type { Grouper } from '../../src/Query/Grouper';
 
 declare global {
     namespace jest {
@@ -40,4 +43,20 @@ export function toSupportGroupingWithProperty(field: Field, property: string) {
             `'${field.fieldName()}' field supports grouping, grouping property set to '${fieldGrouper.property}'.`,
         pass: true,
     };
+}
+
+export function expectGroupHeadingsToBe(grouper: Grouper, tasks: Task[], expectedGroupHeadings: string[]) {
+    tasks.sort(() => Math.random() - 0.5);
+
+    // Act
+    const groups = new TaskGroups([grouper], tasks);
+    const groupHeadings: string[] = [];
+    groups.groups.forEach((taskGroup) => {
+        taskGroup.groupHeadings.forEach((heading) => {
+            groupHeadings.push(heading.displayName);
+        });
+    });
+
+    // Assert
+    expect(groupHeadings).toEqual(expectedGroupHeadings);
 }

--- a/tests/CustomMatchers/CustomMatchersForGrouping.ts
+++ b/tests/CustomMatchers/CustomMatchersForGrouping.ts
@@ -1,3 +1,4 @@
+import { diff } from 'jest-diff';
 import type { TaskGroups } from '../../src/Query/TaskGroups';
 import type { Field } from '../../src/Query/Filter/Field';
 
@@ -5,6 +6,7 @@ declare global {
     namespace jest {
         interface Matchers<R> {
             toSupportGroupingWithProperty(property: string): R;
+            groupHeadingsToBe(expectedGroupHeadings: string[]): R;
         }
 
         interface Expect {
@@ -43,7 +45,7 @@ export function toSupportGroupingWithProperty(field: Field, property: string) {
     };
 }
 
-export function expectGroupHeadingsToBe(groups: TaskGroups, expectedGroupHeadings: string[]) {
+export function groupHeadingsToBe(groups: TaskGroups, expectedGroupHeadings: string[]): jest.CustomMatcherResult {
     const groupHeadings: string[] = [];
     groups.groups.forEach((taskGroup) => {
         taskGroup.groupHeadings.forEach((heading) => {
@@ -51,5 +53,14 @@ export function expectGroupHeadingsToBe(groups: TaskGroups, expectedGroupHeading
         });
     });
 
-    expect(groupHeadings).toEqual(expectedGroupHeadings);
+    const pass: boolean = groupHeadings.join() === expectedGroupHeadings.join();
+    const message: () => string = () =>
+        pass
+            ? `Group headings should not be\n${expectedGroupHeadings.join('\n')}`
+            : `Group headings are not the same as expected: ${diff(expectedGroupHeadings, groupHeadings)}`;
+
+    return {
+        message,
+        pass,
+    };
 }

--- a/tests/CustomMatchers/jest.custom_matchers.setup.ts
+++ b/tests/CustomMatchers/jest.custom_matchers.setup.ts
@@ -31,8 +31,9 @@ expect.extend({
 // ---------------------------------------------------------------------
 // CustomMatchersForGrouping
 // ---------------------------------------------------------------------
-import { toSupportGroupingWithProperty } from './CustomMatchersForGrouping';
+import { groupHeadingsToBe, toSupportGroupingWithProperty } from './CustomMatchersForGrouping';
 expect.extend({
+    groupHeadingsToBe,
     toSupportGroupingWithProperty,
 });
 

--- a/tests/Query/Filter/DueDateField.test.ts
+++ b/tests/Query/Filter/DueDateField.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
+import type { Task } from 'Task';
 import { DueDateField } from '../../../src/Query/Filter/DueDateField';
 import type { FilterOrErrorMessage } from '../../../src/Query/Filter/Filter';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
@@ -531,4 +532,27 @@ describe('grouping by due date', () => {
         expect(grouper.grouper(taskWithDate)).toEqual(['1970-01-01 Thursday']);
         expect(grouper.grouper(taskWithoutDate)).toEqual(['No due date']);
     });
+
+    it('should sort groups for DueDateField', () => {
+        const grouper = new DueDateField().createNormalGrouper();
+        const tasks = withAllRepresentativeDueDates();
+
+        expect({ grouper, tasks }).groupHeadingsToBe([
+            '2023-05-30 Tuesday',
+            '2023-05-31 Wednesday',
+            '2023-06-01 Thursday',
+            'Invalid date',
+            'No due date',
+        ]);
+    });
 });
+
+function withAllRepresentativeDueDates(): Task[] {
+    const dates = ['2023-05-30', '2023-05-31', '2023-06-01', '2023-02-32', null];
+
+    const tasks = dates.map((date) => {
+        return new TaskBuilder().dueDate(date).build();
+    });
+
+    return tasks;
+}

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -225,7 +225,7 @@ describe('grouping by priority', () => {
 
         tasks.sort(() => Math.random() - 0.5);
         const groups = new TaskGroups([grouper], tasks);
-        expect(groups).groupHeadingsToBe(expectedGroupHeadings);
+        expect({ groups }).groupHeadingsToBe(expectedGroupHeadings);
     });
 });
 

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -219,10 +219,12 @@ describe('grouping by priority', () => {
         const tasks = withAllPriorities();
 
         expect({ grouper, tasks }).groupHeadingsToBe([
+            'Priority 0: Highest',
             'Priority 1: High',
             'Priority 2: Medium',
             'Priority 3: None',
             'Priority 4: Low',
+            'Priority 5: Lowest',
         ]);
     });
 });

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -9,8 +9,7 @@ import {
     expectTaskComparesBefore,
     expectTaskComparesEqual,
 } from '../../CustomMatchers/CustomMatchersForSorting';
-import { TaskGroups } from '../../../src/Query/TaskGroups';
-import type { Grouper } from 'Query/Grouper';
+import { expectGroupHeadingsToBe } from '../../CustomMatchers/CustomMatchersForGrouping';
 
 function testTaskFilterForTaskWithPriority(filter: string, priority: Priority, expected: boolean) {
     const builder = new TaskBuilder();
@@ -222,32 +221,11 @@ describe('grouping by priority', () => {
 
         const tasks = withAllPriorities();
 
-        const expectedGroupHeadings = [
-            'Priority 1: High',
-            'Priority 2: Medium',
-            'Priority 3: None',
-            'Priority 4: Low',
-        ];
+        const expectedGroupHeadings = ['Priority 1: High', 'Priority 2: Medium', 'Priority 3: None', 'Priority 4: Low'];
 
-        expectGroupHeadingsToBe(tasks, grouper, expectedGroupHeadings);
+        expectGroupHeadingsToBe(grouper, tasks, expectedGroupHeadings);
     });
 });
-
-function expectGroupHeadingsToBe(tasks: Task[], grouper: Grouper, expectedGroupHeadings: string[]) {
-    tasks.sort(() => Math.random() - 0.5);
-
-    // Act
-    const groups = new TaskGroups([grouper], tasks);
-    const groupHeadings: string[] = [];
-    groups.groups.forEach((taskGroup) => {
-        taskGroup.groupHeadings.forEach((heading) => {
-            groupHeadings.push(heading.displayName);
-        });
-    });
-
-    // Assert
-    expect(groupHeadings).toEqual(expectedGroupHeadings);
-}
 
 function withAllPriorities(): Task[] {
     const tasks: Task[] = [];
@@ -258,4 +236,3 @@ function withAllPriorities(): Task[] {
     });
     return tasks;
 }
-

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -221,6 +221,14 @@ describe('grouping by priority', () => {
         const grouper = [field.createNormalGrouper()];
 
         const tasks = withAllPriorities();
+
+        const expectedGroupHeadings = [
+            'Priority 1: High',
+            'Priority 2: Medium',
+            'Priority 3: None',
+            'Priority 4: Low',
+        ];
+        
         tasks.sort(() => Math.random() - 0.5);
 
         // Act
@@ -233,12 +241,7 @@ describe('grouping by priority', () => {
         });
 
         // Assert
-        expect(groupHeadings).toEqual([
-            'Priority 1: High',
-            'Priority 2: Medium',
-            'Priority 3: None',
-            'Priority 4: Low',
-        ]);
+        expect(groupHeadings).toEqual(expectedGroupHeadings);
     });
 });
 

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -10,7 +10,6 @@ import {
     expectTaskComparesBefore,
     expectTaskComparesEqual,
 } from '../../CustomMatchers/CustomMatchersForSorting';
-import { expectGroupHeadingsToBe } from '../../CustomMatchers/CustomMatchersForGrouping';
 
 function testTaskFilterForTaskWithPriority(filter: string, priority: Priority, expected: boolean) {
     const builder = new TaskBuilder();
@@ -226,7 +225,7 @@ describe('grouping by priority', () => {
 
         tasks.sort(() => Math.random() - 0.5);
         const groups = new TaskGroups([grouper], tasks);
-        expectGroupHeadingsToBe(groups, expectedGroupHeadings);
+        expect(groups).groupHeadingsToBe(expectedGroupHeadings);
     });
 });
 

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -217,8 +217,7 @@ describe('grouping by priority', () => {
 
     it('should sort groups for PriorityField', () => {
         // Prepare
-        const field = new PriorityField();
-        const grouper = [field.createNormalGrouper()];
+        const grouper = new PriorityField().createNormalGrouper();
 
         const tasks = withAllPriorities();
 
@@ -228,11 +227,11 @@ describe('grouping by priority', () => {
             'Priority 3: None',
             'Priority 4: Low',
         ];
-        
+
         tasks.sort(() => Math.random() - 0.5);
 
         // Act
-        const groups = new TaskGroups(grouper, tasks);
+        const groups = new TaskGroups([grouper], tasks);
         const groupHeadings: string[] = [];
         groups.groups.forEach((taskGroup) => {
             taskGroup.groupHeadings.forEach((heading) => {

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -1,3 +1,4 @@
+import { TaskGroups } from '../../../src/Query/TaskGroups';
 import { Priority, Task } from '../../../src/Task';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { testFilter } from '../../TestingTools/FilterTestHelpers';
@@ -223,7 +224,9 @@ describe('grouping by priority', () => {
 
         const expectedGroupHeadings = ['Priority 1: High', 'Priority 2: Medium', 'Priority 3: None', 'Priority 4: Low'];
 
-        expectGroupHeadingsToBe(grouper, tasks, expectedGroupHeadings);
+        tasks.sort(() => Math.random() - 0.5);
+        const groups = new TaskGroups([grouper], tasks);
+        expectGroupHeadingsToBe(groups, expectedGroupHeadings);
     });
 });
 

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -215,13 +215,15 @@ describe('grouping by priority', () => {
     });
 
     it('should sort groups for PriorityField', () => {
-        // Prepare
         const grouper = new PriorityField().createNormalGrouper();
         const tasks = withAllPriorities();
 
-        const expectedGroupHeadings = ['Priority 1: High', 'Priority 2: Medium', 'Priority 3: None', 'Priority 4: Low'];
-
-        expect({ grouper, tasks }).groupHeadingsToBe(expectedGroupHeadings);
+        expect({ grouper, tasks }).groupHeadingsToBe([
+            'Priority 1: High',
+            'Priority 2: Medium',
+            'Priority 3: None',
+            'Priority 4: Low',
+        ]);
     });
 });
 

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -220,12 +220,7 @@ describe('grouping by priority', () => {
         const field = new PriorityField();
         const grouper = [field.createNormalGrouper()];
 
-        const tasks: Task[] = [];
-        const allPriorities = Object.values(Priority);
-        allPriorities.forEach((priority) => {
-            const task = new TaskBuilder().priority(priority).build();
-            tasks.push(task);
-        });
+        const tasks = withAllPriorities();
         tasks.sort(() => Math.random() - 0.5);
 
         // Act
@@ -246,3 +241,14 @@ describe('grouping by priority', () => {
         ]);
     });
 });
+
+function withAllPriorities(): Task[] {
+    const tasks: Task[] = [];
+    const allPriorities = Object.values(Priority);
+    allPriorities.forEach((priority) => {
+        const task = new TaskBuilder().priority(priority).build();
+        tasks.push(task);
+    });
+    return tasks;
+}
+

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -1,4 +1,3 @@
-import { TaskGroups } from '../../../src/Query/TaskGroups';
 import { Priority, Task } from '../../../src/Task';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { testFilter } from '../../TestingTools/FilterTestHelpers';
@@ -218,14 +217,11 @@ describe('grouping by priority', () => {
     it('should sort groups for PriorityField', () => {
         // Prepare
         const grouper = new PriorityField().createNormalGrouper();
-
         const tasks = withAllPriorities();
 
         const expectedGroupHeadings = ['Priority 1: High', 'Priority 2: Medium', 'Priority 3: None', 'Priority 4: Low'];
 
-        tasks.sort(() => Math.random() - 0.5);
-        const groups = new TaskGroups([grouper], tasks);
-        expect({ groups }).groupHeadingsToBe(expectedGroupHeadings);
+        expect({ grouper, tasks }).groupHeadingsToBe(expectedGroupHeadings);
     });
 });
 

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -1,4 +1,4 @@
-import { Priority } from '../../../src/Task';
+import { Priority, Task } from '../../../src/Task';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
 import { testFilter } from '../../TestingTools/FilterTestHelpers';
 import { PriorityField } from '../../../src/Query/Filter/PriorityField';
@@ -9,6 +9,7 @@ import {
     expectTaskComparesBefore,
     expectTaskComparesEqual,
 } from '../../CustomMatchers/CustomMatchersForSorting';
+import { TaskGroups } from '../../../src/Query/TaskGroups';
 
 function testTaskFilterForTaskWithPriority(filter: string, priority: Priority, expected: boolean) {
     const builder = new TaskBuilder();
@@ -212,5 +213,36 @@ describe('grouping by priority', () => {
 
         // Assert
         expect(grouper(fromLine({ line: taskLine }))).toEqual(groups);
+    });
+
+    it('should sort groups for PriorityField', () => {
+        // Prepare
+        const field = new PriorityField();
+        const grouper = [field.createNormalGrouper()];
+
+        const tasks: Task[] = [];
+        const allPriorities = Object.values(Priority);
+        allPriorities.forEach((priority) => {
+            const task = new TaskBuilder().priority(priority).build();
+            tasks.push(task);
+        });
+        tasks.sort(() => Math.random() - 0.5);
+
+        // Act
+        const groups = new TaskGroups(grouper, tasks);
+        const groupHeadings: string[] = [];
+        groups.groups.forEach((taskGroup) => {
+            taskGroup.groupHeadings.forEach((heading) => {
+                groupHeadings.push(heading.displayName);
+            });
+        });
+
+        // Assert
+        expect(groupHeadings).toEqual([
+            'Priority 1: High',
+            'Priority 2: Medium',
+            'Priority 3: None',
+            'Priority 4: Low',
+        ]);
     });
 });

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -10,6 +10,7 @@ import {
     expectTaskComparesEqual,
 } from '../../CustomMatchers/CustomMatchersForSorting';
 import { TaskGroups } from '../../../src/Query/TaskGroups';
+import type { Grouper } from 'Query/Grouper';
 
 function testTaskFilterForTaskWithPriority(filter: string, priority: Priority, expected: boolean) {
     const builder = new TaskBuilder();
@@ -228,21 +229,25 @@ describe('grouping by priority', () => {
             'Priority 4: Low',
         ];
 
-        tasks.sort(() => Math.random() - 0.5);
-
-        // Act
-        const groups = new TaskGroups([grouper], tasks);
-        const groupHeadings: string[] = [];
-        groups.groups.forEach((taskGroup) => {
-            taskGroup.groupHeadings.forEach((heading) => {
-                groupHeadings.push(heading.displayName);
-            });
-        });
-
-        // Assert
-        expect(groupHeadings).toEqual(expectedGroupHeadings);
+        expectGroupHeadingsToBe(tasks, grouper, expectedGroupHeadings);
     });
 });
+
+function expectGroupHeadingsToBe(tasks: Task[], grouper: Grouper, expectedGroupHeadings: string[]) {
+    tasks.sort(() => Math.random() - 0.5);
+
+    // Act
+    const groups = new TaskGroups([grouper], tasks);
+    const groupHeadings: string[] = [];
+    groups.groups.forEach((taskGroup) => {
+        taskGroup.groupHeadings.forEach((heading) => {
+            groupHeadings.push(heading.displayName);
+        });
+    });
+
+    // Assert
+    expect(groupHeadings).toEqual(expectedGroupHeadings);
+}
 
 function withAllPriorities(): Task[] {
     const tasks: Task[] = [];

--- a/tests/Query/Filter/StatusNameField.test.ts
+++ b/tests/Query/Filter/StatusNameField.test.ts
@@ -5,6 +5,9 @@ import {
     expectTaskComparesBefore,
     expectTaskComparesEqual,
 } from '../../CustomMatchers/CustomMatchersForSorting';
+import type { Task } from '../../../src/Task';
+import { TaskBuilder } from '../../TestingTools/TaskBuilder';
+import { Status } from '../../../src/Status';
 
 // Abbreviated names so that the markdown text is aligned
 const todoTask = TestHelpers.fromLine({ line: '- [ ] Xxx' });
@@ -97,4 +100,27 @@ describe('grouping by status.name', () => {
         expect(grouper.grouper(todoTask)).toEqual(['Todo']);
         expect(grouper.grouper(inprTask)).toEqual(['In Progress']);
     });
+
+    it('should sort groups for StatusNameField', () => {
+        const grouper = new StatusNameField().createNormalGrouper();
+        const tasks = withAllStatuses();
+
+        expect({ grouper, tasks }).groupHeadingsToBe(['Cancelled', 'Done', 'EMPTY', 'In Progress', 'Todo']);
+    });
 });
+
+function withAllStatuses(): Task[] {
+    const statuses = [
+        Status.makeCancelled(),
+        Status.makeDone(),
+        Status.makeEmpty(),
+        Status.makeInProgress(),
+        Status.makeTodo(),
+    ];
+
+    const tasks = statuses.map((status) => {
+        return new TaskBuilder().status(status).build();
+    });
+
+    return tasks;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Add custom matcher `groupHeadingsToBe()`
- Use it to test group headings for `DueDateField`, `PriorityField`, `StatusNameField`

## Motivation and Context

- Prepare tests to make future changes in sorting of group order visible

## How has this been tested?

Run all tests.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
