### PR TITLE
fix: Make Edit modal use existing emojis if Global Filter missing

### DIFF
--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -19,7 +19,7 @@ import { getSettings } from '../Config/Settings';
  * @param path - The path of the file containing the line
  */
 export const taskFromLine = ({ line, path }: { line: string; path: string }): Task => {
-    const task = Task.parseLine(
+    const task = Task.parseTaskSignifiers(
         line,
         TaskLocation.fromUnknownPosition(path), // We don't need precise location to toggle it here in the editor.
         DateFallback.fromPath(path), // set the scheduled date from the filename, so it can be displayed in the dialog

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -21,11 +21,11 @@ import { getSettings } from '../Config/Settings';
 export const taskFromLine = ({ line, path }: { line: string; path: string }): Task => {
     const fallbackDate = DateFallback.fromPath(path);
 
-    const task = Task.fromLine({
+    const task = Task.parseLine(
         line,
-        taskLocation: TaskLocation.fromUnknownPosition(path), // We don't need precise location to toggle it here in the editor.
+        TaskLocation.fromUnknownPosition(path), // We don't need precise location to toggle it here in the editor.
         fallbackDate, // set the scheduled date from the filename, so it can be displayed in the dialog
-    });
+    );
 
     if (task !== null) {
         return task;

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -19,6 +19,8 @@ import { getSettings } from '../Config/Settings';
  * @param path - The path of the file containing the line
  */
 export const taskFromLine = ({ line, path }: { line: string; path: string }): Task => {
+    // We get all signifiers from the line, even if the Global Filter is missing.
+    // This helps users who, for some reason, have data in a task line without the Global Filter.
     const task = Task.parseTaskSignifiers(
         line,
         TaskLocation.fromUnknownPosition(path), // We don't need precise location to toggle it here in the editor.

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -19,12 +19,10 @@ import { getSettings } from '../Config/Settings';
  * @param path - The path of the file containing the line
  */
 export const taskFromLine = ({ line, path }: { line: string; path: string }): Task => {
-    const fallbackDate = DateFallback.fromPath(path);
-
     const task = Task.parseLine(
         line,
         TaskLocation.fromUnknownPosition(path), // We don't need precise location to toggle it here in the editor.
-        fallbackDate, // set the scheduled date from the filename, so it can be displayed in the dialog
+        DateFallback.fromPath(path), // set the scheduled date from the filename, so it can be displayed in the dialog
     );
 
     if (task !== null) {

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -32,10 +32,7 @@ export const taskFromLine = ({ line, path }: { line: string; path: string }): Ta
     }
 
     const { setCreatedDate } = getSettings();
-    let createdDate: moment.Moment | null = null;
-    if (setCreatedDate) {
-        createdDate = window.moment();
-    }
+    const createdDate = setCreatedDate ? window.moment() : null;
 
     // If we are not on a line of a task, we take what we have.
     // The non-task line can still be a checklist, for example if it is lacking the global filter.

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -195,7 +195,8 @@ export class Task {
     }
 
     /**
-     * Takes the given line from an obsidian note and returns a Task object.
+     * Takes the given line from an Obsidian note and returns a Task object.
+     * Will check if Global Filter is present in the line.
      *
      * @static
      * @param {string} line - The full line in the note to parse.
@@ -222,7 +223,17 @@ export class Task {
         return Task.parseLine(line, taskLocation, fallbackDate);
     }
 
-    private static parseLine(line: string, taskLocation: TaskLocation, fallbackDate: Moment | null): Task | null {
+    /**
+     * Parses the line in attempt to get the task details.
+     * Parsing only is done. If a Global Filter check is needed,
+     * use {@link Task.fromLine}.
+     *
+     * @param line - the full line to parse
+     * @param taskLocation - The location of the task line
+     * @param fallbackDate - The date to use as the scheduled date if no other date is set
+     * @returns {*} {(Task | null)}
+     */
+    public static parseLine(line: string, taskLocation: TaskLocation, fallbackDate: Moment | null): Task | null {
         // Check the line to see if it is a markdown task.
         const regexMatch = line.match(TaskRegularExpressions.taskRegex);
         if (regexMatch === null) {

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -227,6 +227,9 @@ export class Task {
      * Parses the line in attempt to get the task details.
      * Parsing only is done. If a Global Filter check is needed,
      * use {@link Task.fromLine}.
+     * 
+     * Task is returned regardless if Global Filter is present or not.
+     * However if it is, it will be removed from the tags.
      *
      * @param line - the full line to parse
      * @param taskLocation - The location of the task line

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -226,9 +226,7 @@ export class Task {
         }
 
         // match[4] includes the whole body of the task after the brackets.
-        const body = regexMatch[4].trim();
-
-        let description = body;
+        let description = regexMatch[4].trim();
         const indentation = regexMatch[1];
         const listMarker = regexMatch[2];
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -219,6 +219,10 @@ export class Task {
             return null;
         }
 
+        return Task.parseLine(line, taskLocation, fallbackDate);
+    }
+
+    private static parseLine(line: string, taskLocation: TaskLocation, fallbackDate: Moment | null): Task | null {
         // Check the line to see if it is a markdown task.
         const regexMatch = line.match(TaskRegularExpressions.taskRegex);
         if (regexMatch === null) {

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -220,14 +220,14 @@ export class Task {
             return null;
         }
 
-        return Task.parseLine(line, taskLocation, fallbackDate);
+        return Task.parseTaskSignifiers(line, taskLocation, fallbackDate);
     }
 
     /**
      * Parses the line in attempt to get the task details.
      * Parsing only is done. If a Global Filter check is needed,
      * use {@link Task.fromLine}.
-     * 
+     *
      * Task is returned regardless if Global Filter is present or not.
      * However if it is, it will be removed from the tags.
      *
@@ -236,7 +236,11 @@ export class Task {
      * @param fallbackDate - The date to use as the scheduled date if no other date is set
      * @returns {*} {(Task | null)}
      */
-    public static parseLine(line: string, taskLocation: TaskLocation, fallbackDate: Moment | null): Task | null {
+    public static parseTaskSignifiers(
+        line: string,
+        taskLocation: TaskLocation,
+        fallbackDate: Moment | null,
+    ): Task | null {
         // Check the line to see if it is a markdown task.
         const regexMatch = line.match(TaskRegularExpressions.taskRegex);
         if (regexMatch === null) {

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -213,15 +213,15 @@ export class Task {
         taskLocation: TaskLocation;
         fallbackDate: Moment | null;
     }): Task | null {
-        // Check the line to see if it is a markdown task.
-        const regexMatch = line.match(TaskRegularExpressions.taskRegex);
-        if (regexMatch === null) {
-            return null;
-        }
-
         // return if task does not have the global filter. Do this before processing
         // rest of match to improve performance.
         if (!GlobalFilter.includedIn(line)) {
+            return null;
+        }
+
+        // Check the line to see if it is a markdown task.
+        const regexMatch = line.match(TaskRegularExpressions.taskRegex);
+        if (regexMatch === null) {
             return null;
         }
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -216,6 +216,7 @@ export class Task {
      * @param {(Moment | null)} fallbackDate - The date to use as the scheduled date if no other date is set
      * @return {*}  {(Task | null)}
      * @memberof Task
+     * @see parseTaskSignifiers
      */
     public static fromLine({
         line,
@@ -243,16 +244,18 @@ export class Task {
 
     /**
      * Parses the line in attempt to get the task details.
-     * Parsing only is done. If a Global Filter check is needed,
-     * use {@link Task.fromLine}.
+     *
+     * This reads the task even if the Global Filter is missing.
+     * If a Global Filter check is needed, use {@link Task.fromLine}.
      *
      * Task is returned regardless if Global Filter is present or not.
-     * However if it is, it will be removed from the tags.
+     * However, if it is, it will be removed from the tags.
      *
      * @param line - the full line to parse
      * @param taskLocation - The location of the task line
      * @param fallbackDate - The date to use as the scheduled date if no other date is set
      * @returns {*} {(Task | null)}
+     * @see fromLine
      */
     public static parseTaskSignifiers(
         line: string,

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -56,6 +56,8 @@ export class TaskRegularExpressions {
     // - List marker
     // - Status character
     // - Rest of task after checkbox markdown
+    // See Task.extractTaskComponents() for abstraction around this regular expression.
+    // That is private for now, but could be made public in future if needed.
     public static readonly taskRegex = new RegExp(
         TaskRegularExpressions.indentationRegex.source +
             TaskRegularExpressions.listMarkerRegex.source +

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -226,9 +226,15 @@ export class Task {
         taskLocation: TaskLocation;
         fallbackDate: Moment | null;
     }): Task | null {
+        const taskComponents = this.extractTaskComponents(line);
+        // Check the line to see if it is a markdown task.
+        if (taskComponents === null) {
+            return null;
+        }
+
         // return if the line does not have the global filter. Do this before
         // any other processing to improve performance.
-        if (!GlobalFilter.includedIn(line)) {
+        if (!GlobalFilter.includedIn(taskComponents.body)) {
             return null;
         }
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -227,7 +227,7 @@ export class Task {
         taskLocation: TaskLocation;
         fallbackDate: Moment | null;
     }): Task | null {
-        const taskComponents = this.extractTaskComponents(line);
+        const taskComponents = Task.extractTaskComponents(line);
         // Check the line to see if it is a markdown task.
         if (taskComponents === null) {
             return null;
@@ -262,7 +262,7 @@ export class Task {
         taskLocation: TaskLocation,
         fallbackDate: Moment | null,
     ): Task | null {
-        const taskComponents = this.extractTaskComponents(line);
+        const taskComponents = Task.extractTaskComponents(line);
         // Check the line to see if it is a markdown task.
         if (taskComponents === null) {
             return null;

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -213,8 +213,8 @@ export class Task {
         taskLocation: TaskLocation;
         fallbackDate: Moment | null;
     }): Task | null {
-        // return if task does not have the global filter. Do this before processing
-        // rest of match to improve performance.
+        // return if the line does not have the global filter. Do this before
+        // any other processing to improve performance.
         if (!GlobalFilter.includedIn(line)) {
             return null;
         }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -95,6 +95,10 @@ export class TaskRegularExpressions {
     public static readonly hashTagsFromEnd = new RegExp(this.hashTags.source + '$');
 }
 
+/**
+ * Storage for the task line, broken down in to sections.
+ * See {@link Task.extractTaskComponents} for use.
+ */
 interface TaskComponents {
     indentation: string;
     listMarker: string;

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -219,14 +219,14 @@ export class Task {
             return null;
         }
 
-        // match[4] includes the whole body of the task after the brackets.
-        const body = regexMatch[4].trim();
-
         // return if task does not have the global filter. Do this before processing
         // rest of match to improve performance.
         if (!GlobalFilter.includedIn(line)) {
             return null;
         }
+
+        // match[4] includes the whole body of the task after the brackets.
+        const body = regexMatch[4].trim();
 
         let description = body;
         const indentation = regexMatch[1];

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -225,14 +225,15 @@ export class Task {
             return null;
         }
 
-        // match[4] includes the whole body of the task after the brackets.
-        let description = regexMatch[4].trim();
         const indentation = regexMatch[1];
         const listMarker = regexMatch[2];
 
         // Get the status of the task.
         const statusString = regexMatch[3];
         const status = StatusRegistry.getInstance().bySymbolOrCreate(statusString);
+
+        // match[4] includes the whole body of the task after the brackets.
+        let description = regexMatch[4].trim();
 
         // Match for block link and remove if found. Always expected to be
         // at the end of the line.

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -224,7 +224,7 @@ export class Task {
 
         // return if task does not have the global filter. Do this before processing
         // rest of match to improve performance.
-        if (!GlobalFilter.includedIn(body)) {
+        if (!GlobalFilter.includedIn(line)) {
             return null;
         }
 

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -1,6 +1,12 @@
+/**
+ * @jest-environment jsdom
+ */
+import moment from 'moment';
 import { Priority, TaskRegularExpressions } from '../../src/Task';
 import { taskFromLine } from '../../src/Commands/CreateOrEditTaskParser';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
+
+window.moment = moment;
 
 describe('CreateOrEditTaskParser - testing edited task if line is saved unchanged', () => {
     afterEach(() => {

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
-import { Priority, TaskRegularExpressions } from '../../src/Task';
+import { Priority } from '../../src/Task';
 import { taskFromLine } from '../../src/Commands/CreateOrEditTaskParser';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 
@@ -89,10 +89,10 @@ describe('CreateOrEditTaskParser - task recognition', () => {
 
         expect(task.priority).toStrictEqual(Priority.Lowest);
         expect(task.recurrenceRule).toStrictEqual('every 2 days');
-        expect(task.createdDate?.format(TaskRegularExpressions.dateFormat)).toEqual('2022-03-10');
-        expect(task.startDate?.format(TaskRegularExpressions.dateFormat)).toEqual('2022-01-31');
-        expect(task.scheduledDate?.format(TaskRegularExpressions.dateFormat)).toEqual('2023-06-13');
-        expect(task.dueDate?.format(TaskRegularExpressions.dateFormat)).toEqual('2024-12-10');
-        expect(task.doneDate?.format(TaskRegularExpressions.dateFormat)).toEqual('2023-06-22');
+        expect(task.createdDate).toEqualMoment(moment('2022-03-10'));
+        expect(task.startDate).toEqualMoment(moment('2022-01-31'));
+        expect(task.scheduledDate).toEqualMoment(moment('2023-06-13'));
+        expect(task.dueDate).toEqualMoment(moment('2024-12-10'));
+        expect(task.doneDate).toEqualMoment(moment('2023-06-22'));
     });
 });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -1,4 +1,4 @@
-import { Priority } from '../../src/Task';
+import { Priority, TaskRegularExpressions } from '../../src/Task';
 import { taskFromLine } from '../../src/Commands/CreateOrEditTaskParser';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 
@@ -83,10 +83,10 @@ describe('CreateOrEditTaskParser - task recognition', () => {
         // Priority taken by default, everything else is not recognized
         expect(task.priority).toStrictEqual(Priority.None);
         expect(task.recurrenceRule).toStrictEqual('');
-        expect(task.createdDate).toStrictEqual(null);
-        expect(task.startDate).toStrictEqual(null);
-        expect(task.scheduledDate).toStrictEqual(null);
-        expect(task.dueDate).toStrictEqual(null);
-        expect(task.doneDate).toStrictEqual(null);
+        expect(task.createdDate?.format(TaskRegularExpressions.dateFormat)).toEqual(undefined);
+        expect(task.startDate?.format(TaskRegularExpressions.dateFormat)).toEqual(undefined);
+        expect(task.scheduledDate?.format(TaskRegularExpressions.dateFormat)).toEqual(undefined);
+        expect(task.dueDate?.format(TaskRegularExpressions.dateFormat)).toEqual(undefined);
+        expect(task.doneDate?.format(TaskRegularExpressions.dateFormat)).toEqual(undefined);
     });
 });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -73,7 +73,7 @@ describe('CreateOrEditTaskParser - task recognition', () => {
     it('should recognize task details without global filter', () => {
         GlobalFilter.set('#task');
         const taskLine =
-            '- [ ] without global filter but with all the info ⏬ 🔁 every 2 days ➕ 2022-03-10 🛫 2022-01-31 ⏳ 2023-06-13 📅 2024-12-35 ✅ 2023-06-22';
+            '- [ ] without global filter but with all the info ⏬ 🔁 every 2 days ➕ 2022-03-10 🛫 2022-01-31 ⏳ 2023-06-13 📅 2024-12-10 ✅ 2023-06-22';
         const path = 'a/b/c.md';
 
         const task = taskFromLine({ line: taskLine, path });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -86,13 +86,12 @@ describe('CreateOrEditTaskParser - task recognition', () => {
 
         expect(task.toFileLineString()).toStrictEqual(taskLine);
 
-        // Priority taken by default, everything else is not recognized
-        expect(task.priority).toStrictEqual(Priority.None);
-        expect(task.recurrenceRule).toStrictEqual('');
-        expect(task.createdDate?.format(TaskRegularExpressions.dateFormat)).toEqual(undefined);
-        expect(task.startDate?.format(TaskRegularExpressions.dateFormat)).toEqual(undefined);
-        expect(task.scheduledDate?.format(TaskRegularExpressions.dateFormat)).toEqual(undefined);
-        expect(task.dueDate?.format(TaskRegularExpressions.dateFormat)).toEqual(undefined);
-        expect(task.doneDate?.format(TaskRegularExpressions.dateFormat)).toEqual(undefined);
+        expect(task.priority).toStrictEqual(Priority.Lowest);
+        expect(task.recurrenceRule).toStrictEqual('every 2 days');
+        expect(task.createdDate?.format(TaskRegularExpressions.dateFormat)).toEqual('2022-03-10');
+        expect(task.startDate?.format(TaskRegularExpressions.dateFormat)).toEqual('2022-01-31');
+        expect(task.scheduledDate?.format(TaskRegularExpressions.dateFormat)).toEqual('2023-06-13');
+        expect(task.dueDate?.format(TaskRegularExpressions.dateFormat)).toEqual('2024-12-10');
+        expect(task.doneDate?.format(TaskRegularExpressions.dateFormat)).toEqual('2023-06-22');
     });
 });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -1,3 +1,4 @@
+import { Priority } from '../../src/Task';
 import { taskFromLine } from '../../src/Commands/CreateOrEditTaskParser';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 
@@ -62,4 +63,30 @@ describe('CreateOrEditTaskParser - testing edited task if line is saved unchange
             expect(task.path).toStrictEqual(path);
         },
     );
+});
+
+describe('CreateOrEditTaskParser - task recognition', () => {
+    afterEach(() => {
+        GlobalFilter.reset();
+    });
+
+    it('should recognize task details without global filter', () => {
+        GlobalFilter.set('#task');
+        const taskLine =
+            '- [ ] without global filter but with all the info ⏬ 🔁 every 2 days ➕ 2022-03-10 🛫 2022-01-31 ⏳ 2023-06-13 📅 2024-12-35 ✅ 2023-06-22';
+        const path = 'a/b/c.md';
+
+        const task = taskFromLine({ line: taskLine, path });
+
+        expect(task.toFileLineString()).toStrictEqual(taskLine);
+
+        // Priority taken by default, everything else is not recognized
+        expect(task.priority).toStrictEqual(Priority.None);
+        expect(task.recurrenceRule).toStrictEqual('');
+        expect(task.createdDate).toStrictEqual(null);
+        expect(task.startDate).toStrictEqual(null);
+        expect(task.scheduledDate).toStrictEqual(null);
+        expect(task.dueDate).toStrictEqual(null);
+        expect(task.doneDate).toStrictEqual(null);
+    });
 });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -85,6 +85,7 @@ describe('CreateOrEditTaskParser - task recognition', () => {
         const task = taskFromLine({ line: taskLine, path });
 
         expect(task.toFileLineString()).toStrictEqual(taskLine);
+        expect(task.path).toStrictEqual('a/b/c.md');
 
         expect(task.priority).toStrictEqual(Priority.Lowest);
         expect(task.recurrenceRule).toStrictEqual('every 2 days');

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -64,18 +64,15 @@ describe('Task rendering', () => {
         );
     });
 
-    it.failing(
-        'should display task description with emoji removed, even if the global filter is missing from initial line (bug 2037)',
-        () => {
-            GlobalFilter.set('#todo');
-            // When written, this was a demonstration of the behaviour logged in
-            // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2037
-            testDescriptionRender(
-                'without global filter but with scheduled date ⏳ 2023-06-13',
-                'without global filter but with scheduled date', // fails, as the absence of the global filter means the line is not parsed, and the emoji stays in the description.
-            );
-        },
-    );
+    it('should display task description with emoji removed, even if the global filter is missing from initial line (bug 2037)', () => {
+        GlobalFilter.set('#todo');
+        // When written, this was a demonstration of the behaviour logged in
+        // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2037
+        testDescriptionRender(
+            'without global filter but with scheduled date ⏳ 2023-06-13',
+            'without global filter but with scheduled date', // fails, as the absence of the global filter means the line is not parsed, and the emoji stays in the description.
+        );
+    });
 });
 
 describe('Task editing', () => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -395,6 +395,10 @@ describe('parsing tags', () => {
 });
 
 describe('task parsing VS global filter', () => {
+    afterEach(() => {
+        GlobalFilter.reset();
+    });
+
     it('returns null when task does not have global filter', () => {
         // Arrange
         GlobalFilter.set('#task');
@@ -407,9 +411,6 @@ describe('task parsing VS global filter', () => {
 
         // Assert
         expect(task).toBeNull();
-
-        // Cleanup
-        GlobalFilter.reset();
     });
 });
 

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -431,7 +431,7 @@ describe('task parsing VS global filter', () => {
         expect(task).toBeNull();
     });
 
-    it.failing('should not consider task status when searching for global filter', () => {
+    it('should not consider task status when searching for global filter', () => {
         // Arrange
         GlobalFilter.set('@');
 

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -430,6 +430,19 @@ describe('task parsing VS global filter', () => {
         // Assert
         expect(task).toBeNull();
     });
+
+    it.failing('should not consider task status when searching for global filter', () => {
+        // Arrange
+        GlobalFilter.set('@');
+
+        // Act
+        const task = fromLine({
+            line: '- [@] Hello',
+        });
+
+        // Assert
+        expect(task).toBeNull();
+    });
 });
 
 describe('properties for scripting', () => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -87,23 +87,6 @@ describe('parsing', () => {
         expect(task!.originalMarkdown).toStrictEqual(line);
     });
 
-    it('returns null when task does not have global filter', () => {
-        // Arrange
-        GlobalFilter.set('#task');
-        const line = '- [x] this is a done task 🗓 2021-09-12 ✅ 2021-06-20';
-
-        // Act
-        const task = fromLine({
-            line,
-        });
-
-        // Assert
-        expect(task).toBeNull();
-
-        // Cleanup
-        GlobalFilter.reset();
-    });
-
     it('supports capitalised status characters', () => {
         // See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/520
         // "In combination with SlrVb's S-Checkbox CSS, Task Plugin breaks that style"
@@ -409,6 +392,25 @@ describe('parsing tags', () => {
             }
         },
     );
+});
+
+describe('task parsing VS global filter', () => {
+    it('returns null when task does not have global filter', () => {
+        // Arrange
+        GlobalFilter.set('#task');
+        const line = '- [x] this is a done task 🗓 2021-09-12 ✅ 2021-06-20';
+
+        // Act
+        const task = fromLine({
+            line,
+        });
+
+        // Assert
+        expect(task).toBeNull();
+
+        // Cleanup
+        GlobalFilter.reset();
+    });
 });
 
 describe('properties for scripting', () => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -412,6 +412,24 @@ describe('task parsing VS global filter', () => {
         // Assert
         expect(task).toBeNull();
     });
+
+    it.each([
+        '#task - [ ] this is a task 🗓 2021-09-12',
+        '- #task [ ] this is a task 🗓 2021-09-12',
+        '- [#task] this is a task 🗓 2021-09-12',
+        '- [ #task ] this is a task 🗓 2021-09-12',
+    ])('should not parse task with global filter outside of the description: "%s"', (line: string) => {
+        // Arrange
+        GlobalFilter.set('#task');
+
+        // Act
+        const task = fromLine({
+            line,
+        });
+
+        // Assert
+        expect(task).toBeNull();
+    });
 });
 
 describe('properties for scripting', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Parse the task line for all the details including recurrence, scheduled, due & starts dates when opening the task edit modal.

## Motivation and Context

Fix #2037 

## How has this been tested?

Added unit tests + smoke test on my live vault on the following:

```
- [ ] #task action1
- [ ] action2 🛫 2023-06-27 ⏳ 2023-06-20 📅 2023-06-21
```

## Screenshots (if appropriate)
![Снимок экрана 2023-06-20 в 18 23 59](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/7785ea7e-5a51-4803-a98c-c18a4eda433f)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
