### PR TITLE
refactor: Extract generic class QueryComponentOrError 

### DIFF
--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -20,19 +20,27 @@ import type { Filter, FilterFunction } from './Filter';
  */
 export class FilterOrErrorMessage {
     readonly instruction: string;
-    private _filter: Filter | undefined;
+    private _object: Filter | undefined;
     private _error: string | undefined;
 
     constructor(instruction: string) {
         this.instruction = instruction;
     }
 
+    public get object(): Filter | undefined {
+        return this._object;
+    }
+
+    private set object(value: Filter | undefined) {
+        this._object = value;
+    }
+
     public get filter(): Filter | undefined {
-        return this._filter;
+        return this.object;
     }
 
     private set filter(value: Filter | undefined) {
-        this._filter = value;
+        this.object = value;
     }
 
     public get error(): string | undefined {
@@ -44,8 +52,8 @@ export class FilterOrErrorMessage {
     }
 
     get filterFunction(): FilterFunction | undefined {
-        if (this._filter) {
-            return this._filter.filterFunction;
+        if (this.filter) {
+            return this.filter.filterFunction;
         } else {
             return undefined;
         }
@@ -56,12 +64,23 @@ export class FilterOrErrorMessage {
      *
      * This function allows a meaningful {@link Explanation} to be supplied.
      *
+     * @param object - a {@link Filter}
+     */
+    public static fromObject(object: Filter): FilterOrErrorMessage {
+        const result = new FilterOrErrorMessage(object.instruction);
+        result._object = object;
+        return result;
+    }
+
+    /**
+     * Construct a FilterOrErrorMessage with the filter.
+     *
+     * This function allows a meaningful {@link Explanation} to be supplied.
+     *
      * @param filter - a {@link Filter}
      */
     public static fromFilter(filter: Filter): FilterOrErrorMessage {
-        const result = new FilterOrErrorMessage(filter.instruction);
-        result.filter = filter;
-        return result;
+        return FilterOrErrorMessage.fromObject(filter);
     }
 
     /**

--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -13,7 +13,7 @@ class ObjectOrErrorMessage {
         return this._object;
     }
 
-    protected set object(value: Filter | undefined) {
+    private set object(value: Filter | undefined) {
         this._object = value;
     }
 
@@ -75,10 +75,6 @@ export class FilterOrErrorMessage extends ObjectOrErrorMessage {
 
     public get filter(): Filter | undefined {
         return this.object;
-    }
-
-    private set filter(value: Filter | undefined) {
-        this.object = value;
     }
 
     get filterFunction(): FilterFunction | undefined {

--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -58,6 +58,11 @@ export class FilterOrErrorMessage {
         return new FilterOrErrorMessage(object);
     }
 
+    /**
+     * Construct a FilterOrErrorMessage with the given error message.
+     * @param instruction
+     * @param errorMessage
+     */
     public static fromError(instruction: string, errorMessage: string): FilterOrErrorMessage {
         return new FilterOrErrorMessage(ObjectOrErrorMessage.fromError<Filter>(instruction, errorMessage));
     }

--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -1,54 +1,5 @@
+import { ObjectOrErrorMessage } from '../ObjectOrErrorMessage';
 import type { Filter, FilterFunction } from './Filter';
-
-class ObjectOrErrorMessage {
-    readonly instruction: string;
-    private _object: Filter | undefined;
-    private _error: string | undefined;
-
-    constructor(instruction: string) {
-        this.instruction = instruction;
-    }
-
-    public get object(): Filter | undefined {
-        return this._object;
-    }
-
-    private set object(value: Filter | undefined) {
-        this._object = value;
-    }
-
-    public get error(): string | undefined {
-        return this._error;
-    }
-
-    private set error(value: string | undefined) {
-        this._error = value;
-    }
-
-    /**
-     * Construct a FilterOrErrorMessage with the filter.
-     *
-     * This function allows a meaningful {@link Explanation} to be supplied.
-     *
-     * @param object - a {@link Filter}
-     */
-    public static fromObject(object: Filter): FilterOrErrorMessage {
-        const result = new FilterOrErrorMessage(object.instruction);
-        result._object = object;
-        return result;
-    }
-
-    /**
-     * Construct a FilterOrErrorMessage with the given error message.
-     * @param instruction
-     * @param errorMessage
-     */
-    public static fromError(instruction: string, errorMessage: string): FilterOrErrorMessage {
-        const result = new FilterOrErrorMessage(instruction);
-        result._error = errorMessage;
-        return result;
-    }
-}
 
 /**
  * A class which stores one of:

--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -20,9 +20,9 @@ import type { Filter, FilterFunction } from './Filter';
  * problem line, and perhaps listing allowed options).
  */
 export class FilterOrErrorMessage {
-    public object: ObjectOrErrorMessage;
+    public object: ObjectOrErrorMessage<Filter>;
 
-    private constructor(object: ObjectOrErrorMessage) {
+    private constructor(object: ObjectOrErrorMessage<Filter>) {
         this.object = object;
     }
 
@@ -54,12 +54,11 @@ export class FilterOrErrorMessage {
      * @param filter - a {@link Filter}
      */
     public static fromFilter(filter: Filter): FilterOrErrorMessage {
-        const object = ObjectOrErrorMessage.fromObject(filter.instruction, filter);
+        const object = ObjectOrErrorMessage.fromObject<Filter>(filter.instruction, filter);
         return new FilterOrErrorMessage(object);
     }
 
     public static fromError(instruction: string, errorMessage: string): FilterOrErrorMessage {
-        const object = ObjectOrErrorMessage.fromError(instruction, errorMessage);
-        return new FilterOrErrorMessage(object);
+        return new FilterOrErrorMessage(ObjectOrErrorMessage.fromError<Filter>(instruction, errorMessage));
     }
 }

--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -26,7 +26,7 @@ export class FilterOrErrorMessage {
     }
 
     public get filter(): Filter | undefined {
-        return this.object.object;
+        return this.object.queryComponent;
     }
 
     public get error(): string | undefined {

--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -19,13 +19,23 @@ import type { Filter, FilterFunction } from './Filter';
  * there is scope for making these messages more informative (including the
  * problem line, and perhaps listing allowed options).
  */
-export class FilterOrErrorMessage extends ObjectOrErrorMessage {
-    constructor(instruction: string) {
-        super(instruction);
+export class FilterOrErrorMessage {
+    public object: ObjectOrErrorMessage;
+
+    constructor(object: ObjectOrErrorMessage) {
+        this.object = object;
+    }
+
+    public get instruction(): string {
+        return this.object.instruction;
     }
 
     public get filter(): Filter | undefined {
-        return this.object;
+        return this.object.object;
+    }
+
+    public get error(): string | undefined {
+        return this.object.error;
     }
 
     get filterFunction(): FilterFunction | undefined {
@@ -44,6 +54,12 @@ export class FilterOrErrorMessage extends ObjectOrErrorMessage {
      * @param filter - a {@link Filter}
      */
     public static fromFilter(filter: Filter): FilterOrErrorMessage {
-        return FilterOrErrorMessage.fromObject(filter.instruction, filter);
+        const object = ObjectOrErrorMessage.fromObject(filter.instruction, filter);
+        return new FilterOrErrorMessage(object);
+    }
+
+    public static fromError(instruction: string, errorMessage: string): FilterOrErrorMessage {
+        const object = ObjectOrErrorMessage.fromError(instruction, errorMessage);
+        return new FilterOrErrorMessage(object);
     }
 }

--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -54,8 +54,7 @@ export class FilterOrErrorMessage {
      * @param filter - a {@link Filter}
      */
     public static fromFilter(filter: Filter): FilterOrErrorMessage {
-        const object = ObjectOrErrorMessage.fromObject<Filter>(filter.instruction, filter);
-        return new FilterOrErrorMessage(object);
+        return new FilterOrErrorMessage(ObjectOrErrorMessage.fromObject<Filter>(filter.instruction, filter));
     }
 
     /**

--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -44,6 +44,6 @@ export class FilterOrErrorMessage extends ObjectOrErrorMessage {
      * @param filter - a {@link Filter}
      */
     public static fromFilter(filter: Filter): FilterOrErrorMessage {
-        return FilterOrErrorMessage.fromObject(filter);
+        return FilterOrErrorMessage.fromObject(filter.instruction, filter);
     }
 }

--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -22,7 +22,7 @@ import type { Filter, FilterFunction } from './Filter';
 export class FilterOrErrorMessage {
     public object: ObjectOrErrorMessage;
 
-    constructor(object: ObjectOrErrorMessage) {
+    private constructor(object: ObjectOrErrorMessage) {
         this.object = object;
     }
 

--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -1,4 +1,4 @@
-import { ObjectOrErrorMessage } from '../ObjectOrErrorMessage';
+import { QueryComponentOrError } from '../QueryComponentOrError';
 import type { Filter, FilterFunction } from './Filter';
 
 /**
@@ -15,9 +15,9 @@ import type { Filter, FilterFunction } from './Filter';
  * that match the user's filter instruction.
  */
 export class FilterOrErrorMessage {
-    public object: ObjectOrErrorMessage<Filter>;
+    public object: QueryComponentOrError<Filter>;
 
-    private constructor(object: ObjectOrErrorMessage<Filter>) {
+    private constructor(object: QueryComponentOrError<Filter>) {
         this.object = object;
     }
 
@@ -49,7 +49,7 @@ export class FilterOrErrorMessage {
      * @param filter - a {@link Filter}
      */
     public static fromFilter(filter: Filter): FilterOrErrorMessage {
-        return new FilterOrErrorMessage(ObjectOrErrorMessage.fromObject<Filter>(filter.instruction, filter));
+        return new FilterOrErrorMessage(QueryComponentOrError.fromObject<Filter>(filter.instruction, filter));
     }
 
     /**
@@ -58,6 +58,6 @@ export class FilterOrErrorMessage {
      * @param errorMessage
      */
     public static fromError(instruction: string, errorMessage: string): FilterOrErrorMessage {
-        return new FilterOrErrorMessage(ObjectOrErrorMessage.fromError<Filter>(instruction, errorMessage));
+        return new FilterOrErrorMessage(QueryComponentOrError.fromError<Filter>(instruction, errorMessage));
     }
 }

--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -13,11 +13,6 @@ import type { Filter, FilterFunction } from './Filter';
  * By the time the code has finished with parsing the line, typically the
  * contained {@link Filter} will be saved, for later use in searching for Tasks
  * that match the user's filter instruction.
- *
- * Later, it may gain helper functions for constructing parser error messages,
- * as currently these are created by some rather repetitious code, and also
- * there is scope for making these messages more informative (including the
- * problem line, and perhaps listing allowed options).
  */
 export class FilterOrErrorMessage {
     public object: ObjectOrErrorMessage<Filter>;

--- a/src/Query/Filter/FilterOrErrorMessage.ts
+++ b/src/Query/Filter/FilterOrErrorMessage.ts
@@ -1,5 +1,55 @@
 import type { Filter, FilterFunction } from './Filter';
 
+class ObjectOrErrorMessage {
+    readonly instruction: string;
+    private _object: Filter | undefined;
+    private _error: string | undefined;
+
+    constructor(instruction: string) {
+        this.instruction = instruction;
+    }
+
+    public get object(): Filter | undefined {
+        return this._object;
+    }
+
+    protected set object(value: Filter | undefined) {
+        this._object = value;
+    }
+
+    public get error(): string | undefined {
+        return this._error;
+    }
+
+    private set error(value: string | undefined) {
+        this._error = value;
+    }
+
+    /**
+     * Construct a FilterOrErrorMessage with the filter.
+     *
+     * This function allows a meaningful {@link Explanation} to be supplied.
+     *
+     * @param object - a {@link Filter}
+     */
+    public static fromObject(object: Filter): FilterOrErrorMessage {
+        const result = new FilterOrErrorMessage(object.instruction);
+        result._object = object;
+        return result;
+    }
+
+    /**
+     * Construct a FilterOrErrorMessage with the given error message.
+     * @param instruction
+     * @param errorMessage
+     */
+    public static fromError(instruction: string, errorMessage: string): FilterOrErrorMessage {
+        const result = new FilterOrErrorMessage(instruction);
+        result._error = errorMessage;
+        return result;
+    }
+}
+
 /**
  * A class which stores one of:
  * - The original instruction string - a line from a tasks code block
@@ -18,21 +68,9 @@ import type { Filter, FilterFunction } from './Filter';
  * there is scope for making these messages more informative (including the
  * problem line, and perhaps listing allowed options).
  */
-export class FilterOrErrorMessage {
-    readonly instruction: string;
-    private _object: Filter | undefined;
-    private _error: string | undefined;
-
+export class FilterOrErrorMessage extends ObjectOrErrorMessage {
     constructor(instruction: string) {
-        this.instruction = instruction;
-    }
-
-    public get object(): Filter | undefined {
-        return this._object;
-    }
-
-    private set object(value: Filter | undefined) {
-        this._object = value;
+        super(instruction);
     }
 
     public get filter(): Filter | undefined {
@@ -41,14 +79,6 @@ export class FilterOrErrorMessage {
 
     private set filter(value: Filter | undefined) {
         this.object = value;
-    }
-
-    public get error(): string | undefined {
-        return this._error;
-    }
-
-    private set error(value: string | undefined) {
-        this._error = value;
     }
 
     get filterFunction(): FilterFunction | undefined {
@@ -64,33 +94,9 @@ export class FilterOrErrorMessage {
      *
      * This function allows a meaningful {@link Explanation} to be supplied.
      *
-     * @param object - a {@link Filter}
-     */
-    public static fromObject(object: Filter): FilterOrErrorMessage {
-        const result = new FilterOrErrorMessage(object.instruction);
-        result._object = object;
-        return result;
-    }
-
-    /**
-     * Construct a FilterOrErrorMessage with the filter.
-     *
-     * This function allows a meaningful {@link Explanation} to be supplied.
-     *
      * @param filter - a {@link Filter}
      */
     public static fromFilter(filter: Filter): FilterOrErrorMessage {
         return FilterOrErrorMessage.fromObject(filter);
-    }
-
-    /**
-     * Construct a FilterOrErrorMessage with the given error message.
-     * @param instruction
-     * @param errorMessage
-     */
-    public static fromError(instruction: string, errorMessage: string): FilterOrErrorMessage {
-        const result = new FilterOrErrorMessage(instruction);
-        result._error = errorMessage;
-        return result;
     }
 }

--- a/src/Query/ObjectOrErrorMessage.ts
+++ b/src/Query/ObjectOrErrorMessage.ts
@@ -1,0 +1,53 @@
+// @ts-ignore
+import { Filter } from './Filter/Filter';
+import { FilterOrErrorMessage } from './Filter/FilterOrErrorMessage';
+
+export class ObjectOrErrorMessage {
+    readonly instruction: string;
+    private _object: Filter | undefined;
+    private _error: string | undefined;
+
+    constructor(instruction: string) {
+        this.instruction = instruction;
+    }
+
+    public get object(): Filter | undefined {
+        return this._object;
+    }
+
+    private set object(value: Filter | undefined) {
+        this._object = value;
+    }
+
+    public get error(): string | undefined {
+        return this._error;
+    }
+
+    private set error(value: string | undefined) {
+        this._error = value;
+    }
+
+    /**
+     * Construct a FilterOrErrorMessage with the filter.
+     *
+     * This function allows a meaningful {@link Explanation} to be supplied.
+     *
+     * @param object - a {@link Filter}
+     */
+    public static fromObject(object: Filter): FilterOrErrorMessage {
+        const result = new FilterOrErrorMessage(object.instruction);
+        result._object = object;
+        return result;
+    }
+
+    /**
+     * Construct a FilterOrErrorMessage with the given error message.
+     * @param instruction
+     * @param errorMessage
+     */
+    public static fromError(instruction: string, errorMessage: string): FilterOrErrorMessage {
+        const result = new FilterOrErrorMessage(instruction);
+        result._error = errorMessage;
+        return result;
+    }
+}

--- a/src/Query/ObjectOrErrorMessage.ts
+++ b/src/Query/ObjectOrErrorMessage.ts
@@ -30,9 +30,8 @@ export class ObjectOrErrorMessage<QueryComponent> {
     }
 
     /**
-     * Construct a FilterOrErrorMessage with the filter.
+     * Construct an ObjectOrErrorMessage with the given QueryComponent.
      *
-     * This function allows a meaningful {@link Explanation} to be supplied.
      * @param instruction
      * @param object - a {@link Filter}
      */
@@ -46,7 +45,7 @@ export class ObjectOrErrorMessage<QueryComponent> {
     }
 
     /**
-     * Construct a FilterOrErrorMessage with the given error message.
+     * Construct a ObjectOrErrorMessage with the given error message.
      * @param instruction
      * @param errorMessage
      */

--- a/src/Query/ObjectOrErrorMessage.ts
+++ b/src/Query/ObjectOrErrorMessage.ts
@@ -9,7 +9,7 @@ export class ObjectOrErrorMessage<QueryComponent> {
     private _object: QueryComponent | undefined;
     private _error: string | undefined;
 
-    constructor(instruction: string) {
+    private constructor(instruction: string) {
         this.instruction = instruction;
     }
 

--- a/src/Query/ObjectOrErrorMessage.ts
+++ b/src/Query/ObjectOrErrorMessage.ts
@@ -31,11 +31,11 @@ export class ObjectOrErrorMessage {
      * Construct a FilterOrErrorMessage with the filter.
      *
      * This function allows a meaningful {@link Explanation} to be supplied.
-     *
+     * @param instruction
      * @param object - a {@link Filter}
      */
-    public static fromObject(object: Filter): FilterOrErrorMessage {
-        const result = new FilterOrErrorMessage(object.instruction);
+    public static fromObject(instruction: string, object: Filter): FilterOrErrorMessage {
+        const result = new FilterOrErrorMessage(instruction);
         result._object = object;
         return result;
     }

--- a/src/Query/ObjectOrErrorMessage.ts
+++ b/src/Query/ObjectOrErrorMessage.ts
@@ -1,6 +1,5 @@
 // @ts-ignore
 import { Filter } from './Filter/Filter';
-import { FilterOrErrorMessage } from './Filter/FilterOrErrorMessage';
 
 export class ObjectOrErrorMessage {
     readonly instruction: string;
@@ -34,8 +33,8 @@ export class ObjectOrErrorMessage {
      * @param instruction
      * @param object - a {@link Filter}
      */
-    public static fromObject(instruction: string, object: Filter): FilterOrErrorMessage {
-        const result = new FilterOrErrorMessage(instruction);
+    public static fromObject(instruction: string, object: Filter): ObjectOrErrorMessage {
+        const result = new ObjectOrErrorMessage(instruction);
         result._object = object;
         return result;
     }
@@ -45,8 +44,8 @@ export class ObjectOrErrorMessage {
      * @param instruction
      * @param errorMessage
      */
-    public static fromError(instruction: string, errorMessage: string): FilterOrErrorMessage {
-        const result = new FilterOrErrorMessage(instruction);
+    public static fromError(instruction: string, errorMessage: string): ObjectOrErrorMessage {
+        const result = new ObjectOrErrorMessage(instruction);
         result._error = errorMessage;
         return result;
     }

--- a/src/Query/ObjectOrErrorMessage.ts
+++ b/src/Query/ObjectOrErrorMessage.ts
@@ -1,20 +1,23 @@
-// @ts-ignore
-import { Filter } from './Filter/Filter';
-
-export class ObjectOrErrorMessage {
+/**
+ * Generic class for storing:
+ * - a text instruction.
+ * - an object of type QueryComponent constructed from the instruction, if the instruction is valid.
+ * - otherwise, an error message explaining in what wat the instruction is invalid.
+ */
+export class ObjectOrErrorMessage<QueryComponent> {
     readonly instruction: string;
-    private _object: Filter | undefined;
+    private _object: QueryComponent | undefined;
     private _error: string | undefined;
 
     constructor(instruction: string) {
         this.instruction = instruction;
     }
 
-    public get object(): Filter | undefined {
+    public get object(): QueryComponent | undefined {
         return this._object;
     }
 
-    private set object(value: Filter | undefined) {
+    private set object(value: QueryComponent | undefined) {
         this._object = value;
     }
 
@@ -33,8 +36,11 @@ export class ObjectOrErrorMessage {
      * @param instruction
      * @param object - a {@link Filter}
      */
-    public static fromObject(instruction: string, object: Filter): ObjectOrErrorMessage {
-        const result = new ObjectOrErrorMessage(instruction);
+    public static fromObject<QueryComponent>(
+        instruction: string,
+        object: QueryComponent,
+    ): ObjectOrErrorMessage<QueryComponent> {
+        const result = new ObjectOrErrorMessage<QueryComponent>(instruction);
         result._object = object;
         return result;
     }
@@ -44,8 +50,11 @@ export class ObjectOrErrorMessage {
      * @param instruction
      * @param errorMessage
      */
-    public static fromError(instruction: string, errorMessage: string): ObjectOrErrorMessage {
-        const result = new ObjectOrErrorMessage(instruction);
+    public static fromError<QueryComponent>(
+        instruction: string,
+        errorMessage: string,
+    ): ObjectOrErrorMessage<QueryComponent> {
+        const result = new ObjectOrErrorMessage<QueryComponent>(instruction);
         result._error = errorMessage;
         return result;
     }

--- a/src/Query/QueryComponentOrError.ts
+++ b/src/Query/QueryComponentOrError.ts
@@ -6,19 +6,19 @@
  */
 export class QueryComponentOrError<QueryComponent> {
     readonly instruction: string;
-    private _object: QueryComponent | undefined;
+    private _queryComponent: QueryComponent | undefined;
     private _error: string | undefined;
 
     private constructor(instruction: string) {
         this.instruction = instruction;
     }
 
-    public get object(): QueryComponent | undefined {
-        return this._object;
+    public get queryComponent(): QueryComponent | undefined {
+        return this._queryComponent;
     }
 
-    private set object(value: QueryComponent | undefined) {
-        this._object = value;
+    private set queryComponent(value: QueryComponent | undefined) {
+        this._queryComponent = value;
     }
 
     public get error(): string | undefined {
@@ -40,7 +40,7 @@ export class QueryComponentOrError<QueryComponent> {
         object: QueryComponent,
     ): QueryComponentOrError<QueryComponent> {
         const result = new QueryComponentOrError<QueryComponent>(instruction);
-        result._object = object;
+        result._queryComponent = object;
         return result;
     }
 

--- a/src/Query/QueryComponentOrError.ts
+++ b/src/Query/QueryComponentOrError.ts
@@ -3,6 +3,8 @@
  * - a text instruction.
  * - an object of type QueryComponent constructed from the instruction, if the instruction is valid.
  * - otherwise, an error message explaining in what wat the instruction is invalid.
+ *
+ * An example type of QueryComponent is {@link Filter}. See {@link FilterOrErrorMessage}.
  */
 export class QueryComponentOrError<QueryComponent> {
     readonly instruction: string;

--- a/src/Query/QueryComponentOrError.ts
+++ b/src/Query/QueryComponentOrError.ts
@@ -4,7 +4,7 @@
  * - an object of type QueryComponent constructed from the instruction, if the instruction is valid.
  * - otherwise, an error message explaining in what wat the instruction is invalid.
  */
-export class ObjectOrErrorMessage<QueryComponent> {
+export class QueryComponentOrError<QueryComponent> {
     readonly instruction: string;
     private _object: QueryComponent | undefined;
     private _error: string | undefined;
@@ -38,8 +38,8 @@ export class ObjectOrErrorMessage<QueryComponent> {
     public static fromObject<QueryComponent>(
         instruction: string,
         object: QueryComponent,
-    ): ObjectOrErrorMessage<QueryComponent> {
-        const result = new ObjectOrErrorMessage<QueryComponent>(instruction);
+    ): QueryComponentOrError<QueryComponent> {
+        const result = new QueryComponentOrError<QueryComponent>(instruction);
         result._object = object;
         return result;
     }
@@ -52,8 +52,8 @@ export class ObjectOrErrorMessage<QueryComponent> {
     public static fromError<QueryComponent>(
         instruction: string,
         errorMessage: string,
-    ): ObjectOrErrorMessage<QueryComponent> {
-        const result = new ObjectOrErrorMessage<QueryComponent>(instruction);
+    ): QueryComponentOrError<QueryComponent> {
+        const result = new QueryComponentOrError<QueryComponent>(instruction);
         result._error = errorMessage;
         return result;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I want to start re-using the pattern of:

- store an instruction and one of:
    - an object created from it
    - or an error message, if the instruction was invalid in some way


## Motivation and Context

For example, I want to be able to report syntax errors in JavaScript expressions, for `group by function` and soon `filter by function`.

## How has this been tested?

- running the existing tests
- running the new code in Tasks-Demo vault and confirming that error messages for invalid filters are still displayed

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
