### PR TITLE
feat: 'group by priority' names are now more readable

### DIFF
--- a/docs/Queries/Grouping.md
+++ b/docs/Queries/Grouping.md
@@ -329,12 +329,12 @@ Since Tasks X.Y.Z, **[[Custom Grouping|custom grouping]] by description** is now
 
 - `group by priority`
   - The priority of the task, namely one of:
-    - `Highest`
-    - `High`
-    - `Medium`
-    - `Normal`
-    - `Low`
-    - `Lowest`
+    - `Highest priority`
+    - `High priority`
+    - `Medium priority`
+    - `Normal priority`
+    - `Low priority`
+    - `Lowest priority`
 
 > [!released]
 >

--- a/docs/Queries/Grouping.md
+++ b/docs/Queries/Grouping.md
@@ -329,12 +329,12 @@ Since Tasks X.Y.Z, **[[Custom Grouping|custom grouping]] by description** is now
 
 - `group by priority`
   - The priority of the task, namely one of:
-    - `Priority 0: Highest`
-    - `Priority 1: High`
-    - `Priority 2: Medium`
-    - `Priority 3: None`
-    - `Priority 4: Low`
-    - `Priority 5: Lowest`
+    - `Highest`
+    - `High`
+    - `Medium`
+    - `Normal`
+    - `Low`
+    - `Lowest`
 
 > [!released]
 >

--- a/src/Query/Filter/PriorityField.ts
+++ b/src/Query/Filter/PriorityField.ts
@@ -95,8 +95,8 @@ export class PriorityField extends Field {
 
     public grouper(): GrouperFunction {
         return (task: Task) => {
-            const priorityName = PriorityTools.priorityNameUsingNone(task.priority);
-            return [`Priority ${task.priority}: ${priorityName}`];
+            const priorityName = PriorityTools.priorityNameUsingNormal(task.priority);
+            return [`%%${task.priority}%%${priorityName} priority`];
         };
     }
 }

--- a/tests/Query/Filter/PriorityField.test.ts
+++ b/tests/Query/Filter/PriorityField.test.ts
@@ -200,12 +200,12 @@ describe('grouping by priority', () => {
     });
 
     it.each([
-        ['- [ ] a 🔺', ['Priority 0: Highest']],
-        ['- [ ] a ⏫', ['Priority 1: High']],
-        ['- [ ] a 🔼', ['Priority 2: Medium']],
-        ['- [ ] a', ['Priority 3: None']],
-        ['- [ ] a 🔽', ['Priority 4: Low']],
-        ['- [ ] a ⏬', ['Priority 5: Lowest']],
+        ['- [ ] a 🔺', ['%%0%%Highest priority']],
+        ['- [ ] a ⏫', ['%%1%%High priority']],
+        ['- [ ] a 🔼', ['%%2%%Medium priority']],
+        ['- [ ] a', ['%%3%%Normal priority']],
+        ['- [ ] a 🔽', ['%%4%%Low priority']],
+        ['- [ ] a ⏬', ['%%5%%Lowest priority']],
     ])('task "%s" should have groups: %s', (taskLine: string, groups: string[]) => {
         // Arrange
         const grouper = new PriorityField().createNormalGrouper().grouper;
@@ -219,12 +219,12 @@ describe('grouping by priority', () => {
         const tasks = SampleTasks.withAllPriorities();
 
         expect({ grouper, tasks }).groupHeadingsToBe([
-            'Priority 0: Highest',
-            'Priority 1: High',
-            'Priority 2: Medium',
-            'Priority 3: None',
-            'Priority 4: Low',
-            'Priority 5: Lowest',
+            '%%0%%Highest priority',
+            '%%1%%High priority',
+            '%%2%%Medium priority',
+            '%%3%%Normal priority',
+            '%%4%%Low priority',
+            '%%5%%Lowest priority',
         ]);
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Change group names from `Priority 1: Highest` to `Highest` (and all others too).

| Old name              | New name           |
| --------------------- | ------------------ |
| `Priority 0: Highest` | `Highest priority` |
| `Priority 1: High`    | `High priority`    |
| `Priority 2: Medium`  | `Medium priority`  |
| `Priority 3: None`    | `Normal priority`  |
| `Priority 4: Low`     | `Low priority`     |
| `Priority 5: Lowest`  | `Lowest priority`  |

## Motivation and Context

Provide shorter group names with only meaningful data.

Fixes #1628

## How has this been tested?

Unit tests (Fixed)

## Types of changes

Changes visible to users:

- [x] **Feature**

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
