### PR TITLE
refactor: separate concerns in `TaskLayout.ApplyOptions()`

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -218,7 +218,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         const layout = new TaskLayout(this.query.layoutOptions);
         const taskList = content.createEl('ul');
         taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);
-        taskList.addClasses(layout.taskListClasses);
+        taskList.addClasses(layout.taskListHiddenClasses);
         const groupingAttribute = this.getGroupingAttribute();
         if (groupingAttribute && groupingAttribute.length > 0) taskList.dataset.taskGroupBy = groupingAttribute;
         for (let i = 0; i < tasksCount; i++) {

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -100,9 +100,10 @@ export class TaskLayout {
             this.taskListClasses.push(`tasks-layout-hide-${component}`);
         }
     }
-    // Remove a component from the taskComponents array if the given layoutOption criteria is met,
-    // and add to the layout's specific classes list the class that denotes that this component
-    // isn't in the layout
+
+    /**
+     * Move a component from the shown to hidden if the given layoutOption criteria is met.
+     */
     private hideComponent(hide: boolean, component: TaskLayoutComponent) {
         if (hide) {
             this.hiddenTaskLayoutComponents.push(component);

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -65,9 +65,7 @@ export class TaskLayout {
     private applyOptions() {
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
-        const hide = this.options.hidePriority;
-        const component = 'priority';
-        const hideAndGenerateClasses: [boolean, TaskLayoutComponent][] = [[hide, component]];
+        const hideAndGenerateClasses: [boolean, TaskLayoutComponent][] = [[this.options.hidePriority, 'priority']];
         for (const [hide, component] of hideAndGenerateClasses) {
             this.hideComponent(hide, component);
             this.generateHiddenClassForTaskList(hide, component);

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -70,45 +70,42 @@ export class TaskLayout {
         // Remove a component from the taskComponents array if the given layoutOption criteria is met,
         // and add to the layout's specific classes list the class that denotes that this component
         // isn't in the layout
-        const removeIf = (
-            taskComponents: TaskLayoutComponent[],
-            shouldRemove: boolean,
-            componentToRemove: TaskLayoutComponent,
-        ) => {
-            return this.removeIf2(shouldRemove, componentToRemove, taskComponents);
-        };
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
-        this.shownTaskLayoutComponents = removeIf(
-            this.shownTaskLayoutComponents,
+        this.shownTaskLayoutComponents = this.removeIf2(
             layoutOptions.hidePriority,
             'priority',
-        );
-        this.shownTaskLayoutComponents = removeIf(
             this.shownTaskLayoutComponents,
+        );
+        this.shownTaskLayoutComponents = this.removeIf2(
             layoutOptions.hideRecurrenceRule,
             'recurrenceRule',
-        );
-        this.shownTaskLayoutComponents = removeIf(
             this.shownTaskLayoutComponents,
+        );
+        this.shownTaskLayoutComponents = this.removeIf2(
             layoutOptions.hideCreatedDate,
             'createdDate',
-        );
-        this.shownTaskLayoutComponents = removeIf(
             this.shownTaskLayoutComponents,
+        );
+        this.shownTaskLayoutComponents = this.removeIf2(
             layoutOptions.hideStartDate,
             'startDate',
-        );
-        this.shownTaskLayoutComponents = removeIf(
             this.shownTaskLayoutComponents,
+        );
+        this.shownTaskLayoutComponents = this.removeIf2(
             layoutOptions.hideScheduledDate,
             'scheduledDate',
-        );
-        this.shownTaskLayoutComponents = removeIf(this.shownTaskLayoutComponents, layoutOptions.hideDueDate, 'dueDate');
-        this.shownTaskLayoutComponents = removeIf(
             this.shownTaskLayoutComponents,
+        );
+        this.shownTaskLayoutComponents = this.removeIf2(
+            layoutOptions.hideDueDate,
+            'dueDate',
+            this.shownTaskLayoutComponents,
+        );
+        this.shownTaskLayoutComponents = this.removeIf2(
             layoutOptions.hideDoneDate,
             'doneDate',
+            this.shownTaskLayoutComponents,
         );
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
 

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -69,41 +69,13 @@ export class TaskLayout {
     applyOptions(layoutOptions: LayoutOptions): TaskLayoutComponent[] {
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
-        this.shownTaskLayoutComponents = this.removeIf2(
-            layoutOptions.hidePriority,
-            'priority',
-            this.shownTaskLayoutComponents,
-        );
-        this.shownTaskLayoutComponents = this.removeIf2(
-            layoutOptions.hideRecurrenceRule,
-            'recurrenceRule',
-            this.shownTaskLayoutComponents,
-        );
-        this.shownTaskLayoutComponents = this.removeIf2(
-            layoutOptions.hideCreatedDate,
-            'createdDate',
-            this.shownTaskLayoutComponents,
-        );
-        this.shownTaskLayoutComponents = this.removeIf2(
-            layoutOptions.hideStartDate,
-            'startDate',
-            this.shownTaskLayoutComponents,
-        );
-        this.shownTaskLayoutComponents = this.removeIf2(
-            layoutOptions.hideScheduledDate,
-            'scheduledDate',
-            this.shownTaskLayoutComponents,
-        );
-        this.shownTaskLayoutComponents = this.removeIf2(
-            layoutOptions.hideDueDate,
-            'dueDate',
-            this.shownTaskLayoutComponents,
-        );
-        this.shownTaskLayoutComponents = this.removeIf2(
-            layoutOptions.hideDoneDate,
-            'doneDate',
-            this.shownTaskLayoutComponents,
-        );
+        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hidePriority, 'priority');
+        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hideRecurrenceRule, 'recurrenceRule');
+        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hideCreatedDate, 'createdDate');
+        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hideStartDate, 'startDate');
+        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hideScheduledDate, 'scheduledDate');
+        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hideDueDate, 'dueDate');
+        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hideDoneDate, 'doneDate');
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
 
         this.markHiddenQueryComponents(layoutOptions);
@@ -113,11 +85,7 @@ export class TaskLayout {
     // Remove a component from the taskComponents array if the given layoutOption criteria is met,
     // and add to the layout's specific classes list the class that denotes that this component
     // isn't in the layout
-    private removeIf2(
-        shouldRemove: boolean,
-        componentToRemove: TaskLayoutComponent,
-        _taskComponents: TaskLayoutComponent[],
-    ) {
+    private removeIf2(shouldRemove: boolean, componentToRemove: TaskLayoutComponent) {
         if (shouldRemove) {
             this.taskListClasses.push(`tasks-layout-hide-${componentToRemove}`);
             this.hiddenTaskLayoutComponents.push(componentToRemove);

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -72,7 +72,6 @@ export class TaskLayout {
         this.removeIf2(this.options.hideScheduledDate, 'scheduledDate');
         this.removeIf2(this.options.hideDueDate, 'dueDate');
         this.removeIf2(this.options.hideDoneDate, 'doneDate');
-        // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
 
         this.markHiddenQueryComponents(this.options);
     }
@@ -97,6 +96,7 @@ export class TaskLayout {
             }
         };
 
+        // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
         markHiddenQueryComponent(layoutOptions.hideTags, 'tags');
 
         // The following components are handled in QueryRenderer.ts and thus are not part of the same flow that

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -93,9 +93,6 @@ export class TaskLayout {
         }
     }
 
-    // Remove a component from the taskComponents array if the given layoutOption criteria is met,
-    // and add to the layout's specific classes list the class that denotes that this component
-    // isn't in the layout
 
     private removeIf2(hide: boolean, component: TaskLayoutComponent) {
         this.generateHiddenClassForTaskList(hide, component);
@@ -103,6 +100,9 @@ export class TaskLayout {
         this.hideComponent(hide, component);
     }
 
+    // Remove a component from the taskComponents array if the given layoutOption criteria is met,
+    // and add to the layout's specific classes list the class that denotes that this component
+    // isn't in the layout
     private hideComponent(hide: boolean, component: TaskLayoutComponent) {
         if (hide) {
             this.hiddenTaskLayoutComponents.push(component);

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -73,7 +73,24 @@ export class TaskLayout {
         this.removeIf2(this.options.hideDueDate, 'dueDate');
         this.removeIf2(this.options.hideDoneDate, 'doneDate');
 
-        this.markHiddenQueryComponents(this.options);
+        const markHiddenQueryComponent = (hidden: boolean, hiddenComponentName: string) => {
+            if (hidden) {
+                this.taskListClasses.push(`tasks-layout-hide-${hiddenComponentName}`);
+            }
+        };
+
+        // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
+        markHiddenQueryComponent(this.options.hideTags, 'tags');
+
+        // The following components are handled in QueryRenderer.ts and thus are not part of the same flow that
+        // hides TaskLayoutComponent items. However, we still want to have 'tasks-layout-hide' items for them
+        // (see https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1866).
+        // This can benefit from some refactoring, i.e. render these components in a similar flow rather than
+        // separately.
+        markHiddenQueryComponent(this.options.hideUrgency, 'urgency');
+        markHiddenQueryComponent(this.options.hideBacklinks, 'backlinks');
+        markHiddenQueryComponent(this.options.hideEditButton, 'edit-button');
+        if (this.options.shortMode) this.taskListClasses.push('tasks-layout-short-mode');
     }
 
     // Remove a component from the taskComponents array if the given layoutOption criteria is met,
@@ -87,26 +104,5 @@ export class TaskLayout {
                 (element) => element != componentToRemove,
             );
         }
-    }
-
-    private markHiddenQueryComponents(layoutOptions: LayoutOptions) {
-        const markHiddenQueryComponent = (hidden: boolean, hiddenComponentName: string) => {
-            if (hidden) {
-                this.taskListClasses.push(`tasks-layout-hide-${hiddenComponentName}`);
-            }
-        };
-
-        // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
-        markHiddenQueryComponent(layoutOptions.hideTags, 'tags');
-
-        // The following components are handled in QueryRenderer.ts and thus are not part of the same flow that
-        // hides TaskLayoutComponent items. However, we still want to have 'tasks-layout-hide' items for them
-        // (see https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1866).
-        // This can benefit from some refactoring, i.e. render these components in a similar flow rather than
-        // separately.
-        markHiddenQueryComponent(layoutOptions.hideUrgency, 'urgency');
-        markHiddenQueryComponent(layoutOptions.hideBacklinks, 'backlinks');
-        markHiddenQueryComponent(layoutOptions.hideEditButton, 'edit-button');
-        if (layoutOptions.shortMode) this.taskListClasses.push('tasks-layout-short-mode');
     }
 }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -50,7 +50,7 @@ export class TaskLayout {
     public shownTaskLayoutComponents: TaskLayoutComponent[];
     public hiddenTaskLayoutComponents: TaskLayoutComponent[] = [];
     public options: LayoutOptions;
-    public taskListClasses: string[] = [];
+    public taskListHiddenClasses: string[] = [];
 
     constructor(options?: LayoutOptions) {
         if (options) {
@@ -92,12 +92,12 @@ export class TaskLayout {
         this.generateHiddenClassForTaskList(this.options.hideUrgency, 'urgency');
         this.generateHiddenClassForTaskList(this.options.hideBacklinks, 'backlinks');
         this.generateHiddenClassForTaskList(this.options.hideEditButton, 'edit-button');
-        if (this.options.shortMode) this.taskListClasses.push('tasks-layout-short-mode');
+        if (this.options.shortMode) this.taskListHiddenClasses.push('tasks-layout-short-mode');
     }
 
     private generateHiddenClassForTaskList(hide: boolean, component: string) {
         if (hide) {
-            this.taskListClasses.push(`tasks-layout-hide-${component}`);
+            this.taskListHiddenClasses.push(`tasks-layout-hide-${component}`);
         }
     }
 

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -93,16 +93,14 @@ export class TaskLayout {
         }
     }
 
-// Remove a component from the taskComponents array if the given layoutOption criteria is met,
+    // Remove a component from the taskComponents array if the given layoutOption criteria is met,
     // and add to the layout's specific classes list the class that denotes that this component
     // isn't in the layout
-    private removeIf2(shouldRemove: boolean, componentToRemove: TaskLayoutComponent) {
-        if (shouldRemove) {
-            this.taskListClasses.push(`tasks-layout-hide-${componentToRemove}`);
-            this.hiddenTaskLayoutComponents.push(componentToRemove);
-            this.shownTaskLayoutComponents = this.shownTaskLayoutComponents.filter(
-                (element) => element != componentToRemove,
-            );
+    private removeIf2(hide: boolean, component: TaskLayoutComponent) {
+        if (hide) {
+            this.taskListClasses.push(`tasks-layout-hide-${component}`);
+            this.hiddenTaskLayoutComponents.push(component);
+            this.shownTaskLayoutComponents = this.shownTaskLayoutComponents.filter((element) => element != component);
         }
     }
 }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -67,6 +67,7 @@ export class TaskLayout {
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
         const hide = this.options.hidePriority;
         const component = 'priority';
+        const hideAndGenerateClasses: [boolean, TaskLayoutComponent][] = [[hide, component]];
         this.hideComponent(hide, component);
         this.hideComponent(this.options.hideRecurrenceRule, 'recurrenceRule');
         this.hideComponent(this.options.hideCreatedDate, 'createdDate');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -65,13 +65,20 @@ export class TaskLayout {
     private applyOptions() {
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
-        this.removeIf2(this.options.hidePriority, 'priority');
-        this.removeIf2(this.options.hideRecurrenceRule, 'recurrenceRule');
-        this.removeIf2(this.options.hideCreatedDate, 'createdDate');
-        this.removeIf2(this.options.hideStartDate, 'startDate');
-        this.removeIf2(this.options.hideScheduledDate, 'scheduledDate');
-        this.removeIf2(this.options.hideDueDate, 'dueDate');
-        this.removeIf2(this.options.hideDoneDate, 'doneDate');
+        this.generateHiddenClassForTaskList(this.options.hidePriority, 'priority');
+        this.hideComponent(this.options.hidePriority, 'priority');
+        this.generateHiddenClassForTaskList(this.options.hideRecurrenceRule, 'recurrenceRule');
+        this.hideComponent(this.options.hideRecurrenceRule, 'recurrenceRule');
+        this.generateHiddenClassForTaskList(this.options.hideCreatedDate, 'createdDate');
+        this.hideComponent(this.options.hideCreatedDate, 'createdDate');
+        this.generateHiddenClassForTaskList(this.options.hideStartDate, 'startDate');
+        this.hideComponent(this.options.hideStartDate, 'startDate');
+        this.generateHiddenClassForTaskList(this.options.hideScheduledDate, 'scheduledDate');
+        this.hideComponent(this.options.hideScheduledDate, 'scheduledDate');
+        this.generateHiddenClassForTaskList(this.options.hideDueDate, 'dueDate');
+        this.hideComponent(this.options.hideDueDate, 'dueDate');
+        this.generateHiddenClassForTaskList(this.options.hideDoneDate, 'doneDate');
+        this.hideComponent(this.options.hideDoneDate, 'doneDate');
 
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
         this.generateHiddenClassForTaskList(this.options.hideTags, 'tags');
@@ -92,14 +99,6 @@ export class TaskLayout {
             this.taskListClasses.push(`tasks-layout-hide-${component}`);
         }
     }
-
-
-    private removeIf2(hide: boolean, component: TaskLayoutComponent) {
-        this.generateHiddenClassForTaskList(hide, component);
-
-        this.hideComponent(hide, component);
-    }
-
     // Remove a component from the taskComponents array if the given layoutOption criteria is met,
     // and add to the layout's specific classes list the class that denotes that this component
     // isn't in the layout

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -68,7 +68,10 @@ export class TaskLayout {
         const hide = this.options.hidePriority;
         const component = 'priority';
         const hideAndGenerateClasses: [boolean, TaskLayoutComponent][] = [[hide, component]];
-        this.hideComponent(hide, component);
+        for (const [hide, component] of hideAndGenerateClasses) {
+            this.hideComponent(hide, component);
+        }
+
         this.hideComponent(this.options.hideRecurrenceRule, 'recurrenceRule');
         this.hideComponent(this.options.hideCreatedDate, 'createdDate');
         this.hideComponent(this.options.hideStartDate, 'startDate');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -121,7 +121,7 @@ export class TaskLayout {
         if (shouldRemove) {
             this.taskListClasses.push(`tasks-layout-hide-${componentToRemove}`);
             this.hiddenTaskLayoutComponents.push(componentToRemove);
-            return taskComponents.filter((element) => element != componentToRemove);
+            taskComponents = taskComponents.filter((element) => element != componentToRemove);
         }
         return taskComponents;
     }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -60,13 +60,13 @@ export class TaskLayout {
         }
 
         this.shownTaskLayoutComponents = this.defaultLayout;
-        this.shownTaskLayoutComponents = this.applyOptions(this.options);
+        this.applyOptions(this.options);
     }
 
     /**
      * Return a new list of components with the given options applied.
      */
-    applyOptions(layoutOptions: LayoutOptions): TaskLayoutComponent[] {
+    applyOptions(layoutOptions: LayoutOptions) {
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
         this.removeIf2(layoutOptions.hidePriority, 'priority');
@@ -79,7 +79,6 @@ export class TaskLayout {
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
 
         this.markHiddenQueryComponents(layoutOptions);
-        return this.shownTaskLayoutComponents;
     }
 
     // Remove a component from the taskComponents array if the given layoutOption criteria is met,

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -66,7 +66,8 @@ export class TaskLayout {
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
         const hide = this.options.hidePriority;
-        this.hideComponent(hide, 'priority');
+        const component = 'priority';
+        this.hideComponent(hide, component);
         this.hideComponent(this.options.hideRecurrenceRule, 'recurrenceRule');
         this.hideComponent(this.options.hideCreatedDate, 'createdDate');
         this.hideComponent(this.options.hideStartDate, 'startDate');
@@ -74,7 +75,7 @@ export class TaskLayout {
         this.hideComponent(this.options.hideDueDate, 'dueDate');
         this.hideComponent(this.options.hideDoneDate, 'doneDate');
 
-        this.generateHiddenClassForTaskList(hide, 'priority');
+        this.generateHiddenClassForTaskList(hide, component);
         this.generateHiddenClassForTaskList(this.options.hideRecurrenceRule, 'recurrenceRule');
         this.generateHiddenClassForTaskList(this.options.hideCreatedDate, 'createdDate');
         this.generateHiddenClassForTaskList(this.options.hideStartDate, 'startDate');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -65,20 +65,21 @@ export class TaskLayout {
     private applyOptions() {
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
-        const hideAndGenerateClasses: [boolean, TaskLayoutComponent][] = [[this.options.hidePriority, 'priority']];
+        const hideAndGenerateClasses: [boolean, TaskLayoutComponent][] = [
+            [this.options.hidePriority, 'priority'],
+            [this.options.hideRecurrenceRule, 'recurrenceRule'],
+        ];
         for (const [hide, component] of hideAndGenerateClasses) {
             this.hideComponent(hide, component);
             this.generateHiddenClassForTaskList(hide, component);
         }
 
-        this.hideComponent(this.options.hideRecurrenceRule, 'recurrenceRule');
         this.hideComponent(this.options.hideCreatedDate, 'createdDate');
         this.hideComponent(this.options.hideStartDate, 'startDate');
         this.hideComponent(this.options.hideScheduledDate, 'scheduledDate');
         this.hideComponent(this.options.hideDueDate, 'dueDate');
         this.hideComponent(this.options.hideDoneDate, 'doneDate');
 
-        this.generateHiddenClassForTaskList(this.options.hideRecurrenceRule, 'recurrenceRule');
         this.generateHiddenClassForTaskList(this.options.hideCreatedDate, 'createdDate');
         this.generateHiddenClassForTaskList(this.options.hideStartDate, 'startDate');
         this.generateHiddenClassForTaskList(this.options.hideScheduledDate, 'scheduledDate');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -73,21 +73,17 @@ export class TaskLayout {
         this.removeIf2(this.options.hideDueDate, 'dueDate');
         this.removeIf2(this.options.hideDoneDate, 'doneDate');
 
-        const markHiddenQueryComponent = (hidden: boolean, hiddenComponentName: string) => {
-            this.generateHiddenClassForTaskList(hidden, hiddenComponentName);
-        };
-
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
-        markHiddenQueryComponent(this.options.hideTags, 'tags');
+        this.generateHiddenClassForTaskList(this.options.hideTags, 'tags');
 
         // The following components are handled in QueryRenderer.ts and thus are not part of the same flow that
         // hides TaskLayoutComponent items. However, we still want to have 'tasks-layout-hide' items for them
         // (see https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1866).
         // This can benefit from some refactoring, i.e. render these components in a similar flow rather than
         // separately.
-        markHiddenQueryComponent(this.options.hideUrgency, 'urgency');
-        markHiddenQueryComponent(this.options.hideBacklinks, 'backlinks');
-        markHiddenQueryComponent(this.options.hideEditButton, 'edit-button');
+        this.generateHiddenClassForTaskList(this.options.hideUrgency, 'urgency');
+        this.generateHiddenClassForTaskList(this.options.hideBacklinks, 'backlinks');
+        this.generateHiddenClassForTaskList(this.options.hideEditButton, 'edit-button');
         if (this.options.shortMode) this.taskListClasses.push('tasks-layout-short-mode');
     }
 

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -63,26 +63,18 @@ export class TaskLayout {
     }
 
     private applyOption2() {
-        this.shownTaskLayoutComponents = this.defaultLayout;
-        this.applyOptions(this.options);
-    }
-
-    /**
-     * Return a new list of components with the given options applied.
-     */
-    applyOptions(layoutOptions: LayoutOptions) {
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
-        this.removeIf2(layoutOptions.hidePriority, 'priority');
-        this.removeIf2(layoutOptions.hideRecurrenceRule, 'recurrenceRule');
-        this.removeIf2(layoutOptions.hideCreatedDate, 'createdDate');
-        this.removeIf2(layoutOptions.hideStartDate, 'startDate');
-        this.removeIf2(layoutOptions.hideScheduledDate, 'scheduledDate');
-        this.removeIf2(layoutOptions.hideDueDate, 'dueDate');
-        this.removeIf2(layoutOptions.hideDoneDate, 'doneDate');
+        this.removeIf2(this.options.hidePriority, 'priority');
+        this.removeIf2(this.options.hideRecurrenceRule, 'recurrenceRule');
+        this.removeIf2(this.options.hideCreatedDate, 'createdDate');
+        this.removeIf2(this.options.hideStartDate, 'startDate');
+        this.removeIf2(this.options.hideScheduledDate, 'scheduledDate');
+        this.removeIf2(this.options.hideDueDate, 'dueDate');
+        this.removeIf2(this.options.hideDoneDate, 'doneDate');
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
 
-        this.markHiddenQueryComponents(layoutOptions);
+        this.markHiddenQueryComponents(this.options);
     }
 
     // Remove a component from the taskComponents array if the given layoutOption criteria is met,

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -65,7 +65,7 @@ export class TaskLayout {
     private applyOptions() {
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
-        const hideAndGenerateClasses: [boolean, TaskLayoutComponent][] = [
+        const componentsToHideAndGenerateClasses: [boolean, TaskLayoutComponent][] = [
             [this.options.hidePriority, 'priority'],
             [this.options.hideRecurrenceRule, 'recurrenceRule'],
             [this.options.hideCreatedDate, 'createdDate'],
@@ -74,7 +74,7 @@ export class TaskLayout {
             [this.options.hideDueDate, 'dueDate'],
             [this.options.hideDoneDate, 'doneDate'],
         ];
-        for (const [hide, component] of hideAndGenerateClasses) {
+        for (const [hide, component] of componentsToHideAndGenerateClasses) {
             this.hideComponent(hide, component);
             this.generateHiddenClassForTaskList(hide, component);
         }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -59,10 +59,10 @@ export class TaskLayout {
             this.options = new LayoutOptions();
         }
         this.shownTaskLayoutComponents = this.defaultLayout;
-        this.applyOption2();
+        this.applyOptions();
     }
 
-    private applyOption2() {
+    private applyOptions() {
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
         this.removeIf2(this.options.hidePriority, 'priority');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -85,18 +85,41 @@ export class TaskLayout {
         };
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
-        let newComponents = this.shownTaskLayoutComponents;
-        newComponents = removeIf(newComponents, layoutOptions.hidePriority, 'priority');
-        newComponents = removeIf(newComponents, layoutOptions.hideRecurrenceRule, 'recurrenceRule');
-        newComponents = removeIf(newComponents, layoutOptions.hideCreatedDate, 'createdDate');
-        newComponents = removeIf(newComponents, layoutOptions.hideStartDate, 'startDate');
-        newComponents = removeIf(newComponents, layoutOptions.hideScheduledDate, 'scheduledDate');
-        newComponents = removeIf(newComponents, layoutOptions.hideDueDate, 'dueDate');
-        newComponents = removeIf(newComponents, layoutOptions.hideDoneDate, 'doneDate');
+        this.shownTaskLayoutComponents = removeIf(
+            this.shownTaskLayoutComponents,
+            layoutOptions.hidePriority,
+            'priority',
+        );
+        this.shownTaskLayoutComponents = removeIf(
+            this.shownTaskLayoutComponents,
+            layoutOptions.hideRecurrenceRule,
+            'recurrenceRule',
+        );
+        this.shownTaskLayoutComponents = removeIf(
+            this.shownTaskLayoutComponents,
+            layoutOptions.hideCreatedDate,
+            'createdDate',
+        );
+        this.shownTaskLayoutComponents = removeIf(
+            this.shownTaskLayoutComponents,
+            layoutOptions.hideStartDate,
+            'startDate',
+        );
+        this.shownTaskLayoutComponents = removeIf(
+            this.shownTaskLayoutComponents,
+            layoutOptions.hideScheduledDate,
+            'scheduledDate',
+        );
+        this.shownTaskLayoutComponents = removeIf(this.shownTaskLayoutComponents, layoutOptions.hideDueDate, 'dueDate');
+        this.shownTaskLayoutComponents = removeIf(
+            this.shownTaskLayoutComponents,
+            layoutOptions.hideDoneDate,
+            'doneDate',
+        );
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
 
         this.markHiddenQueryComponents(layoutOptions);
-        return newComponents;
+        return this.shownTaskLayoutComponents;
     }
 
     private markHiddenQueryComponents(layoutOptions: LayoutOptions) {

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -58,7 +58,11 @@ export class TaskLayout {
         } else {
             this.options = new LayoutOptions();
         }
+        this.shownTaskLayoutComponents = this.defaultLayout;
+        this.applyOption2();
+    }
 
+    private applyOption2() {
         this.shownTaskLayoutComponents = this.defaultLayout;
         this.applyOptions(this.options);
     }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -80,7 +80,10 @@ export class TaskLayout {
         }
 
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
-        const generateClasses: [boolean, string][] = [[this.options.hideTags, 'tags']];
+        const generateClasses: [boolean, string][] = [
+            [this.options.hideTags, 'tags'],
+            [this.options.hideUrgency, 'urgency'],
+        ];
         for (const [hide, component] of generateClasses) {
             this.generateHiddenClassForTaskList(hide, component);
         }
@@ -90,7 +93,6 @@ export class TaskLayout {
         // (see https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1866).
         // This can benefit from some refactoring, i.e. render these components in a similar flow rather than
         // separately.
-        this.generateHiddenClassForTaskList(this.options.hideUrgency, 'urgency');
         this.generateHiddenClassForTaskList(this.options.hideBacklinks, 'backlinks');
         this.generateHiddenClassForTaskList(this.options.hideEditButton, 'edit-button');
         if (this.options.shortMode) this.taskListHiddenClasses.push('tasks-layout-short-mode');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -70,17 +70,16 @@ export class TaskLayout {
             [this.options.hideRecurrenceRule, 'recurrenceRule'],
             [this.options.hideCreatedDate, 'createdDate'],
             [this.options.hideStartDate, 'startDate'],
+            [this.options.hideScheduledDate, 'scheduledDate'],
         ];
         for (const [hide, component] of hideAndGenerateClasses) {
             this.hideComponent(hide, component);
             this.generateHiddenClassForTaskList(hide, component);
         }
 
-        this.hideComponent(this.options.hideScheduledDate, 'scheduledDate');
         this.hideComponent(this.options.hideDueDate, 'dueDate');
         this.hideComponent(this.options.hideDoneDate, 'doneDate');
 
-        this.generateHiddenClassForTaskList(this.options.hideScheduledDate, 'scheduledDate');
         this.generateHiddenClassForTaskList(this.options.hideDueDate, 'dueDate');
         this.generateHiddenClassForTaskList(this.options.hideDoneDate, 'doneDate');
 

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -68,19 +68,18 @@ export class TaskLayout {
         const hideAndGenerateClasses: [boolean, TaskLayoutComponent][] = [
             [this.options.hidePriority, 'priority'],
             [this.options.hideRecurrenceRule, 'recurrenceRule'],
+            [this.options.hideCreatedDate, 'createdDate'],
         ];
         for (const [hide, component] of hideAndGenerateClasses) {
             this.hideComponent(hide, component);
             this.generateHiddenClassForTaskList(hide, component);
         }
 
-        this.hideComponent(this.options.hideCreatedDate, 'createdDate');
         this.hideComponent(this.options.hideStartDate, 'startDate');
         this.hideComponent(this.options.hideScheduledDate, 'scheduledDate');
         this.hideComponent(this.options.hideDueDate, 'dueDate');
         this.hideComponent(this.options.hideDoneDate, 'doneDate');
 
-        this.generateHiddenClassForTaskList(this.options.hideCreatedDate, 'createdDate');
         this.generateHiddenClassForTaskList(this.options.hideStartDate, 'startDate');
         this.generateHiddenClassForTaskList(this.options.hideScheduledDate, 'scheduledDate');
         this.generateHiddenClassForTaskList(this.options.hideDueDate, 'dueDate');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -95,6 +95,11 @@ export class TaskLayout {
         newComponents = removeIf(newComponents, layoutOptions.hideDoneDate, 'doneDate');
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
 
+        this.markHiddenQueryComponents(layoutOptions);
+        return newComponents;
+    }
+
+    private markHiddenQueryComponents(layoutOptions: LayoutOptions) {
         const markHiddenQueryComponent = (hidden: boolean, hiddenComponentName: string) => {
             if (hidden) {
                 this.taskListClasses.push(`tasks-layout-hide-${hiddenComponentName}`);
@@ -112,6 +117,5 @@ export class TaskLayout {
         markHiddenQueryComponent(layoutOptions.hideBacklinks, 'backlinks');
         markHiddenQueryComponent(layoutOptions.hideEditButton, 'edit-button');
         if (layoutOptions.shortMode) this.taskListClasses.push('tasks-layout-short-mode');
-        return newComponents;
     }
 }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -93,21 +93,21 @@ export class TaskLayout {
         }
     }
 
+    private generateHiddenClassForTaskList2(hide: boolean, component: string) {
+        if (hide) {
+            this.taskListClasses.push(`tasks-layout-hide-${component}`);
+        }
+    }
     // Remove a component from the taskComponents array if the given layoutOption criteria is met,
     // and add to the layout's specific classes list the class that denotes that this component
     // isn't in the layout
+
     private removeIf2(hide: boolean, component: TaskLayoutComponent) {
         this.generateHiddenClassForTaskList2(hide, component);
 
         if (hide) {
             this.hiddenTaskLayoutComponents.push(component);
             this.shownTaskLayoutComponents = this.shownTaskLayoutComponents.filter((element) => element != component);
-        }
-    }
-
-    private generateHiddenClassForTaskList2(hide: boolean, component: string) {
-        if (hide) {
-            this.taskListClasses.push(`tasks-layout-hide-${component}`);
         }
     }
 }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -83,11 +83,6 @@ export class TaskLayout {
                 return taskComponents;
             }
         };
-        const markHiddenQueryComponent = (hidden: boolean, hiddenComponentName: string) => {
-            if (hidden) {
-                this.taskListClasses.push(`tasks-layout-hide-${hiddenComponentName}`);
-            }
-        };
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
         let newComponents = this.shownTaskLayoutComponents;
@@ -98,8 +93,14 @@ export class TaskLayout {
         newComponents = removeIf(newComponents, layoutOptions.hideScheduledDate, 'scheduledDate');
         newComponents = removeIf(newComponents, layoutOptions.hideDueDate, 'dueDate');
         newComponents = removeIf(newComponents, layoutOptions.hideDoneDate, 'doneDate');
-
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
+
+        const markHiddenQueryComponent = (hidden: boolean, hiddenComponentName: string) => {
+            if (hidden) {
+                this.taskListClasses.push(`tasks-layout-hide-${hiddenComponentName}`);
+            }
+        };
+
         markHiddenQueryComponent(layoutOptions.hideTags, 'tags');
 
         // The following components are handled in QueryRenderer.ts and thus are not part of the same flow that

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -83,7 +83,9 @@ export class TaskLayout {
         const hide = this.options.hideTags;
         const component = 'tags';
         const generateClasses: [boolean, string][] = [[hide, component]];
-        this.generateHiddenClassForTaskList(hide, component);
+        for (const [hide, component] of generateClasses) {
+            this.generateHiddenClassForTaskList(hide, component);
+        }
 
         // The following components are handled in QueryRenderer.ts and thus are not part of the same flow that
         // hides TaskLayoutComponent items. However, we still want to have 'tasks-layout-hide' items for them

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -69,13 +69,13 @@ export class TaskLayout {
     applyOptions(layoutOptions: LayoutOptions): TaskLayoutComponent[] {
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
-        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hidePriority, 'priority');
-        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hideRecurrenceRule, 'recurrenceRule');
-        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hideCreatedDate, 'createdDate');
-        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hideStartDate, 'startDate');
-        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hideScheduledDate, 'scheduledDate');
-        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hideDueDate, 'dueDate');
-        this.shownTaskLayoutComponents = this.removeIf2(layoutOptions.hideDoneDate, 'doneDate');
+        this.removeIf2(layoutOptions.hidePriority, 'priority');
+        this.removeIf2(layoutOptions.hideRecurrenceRule, 'recurrenceRule');
+        this.removeIf2(layoutOptions.hideCreatedDate, 'createdDate');
+        this.removeIf2(layoutOptions.hideStartDate, 'startDate');
+        this.removeIf2(layoutOptions.hideScheduledDate, 'scheduledDate');
+        this.removeIf2(layoutOptions.hideDueDate, 'dueDate');
+        this.removeIf2(layoutOptions.hideDoneDate, 'doneDate');
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
 
         this.markHiddenQueryComponents(layoutOptions);
@@ -93,7 +93,6 @@ export class TaskLayout {
                 (element) => element != componentToRemove,
             );
         }
-        return this.shownTaskLayoutComponents;
     }
 
     private markHiddenQueryComponents(layoutOptions: LayoutOptions) {

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -69,18 +69,17 @@ export class TaskLayout {
             [this.options.hidePriority, 'priority'],
             [this.options.hideRecurrenceRule, 'recurrenceRule'],
             [this.options.hideCreatedDate, 'createdDate'],
+            [this.options.hideStartDate, 'startDate'],
         ];
         for (const [hide, component] of hideAndGenerateClasses) {
             this.hideComponent(hide, component);
             this.generateHiddenClassForTaskList(hide, component);
         }
 
-        this.hideComponent(this.options.hideStartDate, 'startDate');
         this.hideComponent(this.options.hideScheduledDate, 'scheduledDate');
         this.hideComponent(this.options.hideDueDate, 'dueDate');
         this.hideComponent(this.options.hideDoneDate, 'doneDate');
 
-        this.generateHiddenClassForTaskList(this.options.hideStartDate, 'startDate');
         this.generateHiddenClassForTaskList(this.options.hideScheduledDate, 'scheduledDate');
         this.generateHiddenClassForTaskList(this.options.hideDueDate, 'dueDate');
         this.generateHiddenClassForTaskList(this.options.hideDoneDate, 'doneDate');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -80,7 +80,9 @@ export class TaskLayout {
         }
 
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
-        this.generateHiddenClassForTaskList(this.options.hideTags, 'tags');
+        const hide = this.options.hideTags;
+        const component = 'tags';
+        this.generateHiddenClassForTaskList(hide, component);
 
         // The following components are handled in QueryRenderer.ts and thus are not part of the same flow that
         // hides TaskLayoutComponent items. However, we still want to have 'tasks-layout-hide' items for them

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -122,9 +122,8 @@ export class TaskLayout {
             this.taskListClasses.push(`tasks-layout-hide-${componentToRemove}`);
             this.hiddenTaskLayoutComponents.push(componentToRemove);
             return taskComponents.filter((element) => element != componentToRemove);
-        } else {
-            return taskComponents;
         }
+        return taskComponents;
     }
 
     private markHiddenQueryComponents(layoutOptions: LayoutOptions) {

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -79,7 +79,7 @@ export class TaskLayout {
             this.generateHiddenClassForTaskList(hide, component);
         }
 
-        const generateClasses: [boolean, string][] = [
+        const componentsToGenerateClassesOnly: [boolean, string][] = [
             // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
             [this.options.hideTags, 'tags'],
 
@@ -92,7 +92,7 @@ export class TaskLayout {
             [this.options.hideBacklinks, 'backlinks'],
             [this.options.hideEditButton, 'edit-button'],
         ];
-        for (const [hide, component] of generateClasses) {
+        for (const [hide, component] of componentsToGenerateClassesOnly) {
             this.generateHiddenClassForTaskList(hide, component);
         }
 

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -65,7 +65,8 @@ export class TaskLayout {
     private applyOptions() {
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
-        this.hideComponent(this.options.hidePriority, 'priority');
+        const hide = this.options.hidePriority;
+        this.hideComponent(hide, 'priority');
         this.hideComponent(this.options.hideRecurrenceRule, 'recurrenceRule');
         this.hideComponent(this.options.hideCreatedDate, 'createdDate');
         this.hideComponent(this.options.hideStartDate, 'startDate');
@@ -73,7 +74,7 @@ export class TaskLayout {
         this.hideComponent(this.options.hideDueDate, 'dueDate');
         this.hideComponent(this.options.hideDoneDate, 'doneDate');
 
-        this.generateHiddenClassForTaskList(this.options.hidePriority, 'priority');
+        this.generateHiddenClassForTaskList(hide, 'priority');
         this.generateHiddenClassForTaskList(this.options.hideRecurrenceRule, 'recurrenceRule');
         this.generateHiddenClassForTaskList(this.options.hideCreatedDate, 'createdDate');
         this.generateHiddenClassForTaskList(this.options.hideStartDate, 'startDate');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -75,13 +75,7 @@ export class TaskLayout {
             shouldRemove: boolean,
             componentToRemove: TaskLayoutComponent,
         ) => {
-            if (shouldRemove) {
-                this.taskListClasses.push(`tasks-layout-hide-${componentToRemove}`);
-                this.hiddenTaskLayoutComponents.push(componentToRemove);
-                return taskComponents.filter((element) => element != componentToRemove);
-            } else {
-                return taskComponents;
-            }
+            return this.removeIf2(shouldRemove, componentToRemove, taskComponents);
         };
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
@@ -120,6 +114,29 @@ export class TaskLayout {
 
         this.markHiddenQueryComponents(layoutOptions);
         return this.shownTaskLayoutComponents;
+    }
+
+    private removeIf2(
+        shouldRemove: boolean,
+        componentToRemove:
+            | 'description'
+            | 'priority'
+            | 'recurrenceRule'
+            | 'createdDate'
+            | 'startDate'
+            | 'scheduledDate'
+            | 'dueDate'
+            | 'doneDate'
+            | 'blockLink',
+        taskComponents: TaskLayoutComponent[],
+    ) {
+        if (shouldRemove) {
+            this.taskListClasses.push(`tasks-layout-hide-${componentToRemove}`);
+            this.hiddenTaskLayoutComponents.push(componentToRemove);
+            return taskComponents.filter((element) => element != componentToRemove);
+        } else {
+            return taskComponents;
+        }
     }
 
     private markHiddenQueryComponents(layoutOptions: LayoutOptions) {

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -65,20 +65,21 @@ export class TaskLayout {
     private applyOptions() {
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
-        this.generateHiddenClassForTaskList(this.options.hidePriority, 'priority');
         this.hideComponent(this.options.hidePriority, 'priority');
-        this.generateHiddenClassForTaskList(this.options.hideRecurrenceRule, 'recurrenceRule');
         this.hideComponent(this.options.hideRecurrenceRule, 'recurrenceRule');
-        this.generateHiddenClassForTaskList(this.options.hideCreatedDate, 'createdDate');
         this.hideComponent(this.options.hideCreatedDate, 'createdDate');
-        this.generateHiddenClassForTaskList(this.options.hideStartDate, 'startDate');
         this.hideComponent(this.options.hideStartDate, 'startDate');
-        this.generateHiddenClassForTaskList(this.options.hideScheduledDate, 'scheduledDate');
         this.hideComponent(this.options.hideScheduledDate, 'scheduledDate');
-        this.generateHiddenClassForTaskList(this.options.hideDueDate, 'dueDate');
         this.hideComponent(this.options.hideDueDate, 'dueDate');
-        this.generateHiddenClassForTaskList(this.options.hideDoneDate, 'doneDate');
         this.hideComponent(this.options.hideDoneDate, 'doneDate');
+
+        this.generateHiddenClassForTaskList(this.options.hidePriority, 'priority');
+        this.generateHiddenClassForTaskList(this.options.hideRecurrenceRule, 'recurrenceRule');
+        this.generateHiddenClassForTaskList(this.options.hideCreatedDate, 'createdDate');
+        this.generateHiddenClassForTaskList(this.options.hideStartDate, 'startDate');
+        this.generateHiddenClassForTaskList(this.options.hideScheduledDate, 'scheduledDate');
+        this.generateHiddenClassForTaskList(this.options.hideDueDate, 'dueDate');
+        this.generateHiddenClassForTaskList(this.options.hideDoneDate, 'doneDate');
 
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
         this.generateHiddenClassForTaskList(this.options.hideTags, 'tags');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -84,6 +84,7 @@ export class TaskLayout {
             [this.options.hideTags, 'tags'],
             [this.options.hideUrgency, 'urgency'],
             [this.options.hideBacklinks, 'backlinks'],
+            [this.options.hideEditButton, 'edit-button'],
         ];
         for (const [hide, component] of generateClasses) {
             this.generateHiddenClassForTaskList(hide, component);
@@ -94,7 +95,6 @@ export class TaskLayout {
         // (see https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1866).
         // This can benefit from some refactoring, i.e. render these components in a similar flow rather than
         // separately.
-        this.generateHiddenClassForTaskList(this.options.hideEditButton, 'edit-button');
         if (this.options.shortMode) this.taskListHiddenClasses.push('tasks-layout-short-mode');
     }
 

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -70,6 +70,7 @@ export class TaskLayout {
         const hideAndGenerateClasses: [boolean, TaskLayoutComponent][] = [[hide, component]];
         for (const [hide, component] of hideAndGenerateClasses) {
             this.hideComponent(hide, component);
+            this.generateHiddenClassForTaskList(hide, component);
         }
 
         this.hideComponent(this.options.hideRecurrenceRule, 'recurrenceRule');
@@ -79,7 +80,6 @@ export class TaskLayout {
         this.hideComponent(this.options.hideDueDate, 'dueDate');
         this.hideComponent(this.options.hideDoneDate, 'doneDate');
 
-        this.generateHiddenClassForTaskList(hide, component);
         this.generateHiddenClassForTaskList(this.options.hideRecurrenceRule, 'recurrenceRule');
         this.generateHiddenClassForTaskList(this.options.hideCreatedDate, 'createdDate');
         this.generateHiddenClassForTaskList(this.options.hideStartDate, 'startDate');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -74,9 +74,7 @@ export class TaskLayout {
         this.removeIf2(this.options.hideDoneDate, 'doneDate');
 
         const markHiddenQueryComponent = (hidden: boolean, hiddenComponentName: string) => {
-            if (hidden) {
-                this.taskListClasses.push(`tasks-layout-hide-${hiddenComponentName}`);
-            }
+            this.generateHiddenClassForTaskList(hidden, hiddenComponentName);
         };
 
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
@@ -93,7 +91,13 @@ export class TaskLayout {
         if (this.options.shortMode) this.taskListClasses.push('tasks-layout-short-mode');
     }
 
-    // Remove a component from the taskComponents array if the given layoutOption criteria is met,
+    private generateHiddenClassForTaskList(hidden: boolean, hiddenComponentName: string) {
+        if (hidden) {
+            this.taskListClasses.push(`tasks-layout-hide-${hiddenComponentName}`);
+        }
+    }
+
+// Remove a component from the taskComponents array if the given layoutOption criteria is met,
     // and add to the layout's specific classes list the class that denotes that this component
     // isn't in the layout
     private removeIf2(shouldRemove: boolean, componentToRemove: TaskLayoutComponent) {

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -82,6 +82,12 @@ export class TaskLayout {
         const generateClasses: [boolean, string][] = [
             // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
             [this.options.hideTags, 'tags'],
+
+            // The following components are handled in QueryRenderer.ts and thus are not part of the same flow that
+            // hides TaskLayoutComponent items. However, we still want to have 'tasks-layout-hide' items for them
+            // (see https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1866).
+            // This can benefit from some refactoring, i.e. render these components in a similar flow rather than
+            // separately.
             [this.options.hideUrgency, 'urgency'],
             [this.options.hideBacklinks, 'backlinks'],
             [this.options.hideEditButton, 'edit-button'],
@@ -90,11 +96,6 @@ export class TaskLayout {
             this.generateHiddenClassForTaskList(hide, component);
         }
 
-        // The following components are handled in QueryRenderer.ts and thus are not part of the same flow that
-        // hides TaskLayoutComponent items. However, we still want to have 'tasks-layout-hide' items for them
-        // (see https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1866).
-        // This can benefit from some refactoring, i.e. render these components in a similar flow rather than
-        // separately.
         if (this.options.shortMode) this.taskListHiddenClasses.push('tasks-layout-short-mode');
     }
 

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -67,9 +67,6 @@ export class TaskLayout {
      * Return a new list of components with the given options applied.
      */
     applyOptions(layoutOptions: LayoutOptions): TaskLayoutComponent[] {
-        // Remove a component from the taskComponents array if the given layoutOption criteria is met,
-        // and add to the layout's specific classes list the class that denotes that this component
-        // isn't in the layout
         // Remove components from the layout according to the task options. These represent the existing task options,
         // so some components (e.g. the description) are not here because there are no layout options to remove them.
         this.shownTaskLayoutComponents = this.removeIf2(
@@ -113,6 +110,9 @@ export class TaskLayout {
         return this.shownTaskLayoutComponents;
     }
 
+    // Remove a component from the taskComponents array if the given layoutOption criteria is met,
+    // and add to the layout's specific classes list the class that denotes that this component
+    // isn't in the layout
     private removeIf2(
         shouldRemove: boolean,
         componentToRemove: TaskLayoutComponent,

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -121,9 +121,11 @@ export class TaskLayout {
         if (shouldRemove) {
             this.taskListClasses.push(`tasks-layout-hide-${componentToRemove}`);
             this.hiddenTaskLayoutComponents.push(componentToRemove);
-            _taskComponents = _taskComponents.filter((element) => element != componentToRemove);
+            this.shownTaskLayoutComponents = this.shownTaskLayoutComponents.filter(
+                (element) => element != componentToRemove,
+            );
         }
-        return _taskComponents;
+        return this.shownTaskLayoutComponents;
     }
 
     private markHiddenQueryComponents(layoutOptions: LayoutOptions) {

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -79,8 +79,8 @@ export class TaskLayout {
             this.generateHiddenClassForTaskList(hide, component);
         }
 
-        // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
         const generateClasses: [boolean, string][] = [
+            // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
             [this.options.hideTags, 'tags'],
             [this.options.hideUrgency, 'urgency'],
             [this.options.hideBacklinks, 'backlinks'],

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -72,15 +72,12 @@ export class TaskLayout {
             [this.options.hideStartDate, 'startDate'],
             [this.options.hideScheduledDate, 'scheduledDate'],
             [this.options.hideDueDate, 'dueDate'],
+            [this.options.hideDoneDate, 'doneDate'],
         ];
         for (const [hide, component] of hideAndGenerateClasses) {
             this.hideComponent(hide, component);
             this.generateHiddenClassForTaskList(hide, component);
         }
-
-        this.hideComponent(this.options.hideDoneDate, 'doneDate');
-
-        this.generateHiddenClassForTaskList(this.options.hideDoneDate, 'doneDate');
 
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
         this.generateHiddenClassForTaskList(this.options.hideTags, 'tags');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -99,6 +99,9 @@ export class TaskLayout {
     private removeIf2(hide: boolean, component: TaskLayoutComponent) {
         if (hide) {
             this.taskListClasses.push(`tasks-layout-hide-${component}`);
+        }
+
+        if (hide) {
             this.hiddenTaskLayoutComponents.push(component);
             this.shownTaskLayoutComponents = this.shownTaskLayoutComponents.filter((element) => element != component);
         }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -118,16 +118,7 @@ export class TaskLayout {
 
     private removeIf2(
         shouldRemove: boolean,
-        componentToRemove:
-            | 'description'
-            | 'priority'
-            | 'recurrenceRule'
-            | 'createdDate'
-            | 'startDate'
-            | 'scheduledDate'
-            | 'dueDate'
-            | 'doneDate'
-            | 'blockLink',
+        componentToRemove: TaskLayoutComponent,
         taskComponents: TaskLayoutComponent[],
     ) {
         if (shouldRemove) {

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -97,13 +97,17 @@ export class TaskLayout {
     // and add to the layout's specific classes list the class that denotes that this component
     // isn't in the layout
     private removeIf2(hide: boolean, component: TaskLayoutComponent) {
-        if (hide) {
-            this.taskListClasses.push(`tasks-layout-hide-${component}`);
-        }
+        this.generateHiddenClassForTaskList2(hide, component);
 
         if (hide) {
             this.hiddenTaskLayoutComponents.push(component);
             this.shownTaskLayoutComponents = this.shownTaskLayoutComponents.filter((element) => element != component);
+        }
+    }
+
+    private generateHiddenClassForTaskList2(hide: boolean, component: string) {
+        if (hide) {
+            this.taskListClasses.push(`tasks-layout-hide-${component}`);
         }
     }
 }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -80,9 +80,7 @@ export class TaskLayout {
         }
 
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
-        const hide = this.options.hideTags;
-        const component = 'tags';
-        const generateClasses: [boolean, string][] = [[hide, component]];
+        const generateClasses: [boolean, string][] = [[this.options.hideTags, 'tags']];
         for (const [hide, component] of generateClasses) {
             this.generateHiddenClassForTaskList(hide, component);
         }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -71,16 +71,15 @@ export class TaskLayout {
             [this.options.hideCreatedDate, 'createdDate'],
             [this.options.hideStartDate, 'startDate'],
             [this.options.hideScheduledDate, 'scheduledDate'],
+            [this.options.hideDueDate, 'dueDate'],
         ];
         for (const [hide, component] of hideAndGenerateClasses) {
             this.hideComponent(hide, component);
             this.generateHiddenClassForTaskList(hide, component);
         }
 
-        this.hideComponent(this.options.hideDueDate, 'dueDate');
         this.hideComponent(this.options.hideDoneDate, 'doneDate');
 
-        this.generateHiddenClassForTaskList(this.options.hideDueDate, 'dueDate');
         this.generateHiddenClassForTaskList(this.options.hideDoneDate, 'doneDate');
 
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -83,6 +83,7 @@ export class TaskLayout {
         const generateClasses: [boolean, string][] = [
             [this.options.hideTags, 'tags'],
             [this.options.hideUrgency, 'urgency'],
+            [this.options.hideBacklinks, 'backlinks'],
         ];
         for (const [hide, component] of generateClasses) {
             this.generateHiddenClassForTaskList(hide, component);
@@ -93,7 +94,6 @@ export class TaskLayout {
         // (see https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1866).
         // This can benefit from some refactoring, i.e. render these components in a similar flow rather than
         // separately.
-        this.generateHiddenClassForTaskList(this.options.hideBacklinks, 'backlinks');
         this.generateHiddenClassForTaskList(this.options.hideEditButton, 'edit-button');
         if (this.options.shortMode) this.taskListHiddenClasses.push('tasks-layout-short-mode');
     }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -93,17 +93,12 @@ export class TaskLayout {
         }
     }
 
-    private generateHiddenClassForTaskList2(hide: boolean, component: string) {
-        if (hide) {
-            this.taskListClasses.push(`tasks-layout-hide-${component}`);
-        }
-    }
     // Remove a component from the taskComponents array if the given layoutOption criteria is met,
     // and add to the layout's specific classes list the class that denotes that this component
     // isn't in the layout
 
     private removeIf2(hide: boolean, component: TaskLayoutComponent) {
-        this.generateHiddenClassForTaskList2(hide, component);
+        this.generateHiddenClassForTaskList(hide, component);
 
         if (hide) {
             this.hiddenTaskLayoutComponents.push(component);

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -116,14 +116,14 @@ export class TaskLayout {
     private removeIf2(
         shouldRemove: boolean,
         componentToRemove: TaskLayoutComponent,
-        taskComponents: TaskLayoutComponent[],
+        _taskComponents: TaskLayoutComponent[],
     ) {
         if (shouldRemove) {
             this.taskListClasses.push(`tasks-layout-hide-${componentToRemove}`);
             this.hiddenTaskLayoutComponents.push(componentToRemove);
-            taskComponents = taskComponents.filter((element) => element != componentToRemove);
+            _taskComponents = _taskComponents.filter((element) => element != componentToRemove);
         }
-        return taskComponents;
+        return _taskComponents;
     }
 
     private markHiddenQueryComponents(layoutOptions: LayoutOptions) {

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -87,9 +87,9 @@ export class TaskLayout {
         if (this.options.shortMode) this.taskListClasses.push('tasks-layout-short-mode');
     }
 
-    private generateHiddenClassForTaskList(hidden: boolean, hiddenComponentName: string) {
-        if (hidden) {
-            this.taskListClasses.push(`tasks-layout-hide-${hiddenComponentName}`);
+    private generateHiddenClassForTaskList(hide: boolean, component: string) {
+        if (hide) {
+            this.taskListClasses.push(`tasks-layout-hide-${component}`);
         }
     }
 

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -100,6 +100,10 @@ export class TaskLayout {
     private removeIf2(hide: boolean, component: TaskLayoutComponent) {
         this.generateHiddenClassForTaskList(hide, component);
 
+        this.hideComponent(hide, component);
+    }
+
+    private hideComponent(hide: boolean, component: TaskLayoutComponent) {
         if (hide) {
             this.hiddenTaskLayoutComponents.push(component);
             this.shownTaskLayoutComponents = this.shownTaskLayoutComponents.filter((element) => element != component);

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -82,6 +82,7 @@ export class TaskLayout {
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
         const hide = this.options.hideTags;
         const component = 'tags';
+        const generateClasses: [boolean, string][] = [[hide, component]];
         this.generateHiddenClassForTaskList(hide, component);
 
         // The following components are handled in QueryRenderer.ts and thus are not part of the same flow that

--- a/tests/TaskLayout.test.ts
+++ b/tests/TaskLayout.test.ts
@@ -19,7 +19,7 @@ describe('TaskLayout tests', () => {
             blockLink"
         `);
         expect(taskLayout.hiddenTaskLayoutComponents.join('\n')).toMatchInlineSnapshot('""');
-        expect(taskLayout.taskListClasses.join('\n')).toMatchInlineSnapshot('"tasks-layout-hide-urgency"');
+        expect(taskLayout.taskListHiddenClasses.join('\n')).toMatchInlineSnapshot('"tasks-layout-hide-urgency"');
     });
 
     it('should generate expected CSS components with all default option reversed', () => {
@@ -46,7 +46,7 @@ describe('TaskLayout tests', () => {
             dueDate
             doneDate"
         `);
-        expect(taskLayout.taskListClasses.join('\n')).toMatchInlineSnapshot(`
+        expect(taskLayout.taskListHiddenClasses.join('\n')).toMatchInlineSnapshot(`
             "tasks-layout-hide-priority
             tasks-layout-hide-recurrenceRule
             tasks-layout-hide-createdDate


### PR DESCRIPTION
# Description

Separate management of `shownTaskLayoutComponents` & `hiddenTaskLayoutComponents` and the generation of hidden CSS classes in `taskListHiddenClasses`.

## Motivation and Context

Continue #2226 towards an abstraction in `TaskLayout`.

## How has this been tested?

Unit tests. Some commits tested by breaking code.

## Types of changes

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
