### PR TITLE
test: Simplify code-review of filter, sort and group additions

### DIFF
--- a/src/Query/FilterParser.ts
+++ b/src/Query/FilterParser.ts
@@ -33,7 +33,7 @@ import { BacklinkField } from './Filter/BacklinkField';
 // be kept last.
 // When adding new fields keep this order in mind, putting fields that are more specific before fields that
 // may contain them, and keep BooleanField last.
-const fieldCreators: EndsWith<BooleanField> = [
+export const fieldCreators: EndsWith<BooleanField> = [
     () => new StatusNameField(), // status.name is before status, to avoid ambiguity
     () => new StatusTypeField(), // status.type is before status, to avoid ambiguity
     () => new StatusField(),

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -17,6 +17,17 @@ import { TaskBuilder } from './TestingTools/TaskBuilder';
 
 window.moment = moment;
 
+interface NamedField {
+    name: string;
+    field: Field;
+}
+const namedFieldCreators: ReadonlyArray<NamedField> = fieldCreators
+    .map((creator) => {
+        const field = creator();
+        return { name: field.fieldName(), field };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+
 function sortInstructionLines(filters: ReadonlyArray<string>) {
     // Sort a copy of the array of filters.
     return [...filters].sort((a: string, b: string) => a.localeCompare(b, undefined, { numeric: true }));
@@ -353,17 +364,6 @@ urgency
         function linesMatchingField(field: Field | BooleanField) {
             return filters.filter((instruction) => field.createGrouperFromLine(instruction) !== null);
         }
-
-        interface NamedField {
-            name: string;
-            field: Field;
-        }
-        const namedFieldCreators: ReadonlyArray<NamedField> = fieldCreators
-            .map((creator) => {
-                const field = creator();
-                return { name: field.fieldName(), field };
-            })
-            .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
 
         describe.each(namedFieldCreators)('has sufficient sample "group by" lines for field "%s"', ({ field }) => {
             if (!field.supportsGrouping()) {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -19,7 +19,7 @@ window.moment = moment;
 
 describe('Query parsing', () => {
     // In alphabetical order, please
-    const filters = [
+    const filters: ReadonlyArray<string> = [
         '(due this week) AND (description includes Hello World)',
         'created after 2021-12-27',
         'created before 2021-12-27',
@@ -206,7 +206,7 @@ urgency
 
     describe('should recognise every sort instruction', () => {
         // In alphabetical order, please
-        const filters = [
+        const filters: ReadonlyArray<string> = [
             'sort by created reverse',
             'sort by created',
             'sort by description reverse',
@@ -253,7 +253,7 @@ urgency
 
     describe('should recognise every group instruction', () => {
         // In alphabetical order, please
-        const filters = [
+        const filters: ReadonlyArray<string> = [
             'group by created',
             'group by created reverse',
             'group by backlink',
@@ -310,7 +310,7 @@ urgency
 
     describe('should recognise every other instruction', () => {
         // In alphabetical order, please
-        const filters = [
+        const filters: ReadonlyArray<string> = [
             '# Comment lines are ignored',
             'explain',
             'hide backlink',
@@ -354,7 +354,7 @@ urgency
     });
 
     describe('should recognize boolean queries', () => {
-        const filters = [
+        const filters: ReadonlyArray<string> = [
             '# Comment lines are ignored',
             '(description includes wibble) OR (has due date)',
             '(has due date) OR ((has start date) AND (due after 2021-12-27))',

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -335,11 +335,11 @@ urgency
             'hide task count',
             'hide urgency',
             'limit 42',
-            'limit to 42 tasks',
             'limit groups 31',
             'limit groups to 31 tasks',
-            'short mode',
+            'limit to 42 tasks',
             'short',
+            'short mode',
             'show backlink',
             'show created date',
             'show done date',
@@ -359,6 +359,10 @@ urgency
 
             // Assert
             expect(query.error).toBeUndefined();
+        });
+
+        it('sample lines really are in alphabetical order', () => {
+            expect(filters.join('\n')).toStrictEqual(sortInstructionLines(filters).join('\n'));
         });
     });
 

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -30,13 +30,13 @@ describe('Query parsing', () => {
         'description does not include wibble',
         'description includes AND', // Verify Query doesn't confuse this with a boolean query
         'description includes wibble',
+        'done',
         'done after 2021-12-27',
         'done before 2021-12-27',
         'done date is invalid',
         'done in 2021-12-27 2021-12-29',
         'done on 2021-12-27',
         'done this week',
-        'done',
         'due after 2021-12-27',
         'due before 2021-12-27',
         'due date is invalid',
@@ -60,8 +60,8 @@ describe('Query parsing', () => {
         'has happens date',
         'has scheduled date',
         'has start date',
-        'has tags',
         'has tag',
+        'has tags',
         'heading does not include wibble',
         'heading includes AND', // Verify Query doesn't confuse this with a boolean query
         'heading includes wibble',
@@ -73,8 +73,8 @@ describe('Query parsing', () => {
         'no happens date',
         'no scheduled date',
         'no start date',
-        'no tags',
         'no tag',
+        'no tags',
         'not done',
         'path does not include some/path',
         'path includes AND', // Verify Query doesn't confuse this with a boolean query
@@ -137,6 +137,14 @@ describe('Query parsing', () => {
             expect(query.filters.length).toEqual(1);
             expect(query.filters[0]).toBeDefined();
         });
+    });
+
+    it('sample filter lines really are in alphabetical order', () => {
+        // Sort a copy of the array of filters.
+        const filtersSorted = [...filters].sort((a: string, b: string) =>
+            a.localeCompare(b, undefined, { numeric: true }),
+        );
+        expect(filters.join('\n')).toStrictEqual(filtersSorted.join('\n'));
     });
 
     it('has a sample line for every supported filter', () => {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -254,6 +254,38 @@ urgency
         it('sample lines really are in alphabetical order', () => {
             expect(filters).toStrictEqual(sortInstructionLines(filters));
         });
+
+        function haveExampleInstructionForField(field: Field | BooleanField) {
+            for (const instruction of filters) {
+                if (field.createSorterFromLine(instruction) !== null) {
+                    // We found a sample instruction line that matches the sorter in the Field.
+                    return true;
+                }
+            }
+            // We couldn't find any sample instruction lines that match the sorter in the Field.
+            return false;
+        }
+
+        it('has a sample line for every supported sorter', () => {
+            // This test guards against correctly adding a new sorter,
+            // but forgetting to add an example of it to the sorters variable above.
+            // So it's really testing the current tests are complete.
+
+            const introLine = 'No sample sort instructions found for the following Fields';
+            let warnings = introLine + '\n';
+            for (const creator of fieldCreators) {
+                const field = creator();
+                if (!field.supportsSorting()) {
+                    continue;
+                }
+                if (!haveExampleInstructionForField(field)) {
+                    warnings += `${field.fieldName()}\n`;
+                }
+            }
+            const expectedWarnings = `${introLine}
+`;
+            expect(warnings).toEqual(expectedWarnings);
+        });
     });
 
     describe('should recognise every group instruction', () => {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -354,11 +354,16 @@ urgency
             return filters.filter((instruction) => field.createGrouperFromLine(instruction) !== null);
         }
 
-        const namedFieldCreators = fieldCreators.map((creator) => {
-            const field = creator();
-            return { name: field.fieldName(), field };
-        });
-        namedFieldCreators.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+        interface NamedField {
+            name: string;
+            field: Field;
+        }
+        const namedFieldCreators: ReadonlyArray<NamedField> = fieldCreators
+            .map((creator) => {
+                const field = creator();
+                return { name: field.fieldName(), field };
+            })
+            .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
 
         describe.each(namedFieldCreators)('has sufficient sample "group by" lines for field "%s"', ({ field }) => {
             if (!field.supportsGrouping()) {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -267,6 +267,7 @@ urgency
             const field = creator();
             return [field.fieldName(), field];
         });
+        namedFieldCreators.sort((a, b) => (a[0] as string).localeCompare(b[0] as string, undefined, { numeric: true }));
 
         describe.each(namedFieldCreators)(
             'has sufficient sample "sort by" lines for field "%s"',

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -274,31 +274,21 @@ urgency
             return filters.filter((instruction) => field.createSorterFromLine(instruction) !== null);
         }
 
-        const namedFieldCreators = fieldCreators.map((creator) => {
-            const field = creator();
-            return [field.fieldName(), field];
+        describe.each(namedFieldCreators)('has sufficient sample "sort by" lines for field "%s"', ({ field }) => {
+            if (!field.supportsSorting()) {
+                return;
+            }
+
+            const matchingLines = linesMatchingField(field);
+
+            it('has at least one test for normal sorting', () => {
+                expect(matchingLines.filter((line) => !line.includes(' reverse')).length).toBeGreaterThan(0);
+            });
+
+            it('has at least one test for reverse sorting', () => {
+                expect(matchingLines.filter((line) => line.includes(' reverse')).length).toBeGreaterThan(0);
+            });
         });
-        namedFieldCreators.sort((a, b) => (a[0] as string).localeCompare(b[0] as string, undefined, { numeric: true }));
-
-        describe.each(namedFieldCreators)(
-            'has sufficient sample "sort by" lines for field "%s"',
-            (_, fieldNeedsCasting) => {
-                const field = fieldNeedsCasting as Field;
-                if (!field.supportsSorting()) {
-                    return;
-                }
-
-                const matchingLines = linesMatchingField(field);
-
-                it('has at least one test for normal sorting', () => {
-                    expect(matchingLines.filter((line) => !line.includes(' reverse')).length).toBeGreaterThan(0);
-                });
-
-                it('has at least one test for reverse sorting', () => {
-                    expect(matchingLines.filter((line) => line.includes(' reverse')).length).toBeGreaterThan(0);
-                });
-            },
-        );
     });
 
     describe('should recognise every group instruction', () => {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -20,6 +20,7 @@ window.moment = moment;
 describe('Query parsing', () => {
     // In alphabetical order, please
     const filters = [
+        '(due this week) AND (description includes Hello World)',
         'created after 2021-12-27',
         'created before 2021-12-27',
         'created date is invalid',
@@ -44,6 +45,10 @@ describe('Query parsing', () => {
         'due this week',
         'exclude sub-items',
         'filename includes wibble',
+        'filter by function task.isDone', // This cannot contain any () because of issue #1500
+        'folder does not include some/path',
+        'folder includes AND', // Verify Query doesn't confuse this with a boolean query
+        'folder includes some/path',
         'happens after 2021-12-27',
         'happens before 2021-12-27',
         'happens in 2021-12-27 2021-12-29',
@@ -82,6 +87,9 @@ describe('Query parsing', () => {
         'priority is none',
         'recurrence does not include wednesday',
         'recurrence includes wednesday',
+        'root does not include some',
+        'root includes AND', // Verify Query doesn't confuse this with a boolean query
+        'root includes some',
         'scheduled after 2021-12-27',
         'scheduled before 2021-12-27',
         'scheduled date is invalid',
@@ -131,7 +139,7 @@ describe('Query parsing', () => {
         });
     });
 
-    it.failing('has a sample line for every supported filter', () => {
+    it('has a sample line for every supported filter', () => {
         // This test guards against correctly adding a new filter,
         // but forgetting to add an example of it to the filters variable above.
         // So it's really testing the current tests are complete.
@@ -150,8 +158,8 @@ describe('Query parsing', () => {
             return false;
         }
 
-        const introLine = 'No sample filter instructions found for the following Fields\n';
-        let warnings = introLine;
+        const introLine = 'No sample filter instructions found for the following Fields';
+        let warnings = introLine + '\n';
         for (const creator of fieldCreators) {
             const field = creator();
             if (!haveExampleInstructionForField(field)) {
@@ -159,8 +167,7 @@ describe('Query parsing', () => {
             }
         }
         // These fields do not support filtering.
-        const expectedWarnings = `
-${introLine}
+        const expectedWarnings = `${introLine}
 backlink
 urgency
 `;

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -356,29 +356,25 @@ urgency
 
         const namedFieldCreators = fieldCreators.map((creator) => {
             const field = creator();
-            return [field.fieldName(), field];
+            return { name: field.fieldName(), field };
         });
-        namedFieldCreators.sort((a, b) => (a[0] as string).localeCompare(b[0] as string, undefined, { numeric: true }));
+        namedFieldCreators.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
 
-        describe.each(namedFieldCreators)(
-            'has sufficient sample "group by" lines for field "%s"',
-            (_, fieldNeedsCasting) => {
-                const field = fieldNeedsCasting as Field;
-                if (!field.supportsGrouping()) {
-                    return;
-                }
+        describe.each(namedFieldCreators)('has sufficient sample "group by" lines for field "%s"', ({ field }) => {
+            if (!field.supportsGrouping()) {
+                return;
+            }
 
-                const matchingLines = linesMatchingField(field);
+            const matchingLines = linesMatchingField(field);
 
-                it('has at least one test for normal grouping', () => {
-                    expect(matchingLines.filter((line) => !line.includes(' reverse')).length).toBeGreaterThan(0);
-                });
+            it('has at least one test for normal grouping', () => {
+                expect(matchingLines.filter((line) => !line.includes(' reverse')).length).toBeGreaterThan(0);
+            });
 
-                it('has at least one test for reverse grouping', () => {
-                    expect(matchingLines.filter((line) => line.includes(' reverse')).length).toBeGreaterThan(0);
-                });
-            },
-        );
+            it('has at least one test for reverse grouping', () => {
+                expect(matchingLines.filter((line) => line.includes(' reverse')).length).toBeGreaterThan(0);
+            });
+        });
     });
 
     describe('should recognise every other instruction', () => {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -21,7 +21,7 @@ interface NamedField {
     name: string;
     field: Field;
 }
-const namedFieldCreators: ReadonlyArray<NamedField> = fieldCreators
+const namedFields: ReadonlyArray<NamedField> = fieldCreators
     .map((creator) => {
         const field = creator();
         return { name: field.fieldName(), field };
@@ -167,7 +167,7 @@ describe('Query parsing', () => {
             });
         }
 
-        describe.each(namedFieldCreators)('has sufficient sample "filter" lines for field "%s"', ({ name, field }) => {
+        describe.each(namedFields)('has sufficient sample "filter" lines for field "%s"', ({ name, field }) => {
             function fieldDoesNotSupportFiltering() {
                 return name === 'backlink' || name === 'urgency';
             }
@@ -266,7 +266,7 @@ describe('Query parsing', () => {
             return filters.filter((instruction) => field.createSorterFromLine(instruction) !== null);
         }
 
-        describe.each(namedFieldCreators)('has sufficient sample "sort by" lines for field "%s"', ({ field }) => {
+        describe.each(namedFields)('has sufficient sample "sort by" lines for field "%s"', ({ field }) => {
             if (!field.supportsSorting()) {
                 return;
             }
@@ -347,7 +347,7 @@ describe('Query parsing', () => {
             return filters.filter((instruction) => field.createGrouperFromLine(instruction) !== null);
         }
 
-        describe.each(namedFieldCreators)('has sufficient sample "group by" lines for field "%s"', ({ field }) => {
+        describe.each(namedFields)('has sufficient sample "group by" lines for field "%s"', ({ field }) => {
             if (!field.supportsGrouping()) {
                 return;
             }

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -217,13 +217,17 @@ urgency
             'sort by due',
             'sort by due reverse',
             'sort by filename',
+            'sort by filename reverse',
             'sort by happens',
+            'sort by happens reverse',
             'sort by heading',
+            'sort by heading reverse',
             'sort by path',
             'sort by path reverse',
             'sort by priority',
             'sort by priority reverse',
             'sort by recurring',
+            'sort by recurring reverse',
             'sort by scheduled',
             'sort by scheduled reverse',
             'sort by start',
@@ -255,15 +259,8 @@ urgency
             expect(filters).toStrictEqual(sortInstructionLines(filters));
         });
 
-        function haveExampleInstructionForField(field: Field | BooleanField) {
-            for (const instruction of filters) {
-                if (field.createSorterFromLine(instruction) !== null) {
-                    // We found a sample instruction line that matches the sorter in the Field.
-                    return true;
-                }
-            }
-            // We couldn't find any sample instruction lines that match the sorter in the Field.
-            return false;
+        function linesMatchingField(field: Field | BooleanField) {
+            return filters.filter((instruction) => field.createSorterFromLine(instruction) !== null);
         }
 
         it('has a sample line for every supported sorter', () => {
@@ -278,8 +275,16 @@ urgency
                 if (!field.supportsSorting()) {
                     continue;
                 }
-                if (!haveExampleInstructionForField(field)) {
-                    warnings += `${field.fieldName()}\n`;
+
+                const matchingLines = linesMatchingField(field);
+                // Is there a sample instruction with normal order?
+                if (!matchingLines.find((line) => !line.includes(' reverse'))) {
+                    warnings += `${field.fieldName()} (normal order)\n`;
+                }
+
+                // Is there a sample instruction with reverse order?
+                if (!matchingLines.find((line) => line.includes(' reverse'))) {
+                    warnings += `${field.fieldName()} (reverse order)\n`;
                 }
             }
             const expectedWarnings = `${introLine}

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -143,7 +143,7 @@ describe('Query parsing', () => {
             expect(query.filters[0]).toBeDefined();
         });
 
-        it('sample filter lines really are in alphabetical order', () => {
+        it('sample lines really are in alphabetical order', () => {
             expect(filters.join('\n')).toStrictEqual(sortInstructionLines(filters).join('\n'));
         });
 
@@ -208,38 +208,38 @@ urgency
     describe('should recognise every sort instruction', () => {
         // In alphabetical order, please
         const filters: ReadonlyArray<string> = [
-            'sort by created reverse',
             'sort by created',
-            'sort by description reverse',
+            'sort by created reverse',
             'sort by description',
-            'sort by done reverse',
+            'sort by description reverse',
             'sort by done',
-            'sort by due reverse',
+            'sort by done reverse',
             'sort by due',
+            'sort by due reverse',
             'sort by filename',
             'sort by happens',
             'sort by heading',
-            'sort by path reverse',
             'sort by path',
-            'sort by priority reverse',
+            'sort by path reverse',
             'sort by priority',
+            'sort by priority reverse',
             'sort by recurring',
-            'sort by scheduled reverse',
             'sort by scheduled',
-            'sort by start reverse',
+            'sort by scheduled reverse',
             'sort by start',
-            'sort by status reverse',
+            'sort by start reverse',
             'sort by status',
+            'sort by status reverse',
             'sort by status.name',
             'sort by status.name reverse',
             'sort by status.type',
             'sort by status.type reverse',
-            'sort by tag 5',
-            'sort by tag reverse 3',
-            'sort by tag reverse',
             'sort by tag',
-            'sort by urgency reverse',
+            'sort by tag 5',
+            'sort by tag reverse',
+            'sort by tag reverse 3',
             'sort by urgency',
+            'sort by urgency reverse',
         ];
         test.concurrent.each<string>(filters)('recognises %j', (filter) => {
             // Arrange
@@ -249,6 +249,10 @@ urgency
             expect(query.error).toBeUndefined();
             expect(query.sorting.length).toEqual(1);
             expect(query.sorting[0]).toBeDefined();
+        });
+
+        it('sample lines really are in alphabetical order', () => {
+            expect(filters.join('\n')).toStrictEqual(sortInstructionLines(filters).join('\n'));
         });
     });
 

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -349,6 +349,36 @@ urgency
         it('sample lines really are in alphabetical order', () => {
             expect(filters).toStrictEqual(sortInstructionLines(filters));
         });
+
+        function linesMatchingField(field: Field | BooleanField) {
+            return filters.filter((instruction) => field.createGrouperFromLine(instruction) !== null);
+        }
+
+        const namedFieldCreators = fieldCreators.map((creator) => {
+            const field = creator();
+            return [field.fieldName(), field];
+        });
+        namedFieldCreators.sort((a, b) => (a[0] as string).localeCompare(b[0] as string, undefined, { numeric: true }));
+
+        describe.each(namedFieldCreators)(
+            'has sufficient sample "group by" lines for field "%s"',
+            (_, fieldNeedsCasting) => {
+                const field = fieldNeedsCasting as Field;
+                if (!field.supportsGrouping()) {
+                    return;
+                }
+
+                const matchingLines = linesMatchingField(field);
+
+                it('has at least one test for normal grouping', () => {
+                    expect(matchingLines.filter((line) => !line.includes(' reverse')).length).toBeGreaterThan(0);
+                });
+
+                it('has at least one test for reverse grouping', () => {
+                    expect(matchingLines.filter((line) => line.includes(' reverse')).length).toBeGreaterThan(0);
+                });
+            },
+        );
     });
 
     describe('should recognise every other instruction', () => {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -144,7 +144,7 @@ describe('Query parsing', () => {
         });
 
         it('sample lines really are in alphabetical order', () => {
-            expect(filters.join('\n')).toStrictEqual(sortInstructionLines(filters).join('\n'));
+            expect(filters).toStrictEqual(sortInstructionLines(filters));
         });
 
         it('has a sample line for every supported filter', () => {
@@ -252,7 +252,7 @@ urgency
         });
 
         it('sample lines really are in alphabetical order', () => {
-            expect(filters.join('\n')).toStrictEqual(sortInstructionLines(filters).join('\n'));
+            expect(filters).toStrictEqual(sortInstructionLines(filters));
         });
     });
 
@@ -313,7 +313,7 @@ urgency
         });
 
         it('sample lines really are in alphabetical order', () => {
-            expect(filters.join('\n')).toStrictEqual(sortInstructionLines(filters).join('\n'));
+            expect(filters).toStrictEqual(sortInstructionLines(filters));
         });
     });
 
@@ -362,7 +362,7 @@ urgency
         });
 
         it('sample lines really are in alphabetical order', () => {
-            expect(filters.join('\n')).toStrictEqual(sortInstructionLines(filters).join('\n'));
+            expect(filters).toStrictEqual(sortInstructionLines(filters));
         });
     });
 

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -142,45 +142,45 @@ describe('Query parsing', () => {
             expect(query.filters.length).toEqual(1);
             expect(query.filters[0]).toBeDefined();
         });
-    });
 
-    it('sample filter lines really are in alphabetical order', () => {
-        expect(filters.join('\n')).toStrictEqual(sortInstructionLines(filters).join('\n'));
-    });
+        it('sample filter lines really are in alphabetical order', () => {
+            expect(filters.join('\n')).toStrictEqual(sortInstructionLines(filters).join('\n'));
+        });
 
-    it('has a sample line for every supported filter', () => {
-        // This test guards against correctly adding a new filter,
-        // but forgetting to add an example of it to the filters variable above.
-        // So it's really testing the current tests are complete.
+        it('has a sample line for every supported filter', () => {
+            // This test guards against correctly adding a new filter,
+            // but forgetting to add an example of it to the filters variable above.
+            // So it's really testing the current tests are complete.
 
-        function haveExampleInstructionForField(field: Field | BooleanField) {
-            for (const instruction of filters) {
-                if (!field.canCreateFilterForLine(instruction)) {
-                    continue;
+            function haveExampleInstructionForField(field: Field | BooleanField) {
+                for (const instruction of filters) {
+                    if (!field.canCreateFilterForLine(instruction)) {
+                        continue;
+                    }
+                    if (field.createFilterOrErrorMessage(instruction).error === undefined) {
+                        // We found a sample instruction line that matches the filter in the Field.
+                        return true;
+                    }
                 }
-                if (field.createFilterOrErrorMessage(instruction).error === undefined) {
-                    // We found a sample instruction line that matches the filter in the Field.
-                    return true;
+                // We couldn't find any sample instruction lines that match the filter in the Field.
+                return false;
+            }
+
+            const introLine = 'No sample filter instructions found for the following Fields';
+            let warnings = introLine + '\n';
+            for (const creator of fieldCreators) {
+                const field = creator();
+                if (!haveExampleInstructionForField(field)) {
+                    warnings += `${field.fieldName()}\n`;
                 }
             }
-            // We couldn't find any sample instruction lines that match the filter in the Field.
-            return false;
-        }
-
-        const introLine = 'No sample filter instructions found for the following Fields';
-        let warnings = introLine + '\n';
-        for (const creator of fieldCreators) {
-            const field = creator();
-            if (!haveExampleInstructionForField(field)) {
-                warnings += `${field.fieldName()}\n`;
-            }
-        }
-        // These fields do not support filtering.
-        const expectedWarnings = `${introLine}
+            // These fields do not support filtering.
+            const expectedWarnings = `${introLine}
 backlink
 urgency
 `;
-        expect(warnings).toEqual(expectedWarnings);
+            expect(warnings).toEqual(expectedWarnings);
+        });
     });
 
     describe('should not confuse a boolean query for any other single field', () => {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -147,24 +147,24 @@ describe('Query parsing', () => {
             expect(filters).toStrictEqual(sortInstructionLines(filters));
         });
 
+        function haveExampleInstructionForField(field: Field | BooleanField) {
+            for (const instruction of filters) {
+                if (!field.canCreateFilterForLine(instruction)) {
+                    continue;
+                }
+                if (field.createFilterOrErrorMessage(instruction).error === undefined) {
+                    // We found a sample instruction line that matches the filter in the Field.
+                    return true;
+                }
+            }
+            // We couldn't find any sample instruction lines that match the filter in the Field.
+            return false;
+        }
+
         it('has a sample line for every supported filter', () => {
             // This test guards against correctly adding a new filter,
             // but forgetting to add an example of it to the filters variable above.
             // So it's really testing the current tests are complete.
-
-            function haveExampleInstructionForField(field: Field | BooleanField) {
-                for (const instruction of filters) {
-                    if (!field.canCreateFilterForLine(instruction)) {
-                        continue;
-                    }
-                    if (field.createFilterOrErrorMessage(instruction).error === undefined) {
-                        // We found a sample instruction line that matches the filter in the Field.
-                        return true;
-                    }
-                }
-                // We couldn't find any sample instruction lines that match the filter in the Field.
-                return false;
-            }
 
             const introLine = 'No sample filter instructions found for the following Fields';
             let warnings = introLine + '\n';

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -259,10 +259,10 @@ urgency
     describe('should recognise every group instruction', () => {
         // In alphabetical order, please
         const filters: ReadonlyArray<string> = [
-            'group by created',
-            'group by created reverse',
             'group by backlink',
             'group by backlink reverse',
+            'group by created',
+            'group by created reverse',
             'group by done',
             'group by done reverse',
             'group by due',
@@ -271,8 +271,8 @@ urgency
             'group by filename reverse',
             'group by folder',
             'group by folder reverse',
-            'group by function task.status.symbol.replace(" ", "space")',
             'group by function reverse task.status.symbol.replace(" ", "space")',
+            'group by function task.status.symbol.replace(" ", "space")',
             'group by happens',
             'group by happens reverse',
             'group by heading',
@@ -310,6 +310,10 @@ urgency
             expect(query.error).toBeUndefined();
             expect(query.grouping.length).toEqual(1);
             expect(query.grouping[0]).toBeDefined();
+        });
+
+        it('sample lines really are in alphabetical order', () => {
+            expect(filters.join('\n')).toStrictEqual(sortInstructionLines(filters).join('\n'));
         });
     });
 

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -268,31 +268,23 @@ urgency
             return [field.fieldName(), field];
         });
 
-        test.concurrent.each(namedFieldCreators)(
+        describe.each(namedFieldCreators)(
             'has sufficient sample "sort by" lines for field "%s"',
-            (name, fieldNeedsCasting) => {
+            (_, fieldNeedsCasting) => {
                 const field = fieldNeedsCasting as Field;
                 if (!field.supportsSorting()) {
                     return;
                 }
 
-                const introLine = 'No sample sort instructions found for the following Fields';
-                let warnings = introLine + '\n';
-
                 const matchingLines = linesMatchingField(field);
-                // Is there a sample instruction with normal order?
-                if (!matchingLines.find((line) => !line.includes(' reverse'))) {
-                    warnings += `${name} (normal order)\n`;
-                }
 
-                // Is there a sample instruction with reverse order?
-                if (!matchingLines.find((line) => line.includes(' reverse'))) {
-                    warnings += `${name} (reverse order)\n`;
-                }
+                it('has at least one test for normal sorting', () => {
+                    expect(matchingLines.filter((line) => !line.includes(' reverse')).length).toBeGreaterThan(0);
+                });
 
-                const expectedWarnings = `${introLine}
-`;
-                expect(warnings).toEqual(expectedWarnings);
+                it('has at least one test for reverse sorting', () => {
+                    expect(matchingLines.filter((line) => line.includes(' reverse')).length).toBeGreaterThan(0);
+                });
             },
         );
     });

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -17,6 +17,11 @@ import { TaskBuilder } from './TestingTools/TaskBuilder';
 
 window.moment = moment;
 
+function sortInstructionLines(filters: ReadonlyArray<string>) {
+    // Sort a copy of the array of filters.
+    return [...filters].sort((a: string, b: string) => a.localeCompare(b, undefined, { numeric: true }));
+}
+
 describe('Query parsing', () => {
     // In alphabetical order, please
     const filters: ReadonlyArray<string> = [
@@ -140,11 +145,7 @@ describe('Query parsing', () => {
     });
 
     it('sample filter lines really are in alphabetical order', () => {
-        // Sort a copy of the array of filters.
-        const filtersSorted = [...filters].sort((a: string, b: string) =>
-            a.localeCompare(b, undefined, { numeric: true }),
-        );
-        expect(filters.join('\n')).toStrictEqual(filtersSorted.join('\n'));
+        expect(filters.join('\n')).toStrictEqual(sortInstructionLines(filters).join('\n'));
     });
 
     it('has a sample line for every supported filter', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I noticed a few gaps in tests of ensuring that Query parses all filter, sort and group instructions.

And ended up adding tests to cross-check the data with the supported fields, to remove the need to manually check for missing instructions when reviewing PRs.

Some of the missing lines were down to me, and I didn't want to have to keep remembering to add them.

## Motivation and Context

See above.

## How has this been tested?

- Existing tests pass
- New tests added.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
