### PR TITLE
refactor: simplify `getTaskComponentClass()`

### DIFF
--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -266,8 +266,6 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
             break;
         case 'createdDate':
         case 'dueDate':
-            addGenericDateClasses(task[component], LayoutClasses[component]);
-            break;
         case 'startDate':
             addGenericDateClasses(task[component], LayoutClasses[component]);
             break;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -245,8 +245,7 @@ async function renderComponentText(
 export type AttributesDictionary = { [key: string]: string };
 
 /**
- * The genericClasses describe what the component is, e.g. a due date or a priority, and are one of the
- * options in LayoutClasses.
+ * The CSS class that describes what the component is, e.g. a due date or a priority, and is a value from LayoutClasses.
  */
 function getTaskComponentClass(component: TaskLayoutComponent, task: Task) {
     const taskClasses: string[] = [];

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -261,30 +261,24 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
     switch (component) {
         case 'description':
         case 'priority':
-        case 'recurrenceRule': {
+        case 'recurrenceRule':
             taskClasses.push(LayoutClasses[component]);
             break;
-        }
-        case 'createdDate': {
+        case 'createdDate':
             addGenericDateClasses(task[component], LayoutClasses[component]);
             break;
-        }
-        case 'dueDate': {
+        case 'dueDate':
             addGenericDateClasses(task[component], LayoutClasses[component]);
             break;
-        }
-        case 'startDate': {
+        case 'startDate':
             addGenericDateClasses(task[component], LayoutClasses[component]);
             break;
-        }
-        case 'scheduledDate': {
+        case 'scheduledDate':
             addGenericDateClasses(task[component], LayoutClasses[component]);
             break;
-        }
-        case 'doneDate': {
+        case 'doneDate':
             addGenericDateClasses(task[component], LayoutClasses[component]);
             break;
-        }
     }
     return taskClasses;
 }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -260,11 +260,8 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
     // Update "generic" classes
     switch (component) {
         case 'description':
+        case 'priority':
         case 'recurrenceRule': {
-            taskClasses.push(LayoutClasses[component]);
-            break;
-        }
-        case 'priority': {
             taskClasses.push(LayoutClasses[component]);
             break;
         }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -268,8 +268,6 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
         case 'dueDate':
         case 'startDate':
         case 'scheduledDate':
-            addGenericDateClasses(task[component], LayoutClasses[component]);
-            break;
         case 'doneDate':
             addGenericDateClasses(task[component], LayoutClasses[component]);
             break;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -251,12 +251,6 @@ export type AttributesDictionary = { [key: string]: string };
 function getTaskClasses(component: TaskLayoutComponent, task: Task) {
     const taskClasses: string[] = [];
 
-    function addGenericDateClasses(date: moment.Moment | null, classes: string) {
-        if (date) {
-            taskClasses.push(classes);
-        }
-    }
-
     // Update "generic" classes
     switch (component) {
         case 'description':
@@ -269,7 +263,9 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
         case 'startDate':
         case 'scheduledDate':
         case 'doneDate':
-            addGenericDateClasses(task[component], LayoutClasses[component]);
+            if (task[component]) {
+                taskClasses.push(LayoutClasses[component]);
+            }
             break;
     }
     return taskClasses;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -263,7 +263,8 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
         case 'startDate':
         case 'scheduledDate':
         case 'doneDate': {
-            if (task[component]) {
+            const date = task[component];
+            if (date) {
                 taskClasses.push(LayoutClasses[component]);
             }
             break;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -161,7 +161,7 @@ async function taskToHtml(
                 );
                 addInternalClasses(component, internalSpan);
 
-                // Add the generic classes that apply to what this component is (priority, due date etc)
+                // Add the component's CSS class describing what this component is (priority, due date etc)
                 const componentClass = getTaskComponentClass(component, task);
                 span.classList.add(...componentClass);
 

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -274,7 +274,7 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'startDate': {
-            addGenericDateClasses(task.startDate, LayoutClasses[component]);
+            addGenericDateClasses(task[component], LayoutClasses[component]);
             break;
         }
         case 'scheduledDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -266,7 +266,7 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'createdDate': {
-            addGenericDateClasses(task.createdDate, LayoutClasses[component]);
+            addGenericDateClasses(task[component], LayoutClasses[component]);
             break;
         }
         case 'dueDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -251,7 +251,6 @@ export type AttributesDictionary = { [key: string]: string };
 function getTaskClasses(component: TaskLayoutComponent, task: Task) {
     const taskClasses: string[] = [];
 
-    // Update "generic" classes
     const componentClass = LayoutClasses[component];
     switch (component) {
         case 'description':

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -265,8 +265,6 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
             taskClasses.push(LayoutClasses[component]);
             break;
         case 'createdDate':
-            addGenericDateClasses(task[component], LayoutClasses[component]);
-            break;
         case 'dueDate':
             addGenericDateClasses(task[component], LayoutClasses[component]);
             break;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -252,11 +252,12 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
     const taskClasses: string[] = [];
 
     // Update "generic" classes
+    const componentClass = LayoutClasses[component];
     switch (component) {
         case 'description':
         case 'priority':
         case 'recurrenceRule':
-            taskClasses.push(LayoutClasses[component]);
+            taskClasses.push(componentClass);
             break;
         case 'createdDate':
         case 'dueDate':
@@ -265,7 +266,7 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
         case 'doneDate': {
             const date = task[component];
             if (date) {
-                taskClasses.push(LayoutClasses[component]);
+                taskClasses.push(componentClass);
             }
             break;
         }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -270,7 +270,7 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'dueDate': {
-            addGenericDateClasses(task.dueDate, LayoutClasses[component]);
+            addGenericDateClasses(task[component], LayoutClasses[component]);
             break;
         }
         case 'startDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -162,7 +162,7 @@ async function taskToHtml(
                 addInternalClasses(component, internalSpan);
 
                 // Add the generic classes that apply to what this component is (priority, due date etc)
-                const taskClasses = getTaskClasses(component, task);
+                const taskClasses = getTaskComponentClass(component, task);
                 span.classList.add(...taskClasses);
 
                 // Add the attributes to the component ('priority-medium', 'due-past-1d' etc)
@@ -248,7 +248,7 @@ export type AttributesDictionary = { [key: string]: string };
  * The genericClasses describe what the component is, e.g. a due date or a priority, and are one of the
  * options in LayoutClasses.
  */
-function getTaskClasses(component: TaskLayoutComponent, task: Task) {
+function getTaskComponentClass(component: TaskLayoutComponent, task: Task) {
     const taskClasses: string[] = [];
 
     const componentClass = LayoutClasses[component];

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -248,14 +248,14 @@ export type AttributesDictionary = { [key: string]: string };
  * The CSS class that describes what the component is, e.g. a due date or a priority, and is a value from LayoutClasses.
  */
 function getTaskComponentClass(component: TaskLayoutComponent, task: Task) {
-    const taskClasses: string[] = [];
+    const componentClassContainer: string[] = [];
 
     const componentClass = LayoutClasses[component];
     switch (component) {
         case 'description':
         case 'priority':
         case 'recurrenceRule':
-            taskClasses.push(componentClass);
+            componentClassContainer.push(componentClass);
             break;
         case 'createdDate':
         case 'dueDate':
@@ -264,12 +264,12 @@ function getTaskComponentClass(component: TaskLayoutComponent, task: Task) {
         case 'doneDate': {
             const date = task[component];
             if (date) {
-                taskClasses.push(componentClass);
+                componentClassContainer.push(componentClass);
             }
             break;
         }
     }
-    return taskClasses;
+    return componentClassContainer;
 }
 
 /**

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -267,8 +267,6 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
         case 'createdDate':
         case 'dueDate':
         case 'startDate':
-            addGenericDateClasses(task[component], LayoutClasses[component]);
-            break;
         case 'scheduledDate':
             addGenericDateClasses(task[component], LayoutClasses[component]);
             break;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -161,7 +161,7 @@ async function taskToHtml(
                 );
                 addInternalClasses(component, internalSpan);
 
-                // Add the component's CSS class describing what this component is (priority, due date etc)
+                // Add the component's CSS class describing what this component is (priority, due date etc.)
                 const componentClass = getTaskComponentClass(component, task);
                 span.classList.add(...componentClass);
 

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -249,11 +249,11 @@ export type AttributesDictionary = { [key: string]: string };
  * options in LayoutClasses.
  */
 function getTaskClasses(component: TaskLayoutComponent, task: Task) {
-    const genericClasses: string[] = [];
+    const taskClasses: string[] = [];
 
     function addGenericDateClasses(date: moment.Moment | null, classes: string) {
         if (date) {
-            genericClasses.push(classes);
+            taskClasses.push(classes);
         }
     }
 
@@ -261,11 +261,11 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
     switch (component) {
         case 'description':
         case 'recurrenceRule': {
-            genericClasses.push(LayoutClasses[component]);
+            taskClasses.push(LayoutClasses[component]);
             break;
         }
         case 'priority': {
-            genericClasses.push(LayoutClasses[component]);
+            taskClasses.push(LayoutClasses[component]);
             break;
         }
         case 'createdDate': {
@@ -289,7 +289,7 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
             break;
         }
     }
-    return genericClasses;
+    return taskClasses;
 }
 
 /**

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -278,7 +278,7 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'scheduledDate': {
-            addGenericDateClasses(task.scheduledDate, LayoutClasses[component]);
+            addGenericDateClasses(task[component], LayoutClasses[component]);
             break;
         }
         case 'doneDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -262,11 +262,12 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
         case 'dueDate':
         case 'startDate':
         case 'scheduledDate':
-        case 'doneDate':
+        case 'doneDate': {
             if (task[component]) {
                 taskClasses.push(LayoutClasses[component]);
             }
             break;
+        }
     }
     return taskClasses;
 }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -162,8 +162,8 @@ async function taskToHtml(
                 addInternalClasses(component, internalSpan);
 
                 // Add the generic classes that apply to what this component is (priority, due date etc)
-                const taskClasses = getTaskComponentClass(component, task);
-                span.classList.add(...taskClasses);
+                const componentClass = getTaskComponentClass(component, task);
+                span.classList.add(...componentClass);
 
                 // Add the attributes to the component ('priority-medium', 'due-past-1d' etc)
                 const dataAttributes = getTaskDataAttributes(component, task);

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -252,6 +252,8 @@ function getTaskComponentClass(component: TaskLayoutComponent, task: Task) {
 
     const componentClass = LayoutClasses[component];
     switch (component) {
+        case 'blockLink':
+            break;
         case 'description':
         case 'priority':
         case 'recurrenceRule':

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -282,7 +282,7 @@ function getTaskClasses(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'doneDate': {
-            addGenericDateClasses(task.doneDate, LayoutClasses[component]);
+            addGenericDateClasses(task[component], LayoutClasses[component]);
             break;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Pure refactor, Arlo's commit notation used, continuation on #2226 .

## Motivation and Context

Make simpler code - unify same cases and ease new date introduction mentioned in #2226 (Now there is just one line needed: `case newDate:`.

See whether making PR's with this new notation will be easier for the maintainer to review.

## How has this been tested?

Breaking code at `-` steps to have failing tests. Unit testing.

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
