### PR TITLE
fix: Prevent auto-suggest appearing before the end of the checkbox

### DIFF
--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -19,7 +19,7 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
     onTrigger(cursor: EditorPosition, editor: Editor, _file: TFile): EditorSuggestTriggerInfo | null {
         if (!this.settings.autoSuggestInEditor) return null;
         const line = editor.getLine(cursor.line);
-        if (canSuggestForLine(line)) {
+        if (canSuggestForLine(line, cursor.ch)) {
             return {
                 start: { line: cursor.line, ch: 0 },
                 end: {

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -418,18 +418,20 @@ export function canSuggestForLine(line: string, cursorPosition: number) {
     return (
         GlobalFilter.includedIn(line) &&
         line.match(task.TaskRegularExpressions.taskRegex) !== null &&
-        cursorIsInDescription(line, cursorPosition)
+        cursorIsInTaskLineDescription(line, cursorPosition)
     );
 }
 
 /**
- * Return true if the cursor is in a task line's description.
+ * Return true if:
+ * - line is a task line, that is, it is a list item with a checkbox.
+ * - the cursor is in a task line's description.
  *
  * Here, description includes any task signifiers, as well as the vanilla description.
  * @param line
  * @param cursorPosition
  */
-function cursorIsInDescription(line: string, cursorPosition: number) {
+function cursorIsInTaskLineDescription(line: string, cursorPosition: number) {
     if (line.length === 0) {
         return false;
     }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -411,7 +411,9 @@ export function onlySuggestIfBracketOpen(fn: SuggestionBuilder, brackets: [strin
  *  - Is the global filter (if set) in the line?
  *  - Is the line a task line (with a checkbox)
  * @param line
+ * @param _cursorPosition - the cursor position, when 0 is presumed to mean 'at the start of the line'.
+ *                          See 'ch' in https://docs.obsidian.md/Reference/TypeScript+API/EditorPosition/EditorPosition
  */
-export function canSuggestForLine(line: string) {
+export function canSuggestForLine(line: string, _cursorPosition: number) {
     return GlobalFilter.includedIn(line) && line.match(task.TaskRegularExpressions.taskRegex) !== null;
 }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -422,7 +422,12 @@ export function canSuggestForLine(line: string, cursorPosition: number) {
     );
 }
 
-function cursorIsInDescription(_line: string, _cursorPosition: number) {
+function cursorIsInDescription(_line: string, cursorPosition: number) {
+    // Initial hard-coded assumption that at least the characters '- [ ] ' must be present,
+    // for the cursor to be in the description:
+    if (cursorPosition < 6) {
+        return false;
+    }
     // TODO Implement via TDD
     return true;
 }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -441,7 +441,7 @@ function cursorIsInDescription(line: string, cursorPosition: number) {
     }
 
     // Reconstruct the contents of the line, up to the space after the closing ']' in the checkbox:
-    const beforeDescription = components.listMarker + ' [' + components.status.symbol + '] ';
+    const beforeDescription = components.indentation + components.listMarker + ' [' + components.status.symbol + '] ';
 
     return cursorPosition >= beforeDescription.length;
 }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -3,7 +3,6 @@ import { DateParser } from '../Query/DateParser';
 import { doAutocomplete } from '../DateAbbreviations';
 import { Recurrence } from '../Recurrence';
 import type { DefaultTaskSerializerSymbols } from '../TaskSerializer/DefaultTaskSerializer';
-import * as task from '../Task';
 import { Task, TaskRegularExpressions } from '../Task';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import type { SuggestInfo, SuggestionBuilder } from '.';
@@ -415,11 +414,7 @@ export function onlySuggestIfBracketOpen(fn: SuggestionBuilder, brackets: [strin
  *                          See 'ch' in https://docs.obsidian.md/Reference/TypeScript+API/EditorPosition/EditorPosition
  */
 export function canSuggestForLine(line: string, cursorPosition: number) {
-    return (
-        GlobalFilter.includedIn(line) &&
-        line.match(task.TaskRegularExpressions.taskRegex) !== null &&
-        cursorIsInTaskLineDescription(line, cursorPosition)
-    );
+    return GlobalFilter.includedIn(line) && cursorIsInTaskLineDescription(line, cursorPosition);
 }
 
 /**

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -411,9 +411,18 @@ export function onlySuggestIfBracketOpen(fn: SuggestionBuilder, brackets: [strin
  *  - Is the global filter (if set) in the line?
  *  - Is the line a task line (with a checkbox)
  * @param line
- * @param _cursorPosition - the cursor position, when 0 is presumed to mean 'at the start of the line'.
+ * @param cursorPosition - the cursor position, when 0 is presumed to mean 'at the start of the line'.
  *                          See 'ch' in https://docs.obsidian.md/Reference/TypeScript+API/EditorPosition/EditorPosition
  */
-export function canSuggestForLine(line: string, _cursorPosition: number) {
-    return GlobalFilter.includedIn(line) && line.match(task.TaskRegularExpressions.taskRegex) !== null;
+export function canSuggestForLine(line: string, cursorPosition: number) {
+    return (
+        GlobalFilter.includedIn(line) &&
+        line.match(task.TaskRegularExpressions.taskRegex) !== null &&
+        cursorIsInDescription(line, cursorPosition)
+    );
+}
+
+function cursorIsInDescription(_line: string, _cursorPosition: number) {
+    // TODO Implement via TDD
+    return true;
 }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -297,7 +297,12 @@ export class Task {
         });
     }
 
-    private static extractTaskComponents(line: string): TaskComponents | null {
+    /**
+     * Extract the component parts of the task line.
+     * @param line
+     * @returns a {@link TaskComponents} object containing the component parts of the task line
+     */
+    static extractTaskComponents(line: string): TaskComponents | null {
         // Check the line to see if it is a markdown task.
         const regexMatch = line.match(TaskRegularExpressions.taskRegex);
         if (regexMatch === null) {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -235,21 +235,21 @@ describe('canSuggestForLine', () => {
 
     it('should not suggest if there is no checkbox', () => {
         GlobalFilter.reset();
-        expect(canSuggestForLine('- not a task line', 0)).toEqual(false);
+        expect(canSuggestForLine(...cursorPosition('- not a task line|'))).toEqual(false);
     });
 
     it('should suggest if there is no global filter', () => {
         GlobalFilter.reset();
-        expect(canSuggestForLine('- [ ] global filter is not set', 0)).toEqual(true);
+        expect(canSuggestForLine(...cursorPosition('- [ ] global filter is not set|'))).toEqual(true);
     });
 
     it('should suggest if global filter missing from line', () => {
         GlobalFilter.set('#todo');
-        expect(canSuggestForLine('- [ ] #todo has global filter', 0)).toEqual(true);
+        expect(canSuggestForLine(...cursorPosition('- [ ] #todo has global filter|'))).toEqual(true);
     });
 
     it('should not suggest if global filter missing from line', () => {
         GlobalFilter.set('#todo');
-        expect(canSuggestForLine('- [ ] no global filter', 0)).toEqual(false);
+        expect(canSuggestForLine(...cursorPosition('- [ ] no global filter|'))).toEqual(false);
     });
 });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -270,7 +270,7 @@ describe('canSuggestForLine', () => {
         expect(canSuggestForLineWithCursor('- [ ] |')).toEqual(true);
     });
 
-    it.failing('should suggest correctly when task is in a numbered list', () => {
+    it('should suggest correctly when task is in a numbered list', () => {
         expect(canSuggestForLineWithCursor('1. [ ]|')).toEqual(false);
         expect(canSuggestForLineWithCursor('1. [ ] |')).toEqual(true);
     });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -233,23 +233,27 @@ describe('canSuggestForLine', () => {
         GlobalFilter.reset();
     });
 
+    function canSuggestForLineWithCursor(line: string) {
+        return canSuggestForLine(...cursorPosition(line));
+    }
+
     it('should not suggest if there is no checkbox', () => {
         GlobalFilter.reset();
-        expect(canSuggestForLine(...cursorPosition('- not a task line|'))).toEqual(false);
+        expect(canSuggestForLineWithCursor('- not a task line|')).toEqual(false);
     });
 
     it('should suggest if there is no global filter', () => {
         GlobalFilter.reset();
-        expect(canSuggestForLine(...cursorPosition('- [ ] global filter is not set|'))).toEqual(true);
+        expect(canSuggestForLineWithCursor('- [ ] global filter is not set|')).toEqual(true);
     });
 
     it('should suggest if global filter missing from line', () => {
         GlobalFilter.set('#todo');
-        expect(canSuggestForLine(...cursorPosition('- [ ] #todo has global filter|'))).toEqual(true);
+        expect(canSuggestForLineWithCursor('- [ ] #todo has global filter|')).toEqual(true);
     });
 
     it('should not suggest if global filter missing from line', () => {
         GlobalFilter.set('#todo');
-        expect(canSuggestForLine(...cursorPosition('- [ ] no global filter|'))).toEqual(false);
+        expect(canSuggestForLineWithCursor('- [ ] no global filter|')).toEqual(false);
     });
 });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -260,4 +260,9 @@ describe('canSuggestForLine', () => {
     it('should not suggest when cursor is in empty line', () => {
         expect(canSuggestForLineWithCursor('|')).toEqual(false);
     });
+
+    it.failing('should not suggest when cursor is in the checkbox', () => {
+        expect(canSuggestForLineWithCursor('- [ |] ')).toEqual(false);
+        expect(canSuggestForLineWithCursor('- [ ]| ')).toEqual(false);
+    });
 });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -261,7 +261,7 @@ describe('canSuggestForLine', () => {
         expect(canSuggestForLineWithCursor('|')).toEqual(false);
     });
 
-    it.failing('should not suggest when cursor is in the checkbox', () => {
+    it('should not suggest when cursor is in the checkbox', () => {
         expect(canSuggestForLineWithCursor('- [ |] ')).toEqual(false);
         expect(canSuggestForLineWithCursor('- [ ]| ')).toEqual(false);
     });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -28,6 +28,23 @@ afterAll(() => {
     chronoSpy.mockRestore();
 });
 
+/**
+ * Given a string with **exactly** one vertical bar (`|`), returns the string with the vertical bar removed
+ * and the index of the bar.
+ *
+ * This is used as a helper when writing tests, since it provides a less error prone
+ * and more readable way to represent a cursor's position, denoted by the vertical bar, and the string.
+ *
+ * @param line - A string that contains exactly one vertical bar (`|`)
+ * @returns A tuple of the line without the vertical bar, and the index of the vertical bar.
+ */
+function cursorPosition(line: string): [lineWithoutCursor: string, cursorIndex: number] {
+    const line_without_cursor = line.replace(/\|/g, '');
+    // Check that the cursor marker appears exactly once in each input string:
+    expect(line_without_cursor.length).toEqual(line.length - 1);
+    return [line_without_cursor, line.indexOf('|')];
+}
+
 const MAX_GENERIC_SUGGESTIONS_FOR_TESTS = 50;
 
 describe.each([
@@ -167,23 +184,6 @@ describe('onlySuggestIfBracketOpen', () => {
     );
 
     const emptySuggestion = [] as unknown;
-
-    /**
-     * Given a string with **exactly** one vertical bar (`|`), returns the string with the vertical bar removed
-     * and the index of the bar.
-     *
-     * This is used as a helper when writing tests, since it provides a less error prone
-     * and more readable way to represent a cursor's position, denoted by the vertical bar, and the string.
-     *
-     * @param line - A string that contains exactly one vertical bar (`|`)
-     * @returns A tuple of the line without the vertical bar, and the index of the vertical bar.
-     */
-    function cursorPosition(line: string): [lineWithoutCursor: string, cursorIndex: number] {
-        const line_without_cursor = line.replace(/\|/g, '');
-        // Check that the cursor marker appears exactly once in each input string:
-        expect(line_without_cursor.length).toEqual(line.length - 1);
-        return [line_without_cursor, line.indexOf('|')];
-    }
 
     it('should suggest if cursor at end of line with an open pair', () => {
         const settings = getSettings();

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -265,4 +265,18 @@ describe('canSuggestForLine', () => {
         expect(canSuggestForLineWithCursor('- [ |] ')).toEqual(false);
         expect(canSuggestForLineWithCursor('- [ ]| ')).toEqual(false);
     });
+
+    it('should suggest when the cursor is at least one character past the checkbox', () => {
+        expect(canSuggestForLineWithCursor('- [ ] |')).toEqual(true);
+    });
+
+    it.failing('should suggest correctly when task is in a numbered list', () => {
+        expect(canSuggestForLineWithCursor('1. [ ]|')).toEqual(false);
+        expect(canSuggestForLineWithCursor('1. [ ] |')).toEqual(true);
+    });
+
+    it.failing('should suggest correctly when task is indented', () => {
+        expect(canSuggestForLineWithCursor('    - [ ]|')).toEqual(false);
+        expect(canSuggestForLineWithCursor('    - [ ] |')).toEqual(true);
+    });
 });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -256,4 +256,8 @@ describe('canSuggestForLine', () => {
         GlobalFilter.set('#todo');
         expect(canSuggestForLineWithCursor('- [ ] no global filter|')).toEqual(false);
     });
+
+    it('should not suggest when cursor is in empty line', () => {
+        expect(canSuggestForLineWithCursor('|')).toEqual(false);
+    });
 });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -275,7 +275,7 @@ describe('canSuggestForLine', () => {
         expect(canSuggestForLineWithCursor('1. [ ] |')).toEqual(true);
     });
 
-    it.failing('should suggest correctly when task is indented', () => {
+    it('should suggest correctly when task is indented', () => {
         expect(canSuggestForLineWithCursor('    - [ ]|')).toEqual(false);
         expect(canSuggestForLineWithCursor('    - [ ] |')).toEqual(true);
     });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -235,21 +235,21 @@ describe('canSuggestForLine', () => {
 
     it('should not suggest if there is no checkbox', () => {
         GlobalFilter.reset();
-        expect(canSuggestForLine('- not a task line')).toEqual(false);
+        expect(canSuggestForLine('- not a task line', 0)).toEqual(false);
     });
 
     it('should suggest if there is no global filter', () => {
         GlobalFilter.reset();
-        expect(canSuggestForLine('- [ ] global filter is not set')).toEqual(true);
+        expect(canSuggestForLine('- [ ] global filter is not set', 0)).toEqual(true);
     });
 
     it('should suggest if global filter missing from line', () => {
         GlobalFilter.set('#todo');
-        expect(canSuggestForLine('- [ ] #todo has global filter')).toEqual(true);
+        expect(canSuggestForLine('- [ ] #todo has global filter', 0)).toEqual(true);
     });
 
     it('should not suggest if global filter missing from line', () => {
         GlobalFilter.set('#todo');
-        expect(canSuggestForLine('- [ ] no global filter')).toEqual(false);
+        expect(canSuggestForLine('- [ ] no global filter', 0)).toEqual(false);
     });
 });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -233,6 +233,11 @@ describe('canSuggestForLine', () => {
         GlobalFilter.reset();
     });
 
+    it('should not suggest if there is no checkbox', () => {
+        GlobalFilter.reset();
+        expect(canSuggestForLine('- not a task line')).toEqual(false);
+    });
+
     it('should suggest if there is no global filter', () => {
         GlobalFilter.reset();
         expect(canSuggestForLine('- [ ] global filter is not set')).toEqual(true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I have found that Auto Suggest has a tendency to pop up in situations where it will never be valid, leading to task lines like:

```text
📅 - [ ] 
-📅  [ ] 
- [ 📅 ] 
```

This change means that Auto Suggest will now only pop up when the cursor is beyond one space after the `]` character.

If you imagine that the `|` in the following is the location of the cursor, the auto-suggest menu will no longer pop up in these situations:

```
- [ |] 
- [ ]| 
1. [ ]|
    - [ ]|
```

It will still pop up in these situations:

```
- [ ] |
1. [ ] |
    - [ ] |
```

## Motivation and Context

To make Auto Suggest a bit more specific.

## How has this been tested?

- By adding tests.
- Manual testing in the demo vault

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
