### PR TITLE
fix: Improve readability of exception reports.

### DIFF
--- a/src/lib/ExceptionTools.ts
+++ b/src/lib/ExceptionTools.ts
@@ -4,12 +4,14 @@
  * @param exception - object that was caught in a try/catch block.
  */
 export function errorMessageForException(whatWasHappening: string, exception: any): string {
-    const errorMessage = `Error: ${whatWasHappening}. The error message was:`;
+    const errorMessage = `Error: ${whatWasHappening}.
+The error message was:
+    `;
     let detail: string = '';
     if (exception instanceof Error) {
         detail += exception;
     } else {
         detail += 'Unknown error';
     }
-    return `${errorMessage} "${detail}"`;
+    return `${errorMessage}"${detail}"`;
 }

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -1217,7 +1217,7 @@ At most 8 tasks per group (if any "group by" options are supplied).
 
             // Assert
             expect(queryResult.searchErrorMessage).toEqual(
-                'Error: Search failed. The error message was: "ReferenceError: wibble is not defined"',
+                'Error: Search failed.\nThe error message was:\n    "ReferenceError: wibble is not defined"',
             );
         });
     });

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -31,7 +31,7 @@ describe('FunctionField - filtering', () => {
         const filter = functionField.createFilterOrErrorMessage(instructionWithExtraClosingParen);
         expect(filter).not.toBeValid();
         expect(filter.error).toEqual(
-            'Error: Failed parsing expression "task.status.name.toUpperCase())". The error message was: "SyntaxError: Unexpected token \')\'"',
+            'Error: Failed parsing expression "task.status.name.toUpperCase())".\nThe error message was:\n    "SyntaxError: Unexpected token \')\'"',
         );
     });
 
@@ -119,7 +119,7 @@ describe('FunctionField - grouping - error-handling', () => {
         const line = 'group by function hello';
         const grouper = createGrouper(line);
         toGroupTaskWithPath(grouper, 'journal/a/b.md', [
-            'Error: Failed calculating expression "hello". The error message was: "ReferenceError: hello is not defined"',
+            'Error: Failed calculating expression "hello".\nThe error message was:\n    "ReferenceError: hello is not defined"',
         ]);
     });
 

--- a/tests/Query/Filter/TextField.test.ts
+++ b/tests/Query/Filter/TextField.test.ts
@@ -7,7 +7,9 @@ describe('should report regular expression errors to user ', () => {
         const instruction = 'description regex matches /hello(/';
         const filterOrError = new DescriptionField().createFilterOrErrorMessage(instruction);
         expect(filterOrError.error).toEqual(
-            String.raw`Error: Parsing regular expression. The error message was: "SyntaxError: Invalid regular expression: /hello(/: Unterminated group"
+            String.raw`Error: Parsing regular expression.
+The error message was:
+    "SyntaxError: Invalid regular expression: /hello(/: Unterminated group"
 
 See https://publish.obsidian.md/tasks/Queries/Regular+Expressions
 

--- a/tests/Scripting/Expression.test.ts
+++ b/tests/Scripting/Expression.test.ts
@@ -23,19 +23,19 @@ describe('Expression', () => {
         it('should report meaningful error message for duplicate return statement', () => {
             // evaluateExpression() currently adds a return statement, to save user typing it.
             expect(parseExpression([], 'return 42').error).toEqual(
-                'Error: Failed parsing expression "return 42". The error message was: "SyntaxError: Unexpected token \'return\'"',
+                'Error: Failed parsing expression "return 42".\nThe error message was:\n    "SyntaxError: Unexpected token \'return\'"',
             );
         });
 
         it('should report meaningful error message for parentheses too few parentheses', () => {
             expect(parseExpression([], 'x(').error).toEqual(
-                'Error: Failed parsing expression "x(". The error message was: "SyntaxError: Unexpected token \'}\'"',
+                'Error: Failed parsing expression "x(".\nThe error message was:\n    "SyntaxError: Unexpected token \'}\'"',
             );
         });
 
         it('should report meaningful error message for parentheses too many parentheses', () => {
             expect(parseExpression([], 'x())').error).toEqual(
-                'Error: Failed parsing expression "x())". The error message was: "SyntaxError: Unexpected token \')\'"',
+                'Error: Failed parsing expression "x())".\nThe error message was:\n    "SyntaxError: Unexpected token \')\'"',
             );
         });
     });
@@ -49,7 +49,7 @@ describe('Expression', () => {
 
             const result = evaluateExpressionOrCatch(expression.queryComponent!, paramsArgs, line);
             expect(result).toEqual(
-                'Error: Failed calculating expression "nonExistentVariable". The error message was: "ReferenceError: nonExistentVariable is not defined"',
+                'Error: Failed calculating expression "nonExistentVariable".\nThe error message was:\n    "ReferenceError: nonExistentVariable is not defined"',
             );
         });
 

--- a/tests/Scripting/TaskExpression.test.ts
+++ b/tests/Scripting/TaskExpression.test.ts
@@ -25,7 +25,7 @@ describe('TaskExpression', () => {
             expect(taskExpression.isValid()).toEqual(false);
             expect(taskExpression.line).toEqual(line);
             expect(taskExpression.parseError).toEqual(
-                'Error: Failed parsing expression "task.due.formatAsDate())". The error message was: "SyntaxError: Unexpected token \')\'"',
+                'Error: Failed parsing expression "task.due.formatAsDate())".\nThe error message was:\n    "SyntaxError: Unexpected token \')\'"',
             );
         });
     });
@@ -51,7 +51,7 @@ describe('TaskExpression', () => {
 
             // Assert
             expect(result).toEqual(
-                'Error: Failed calculating expression "wibble". The error message was: "ReferenceError: wibble is not defined"',
+                'Error: Failed calculating expression "wibble".\nThe error message was:\n    "ReferenceError: wibble is not defined"',
             );
 
             // Try again, using evaluate()
@@ -72,7 +72,7 @@ describe('TaskExpression', () => {
 
             // Assert
             const expectedErrorMessage =
-                'Error: Cannot evaluate an expression which is not valid: "task.due.formatAsDate(" gave error: "Error: Failed parsing expression "task.due.formatAsDate(". The error message was: "SyntaxError: Unexpected token \'}\'""';
+                'Error: Cannot evaluate an expression which is not valid: "task.due.formatAsDate(" gave error: "Error: Failed parsing expression "task.due.formatAsDate(".\nThe error message was:\n    "SyntaxError: Unexpected token \'}\'""';
             expect(result).toEqual(expectedErrorMessage);
 
             // Try again, using evaluate()

--- a/tests/lib/ExceptionTools.test.ts
+++ b/tests/lib/ExceptionTools.test.ts
@@ -20,7 +20,9 @@ describe('errorMessageForException()', () => {
         }
 
         // Assert
-        expect(messageReceived).toEqual('Error: testing. The error message was: "RangeError: that was out of range"');
+        expect(messageReceived).toEqual(
+            'Error: testing.\nThe error message was:\n    "RangeError: that was out of range"',
+        );
         expect(messageReceived.includes('RangeError')).toEqual(true);
         expect(messageReceived.includes(exceptionText)).toEqual(true);
     });
@@ -31,6 +33,6 @@ describe('errorMessageForException()', () => {
         const messageReceived = errorMessageForException('testing', nonExceptionValue);
 
         // Assert
-        expect(messageReceived).toEqual('Error: testing. The error message was: "Unknown error"');
+        expect(messageReceived).toEqual('Error: testing.\nThe error message was:\n    "Unknown error"');
     });
 });


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

Improve formatting of exception reports.

The exception text is now written on a new line, indented.

## Motivation and Context

Make long messages more readable

## How has this been tested?

- Updated tests
- Tested manually in demo vault

## Screenshots (if appropriate)

Before:

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/125765e9-eb76-4d8a-a27d-00aaf338db75)

After:

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/4b040603-7259-4f83-82da-4401a7e35d8c)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
