### PR TITLE
Toggle task done command adds global filter text

### DIFF
--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -3,6 +3,7 @@ import { StatusRegistry } from '../StatusRegistry';
 
 import { Task, TaskRegularExpressions } from '../Task';
 import { TaskLocation } from '../TaskLocation';
+import { GlobalFilter } from '../Config/GlobalFilter';
 
 export const toggleDone = (checking: boolean, editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
     if (checking) {
@@ -91,7 +92,9 @@ export const toggleLine = (line: string, path: string): EditorInsertion => {
             return { text: line.replace(TaskRegularExpressions.taskRegex, `$1- [${newStatusString}] $4`) };
         } else if (TaskRegularExpressions.listItemRegex.test(line)) {
             // Convert the list item to a checklist item.
-            const text = line.replace(TaskRegularExpressions.listItemRegex, '$1$2 [ ]');
+            const globalFilter = GlobalFilter.get();
+            const newTaskText = globalFilter == '' ? '[ ]' : `[ ] ${globalFilter}`;
+            const text = line.replace(TaskRegularExpressions.listItemRegex, `$1$2 ${newTaskText}`);
             return { text, moveTo: { ch: text.length } };
         } else {
             // Convert the line to a list item.

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -106,9 +106,9 @@ describe('ToggleDone', () => {
 
         GlobalFilter.set('#task');
 
-        testToggleLine('|- ', '- [ ] |');
-        testToggleLine('- |', '- [ ] |');
-        testToggleLine('- |foobar', '- [ ] foobar|');
+        testToggleLine('|- ', '- [ ] #task |');
+        testToggleLine('- |', '- [ ] #task |');
+        testToggleLine('- |foobar', '- [ ] #task foobar|');
     });
 
     it('should complete a task', () => {


### PR DESCRIPTION
New behavior: if the user has a global filter set then the global filter is inserted when the "Tasks: Toggle task done" is run.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Motivation and Context

Fixes #1320

I like to use the "Tasks: Toggle task done" command to create tasks, but since I have a global filter set I had to manually type the global filter each time. This PR changes the behavior so that if the user has a global filter set then the global filter is inserted when the "Tasks: Toggle task done" is run.

I'm not sure if this requires an update to the documentation. I didn't see anywhere where the behavior of "Tasks: Toggle task done" is explained. However this is a change in behavior that merits a notice in the release notes.

I'm not sure if this should be considered a breaking change.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Tested in a test vault and updated the unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
