### PR TITLE
refactor: Reduce complexity in QueryRenderChild.render()

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -148,29 +148,7 @@ class QueryRenderChild extends MarkdownRenderChild {
 
         const content = this.containerEl.createEl('div');
         if (state === State.Warm && this.query.error === undefined) {
-            console.debug(
-                `Render ${this.queryType} called for a block in active file "${this.filePath}", to select from ${tasks.length} tasks: plugin state: ${state}`,
-            );
-
-            if (this.query.layoutOptions.explainQuery) {
-                this.createExplanation(content);
-            }
-
-            const tasksSortedLimitedGrouped = this.query.applyQueryToTasks(tasks);
-            for (const group of tasksSortedLimitedGrouped.groups) {
-                // If there were no 'group by' instructions, group.groupHeadings
-                // will be empty, and no headings will be added.
-                this.addGroupHeadings(content, group.groupHeadings);
-
-                const { taskList } = await this.createTasksList({
-                    tasks: group.tasks,
-                    content: content,
-                });
-                content.appendChild(taskList);
-            }
-            const totalTasksCount = tasksSortedLimitedGrouped.totalTasksCount();
-            console.debug(`${totalTasksCount} of ${tasks.length} tasks displayed in a block in "${this.filePath}"`);
-            this.addTaskCount(content, totalTasksCount);
+            await this.renderQuerySearchResults(tasks, state, content);
         } else if (this.query.error !== undefined) {
             this.renderErrorMessage(content, this.query.error);
         } else {
@@ -178,6 +156,32 @@ class QueryRenderChild extends MarkdownRenderChild {
         }
 
         this.containerEl.firstChild?.replaceWith(content);
+    }
+
+    private async renderQuerySearchResults(tasks: Task[], state: State.Warm, content: HTMLDivElement) {
+        console.debug(
+            `Render ${this.queryType} called for a block in active file "${this.filePath}", to select from ${tasks.length} tasks: plugin state: ${state}`,
+        );
+
+        if (this.query.layoutOptions.explainQuery) {
+            this.createExplanation(content);
+        }
+
+        const tasksSortedLimitedGrouped = this.query.applyQueryToTasks(tasks);
+        for (const group of tasksSortedLimitedGrouped.groups) {
+            // If there were no 'group by' instructions, group.groupHeadings
+            // will be empty, and no headings will be added.
+            this.addGroupHeadings(content, group.groupHeadings);
+
+            const { taskList } = await this.createTasksList({
+                tasks: group.tasks,
+                content: content,
+            });
+            content.appendChild(taskList);
+        }
+        const totalTasksCount = tasksSortedLimitedGrouped.totalTasksCount();
+        console.debug(`${totalTasksCount} of ${tasks.length} tasks displayed in a block in "${this.filePath}"`);
+        this.addTaskCount(content, totalTasksCount);
     }
 
     private renderErrorMessage(content: HTMLDivElement, errorMessage: string) {

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -41,8 +41,22 @@ export class QueryRenderer {
 class QueryRenderChild extends MarkdownRenderChild {
     private readonly app: App;
     private readonly events: TasksEvents;
-    private readonly source: string; // The complete text in the instruction block, such as 'not done\nshort mode'
-    private readonly filePath: string; // The path of the file that contains the instruction block
+
+    /**
+     * The complete text in the instruction block, such as:
+     * ```
+     *   not done
+     *   short mode
+     * ```
+     *
+     * This does not contain the Global Query from the user's settings.
+     * Use {@link getQueryForQueryRenderer} to get this value prefixed with the Global Query.
+     */
+    private readonly source: string;
+
+    /// The path of the file that contains the instruction block.
+    private readonly filePath: string;
+
     private query: IQuery;
     private queryType: string;
 

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -172,13 +172,16 @@ class QueryRenderChild extends MarkdownRenderChild {
             console.debug(`${totalTasksCount} of ${tasks.length} tasks displayed in a block in "${this.filePath}"`);
             this.addTaskCount(content, totalTasksCount);
         } else if (this.query.error !== undefined) {
-            content.createDiv().innerHTML =
-                '<pre>' + `Tasks query: ${this.query.error.replace(/\n/g, '<br>')}` + '</pre>';
+            this.renderErrorMessage(content, this.query.error);
         } else {
             this.renderLoadingMessage(content);
         }
 
         this.containerEl.firstChild?.replaceWith(content);
+    }
+
+    private renderErrorMessage(content: HTMLDivElement, errorMessage: string) {
+        content.createDiv().innerHTML = '<pre>' + `Tasks query: ${errorMessage.replace(/\n/g, '<br>')}` + '</pre>';
     }
 
     private renderLoadingMessage(content: HTMLDivElement) {

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -175,10 +175,14 @@ class QueryRenderChild extends MarkdownRenderChild {
             content.createDiv().innerHTML =
                 '<pre>' + `Tasks query: ${this.query.error.replace(/\n/g, '<br>')}` + '</pre>';
         } else {
-            content.setText('Loading Tasks ...');
+            this.renderLoadingMessage(content);
         }
 
         this.containerEl.firstChild?.replaceWith(content);
+    }
+
+    private renderLoadingMessage(content: HTMLDivElement) {
+        content.setText('Loading Tasks ...');
     }
 
     // Use the 'explain' instruction to enable this


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I'm going to be adding some error-checking in the task rendering code soon, to allow the imminent `filter by function` to throw exceptions during execution of searches.

The complexity of `QueryRenderChild.render()` was such that this was going to be quite messy to add, so this PR is just a preparatory extracting methods out of `QueryRenderChild.render()`, so there is one method for each of the different behaviours.

See the individual commits for the specific refactoring.

## Motivation and Context

See above.

## How has this been tested?

- Running existing tests
- By building and running the latest code and confirming the display of results is unchanged

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
