### PR TITLE
docs: Add a Tags page, to help with FAQs

### DIFF
--- a/docs/Getting Started/Tags.md
+++ b/docs/Getting Started/Tags.md
@@ -1,0 +1,116 @@
+---
+publish: true
+---
+
+# Tags
+
+## What are tags?
+
+The Obsidian [Tags documentation](https://help.obsidian.md/Editing+and+formatting/Tags) says:
+
+> [!Quote]
+> Tags are keywords or topics that help you quickly find the notes you want.<br>
+> To create a tag, enter a hashtag symbol (#) in the editor, followed by a keyword. For example, `#meeting`.
+
+## Why use tags?
+
+Selection of tags is of course a personal decision.
+
+But here are some examples of tags that might be useful in conjunction with Tasks:
+
+- For [Getting Things Done/GTD](https://en.wikipedia.org/wiki/Getting_Things_Done) concepts, such as context:
+  - `#context/work`, `#context/home/ground-floor`
+- Things to do at the start and end of the day
+  - `#when/morning`, `#when/evening`
+- Categorisation:
+  - `#🏢/companyA`
+
+## Tasks and your task lines
+
+### The simple case
+
+If you keep your tags to a hashtag symbol (`#`) followed by any of the following characters, you can ignore the detail in the [[#Recognising Tags]] section below.
+
+- Alphabetical letters
+- Underscore (`_`)
+- Hyphen (`-`)
+- Forward slash (`/`)
+
+### Recognising Tags
+
+There are some important differences in how Obsidian and Tasks recognise tags.
+
+> [!Info]
+> We are tracking these differences in [issue #929](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/929).<br>
+> It is currently undecided whether tag recognition in Tasks will ever be modified to be more consistent with Obsidian.
+
+| Situation                                  | Obsidian                                                                                                                                                                                                                                                                                                                                                                              | Tasks plugin                                                                                                                |
+|--------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Characters allowed in tags                 | <p>See Obsidian's [Tag format](https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format)</p><ul><li>Alphabetical letters</li><li>Numbers</li><li>Underscore (`_`)</li><li>Hyphen (`-`)</li><li>Forward slash (`/`) for [Nested tags](https://help.obsidian.md/Editing+and+formatting/Tags#Nested+tags)</li></ul><p>Tags must contain at least one non-numerical character.</p> | <p>Any characters **except** the following</p><ul><li><tt>space</tt></li><li><tt>!@#$%^&*(),.?":{}\|&lt;&gt;</tt></li></ul> |
+| Number-only tags                           | Tags must contain at least one non-numerical character.<br>So `#1234` is **not** recognised a tag.                                                                                                                                                                                                                                                                                    | No restriction on all-digit tags.<br>So `#1234` **is** recognised as a tag.                                                 |
+| Tags that look like floating-point numbers | Tags must contain at least one non-numerical character.<br>So `#12.34` is **not** recognised a tag.                                                                                                                                                                                                                                                                                   | No restriction on all-digit tags, but `.` is not allowed in tags.<br>So `#12.34` is treated as a tag `#12`.                 |
+| Tag-like text in `%%` comments             | Ignored                                                                                                                                                                                                                                                                                                                                                                               | Recognised                                                                                                                  |
+| Tag-like text in `<!-- .... -->`  comments | Ignored                                                                                                                                                                                                                                                                                                                                                                               | Recognised                                                                                                                  |
+
+### Using tags in YAML, Frontmatter or file Properties
+
+Obsidian allows [properties](https://help.obsidian.md/Editing+and+formatting/Properties) to be added at the start of notes.
+
+These properties are also referred to as Frontmatter or YAML.
+
+Here is an example, using tags:
+
+```text
+---
+tags:
+ - 🏷/some_tag
+ - 🏢/companyA
+---
+```
+
+Tasks does not currently read this data. We are tracking this in [discussion #232](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/232).
+
+For now, see [Find tasks in notes with particular tag](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/resources/sample_vaults/Tasks-Demo/How%20To/Find%20tasks%20in%20notes%20with%20particular%20tag.md) for a workaround using [[Dataview]] and Tasks together.
+
+### Order of tags in task lines
+
+- Tags can go in any place in any order on the task.
+  - They can be mixed among your signifiers (due, priority etc).
+  - See [[Auto-Suggest#What do I need to know about the order of items in a task?|What do I need to know about the order of items in a task?]]
+- However, when lines are edited by Tasks (for example, via the [[Create or edit Task|‘Create or edit Task’ Modal]], or when a task is completed), the tags may get moved.
+
+## Limitations
+
+- The Description field in the [[Create or edit Task|‘Create or edit Task’ Modal]] does not give any help completing tags as you type them.
+  - We are tracking this in [discussion #229](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/229).
+- If you use a tag for the global filter, do not include it in your searches.
+- Tasks does not read tags (or any other information) from file Frontmatter/YAML/Properties: tag values are only read from task lines
+  - We are tracking this in [discussion #232](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/232).
+  - See [[#Using tags in YAML, Frontmatter or file Properties]] above for a dataview-assisted workaround.
+
+## Tags and the Global Filter
+
+> [!Warning]
+> If the [[Global Filter]] is enabled, and is a tag, **do not use that global filter tag in your Tasks searches**.
+> Global filter tags are removed when reading task lines, so you will not get the results you might expect.
+
+## Related Tasks Block Instructions
+
+The following instructions use any tags on task lines.
+
+- `no tags`
+- `has tags`
+- `tags (include|do not include) <tag>` _or_
+- `tag (includes|does not include) <tag>`
+- `tags (regex matches|regex does not match) /<JavaScript-style Regex>/` _or_
+- `tag (regex matches|regex does not match) /<JavaScript-style Regex>/`
+  - [[Filters#Tags|Documentation]]
+- `sort by tag`
+- `sort by tag 2`
+  - [[Sorting#Tags|Documentation]]
+- `group by tags`
+  - [[Grouping#Tags|Documentation]]
+- `hide tags`
+  - [[Layout|Documentation]]
+- Accessible as `task.tags` in custom filters and groups
+  - [[Task Properties#Values for Other Task Properties|Documentation]]

--- a/docs/Queries/Filters.md
+++ b/docs/Queries/Filters.md
@@ -897,6 +897,8 @@ Using `task.recurrenceRule` - please read [[Task Properties#Values for Other Tas
 > [!released]
 Introduced in Tasks 1.6.0.
 
+See [[Tags]] for important information about how tags behave in the Tasks plugin.
+
 - `no tags`
 - `has tags`
 - `tags (include|do not include) <tag>` _or_

--- a/docs/Queries/Grouping.md
+++ b/docs/Queries/Grouping.md
@@ -440,6 +440,8 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by recurrence** is now 
 
 ### Tags
 
+See [[Tags]] for important information about how tags behave in the Tasks plugin.
+
 - `group by tags`
   - The tags of the tasks or `(No tags)`. If the task has multiple tags, it will show up under every tag.
 

--- a/docs/Queries/Layout.md
+++ b/docs/Queries/Layout.md
@@ -28,8 +28,9 @@ The following elements exist:
 >
 > 1. Only tags recognised by Obsidian are hidden with `hide tags`.
 >     - Tasks is a bit more relaxed in recognising tags than Obsidian. For example,  `#123` is treated as a tag by Tasks, and so is included in Tasks' searches, sorting and grouping code.
->     - However, `#123` is [not recognised a valid Obsidian tag](https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format) and so not hidden.
-> 2. It is not possible to hide or show individual tags. We are tracking this in [discussion #848](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/848).
+>     - However, `#123` is [not recognised as a valid Obsidian tag](https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format) and so not hidden.
+>     - See [[Tags#Recognising Tags]] for more information.
+> 1. It is not possible to hide or show individual tags. We are tracking this in [discussion #848](https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/848).
 
 > [!released]
 `urgency` was introduced in Tasks 1.14.0.<br>

--- a/docs/Queries/Sorting.md
+++ b/docs/Queries/Sorting.md
@@ -98,6 +98,8 @@ For more information, including adding your own customised statuses, see [[Statu
 
 ### Tags
 
+See [[Tags]] for important information about how tags behave in the Tasks plugin.
+
 - `sort by tag` (the description of the task)
 
 If you want to sort by tags, by default it will sort by the first tag found in the description. If you want to sort by a tag that comes after that then you can specify the index at the end of the query. All tasks should have the same amount of tags for optimal sorting and the tags in the same order. The index starts from 1 which is also the default.

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -93,6 +93,8 @@ export class TaskRegularExpressions {
     // EXAMPLE:
     // description: '#dog #car http://www/ddd#ere #house'
     // matches: #dog, #car, #house
+    // MAINTENANCE NOTE:
+    //  If hashTags is modified, please update 'Recognising Tags' in Tags.md in the docs.
     public static readonly hashTags = /(^|\s)#[^ !@#$%^&*(),.?":{}|<>]+/g;
     public static readonly hashTagsFromEnd = new RegExp(this.hashTags.source + '$');
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This adds new Tags page, in Getting Started, with info about using Tags in Tasks.

It also adds a few links to the new page, elsewhere in the docs.

## Motivation and Context

It's a bit detailed for Getting Started, maybe, but contains info that is requested a lot.

## How has this been tested?

- Viewing the edits in Obsidian
- Some proof-reading done by SonarLint and WebStorm

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
