### PR TITLE
feat: Add + sign to supported list markers

### DIFF
--- a/docs/Getting Started/Auto-Suggest.md
+++ b/docs/Getting Started/Auto-Suggest.md
@@ -33,7 +33,10 @@ Here is a more detailed walk through of the creation of a new task, which can be
 
     **Note**: the auto-suggest menu pops up only if the cursor is in a line that is recognized as a task, that is, the line contains:
 
-     - a bullet with a checkbox (`- [ ]` or `* [ ]`)
+     - a bullet with a checkbox, that is, one of:
+         - `- [ ]`
+         - `* [ ]`
+         - `+ [ ]`
      - and the global filter (if any)
 
 2. You can keep typing (to ignore the suggestions), or select one of the menu items in a variety of ways:
@@ -72,7 +75,7 @@ It triggers only on lines that will be recognised as tasks by the Tasks plugin:
 
 - If you use a global task filter, for example `#task`, you will need to provide `- [ ] #task` before the menu pops up.
 - If you don't use a global task filter, you will only need to provide `- [ ]` before the menu pops up.
-- It also recognises lists starting with asterisk (`*`) characters.
+- It also recognises lists starting with asterisk (`*`) and plus (`+`) characters.
 
 The menu is smart: it will only offer valid options:
 

--- a/docs/Getting Started/Getting Started.md
+++ b/docs/Getting Started/Getting Started.md
@@ -8,8 +8,29 @@ publish: true
 
 Tasks tracks your checklist items from your vault.
 The simplest way to create a new task is to create a new checklist item.
-The markdown syntax for checklist items is a list item that starts with spaced brackets: `- [ ] take out the trash`.
+The markdown syntax for checklist items is a list item that starts with spaced brackets:
+
+```text
+- [ ] take out the trash`
+```
+
 Now Tasks tracks that you need to take out the trash!
+
+> [!Info]
+> You can write tasks using any of the following list styles:
+>
+> ```text
+> - [ ] task starting with a hyphen
+>
+> * [ ] task starting with an asterisk
+>
+> + [ ] task starting with a plus sign
+>
+> 1. [ ] a task in a numbered list
+> ```
+
+> [!released]
+> Support for tasks with `+` was introduced in Tasks X.Y.Z.
 
 To list all open tasks in a markdown file, simply add a [[About Queries|query]] as a tasks code block like so:
 

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -6,6 +6,7 @@ publish: true
 
 ## What's New?
 
+- X.Y.Z: 🔥 Support task in list items starting with [[Getting Started#Finding tasks in your vault|`+` signs]]
 - 4.4.0: 🔥 Support [[Expressions#More complex expressions|variables, if statements, and functions]] in custom filters and groups
 - 4.3.0: 🔥 Bug fixes, usability improvements and `explain` support for [[Regular Expressions|regular expression]] searches
 - 4.2.0: 🔥 Add [[Custom Filters|custom filtering]]

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
@@ -65,10 +65,14 @@ Work through all the tasks below, until zero tasks remain in this query:
 
 ### Un-completion of tasks
 
-- [x] #task Mark this task not complete in **Source view** using **Tasks: Toggle task done** command ✅ 2022-07-05
-- [x] #task Mark this task not complete by clicking on it in **Reading view** ✅ 2022-07-05
-- [x] #task Mark this task not complete by clicking on it in **Live Preview** ✅ 2022-07-05
-- [ ] #task **check**: Checked all above methods for **un-completing tasks** - and they worked
+<!-- markdownlint-disable ul-style -->
+
+* [x] #task Mark this task not complete in **Source view** using **Tasks: Toggle task done** command ✅ 2022-07-05
+* [x] #task Mark this task not complete by clicking on it in **Reading view** ✅ 2022-07-05
+* [x] #task Mark this task not complete by clicking on it in **Live Preview** ✅ 2022-07-05
+* [ ] #task **check**: Checked all above methods for **un-completing tasks** - and they worked
+
+<!-- markdownlint-enable ul-style -->
 
 ### Recurring Tasks
 
@@ -88,9 +92,13 @@ Confirm that when a recurring task is completed, a new task is created, all the 
 
 Steps to do:
 
-- [ ] #task View this file in **Reading view** and confirm that the tasks in this section are listed
-- [ ] #task View this file in **Live Preview** and confirm that the tasks in this section are listed
-- [ ] #task **check**: Checked all above steps for **viewing task blocks** worked
+<!-- markdownlint-disable ul-style -->
+
++ [ ] #task View this file in **Reading view** and confirm that the tasks in this section are listed
++ [ ] #task View this file in **Live Preview** and confirm that the tasks in this section are listed
++ [ ] #task **check**: Checked all above steps for **viewing task blocks** worked
+
+<!-- markdownlint-enable ul-style -->
 
 ---
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -42,8 +42,8 @@ export class TaskRegularExpressions {
     // Matches indentation before a list marker (including > for potentially nested blockquotes or Obsidian callouts)
     public static readonly indentationRegex = /^([\s\t>]*)/;
 
-    // Matches - or * list markers, or numbered list markers (eg 1.)
-    public static readonly listMarkerRegex = /([-*]|[0-9]+\.)/;
+    // Matches - * and + list markers, or numbered list markers (eg 1.)
+    public static readonly listMarkerRegex = /([-*+]|[0-9]+\.)/;
 
     // Matches a checkbox and saves the status character inside
     public static readonly checkboxRegex = /\[(.)\]/u;

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -53,6 +53,21 @@ describe('parsing', () => {
         expect(task!.originalMarkdown).toStrictEqual(line);
     });
 
+    it('parses a task from a line starting with plus sign', () => {
+        // Arrange
+        const line = '+ [ ] this is a task in asterisk list';
+
+        // Act
+        const task = fromLine({
+            line,
+        });
+
+        // Assert
+        expect(task).not.toBeNull();
+        expect(task!.listMarker).toEqual('+');
+        expect(task!.originalMarkdown).toStrictEqual(line);
+    });
+
     it('parses a task from a line (numbered)', () => {
         // Arrange
         const line = '1. [x] this is a done task';
@@ -85,6 +100,19 @@ describe('parsing', () => {
         expect(task!.description).toEqual('this is a todo task');
         expect(task!.status).toStrictEqual(Status.TODO);
         expect(task!.originalMarkdown).toStrictEqual(line);
+    });
+
+    it('done not parse a task from a line starting with @ sign', () => {
+        // Arrange
+        const line = '@ [ ] this is a task in asterisk list';
+
+        // Act
+        const task = fromLine({
+            line,
+        });
+
+        // Assert
+        expect(task).toBeNull();
     });
 
     it('supports capitalised status characters', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Adds support for `+` sign as a list marker
- Updates the docs
- Updates the smoke test, to ensure that this is tested periodically

For example:

```text
+ [ ] #task View this file in **Reading view** and confirm that the tasks in this section are listed
+ [ ] #task View this file in **Live Preview** and confirm that the tasks in this section are listed
+ [ ] #task **check**: Checked all above steps for **viewing task blocks** worked
```

## Motivation and Context

Fixes #2192 - which contains background info

I learned that:

> `+` is in a very convenient spot on a German keyboard

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Running existing Jest tests
- Adding new tests
- Adding examples of `*` and `+` lines to the smoke tests
- Running the smoke tests
- Manual exploratory testing

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
