### PR TITLE
fix!!: 'group by urgency' now puts most urgent tasks first, not last

### DIFF
--- a/docs/Queries/Grouping.md
+++ b/docs/Queries/Grouping.md
@@ -369,9 +369,8 @@ Using the priority number:
 ### Urgency
 
 - `group by urgency` ([[Urgency|urgency]])
-  - Currently, the groups run from the lowest urgency to highest.
+  - The groups run from the highest urgency to the lowest.
   - You can reverse this with `group by urgency reverse`.
-  - In a future release, the default group order will become from the highest urgency to lowest.
 
 > [!released]
 >

--- a/src/Query/Filter/UrgencyField.ts
+++ b/src/Query/Filter/UrgencyField.ts
@@ -1,6 +1,6 @@
 import type { Comparator } from '../Sorter';
 import type { Task } from '../../Task';
-import type { GrouperFunction } from '../Grouper';
+import type { Grouper, GrouperFunction } from '../Grouper';
 import { Field } from './Field';
 import { FilterOrErrorMessage } from './Filter';
 
@@ -57,5 +57,13 @@ export class UrgencyField extends Field {
         return (task: Task) => {
             return [`${task.urgency.toFixed(2)}`];
         };
+    }
+
+    /**
+     * Create a {@link Grouper} object for grouping tasks by this field's value.
+     * @param reverse - false for normal group order, true for reverse group order.
+     */
+    public createGrouper(reverse: boolean): Grouper {
+        return super.createGrouper(!reverse);
     }
 }

--- a/src/Query/Filter/UrgencyField.ts
+++ b/src/Query/Filter/UrgencyField.ts
@@ -60,8 +60,12 @@ export class UrgencyField extends Field {
     }
 
     /**
-     * Create a {@link Grouper} object for grouping tasks by this field's value.
-     * @param reverse - false for normal group order, true for reverse group order.
+     * The {@link Field.createGrouper} creates a grouper that sorts by increasing values.
+     * For {@link UrgencyField} the group sorting shall be done by decreasing values, so
+     * the normal order here is the reverse of the regular one.
+     *
+     * @param reverse - false for normal group order (from most urgent to less urgent),
+     * true for reverse group order.
      */
     public createGrouper(reverse: boolean): Grouper {
         return super.createGrouper(!reverse);

--- a/tests/Query/Filter/UrgencyField.test.ts
+++ b/tests/Query/Filter/UrgencyField.test.ts
@@ -98,7 +98,7 @@ describe('grouping by urgency', () => {
     });
 
     it('should sort groups for UrgencyField', () => {
-        const grouper = new UrgencyField().createNormalGrouper();
+        const grouper = new UrgencyField().createReverseGrouper();
         const taskLines = ['- [ ] a ⏫', '- [ ] a 🔼', '- [ ] a', '- [ ] a 🔽'];
         const tasks = taskLines.map((taskLine) => fromLine({ line: taskLine }));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

`group by urgency` now sorts groups from most urgent to less urgency i.e. by decreasing urgency.

## IMPORTANT This is a breaking change.


| Old instruction            | Use this instruction instead |
| -------------------------- | ---------------------------- |
| `group by urgency reverse` | `group by urgency`           |
| `group by urgency`         | `group by urgency reverse`   |


## Motivation and Context

Sort group names in a meaningful order for Urgency field.

## How has this been tested?

Unit tests (Fixed)

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
