### PR TITLE
feat: Minimal sequential tasks implementation

### DIFF
--- a/docs/Getting Started/Sequential Tasks.md
+++ b/docs/Getting Started/Sequential Tasks.md
@@ -1,0 +1,75 @@
+---
+publish: true
+---
+
+# Sequential Tasks (Dependencies)
+
+## Usage
+
+Tasks can be sequential, which means they will not show up in a query until the previous sequential task is complete.
+In order to specify a task as sequential, you simply add the sequential signifier "⬇️".
+
+Sequential tasks can be useful to avoid cluttering up query results with tasks that you aren't able to complete yet.
+For example, lets say you wished to write an article, and add the following tasks that need to be done
+
+- [ ] Choose a topic
+- [ ] Research the subject
+- [ ] Create an outline
+- [ ] Develop main points
+- [ ] Craft a conclusion
+- [ ] Proofread and edit
+- [ ] Publish the article
+
+It's not very helpful for you to see 'Publish the article', or 'Proofread and edit' when you haven't even chosen a topic yet.
+But if you made each task a sequential task
+
+- [ ] Choose a topic ⬇️
+- [ ] Research the subject ⬇️
+- [ ] Create an outline ⬇️
+- [ ] Develop main points ⬇️
+- [ ] Craft a conclusion ⬇️
+- [ ] Proofread and edit ⬇️
+- [ ] Publish the article ⬇️
+
+Now, you will only see 'Choose a topic' in the query window.
+Then once you mark that as complete, 'Research the subject' will appear, and so on.
+This enables your query results to show you only tasks that you can work on right now.
+
+## Behaviour
+
+Obsidian Tasks collects all tasks that are marked with a ⬇️ in a file and treats them as a single sequential set.
+This includes if sequential tasks are separated by other text or even other regular tasks.
+For example in the file below, Obsidian Tasks still treats task 1 and task 2 as sequential.
+
+- [ ] task 1 ⬇️️️
+
+- [ ] Non-sequential task
+
+This is a paragraph of text
+
+- [ ] task 2 ⬇️️️
+
+> [!warning]
+> Existing use of the ⬇️ emoji in tasks prior to this update could result in tasks not showing in queries.
+> Specifically, for files with more than one incomplete task containing ⬇️, only the first task will show in queries
+
+### Subtasks
+
+Sequential tasks does not treat subtasks any differently to any other task. For example,
+
+- [ ] Task 1 ⬇️️️
+  - [ ] Sub-task 1 ⬇️️️
+    - [ ] Sub-sub-task 1 ⬇️️️
+    - [ ] test
+  - [ ] sub-task 2
+  - [ ] sub-task 3 ⬇️️
+
+Will be treated the same as below.
+More specifically, the 4 tasks with a sequential symbol will be treated as a set and shown one after another as they are completed
+
+- [ ] Task 1 ⬇️️️
+- [ ] Sub-task 1 ⬇️️️
+- [ ] Sub-sub-task 1 ⬇️️️
+- [ ] test
+- [ ] sub-task 2
+- [ ] sub-task 3 ⬇️️

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -222,6 +222,21 @@ export class Cache {
             return;
         }
 
+        let sequential_found = false;
+
+        newTasks = newTasks.filter((task) => {
+            const is_sequential = task.sequential && !task.doneDate;
+
+            // found first active sequential task
+            if (!sequential_found && is_sequential) {
+                sequential_found = true;
+                return true;
+            }
+
+            // don't add any others found
+            return !(sequential_found && is_sequential);
+        });
+
         if (this.getState() == State.Warm) {
             // logger.debug(`Cache read: ${file.path}`);
             console.debug(

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -62,6 +62,7 @@ export const taskFromLine = ({ line, path }: { line: string; path: string }): Ta
             tags: [],
             originalMarkdown: '',
             scheduledDateIsInferred: false,
+            sequential: false,
         });
     }
 
@@ -98,5 +99,6 @@ export const taskFromLine = ({ line, path }: { line: string; path: string }): Ta
         originalMarkdown: '',
         // Not needed since the inferred status is always re-computed after submitting.
         scheduledDateIsInferred: false,
+        sequential: false,
     });
 };

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -109,6 +109,11 @@ function addTaskPropertySuggestions(
             displayText: `${symbols.recurrenceSymbol} recurring (repeat)`,
             appendText: `${symbols.recurrenceSymbol} `,
         });
+    if (!line.includes(symbols.sequentialSymbol))
+        genericSuggestions.push({
+            displayText: `${symbols.sequentialSymbol} sequential`,
+            appendText: `${symbols.sequentialSymbol} `,
+        });
     if (!line.includes(symbols.createdDateSymbol)) {
         const parsedDate = DateParser.parseDate('today', true);
         const formattedDate = parsedDate.format(TaskRegularExpressions.dateFormat);

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -117,6 +117,8 @@ export class Task {
     public readonly doneDate: Moment | null;
 
     public readonly recurrence: Recurrence | null;
+    public readonly sequential: boolean;
+
     /** The blockLink is a "^" annotation after the dates/recurrence rules.
      * Any non-empty value must begin with ' ^'. */
     public readonly blockLink: string;
@@ -148,6 +150,7 @@ export class Task {
         tags,
         originalMarkdown,
         scheduledDateIsInferred,
+        sequential,
     }: {
         status: Status;
         description: string;
@@ -165,6 +168,7 @@ export class Task {
         tags: string[] | [];
         originalMarkdown: string;
         scheduledDateIsInferred: boolean;
+        sequential: boolean;
     }) {
         this.status = status;
         this.description = description;
@@ -187,6 +191,8 @@ export class Task {
         this.originalMarkdown = originalMarkdown;
 
         this.scheduledDateIsInferred = scheduledDateIsInferred;
+
+        this.sequential = sequential;
     }
 
     /**
@@ -514,6 +520,7 @@ export class Task {
             'priority',
             'blockLink',
             'scheduledDateIsInferred',
+            'sequential',
         ];
         for (const el of args) {
             if (this[el] !== other[el]) return false;

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -27,6 +27,7 @@ export type TaskLayoutComponent =
     | 'scheduledDate'
     | 'dueDate'
     | 'doneDate'
+    | 'sequential'
     | 'blockLink';
 
 /**
@@ -44,6 +45,7 @@ export class TaskLayout {
         'scheduledDate',
         'dueDate',
         'doneDate',
+        'sequential',
         'blockLink',
     ];
     public layoutComponents: TaskLayoutComponent[];

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -28,6 +28,7 @@ export const LayoutClasses: { [c in TaskLayoutComponent]: string } = {
     doneDate: 'task-done',
     recurrenceRule: 'task-recurring',
     blockLink: '',
+    sequential: '',
 };
 
 const MAX_DAY_VALUE_RANGE = 7;

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -73,6 +73,7 @@ export const DATAVIEW_SYMBOLS = {
     dueDateSymbol: 'due::',
     doneDateSymbol: 'completion::',
     recurrenceSymbol: 'repeat::',
+    sequentialSymbol: 'sequential',
     TaskFormatRegularExpressions: {
         priorityRegex: toInlineFieldRegex(/priority:: *(highest|high|medium|low|lowest)/),
         startDateRegex: toInlineFieldRegex(/start:: *(\d{4}-\d{2}-\d{2})/),
@@ -81,6 +82,7 @@ export const DATAVIEW_SYMBOLS = {
         dueDateRegex: toInlineFieldRegex(/due:: *(\d{4}-\d{2}-\d{2})/),
         doneDateRegex: toInlineFieldRegex(/completion:: *(\d{4}-\d{2}-\d{2})/),
         recurrenceRegex: toInlineFieldRegex(/repeat:: *([a-zA-Z0-9, !]+)/),
+        sequentialRegex: /sequential/,
     },
 } as const;
 

--- a/src/TaskSerializer/index.ts
+++ b/src/TaskSerializer/index.ts
@@ -20,6 +20,7 @@ export type TaskDetails = Writeable<
         | 'doneDate'
         | 'recurrence'
         | 'tags'
+        | 'sequential'
     >
 >;
 

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -33,6 +33,7 @@
         dueDate: string;
         doneDate: string;
         forwardOnly: boolean;
+        sequential: boolean;
     } = {
         description: '',
         status: Status.TODO,
@@ -43,7 +44,8 @@
         scheduledDate: '',
         dueDate: '',
         doneDate: '',
-        forwardOnly: true
+        forwardOnly: true,
+        sequential: false
     };
 
     let isDescriptionValid: boolean = true;
@@ -267,6 +269,7 @@
             dueDate: task.dueDate ? task.dueDate.format('YYYY-MM-DD') : '',
             doneDate: task.doneDate ? task.doneDate.format('YYYY-MM-DD') : '',
             forwardOnly: true,
+            sequential: task.sequential
         };
         setTimeout(() => {
             descriptionInput.focus();
@@ -358,6 +361,7 @@
                 .isValid()
                 ? window.moment(editableTask.doneDate, 'YYYY-MM-DD')
                 : null,
+            sequential: editableTask.sequential
         });
 
         onSubmit([updatedTask]);
@@ -488,6 +492,19 @@
                     type="checkbox"
                     class="task-list-item-checkbox tasks-modal-checkbox"
                     accesskey={accesskey("f")}
+                />
+            </div>
+
+            <!-- --------------------------------------------------------------------------- -->
+            <!--  Sequential Task  -->
+            <!-- --------------------------------------------------------------------------- -->
+            <div>
+                <label for="sequential">Sequential task:</label>
+                <input
+                    bind:checked={editableTask.sequential}
+                    id="sequential"
+                    type="checkbox"
+                    class="task-list-item-checkbox tasks-modal-checkbox"
                 />
             </div>
         </div>

--- a/tests/CustomMatchers/CustomMatchersForTaskSerializer.ts
+++ b/tests/CustomMatchers/CustomMatchersForTaskSerializer.ts
@@ -80,6 +80,7 @@ function summarizeTaskDetails(t: TaskDetails | null): SummarizedTaskDetails | nu
         dueDate: t.dueDate?.format(TaskRegularExpressions.dateFormat) ?? null,
         doneDate: t.doneDate?.format(TaskRegularExpressions.dateFormat) ?? null,
         recurrence: t.recurrence?.toText() ?? null,
+        sequential: t.sequential?.valueOf().toString() ?? null,
     };
 }
 
@@ -102,6 +103,7 @@ function tryBuildTaskDetails(t: object): TaskDetails | null {
         dueDate: null,
         doneDate: null,
         recurrence: null,
+        sequential: false,
         tags: [],
         ...t,
     };

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -345,6 +345,7 @@ describe('Query', () => {
                     originalMarkdown: '',
                     scheduledDateIsInferred: false,
                     createdDate: null,
+                    sequential: false,
                 }),
                 new Task({
                     status: Status.TODO,
@@ -363,6 +364,7 @@ describe('Query', () => {
                     originalMarkdown: '',
                     scheduledDateIsInferred: false,
                     createdDate: null,
+                    sequential: false,
                 }),
             ];
             const input = 'path includes ab/c d';

--- a/tests/Suggestor/Suggestor.test.auto-complete_with__dataview__symbols_show_all_suggested_text.approved.md
+++ b/tests/Suggestor/Suggestor.test.auto-complete_with__dataview__symbols_show_all_suggested_text.approved.md
@@ -10,6 +10,7 @@
 | priority:: highest highest priority | priority:: highest  |
 | priority:: lowest lowest priority | priority:: lowest  |
 | repeat:: recurring (repeat) | repeat::  |
+| sequential sequential | sequential  |
 | created:: created today (2022-07-11) | created:: 2022-07-11  |
 | every | repeat:: every  |
 | every day | repeat:: every day  |

--- a/tests/Suggestor/Suggestor.test.auto-complete_with__emoji__symbols_show_all_suggested_text.approved.md
+++ b/tests/Suggestor/Suggestor.test.auto-complete_with__emoji__symbols_show_all_suggested_text.approved.md
@@ -10,6 +10,7 @@
 | 🔺 highest priority | 🔺  |
 | ⏬ lowest priority | ⏬  |
 | 🔁 recurring (repeat) | 🔁  |
+| ⬇️ sequential | ⬇️  |
 | ➕ created today (2022-07-11) | ➕ 2022-07-11  |
 | every | 🔁 every  |
 | every day | 🔁 every day  |

--- a/tests/TaskSerializer/TaskSerializer.test.ts
+++ b/tests/TaskSerializer/TaskSerializer.test.ts
@@ -68,6 +68,7 @@ describe('TaskSerializer Example', () => {
                 scheduledDate: null,
                 doneDate: null,
                 recurrence: null,
+                sequential: false,
             };
         }
 

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -44,6 +44,7 @@ export class TaskBuilder {
     private _blockLink: string = '';
 
     private _scheduledDateIsInferred: boolean = false;
+    private _sequential: boolean = false;
 
     /**
      * Build a Task
@@ -85,6 +86,7 @@ export class TaskBuilder {
             tags: this._tags,
             originalMarkdown: '',
             scheduledDateIsInferred: this._scheduledDateIsInferred,
+            sequential: this._sequential,
         });
         const markdown = task.toFileLineString();
         return new Task({


### PR DESCRIPTION
# Description

A simple implementation for tasks which only display after the previous task has been completed

- Added a new boolean property of a task called 'sequential' which can be added/edited in the svelte ui or through task suggestion dropdown.
- Added logic where for each file, only the first non-complete sequential task gets added to the cache - subsequent are ignored

## Motivation and Context

Going off the discussions in #463, I've created implementation which automates to some extent [aubreyz](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/463#discussioncomment-4452400) great suggestion. I've used the emoji ⬇️ to denote sequential tasks instead of a custom tag, since this seemed more idiomatic with the rest of obsidian tasks.

I would love to see some/any implementation of sequential/dependent tasks, but I'm aware that a full task dependency system would be more work than is feasible for the demand. As such I thought i'd make this implementation as a suggested compromise, but if this approach isn't workable for any reason or there are other features/mechanics that need to be added for this to be possible im happy to put more time into this and continue the discussion.

Given this is just a experimental implementation, I haven't put time into documentation changes, the dataview implementation, unit testing and so on. If or when the maintainers are happy with my implementation broad strokes im more than happy to do all these.

## How has this been tested?

- Manual testing in a test vault

## Screenshots (if appropriate)

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/85375184/12fb89ed-26eb-4d1f-a5cc-f1a381cdfde1)
![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/85375184/3d7d2820-0e05-4ec5-a27b-14f9a7b231dc)
![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/85375184/bb39dc16-bc43-4129-921f-7ff3429de52e)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
