### PR TITLE
test: Refactoring to simplify EditTask.test.ts

### DIFF
--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -50,8 +50,7 @@ describe('Task rendering', () => {
         const task = taskFromLine({ line: convertDescriptionToTaskLine(taskDescription), path: '' });
 
         const onSubmit = (_: Task[]): void => {};
-        const { container } = render(EditTask, { task, statusOptions, onSubmit });
-        expect(() => container).toBeTruthy();
+        const { container } = renderAndCheckModal(task, onSubmit);
 
         const renderedDescription = getAndCheckRenderedDescription(container);
         expect(renderedDescription!.value).toEqual(expectedDescription);

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -102,6 +102,13 @@ describe('Task rendering', () => {
     });
 });
 
+function renderAndCheckModal(task: Task, onSubmit: (updatedTasks: Task[]) => void) {
+    const result: RenderResult<EditTask> = render(EditTask, { task, statusOptions, onSubmit });
+    const { container } = result;
+    expect(() => container).toBeTruthy();
+    return { result, container };
+}
+
 describe('Task editing', () => {
     afterEach(() => {
         GlobalFilter.reset();
@@ -120,10 +127,7 @@ describe('Task editing', () => {
                 .join('\n');
             resolvePromise(serializedTask);
         };
-
-        const result: RenderResult<EditTask> = render(EditTask, { task, statusOptions, onSubmit });
-        const { container } = result;
-        expect(() => container).toBeTruthy();
+        const { result, container } = renderAndCheckModal(task, onSubmit);
 
         const description = getAndCheckRenderedDescription(container);
         const submit = getAndCheckApplyButton(result);

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -21,7 +21,7 @@ function renderAndCheckModal(task: Task, onSubmit: (updatedTasks: Task[]) => voi
     return { result, container };
 }
 
-function getAndCheckRenderedDescription(container: HTMLElement): HTMLInputElement {
+function getAndCheckRenderedDescriptionElement(container: HTMLElement): HTMLInputElement {
     const renderedDescription = container.ownerDocument.getElementById('description') as HTMLInputElement;
     expect(() => renderedDescription).toBeTruthy();
     return renderedDescription;
@@ -59,7 +59,7 @@ describe('Task rendering', () => {
         const onSubmit = (_: Task[]): void => {};
         const { container } = renderAndCheckModal(task, onSubmit);
 
-        const renderedDescription = getAndCheckRenderedDescription(container);
+        const renderedDescription = getAndCheckRenderedDescriptionElement(container);
         expect(renderedDescription!.value).toEqual(expectedDescription);
     }
 
@@ -128,7 +128,7 @@ describe('Task editing', () => {
         };
         const { result, container } = renderAndCheckModal(task, onSubmit);
 
-        const description = getAndCheckRenderedDescription(container);
+        const description = getAndCheckRenderedDescriptionElement(container);
         const submit = getAndCheckApplyButton(result);
 
         const editedTask = await editDescriptionAndSubmit(description, newDescription, submit, waitForClose);

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent, render } from '@testing-library/svelte';
+import { type RenderResult, fireEvent, render } from '@testing-library/svelte';
 import { describe, expect, it } from '@jest/globals';
 import moment from 'moment';
 import { taskFromLine } from '../src/Commands/CreateOrEditTaskParser';
@@ -110,7 +110,7 @@ describe('Task editing', () => {
             resolvePromise(serializedTask);
         };
 
-        const result = render(EditTask, { task, statusOptions, onSubmit });
+        const result: RenderResult<EditTask> = render(EditTask, { task, statusOptions, onSubmit });
         const { container } = result;
         expect(() => container).toBeTruthy();
 

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -37,13 +37,17 @@ async function editDescriptionAndSubmit(
     return await waitForClose;
 }
 
+function convertDescriptionToTaskLine(taskDescription: string) {
+    return `- [ ] ${taskDescription}`;
+}
+
 describe('Task rendering', () => {
     afterEach(() => {
         GlobalFilter.reset();
     });
 
     function testDescriptionRender(taskDescription: string, expectedDescription: string) {
-        const task = taskFromLine({ line: `- [ ] ${taskDescription}`, path: '' });
+        const task = taskFromLine({ line: convertDescriptionToTaskLine(taskDescription), path: '' });
 
         const onSubmit = (_: Task[]): void => {};
         const { container } = render(EditTask, { task, statusOptions, onSubmit });

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -14,6 +14,13 @@ import { GlobalFilter } from '../src/Config/GlobalFilter';
 window.moment = moment;
 const statusOptions: Status[] = [Status.DONE, Status.TODO];
 
+function renderAndCheckModal(task: Task, onSubmit: (updatedTasks: Task[]) => void) {
+    const result: RenderResult<EditTask> = render(EditTask, { task, statusOptions, onSubmit });
+    const { container } = result;
+    expect(() => container).toBeTruthy();
+    return { result, container };
+}
+
 function getAndCheckRenderedDescription(container: HTMLElement) {
     const renderedDescription = container.ownerDocument.getElementById('description') as HTMLInputElement;
     expect(() => renderedDescription).toBeTruthy();
@@ -100,13 +107,6 @@ describe('Task rendering', () => {
         );
     });
 });
-
-function renderAndCheckModal(task: Task, onSubmit: (updatedTasks: Task[]) => void) {
-    const result: RenderResult<EditTask> = render(EditTask, { task, statusOptions, onSubmit });
-    const { container } = result;
-    expect(() => container).toBeTruthy();
-    return { result, container };
-}
 
 describe('Task editing', () => {
     afterEach(() => {

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -103,8 +103,7 @@ describe('Task editing', () => {
         const { container } = result;
         expect(() => container).toBeTruthy();
 
-        const description = container.ownerDocument.getElementById('description') as HTMLInputElement;
-        expect(description).toBeTruthy();
+        const description = getAndCheckRenderedDescription(container);
         const submit = result.getByText('Apply') as HTMLButtonElement;
         expect(submit).toBeTruthy();
 

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -108,7 +108,7 @@ describe('Task editing', () => {
     });
 
     async function testDescriptionEdit(taskDescription: string, newDescription: string, expectedDescription: string) {
-        const task = taskFromLine({ line: `- [ ] ${taskDescription}`, path: '' });
+        const task = taskFromLine({ line: convertDescriptionToTaskLine(taskDescription), path: '' });
 
         let resolvePromise: (input: string) => void;
         const waitForClose = new Promise<string>((resolve, _) => {

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -20,6 +20,17 @@ function getAndCheckRenderedDescription(container: HTMLElement) {
     return renderedDescription;
 }
 
+async function editDescriptionAndSubmit(
+    description: HTMLInputElement,
+    newDescription: string,
+    submit: HTMLButtonElement,
+    waitForClose: Promise<string>,
+) {
+    await fireEvent.input(description, { target: { value: newDescription } });
+    submit.click();
+    return await waitForClose;
+}
+
 describe('Task rendering', () => {
     afterEach(() => {
         GlobalFilter.reset();
@@ -107,9 +118,7 @@ describe('Task editing', () => {
         const submit = result.getByText('Apply') as HTMLButtonElement;
         expect(submit).toBeTruthy();
 
-        await fireEvent.input(description, { target: { value: newDescription } });
-        submit.click();
-        const editedTask = await waitForClose;
+        const editedTask = await editDescriptionAndSubmit(description, newDescription, submit, waitForClose);
         expect(editedTask).toEqual(`- [ ] ${expectedDescription}`);
     }
 

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -48,6 +48,7 @@ describe('Task rendering', () => {
         const onSubmit = (_: Task[]): void => {};
         const { container } = render(EditTask, { task, statusOptions, onSubmit });
         expect(() => container).toBeTruthy();
+
         const renderedDescription = getAndCheckRenderedDescription(container);
         expect(renderedDescription!.value).toEqual(expectedDescription);
     }

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -21,13 +21,13 @@ function renderAndCheckModal(task: Task, onSubmit: (updatedTasks: Task[]) => voi
     return { result, container };
 }
 
-function getAndCheckRenderedDescription(container: HTMLElement) {
+function getAndCheckRenderedDescription(container: HTMLElement): HTMLInputElement {
     const renderedDescription = container.ownerDocument.getElementById('description') as HTMLInputElement;
     expect(() => renderedDescription).toBeTruthy();
     return renderedDescription;
 }
 
-function getAndCheckApplyButton(result: RenderResult<EditTask>) {
+function getAndCheckApplyButton(result: RenderResult<EditTask>): HTMLButtonElement {
     const submit = result.getByText('Apply') as HTMLButtonElement;
     expect(submit).toBeTruthy();
     return submit;
@@ -38,13 +38,13 @@ async function editDescriptionAndSubmit(
     newDescription: string,
     submit: HTMLButtonElement,
     waitForClose: Promise<string>,
-) {
+): Promise<string> {
     await fireEvent.input(description, { target: { value: newDescription } });
     submit.click();
     return await waitForClose;
 }
 
-function convertDescriptionToTaskLine(taskDescription: string) {
+function convertDescriptionToTaskLine(taskDescription: string): string {
     return `- [ ] ${taskDescription}`;
 }
 

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -20,6 +20,12 @@ function getAndCheckRenderedDescription(container: HTMLElement) {
     return renderedDescription;
 }
 
+function getAndCheckApplyButton(result: RenderResult<EditTask>) {
+    const submit = result.getByText('Apply') as HTMLButtonElement;
+    expect(submit).toBeTruthy();
+    return submit;
+}
+
 async function editDescriptionAndSubmit(
     description: HTMLInputElement,
     newDescription: string,
@@ -115,8 +121,7 @@ describe('Task editing', () => {
         expect(() => container).toBeTruthy();
 
         const description = getAndCheckRenderedDescription(container);
-        const submit = result.getByText('Apply') as HTMLButtonElement;
-        expect(submit).toBeTruthy();
+        const submit = getAndCheckApplyButton(result);
 
         const editedTask = await editDescriptionAndSubmit(description, newDescription, submit, waitForClose);
         expect(editedTask).toEqual(`- [ ] ${expectedDescription}`);

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -14,6 +14,12 @@ import { GlobalFilter } from '../src/Config/GlobalFilter';
 window.moment = moment;
 const statusOptions: Status[] = [Status.DONE, Status.TODO];
 
+function getAndCheckRenderedDescription(container: HTMLElement) {
+    const renderedDescription = container.ownerDocument.getElementById('description') as HTMLInputElement;
+    expect(() => renderedDescription).toBeTruthy();
+    return renderedDescription;
+}
+
 describe('Task rendering', () => {
     afterEach(() => {
         GlobalFilter.reset();
@@ -25,8 +31,7 @@ describe('Task rendering', () => {
         const onSubmit = (_: Task[]): void => {};
         const { container } = render(EditTask, { task, statusOptions, onSubmit });
         expect(() => container).toBeTruthy();
-        const renderedDescription = container.ownerDocument.getElementById('description') as HTMLInputElement;
-        expect(() => renderedDescription).toBeTruthy();
+        const renderedDescription = getAndCheckRenderedDescription(container);
         expect(renderedDescription!.value).toEqual(expectedDescription);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- This mainly eliminates some duplicated code in `EditTask.test.ts`
- It also extracts some named methods to make the more complex code a bit clearer, by at least naming the behaviour

## Motivation and Context

This is in preparation for improving test coverage of `EditTask.ts`

## How has this been tested?

By repeatedly running the existing tests.

It only changed test code, so no manual testing is required.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
