### PR TITLE
test: Add tests for logic in EditorSuggestor.onTrigger()

### DIFF
--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -10,6 +10,15 @@ export type SuggestInfoWithContext = SuggestInfo & {
     context: EditorSuggestContext;
 };
 
+/**
+ * Return a truthy if the Auto-Suggest menu may be shown on the current line,
+ * and a falsy value otherwise.
+ *
+ * This checks for simple pre-conditions:
+ *  - Is the global filter (if set) in the line?
+ *  - Is the line a task line (with a checkbox)
+ * @param line
+ */
 function canSuggestForLine(line: string) {
     return GlobalFilter.includedIn(line) && line.match(task.TaskRegularExpressions.taskRegex);
 }

--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -1,27 +1,12 @@
 import { App, Editor, EditorSuggest, TFile } from 'obsidian';
 import type { EditorPosition, EditorSuggestContext, EditorSuggestTriggerInfo } from 'obsidian';
-
-import { GlobalFilter } from '../Config/GlobalFilter';
 import { type Settings, getUserSelectedTaskFormat } from '../Config/Settings';
-import * as task from '../Task';
+import { canSuggestForLine } from './Suggestor';
 import type { SuggestInfo } from '.';
 
 export type SuggestInfoWithContext = SuggestInfo & {
     context: EditorSuggestContext;
 };
-
-/**
- * Return a truthy if the Auto-Suggest menu may be shown on the current line,
- * and a falsy value otherwise.
- *
- * This checks for simple pre-conditions:
- *  - Is the global filter (if set) in the line?
- *  - Is the line a task line (with a checkbox)
- * @param line
- */
-function canSuggestForLine(line: string) {
-    return GlobalFilter.includedIn(line) && line.match(task.TaskRegularExpressions.taskRegex);
-}
 
 export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
     private settings: Settings;

--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -10,6 +10,10 @@ export type SuggestInfoWithContext = SuggestInfo & {
     context: EditorSuggestContext;
 };
 
+function canSuggestForLine(line: string) {
+    return GlobalFilter.includedIn(line) && line.match(task.TaskRegularExpressions.taskRegex);
+}
+
 export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
     private settings: Settings;
 
@@ -21,7 +25,7 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
     onTrigger(cursor: EditorPosition, editor: Editor, _file: TFile): EditorSuggestTriggerInfo | null {
         if (!this.settings.autoSuggestInEditor) return null;
         const line = editor.getLine(cursor.line);
-        if (GlobalFilter.includedIn(line) && line.match(task.TaskRegularExpressions.taskRegex)) {
+        if (canSuggestForLine(line)) {
             return {
                 start: { line: cursor.line, ch: 0 },
                 end: {

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -404,8 +404,8 @@ export function onlySuggestIfBracketOpen(fn: SuggestionBuilder, brackets: [strin
 }
 
 /**
- * Return a truthy if the Auto-Suggest menu may be shown on the current line,
- * and a falsy value otherwise.
+ * Return true if the Auto-Suggest menu may be shown on the current line,
+ * and false value otherwise.
  *
  * This checks for simple pre-conditions:
  *  - Is the global filter (if set) in the line?
@@ -413,5 +413,5 @@ export function onlySuggestIfBracketOpen(fn: SuggestionBuilder, brackets: [strin
  * @param line
  */
 export function canSuggestForLine(line: string) {
-    return GlobalFilter.includedIn(line) && line.match(task.TaskRegularExpressions.taskRegex);
+    return GlobalFilter.includedIn(line) && line.match(task.TaskRegularExpressions.taskRegex) !== null;
 }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -3,7 +3,9 @@ import { DateParser } from '../Query/DateParser';
 import { doAutocomplete } from '../DateAbbreviations';
 import { Recurrence } from '../Recurrence';
 import type { DefaultTaskSerializerSymbols } from '../TaskSerializer/DefaultTaskSerializer';
+import * as task from '../Task';
 import { TaskRegularExpressions } from '../Task';
+import { GlobalFilter } from '../Config/GlobalFilter';
 import type { SuggestInfo, SuggestionBuilder } from '.';
 
 /**
@@ -399,4 +401,17 @@ export function onlySuggestIfBracketOpen(fn: SuggestionBuilder, brackets: [strin
         }
         return fn(line, cursorPos, settings);
     };
+}
+
+/**
+ * Return a truthy if the Auto-Suggest menu may be shown on the current line,
+ * and a falsy value otherwise.
+ *
+ * This checks for simple pre-conditions:
+ *  - Is the global filter (if set) in the line?
+ *  - Is the line a task line (with a checkbox)
+ * @param line
+ */
+export function canSuggestForLine(line: string) {
+    return GlobalFilter.includedIn(line) && line.match(task.TaskRegularExpressions.taskRegex);
 }

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -235,7 +235,7 @@ describe('canSuggestForLine', () => {
 
     it('should suggest if global filter missing from line', () => {
         GlobalFilter.set('#todo');
-        expect(canSuggestForLine('- [ ] #todo has global filter')).toBeTruthy();
+        expect(canSuggestForLine('- [ ] #todo has global filter')).toEqual(true);
     });
 
     it('should not suggest if global filter missing from line', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -233,6 +233,11 @@ describe('canSuggestForLine', () => {
         GlobalFilter.reset();
     });
 
+    it('should suggest if there is no global filter', () => {
+        GlobalFilter.reset();
+        expect(canSuggestForLine('- [ ] global filter is not set')).toEqual(true);
+    });
+
     it('should suggest if global filter missing from line', () => {
         GlobalFilter.set('#todo');
         expect(canSuggestForLine('- [ ] #todo has global filter')).toEqual(true);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -233,6 +233,11 @@ describe('canSuggestForLine', () => {
         GlobalFilter.reset();
     });
 
+    it('should suggest if global filter missing from line', () => {
+        GlobalFilter.set('#todo');
+        expect(canSuggestForLine('- [ ] #todo has global filter')).toBeTruthy();
+    });
+
     it('should not suggest if global filter missing from line', () => {
         GlobalFilter.set('#todo');
         expect(canSuggestForLine('- [ ] no global filter')).toEqual(false);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -5,10 +5,15 @@ import moment from 'moment';
 import * as chrono from 'chrono-node';
 import { getSettings } from '../../src/Config/Settings';
 import type { SuggestInfo, SuggestionBuilder } from '../../src/Suggestor';
-import { makeDefaultSuggestionBuilder, onlySuggestIfBracketOpen } from '../../src/Suggestor/Suggestor';
+import {
+    canSuggestForLine,
+    makeDefaultSuggestionBuilder,
+    onlySuggestIfBracketOpen,
+} from '../../src/Suggestor/Suggestor';
 import { DEFAULT_SYMBOLS } from '../../src/TaskSerializer/DefaultTaskSerializer';
 import { DATAVIEW_SYMBOLS } from '../../src/TaskSerializer/DataviewTaskSerializer';
 import { MarkdownTable } from '../TestingTools/VerifyMarkdownTable';
+import { GlobalFilter } from '../../src/Config/GlobalFilter';
 
 window.moment = moment;
 
@@ -220,5 +225,16 @@ describe('onlySuggestIfBracketOpen', () => {
     it("should not suggest if there's no open bracket at cursor position", () => {
         const suggestions = buildSuggestions(...cursorPosition('(hello world)|'), getSettings());
         expect(suggestions).toEqual(emptySuggestion);
+    });
+});
+
+describe('canSuggestForLine', () => {
+    afterEach(() => {
+        GlobalFilter.reset();
+    });
+
+    it('should not suggest if global filter missing from line', () => {
+        GlobalFilter.set('#todo');
+        expect(canSuggestForLine('- [ ] no global filter')).toEqual(false);
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I want to change the behaviour of `EditorSuggestor.onTrigger()` to stop the Auto Suggest menu popping up in inconvenient locations like in the middle of a checkbox, or the start of the line.

Before doing so, this PR adds tests for the existing logic, by separating it out to a new function `canSuggestForLine()`, which is in `Suggestor.ts` so that it can be called from test code.

## Motivation and Context

See above.

## How has this been tested?

- By adding tests
- By running the changed code in the Tasks-Demo test vault, to confirm that the behaviour is unchanged.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->



- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
