### PR TITLE
fix: 'hide tags' now preserves styling of description for specific tags

### DIFF
--- a/docs/Advanced/Styling.md
+++ b/docs/Advanced/Styling.md
@@ -317,8 +317,6 @@ The following rule adds a green glow around `#task/atHome` tags inside the descr
 
 <!-- snippet: resources/sample_vaults/Tasks-Demo/.obsidian/snippets/tasks-plugin-highlight-specific-tag-green-glow.css -->
 ```css
-/* Note: This will do nothing in any Task query blocks that use 'hide tags'.    */
-/*       See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2083 */
 a.tag[data-tag-name="#task/atHome"] {
     box-shadow: 0 0 5px green;
 }
@@ -333,8 +331,6 @@ The following rule adds a rounded red background to the description of a task if
 
 <!-- snippet: resources/sample_vaults/Tasks-Demo/.obsidian/snippets/tasks-plugin-highlight-specific-tag-round-red-description.css -->
 ```css
-/* Note: This will not work in any Task query blocks that use 'hide tags'.      */
-/*       See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2083 */
 .task-description span:has(.tag[data-tag-name="#task/strategic"]) {
     background: #ffbfcc;
     border-radius: 10px;
@@ -346,11 +342,6 @@ The following rule adds a rounded red background to the description of a task if
 For example:
 
 ![Example of tasks-plugin-highlight-specific-tag-round-red-description.css snippet](../../images/tasks-plugin-highlight-specific-tag-round-red-description-snippet.png)
-
-> [!warning]
-> The above snippets require the tag to be displayed. Using the `hide tags` instruction prevents these tag-based snippets from working.
->
-> We are tracking this in [issue #2083](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2083).
 
 ### Circle Checkboxes
 

--- a/docs/Queries/Layout.md
+++ b/docs/Queries/Layout.md
@@ -24,12 +24,12 @@ The following elements exist:
 - `tags`
 - `task count`
 
-> [!Info]
-> Only tags recognised by Obsidian are hidden with `hide tags`.
+> [!Info] About `hide tags`
 >
-> Tasks is a bit more relaxed in recognising tags than Obsidian. For example,  `#123` is treated as a tag by Tasks, and so is included in Tasks' searches, sorting and grouping code.
->
-> However, `#123` is [not recognised a valid Obsidian tag](https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format) and so not hidden.
+> 1. Only tags recognised by Obsidian are hidden with `hide tags`.
+>     - Tasks is a bit more relaxed in recognising tags than Obsidian. For example,  `#123` is treated as a tag by Tasks, and so is included in Tasks' searches, sorting and grouping code.
+>     - However, `#123` is [not recognised a valid Obsidian tag](https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format) and so not hidden.
+> 2. It is not possible to hide or show individual tags. We are tracking this in [discussion #848](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/848).
 
 > [!released]
 `urgency` was introduced in Tasks 1.14.0.<br>

--- a/docs/Queries/Layout.md
+++ b/docs/Queries/Layout.md
@@ -24,6 +24,13 @@ The following elements exist:
 - `tags`
 - `task count`
 
+> [!Info]
+> Only tags recognised by Obsidian are hidden with `hide tags`.
+>
+> Tasks is a bit more relaxed in recognising tags than Obsidian. For example,  `#123` is treated as a tag by Tasks, and so is included in Tasks' searches, sorting and grouping code.
+>
+> However, `#123` is [not recognised a valid Obsidian tag](https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format) and so not hidden.
+
 > [!released]
 `urgency` was introduced in Tasks 1.14.0.<br>
 `created date` was introduced in Tasks 2.0.0.<br>

--- a/docs/Queries/Layout.md
+++ b/docs/Queries/Layout.md
@@ -26,14 +26,14 @@ The following elements exist:
 
 > [!released]
 `urgency` was introduced in Tasks 1.14.0.<br>
-`created date` was introduced in Tasks 2.0.0.
+`created date` was introduced in Tasks 2.0.0.<br>
+`tags` was introduced in Tasks X.Y.Z.
 
 All of these elements except `urgency` are shown by default, so you will use the command `hide`
 if you do not want to show any of them, or the command `show` to show the urgency score.
 
 > [!released]
-The `show` commands were introduced in Tasks 1.14.0.<br>
-`hide tags` was introduced in Tasks X.Y.Z.
+The `show` commands were introduced in Tasks 1.14.0.
 
 Example:
 

--- a/docs/Queries/Layout.md
+++ b/docs/Queries/Layout.md
@@ -31,11 +31,6 @@ The following elements exist:
 All of these elements except `urgency` are shown by default, so you will use the command `hide`
 if you do not want to show any of them, or the command `show` to show the urgency score.
 
-> [!warning]
-> Hiding tags with the `hide tags` instruction breaks any CSS rules that use tags in tasks, such as the [[Styling#Highlight for a Specific Tag]] examples.
->
-> We are tracking this in [issue #2083](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2083).
-
 > [!released]
 The `show` commands were introduced in Tasks 1.14.0.<br>
 `hide tags` was introduced in Tasks X.Y.Z.

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/snippets/tasks-plugin-highlight-specific-tag-green-glow.css
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/snippets/tasks-plugin-highlight-specific-tag-green-glow.css
@@ -1,5 +1,3 @@
-/* Note: This will do nothing in any Task query blocks that use 'hide tags'.    */
-/*       See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2083 */
 a.tag[data-tag-name="#task/atHome"] {
     box-shadow: 0 0 5px green;
 }

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/snippets/tasks-plugin-highlight-specific-tag-round-red-description.css
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/snippets/tasks-plugin-highlight-specific-tag-round-red-description.css
@@ -1,5 +1,3 @@
-/* Note: This will not work in any Task query blocks that use 'hide tags'.      */
-/*       See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2083 */
 .task-description span:has(.tag[data-tag-name="#task/strategic"]) {
     background: #ffbfcc;
     border-radius: 10px;

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/snippets/tasks-plugin-smoke-test-query-styling.css
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/snippets/tasks-plugin-smoke-test-query-styling.css
@@ -17,3 +17,11 @@ ul.contains-task-list.tasks-layout-hide-priority.tasks-layout-hide-backlinks.tas
     border-radius: 10px;
     padding: 2px 8px;
 }
+
+/* Put a blue border around Task code blocks, to make the structure of smoke tests easier to see. */
+:not(.callout-content) > .block-language-tasks {
+    padding: 5px 15px;
+    border: 2px solid var(--color-blue);
+    border-radius: 5px;
+    margin: 1em 0;
+}

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/snippets/tasks-plugin-smoke-test-query-styling.css
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/snippets/tasks-plugin-smoke-test-query-styling.css
@@ -11,3 +11,9 @@
 ul.contains-task-list.tasks-layout-hide-priority.tasks-layout-hide-backlinks.tasks-layout-hide-urgency.tasks-layout-hide-edit-button {
     color: red;
 }
+
+.task-description span:has(.tag[data-tag-name="#todo/strategic"]) {
+    background: #ffbfcc;
+    border-radius: 10px;
+    padding: 2px 8px;
+}

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Styling of Queries.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Styling of Queries.md
@@ -14,6 +14,7 @@ To test styling of queries, follow these steps, viewing this file either in **Re
 
 ```tasks
 path includes Styling of Queries
+description includes priority
 group by priority
 ```
 
@@ -21,6 +22,7 @@ group by priority
 
 ```tasks
 path includes Styling of Queries
+description includes priority
 group by due
 ```
 
@@ -28,6 +30,7 @@ group by due
 
 ```tasks
 path includes Styling of Queries
+description includes priority
 short mode
 ```
 
@@ -35,15 +38,34 @@ short mode
 
 ```tasks
 path includes Styling of Queries
+description includes priority
 hide priority
 hide backlinks
 hide urgency
 hide edit button
 ```
 
-- [ ] 6. Open the Obsidian settings of the Demo vault and under Appearance | CSS Snippets, turn **off** `tasks-plugin-smoke-test-query-styling`.
+- [ ] **6. Test the colouring by tag presence** - this should **show** the description in red, and **show** the tag `#todo/strategic`
+
+```tasks
+path includes Styling of Queries
+description includes tag
+hide backlink
+```
+
+- [ ] **7. Test the colouring by tag presence when tags hidden** - this should **show** the description in red, and **hide** the tag `#todo/strategic`
+
+```tasks
+path includes Styling of Queries
+description includes tag
+hide tags
+hide backlink
+```
+
+- [ ] **8. Open the Obsidian settings** of the Demo vault and under Appearance | CSS Snippets, turn **off** `tasks-plugin-smoke-test-query-styling`.
 
 ## Tasks for Reference
 
 - [ ] #task Task with high priority ⏫
 - [ ] #task Task with low priority 🔽
+- [ ] #task I have a tag to make my description red #todo/strategic

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Styling of Queries.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Styling of Queries.md
@@ -45,19 +45,27 @@ hide urgency
 hide edit button
 ```
 
-- [ ] **6. Test the colouring by tag presence** - this should **show** the description in red, and **show** the tag `#todo/strategic`
+- [ ] **6. Test the colouring by tag presence** - this should:
+  - **show** the task's tag `#todo/strategic`:
+  - **show** the description in red
+  - **show** the tag in the group heading
 
 ```tasks
 path includes Styling of Queries
 description includes tag
+group by tags
 hide backlink
 ```
 
-- [ ] **7. Test the colouring by tag presence when tags hidden** - this should **show** the description in red, and **hide** the tag `#todo/strategic`
+- [ ] **7. Test the colouring by tag presence when tags hidden** - this should:
+  - **hide** the task's tag `#todo/strategic`
+  - **still show** the description in red
+  - **still show** the tag in the group heading
 
 ```tasks
 path includes Styling of Queries
 description includes tag
+group by tags
 hide tags
 hide backlink
 ```

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -102,7 +102,7 @@ export class TaskLayout {
         newComponents = removeIf(newComponents, layoutOptions.hideDueDate, 'dueDate');
         newComponents = removeIf(newComponents, layoutOptions.hideDoneDate, 'doneDate');
 
-        // Tags are removed from the description, rather than being a whole component in their own right.
+        // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
         markHiddenQueryComponent(layoutOptions.hideTags, 'tags');
 
         // The following components are handled in QueryRenderer.ts and thus are not part of the same flow that

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -1,6 +1,6 @@
 import { Component, MarkdownRenderer } from 'obsidian';
 import type { Moment } from 'moment';
-import { type Task, TaskRegularExpressions } from './Task';
+import type { Task } from './Task';
 import * as taskModule from './Task';
 import type { LayoutOptions, TaskLayoutComponent } from './TaskLayout';
 import { TaskLayout } from './TaskLayout';
@@ -140,10 +140,6 @@ async function taskToHtml(
         if (componentString) {
             if (component === 'description') {
                 componentString = GlobalFilter.removeAsWordFromDependingOnSettings(componentString);
-
-                if (renderDetails.layoutOptions?.hideTags) {
-                    componentString = componentString.replace(TaskRegularExpressions.hashTags, '').trim();
-                }
             }
             // Create the text span that will hold the rendered component
             const span = document.createElement('span');

--- a/styles.css
+++ b/styles.css
@@ -83,7 +83,7 @@
     white-space: nowrap;
 }
 
-/* Hide tags, if `hide tags` instruction was used. */
+/* Hide tags that Obsidian recognises, if `hide tags` instruction was used. */
 .tasks-layout-hide-tags .task-description a.tag {
     display: none;
 }

--- a/styles.css
+++ b/styles.css
@@ -83,6 +83,11 @@
     white-space: nowrap;
 }
 
+/* Hide tags, if `hide tags` instruction was used. */
+.tasks-layout-hide-tags .task-description a.tag {
+    display: none;
+}
+
 .tasks-setting-important {
     color: red;
     font-weight: bold;

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -67,7 +67,6 @@ function getOtherLayoutComponents(parentElement: HTMLElement): string[] {
 describe('task line rendering', () => {
     afterEach(() => {
         resetSettings();
-        GlobalFilter.reset();
     });
 
     it('creates the correct span structure for a basic task', async () => {

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -280,50 +280,6 @@ describe('task line rendering', () => {
         );
     });
 
-    it.each([
-        // Nominal cases
-        ['tag at the end #todo', 'tag at the end'],
-        ['tag #tag in the middle', 'tag in the middle'],
-        ['#now tag in the beginning', 'tag in the beginning'],
-        ['#important #s a #today #TODO lot #never of tags #now #PERFORMANCE', 'a lot of tags'],
-        ['nested tags #todo/only/today #x/y/z', 'nested tags'],
-        ['tag with hyphens #a-b-c', 'tag with hyphens'],
-
-        // Border cases
-        ['but      keep extra     spaces', 'but      keep extra     spaces'],
-    ])(
-        'renders without tags task with description "%s"',
-        async (taskDescription: string, renderedDescription: string) => {
-            await testLayoutOptions(
-                `- [ ] ${taskDescription} ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day`,
-                { hideTags: true },
-                renderedDescription,
-                [' ⏫', ' 🔁 every day', ' ➕ 2022-07-05', ' 🛫 2022-07-04', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
-            );
-        },
-    );
-
-    it('"hide tags" should hide Global Filter when it is a tag despite Remove Global Filter setting', async () => {
-        const globalFilter = '#task';
-        GlobalFilter.set(globalFilter);
-
-        updateSettings({ removeGlobalFilter: false });
-        await testLayoutOptions(
-            `- [ ] ${globalFilter} Global Filter and tags are hidden when Remove Global Filter setting is 'false' #todo`,
-            { hideTags: true },
-            "Global Filter and tags are hidden when Remove Global Filter setting is 'false'",
-            [],
-        );
-
-        updateSettings({ removeGlobalFilter: true });
-        await testLayoutOptions(
-            `- [ ] ${globalFilter} Global Filter and tags are hidden when Remove Global Filter setting is 'true' #todo`,
-            { hideTags: true },
-            "Global Filter and tags are hidden when Remove Global Filter setting is 'true'",
-            [],
-        );
-    });
-
     const testComponentClasses = async (
         taskLine: string,
         layoutOptions: Partial<LayoutOptions>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This reworks the `hide tags` instruction to now use CSS to hide tags, rather than actually remove the tags from the description.

Because the tags are now present in the rendered tasks, any CSS based upon tags will now continue to work after tags are hidden.

Credit: @esm7 for the suggestion to implement hiding of tags using CSS, and for the CSS to do it.

Note that now only tags recognised by Obsidian are hidden.

For example, in the previous implementation `#123` would have been hidden, but this is [not recognised a valid Obsidian tag](https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format) and so is now not hidden.

This behaviour is documented.

## Motivation and Context

Fixes #2083

## How has this been tested?

- By manual testing
- By updating unit tests
- By adding new steps to the styling smoke test, to confirm the new behaviour - and ensure that `group by tags` still works.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
