### PR TITLE
refactor: use TasksDate to simplify EditTask.svelte

### DIFF
--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -7,6 +7,7 @@
     import { Status } from '../Status';
     import { Priority, Task } from '../Task';
     import { doAutocomplete } from '../DateAbbreviations';
+    import { TasksDate } from '../Scripting/TasksDate';
 
     // These exported variables are passed in as props by TaskModal.onOpen():
     export let task: Task;
@@ -255,17 +256,11 @@
             status: task.status,
             priority,
             recurrenceRule: task.recurrence ? task.recurrence.toText() : '',
-            createdDate: task.createdDate
-                ? task.createdDate.format('YYYY-MM-DD')
-                : '',
-            startDate: task.startDate
-                ? task.startDate.format('YYYY-MM-DD')
-                : '',
-            scheduledDate: task.scheduledDate
-                ? task.scheduledDate.format('YYYY-MM-DD')
-                : '',
-            dueDate: task.dueDate ? task.dueDate.format('YYYY-MM-DD') : '',
-            doneDate: task.doneDate ? task.doneDate.format('YYYY-MM-DD') : '',
+            createdDate: new TasksDate(task.createdDate).formatAsDate(),
+            startDate: new TasksDate(task.startDate).formatAsDate(),
+            scheduledDate: new TasksDate(task.scheduledDate).formatAsDate(),
+            dueDate: new TasksDate(task.dueDate).formatAsDate(),
+            doneDate: new TasksDate(task.doneDate).formatAsDate(),
             forwardOnly: true,
         };
         setTimeout(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Call the existing methods in `TasksDate` instead of manual calculation of format.

## Motivation and Context

Prettier code.

## How has this been tested?

Unit tests.

## Screenshots (if appropriate)

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
