### PR TITLE
refactor: move default comparator to Grouper

### DIFF
--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -3,6 +3,7 @@ import type { Comparator } from '../Sorter';
 import * as RegExpTools from '../../lib/RegExpTools';
 import { Grouper } from '../Grouper';
 import type { GrouperFunction } from '../Grouper';
+import type { Task } from './../../Task';
 import type { FilterOrErrorMessage } from './Filter';
 
 /**
@@ -287,7 +288,7 @@ export abstract class Field {
      * @param reverse - false for normal group order, true for reverse group order.
      */
     public createGrouper(reverse: boolean): Grouper {
-        return new Grouper(this.fieldNameSingular(), this.grouper(), reverse);
+        return new Grouper(this.fieldNameSingular(), this.grouper(), reverse, this.defaultComparator);
     }
 
     /**
@@ -309,4 +310,8 @@ export abstract class Field {
     public createReverseGrouper(): Grouper {
         return this.createGrouper(true);
     }
+
+    protected defaultComparator: Comparator = (_a: Task, _b: Task) => {
+        return 0;
+    };
 }

--- a/src/Query/Filter/Field.ts
+++ b/src/Query/Filter/Field.ts
@@ -311,7 +311,16 @@ export abstract class Field {
         return this.createGrouper(true);
     }
 
-    protected defaultComparator: Comparator = (_a: Task, _b: Task) => {
+    protected defaultComparator: Comparator = (a: Task, b: Task) => {
+        const groupA = this.grouper()(a);
+        const groupB = this.grouper()(b);
+
+        for (let i = 0; i < groupA.length; i++) {
+            // The containers are guaranteed to be identical sizes since we are calling the same grouper
+            return groupA[i].localeCompare(groupB[i], undefined, { numeric: true });
+        }
+
+        // identical if we reach here
         return 0;
     };
 }

--- a/src/Query/Filter/MultiTextField.ts
+++ b/src/Query/Filter/MultiTextField.ts
@@ -64,7 +64,7 @@ export abstract class MultiTextField extends TextField {
      * This overloads {@link Field.createGrouper} to put a plural field name in the {@link Grouper.property}.
      */
     public createGrouper(reverse: boolean): Grouper {
-        return new Grouper(this.fieldNamePlural(), this.grouper(), reverse);
+        return new Grouper(this.fieldNamePlural(), this.grouper(), reverse, this.defaultComparator);
     }
 
     protected grouperRegExp(): RegExp {

--- a/src/Query/Grouper.ts
+++ b/src/Query/Grouper.ts
@@ -1,4 +1,5 @@
 import type { Task } from '../Task';
+import type { Comparator } from './Sorter';
 
 /**
  * A group-naming function, that takes a Task object and returns zero or more
@@ -39,9 +40,12 @@ export class Grouper {
      */
     public readonly reverse: boolean;
 
-    constructor(property: string, grouper: GrouperFunction, reverse: boolean) {
+    public readonly comparator: Comparator;
+
+    constructor(property: string, grouper: GrouperFunction, reverse: boolean, comparator: Comparator) {
         this.property = property;
         this.grouper = grouper;
         this.reverse = reverse;
+        this.comparator = comparator;
     }
 }

--- a/src/Query/Grouper.ts
+++ b/src/Query/Grouper.ts
@@ -37,6 +37,7 @@ export class Grouper {
 
     /**
      * Whether the headings for this group should be reversed.
+     * TODO now reverse used only in TaskGroups.toString(), shall be removed.
      */
     public readonly reverse: boolean;
 
@@ -46,6 +47,10 @@ export class Grouper {
         this.property = property;
         this.grouper = grouper;
         this.reverse = reverse;
-        this.comparator = comparator;
+        this.comparator = (a: Task, b: Task) => {
+            const result = comparator(a, b);
+
+            return reverse ? -result : result;
+        };
     }
 }

--- a/src/Query/TaskGroups.ts
+++ b/src/Query/TaskGroups.ts
@@ -110,7 +110,7 @@ export class TaskGroups {
                 const grouper = this._groupers[i];
                 const result = grouper.comparator(group1.tasks[0], group2.tasks[0]);
                 if (result !== 0) {
-                    return grouper.reverse ? -result : result;
+                    return result;
                 }
             }
             // identical if we reach here

--- a/src/Query/TaskGroups.ts
+++ b/src/Query/TaskGroups.ts
@@ -105,18 +105,10 @@ export class TaskGroups {
 
     private sortTaskGroups() {
         const compareFn = (group1: TaskGroup, group2: TaskGroup) => {
-            // Compare two TaskGroup objects, sorting them by the group names at each grouping level.
-            const groupNames1 = group1.groups;
-            const groupNames2 = group2.groups;
-            // The containers are guaranteed to be identical sizes,
-            // they have one value for each 'group by' line in the query.
-            for (let i = 0; i < groupNames1.length; i++) {
-                // For now, we only have one sort option: sort by the names of the groups.
-                // In future, we will add control over the sorting of group headings,
-                // which will likely involve adjusting this code to sort by applying a Comparator
-                // to the first Task in each group.
+            // Compare two TaskGroup objects, sorting them by first task in each group.
+            for (let i = 0; i < this._groupers.length; i++) {
                 const grouper = this._groupers[i];
-                const result = groupNames1[i].localeCompare(groupNames2[i], undefined, { numeric: true });
+                const result = grouper.comparator(group1.tasks[0], group2.tasks[0]);
                 if (result !== 0) {
                     return grouper.reverse ? -result : result;
                 }

--- a/tests/TaskGroups.test.ts
+++ b/tests/TaskGroups.test.ts
@@ -252,7 +252,8 @@ describe('Grouping tasks', () => {
         const inputs = [a, b];
 
         const groupByTags: GrouperFunction = (task: Task) => task.tags;
-        const grouper = new Grouper('custom tag grouper', groupByTags, false);
+        const groupComparator = new TagsField().comparator();
+        const grouper = new Grouper('custom tag grouper', groupByTags, false, groupComparator);
         const groups = new TaskGroups([grouper], inputs);
 
         expect(groups.totalTasksCount()).toEqual(2);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Move the default comparator from `TaskGroups` to `Grouper`.

## Motivation and Context

Preparing for fixes group ordering of `UrgencyField` and others. Next step will be the fix.

Split of #1966

## How has this been tested?

Unit test, some new test added.

## Screenshots (if appropriate)

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
