### PR TITLE
refactor: simplify if-elses in DateField

### DIFF
--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -163,10 +163,7 @@ export abstract class DateField extends Field {
                 explanationDates = filterDates.end.format(dateFormat);
                 break;
             default:
-                if (filterDates.start.isSame(filterDates.end)) {
-                    relationship = 'on';
-                    explanationDates = filterDates.start.format(dateFormat);
-                } else {
+                if (!filterDates.start.isSame(filterDates.end)) {
                     // This is a special case where a multi-line explanation has to be built
                     // All other cases need only one line
                     const firstLine = `${fieldName} date is between:`;
@@ -183,6 +180,9 @@ export abstract class DateField extends Field {
                     }
 
                     return new Explanation(firstLine, subExplanations);
+                } else {
+                    relationship = 'on';
+                    explanationDates = filterDates.start.format(dateFormat);
                 }
                 break;
         }

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -51,7 +51,12 @@ export abstract class DateField extends Field {
         }
 
         const fieldNameKeywordDate = Field.getMatch(this.filterRegExp(), line);
-        if (fieldNameKeywordDate !== null) {
+        if (fieldNameKeywordDate === null) {
+            return FilterOrErrorMessage.fromError(
+                line,
+                'do not understand query filter (' + this.fieldName() + ' date)',
+            );
+        } else {
             const keywordAndDateString = fieldNameKeywordDate[1]; // Will contain the whole line except the field name
             const fieldKeyword = fieldNameKeywordDate[2]; // Will be 'before', 'after', 'in', 'on' or undefined
             const fieldDateString = fieldNameKeywordDate[3]; // Will contain the remainder of the instruction
@@ -83,11 +88,6 @@ export abstract class DateField extends Field {
                 );
                 return FilterOrErrorMessage.fromFilter(new Filter(line, filterFunction, explanation));
             }
-        } else {
-            return FilterOrErrorMessage.fromError(
-                line,
-                'do not understand query filter (' + this.fieldName() + ' date)',
-            );
         }
     }
 

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -78,17 +78,17 @@ export abstract class DateField extends Field {
 
         if (!fieldDates.isValid()) {
             return FilterOrErrorMessage.fromError(line, 'do not understand ' + this.fieldName() + ' date');
-        } else {
-            const filterFunction = this.buildFilterFunction(fieldKeyword, fieldDates);
-
-            const explanation = DateField.buildExplanation(
-                this.fieldNameForExplanation(),
-                fieldKeyword,
-                this.filterResultIfFieldMissing(),
-                fieldDates,
-            );
-            return FilterOrErrorMessage.fromFilter(new Filter(line, filterFunction, explanation));
         }
+
+        const filterFunction = this.buildFilterFunction(fieldKeyword, fieldDates);
+
+        const explanation = DateField.buildExplanation(
+            this.fieldNameForExplanation(),
+            fieldKeyword,
+            this.filterResultIfFieldMissing(),
+            fieldDates,
+        );
+        return FilterOrErrorMessage.fromFilter(new Filter(line, filterFunction, explanation));
     }
 
     /**

--- a/src/Query/Filter/DateField.ts
+++ b/src/Query/Filter/DateField.ts
@@ -180,10 +180,10 @@ export abstract class DateField extends Field {
                     }
 
                     return new Explanation(firstLine, subExplanations);
-                } else {
-                    relationship = 'on';
-                    explanationDates = filterDates.start.format(dateFormat);
                 }
+
+                relationship = 'on';
+                explanationDates = filterDates.start.format(dateFormat);
                 break;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I stumbled on some if-else that could be simplified by reversing them and removing the else afterwards.

## Motivation and Context

Remove nesting levels and make the code easier to read.

## How has this been tested?

Unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
