### PR TITLE
fix: Prevent date components of Urgency changing and midday

### DIFF
--- a/src/Urgency.ts
+++ b/src/Urgency.ts
@@ -13,7 +13,8 @@ export class Urgency {
 
         if (task.dueDate !== null) {
             // Map a range of 21 days to the value 0.2 - 1.0
-            const daysOverdue = Math.round(window.moment().diff(task.dueDate) / Urgency.milliSecondsPerDay);
+            const startOfToday = window.moment().startOf('day');
+            const daysOverdue = Math.round(startOfToday.diff(task.dueDate) / Urgency.milliSecondsPerDay);
 
             let dueMultiplier: number;
             if (daysOverdue >= 7.0) {


### PR DESCRIPTION
# Description

Adjust the Urgency calculation code so that it no longer depends on the time of day.

Previously at mid-day a task due on today's date changed its score to be the value for `a task due yesterday`. See #2068.

The fix was identified by @schemar - thank you!

## Motivation and Context

This fixes #2068.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- With a failing test that then passed after the bug fix
- Manually in the Demo vault.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
