### PR TITLE
feat: 'group by status.type' names are now more readable

### DIFF
--- a/docs/Queries/Grouping.md
+++ b/docs/Queries/Grouping.md
@@ -97,11 +97,11 @@ Since Tasks X.Y.Z, **[[Custom Grouping|custom grouping]] by status names** is no
 - `group by status.type`
   - This groups by the types you have given to your custom statuses.
   - In order to impose a useful sort order, the types are prefixed with a number, so the groups will appear in this order, and with these group names:
-    - `1 IN_PROGRESS`
-    - `2 TODO`
-    - `3 DONE`
-    - `4 CANCELLED`
-    - `5 NON_TASK`
+    - `IN_PROGRESS`
+    - `TODO`
+    - `DONE`
+    - `CANCELLED`
+    - `NON_TASK`
 
 > [!released]
 `group by status.type` was introduced in Tasks 1.23.0.

--- a/src/Query/Filter/StatusTypeField.ts
+++ b/src/Query/Filter/StatusTypeField.ts
@@ -134,6 +134,6 @@ export class StatusTypeField extends Field {
                 prefix = '6';
                 break;
         }
-        return prefix + ' ' + task.status.type;
+        return `%%${prefix}%%${task.status.type}`;
     }
 }

--- a/tests/DocumentationSamples/DocsSamplesForStatuses.test.Status_Transitions_status-types.approved.md
+++ b/tests/DocumentationSamples/DocsSamplesForStatuses.test.Status_Transitions_status-types.approved.md
@@ -15,7 +15,7 @@
 | Matches `status.name includes done` | no | no | YES | no | no |
 | Matches `status.name includes cancelled` | no | no | no | YES | no |
 | Name for `group by status` | Todo | Done | Done | Done | Done |
-| Name for `group by status.type` | 2 TODO | 1 IN_PROGRESS | 3 DONE | 4 CANCELLED | 5 NON_TASK |
+| Name for `group by status.type` | %%2%%TODO | %%1%%IN_PROGRESS | %%3%%DONE | %%4%%CANCELLED | %%5%%NON_TASK |
 | Name for `group by status.name` | Todo | In Progress | Done | Cancelled | My custom status |
 
 

--- a/tests/Query/Filter/StatusTypeField.test.ts
+++ b/tests/Query/Filter/StatusTypeField.test.ts
@@ -152,13 +152,13 @@ describe('grouping by status.type', () => {
         const grouper = new StatusTypeField().createNormalGrouper();
 
         // // Assert
-        expect(grouper.grouper(inprTask)).toEqual(['1 IN_PROGRESS']);
-        expect(grouper.grouper(todoTask)).toEqual(['2 TODO']);
-        expect(grouper.grouper(unknTask)).toEqual(['2 TODO']);
-        expect(grouper.grouper(doneTask)).toEqual(['3 DONE']);
-        expect(grouper.grouper(cancTask)).toEqual(['4 CANCELLED']);
-        expect(grouper.grouper(non_Task)).toEqual(['5 NON_TASK']);
-        expect(grouper.grouper(emptTask)).toEqual(['6 EMPTY']); // won't be seen by users
+        expect(grouper.grouper(inprTask)).toEqual(['%%1%%IN_PROGRESS']);
+        expect(grouper.grouper(todoTask)).toEqual(['%%2%%TODO']);
+        expect(grouper.grouper(unknTask)).toEqual(['%%2%%TODO']);
+        expect(grouper.grouper(doneTask)).toEqual(['%%3%%DONE']);
+        expect(grouper.grouper(cancTask)).toEqual(['%%4%%CANCELLED']);
+        expect(grouper.grouper(non_Task)).toEqual(['%%5%%NON_TASK']);
+        expect(grouper.grouper(emptTask)).toEqual(['%%6%%EMPTY']); // won't be seen by users
     });
 
     it('should sort groups for StatusTypeField', () => {
@@ -166,12 +166,12 @@ describe('grouping by status.type', () => {
         const tasks = SampleTasks.withAllStatusTypes();
 
         expect({ grouper, tasks }).groupHeadingsToBe([
-            '1 IN_PROGRESS',
-            '2 TODO',
-            '3 DONE',
-            '4 CANCELLED',
-            '5 NON_TASK',
-            '6 EMPTY',
+            '%%1%%IN_PROGRESS',
+            '%%2%%TODO',
+            '%%3%%DONE',
+            '%%4%%CANCELLED',
+            '%%5%%NON_TASK',
+            '%%6%%EMPTY',
         ]);
     });
 });

--- a/tests/TaskGroups.test.ts
+++ b/tests/TaskGroups.test.ts
@@ -361,20 +361,20 @@ describe('Grouping tasks', () => {
             - status.type
             - happens
 
-            Group names: [2 TODO,2022-09-19 Monday]
-            #### [status.type] 2 TODO
+            Group names: [%%2%%TODO,2022-09-19 Monday]
+            #### [status.type] %%2%%TODO
             ##### [happens] 2022-09-19 Monday
             - [ ] Task a - early date 📅 2022-09-19
 
             ---
 
-            Group names: [2 TODO,2022-10-06 Thursday]
+            Group names: [%%2%%TODO,2022-10-06 Thursday]
             ##### [happens] 2022-10-06 Thursday
             - [ ] Task c - intermediate date ⏳ 2022-10-06
 
             ---
 
-            Group names: [2 TODO,2022-12-06 Tuesday]
+            Group names: [%%2%%TODO,2022-12-06 Tuesday]
             ##### [happens] 2022-12-06 Tuesday
             - [ ] Task b - later date ⏳ 2022-12-06
 


### PR DESCRIPTION
# Description

Remove numbers in StatusType group names: `2 TODO` -> `TODO` by including the number in comments. This way the sort order of the StatusType is not changed.


| Old name        | New name      |
| --------------- | ------------- |
| `1 IN_PROGRESS` | `IN_PROGRESS` |
| `2 TODO`        | `TODO`        |
| `3 DONE`        | `DONE`        |
| `4 CANCELLED`   | `CANCELLED`   |
| `5 NON_TASK`    | `NON_TASK`    |
| `6 EMPTY`       | `EMPTY`       |

## Motivation and Context

Provide shorter group names with only meaningful data.

## How has this been tested?

Unit testing (with fixes).

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
