### PR TITLE
feat: templating in queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@testing-library/svelte": "^3.2.2",
     "@tsconfig/svelte": "^3.0.0",
     "@types/jest": "^29.5.2",
+    "@types/mustache": "^4.2.2",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
     "approvals": "^6.2.1",
@@ -59,6 +60,8 @@
     "boon-js": "^2.0.3",
     "chrono-node": "2.3.9",
     "eventemitter2": "^6.4.5",
+    "mustache": "^4.2.0",
+    "mustache-validator": "^0.2.0",
     "rrule": "^2.7.1"
   }
 }

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -89,12 +89,12 @@ class QueryRenderChild extends MarkdownRenderChild {
         // added later.
         switch (this.containerEl.className) {
             case 'block-language-tasks':
-                this.query = getQueryForQueryRenderer(this.source);
+                this.query = getQueryForQueryRenderer(this.source, this.filePath);
                 this.queryType = 'tasks';
                 break;
 
             default:
-                this.query = getQueryForQueryRenderer(this.source);
+                this.query = getQueryForQueryRenderer(this.source, this.filePath);
                 this.queryType = 'tasks';
                 break;
         }
@@ -135,7 +135,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         const millisecondsToMidnight = midnight.getTime() - now.getTime();
 
         this.queryReloadTimeout = setTimeout(() => {
-            this.query = getQueryForQueryRenderer(this.source);
+            this.query = getQueryForQueryRenderer(this.source, this.filePath);
             // Process the current cache state:
             this.events.triggerRequestCacheUpdate(this.render.bind(this));
             this.reloadQueryAtMidnight();
@@ -198,7 +198,7 @@ class QueryRenderChild extends MarkdownRenderChild {
 
     // Use the 'explain' instruction to enable this
     private createExplanation(content: HTMLDivElement) {
-        const explanationAsString = explainResults(this.source);
+        const explanationAsString = explainResults(this.source, this.filePath);
 
         const explanationsBlock = content.createEl('pre');
         explanationsBlock.addClasses(['plugin-tasks-query-explanation']);

--- a/src/lib/ExpandTemplate.ts
+++ b/src/lib/ExpandTemplate.ts
@@ -1,0 +1,14 @@
+import Mustache from 'mustache';
+import proxyData from 'mustache-validator';
+
+// https://github.com/janl/mustache.js
+
+export function expandMustacheTemplate(template: string, view: any): string {
+    // Turn off HTML escaping of things like '/' in file paths:
+    // https://github.com/janl/mustache.js#variables
+    Mustache.escape = function (text) {
+        return text;
+    };
+
+    return Mustache.render(template, proxyData(view));
+}

--- a/src/lib/QueryContext.ts
+++ b/src/lib/QueryContext.ts
@@ -1,0 +1,20 @@
+import { TasksFile } from '../Scripting/TasksFile';
+
+export interface QueryContext {
+    query: {
+        file: TasksFile;
+    };
+}
+
+export function makeQueryContext(path: string): QueryContext {
+    const tasksFile = new TasksFile(path);
+    return {
+        query: {
+            file: tasksFile,
+        },
+    };
+}
+
+export function makeQueryContextFromPath(path: string) {
+    return makeQueryContext(path);
+}

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -20,19 +20,20 @@ import { Query } from '../Query/Query';
  *     * Explains the query described by {@link source}
  *
  * @param {string} source The source of the task block to explain
+ * @param {string} path The location of the task block, if known
  * @returns {string}
  */
-export function explainResults(source: string): string {
+export function explainResults(source: string, path: string | undefined = undefined): string {
     let result = '';
 
     if (!GlobalFilter.isEmpty()) {
         result += `Only tasks containing the global filter '${GlobalFilter.get()}'.\n\n`;
     }
 
-    const tasksBlockQuery = new Query({ source });
+    const tasksBlockQuery = new Query({ source }, path);
 
     if (!tasksBlockQuery.ignoreGlobalQuery) {
-        const globalQuery: IQuery = new Query(getGlobalQuerySource());
+        const globalQuery: IQuery = new Query(getGlobalQuerySource(), path);
 
         if (globalQuery.source.trim() !== '') {
             result += `Explanation of the global query:\n\n${globalQuery.explainQuery()}\n`;
@@ -50,11 +51,12 @@ export function explainResults(source: string): string {
  * This query is the result of joining the global query with the query in the task block
  *
  * @param {string} source The query source from the task block
+ * @param {string | undefined} path The path to the file containing the query, if available.
  * @returns {Query} The query to execute
  */
-export function getQueryForQueryRenderer(source: string): Query {
-    const globalQuery = new Query(getGlobalQuerySource());
-    const tasksBlockQuery = new Query({ source });
+export function getQueryForQueryRenderer(source: string, path: string | undefined): Query {
+    const globalQuery = new Query(getGlobalQuerySource(), path);
+    const tasksBlockQuery = new Query({ source }, path);
 
     if (tasksBlockQuery.ignoreGlobalQuery) {
         return tasksBlockQuery;

--- a/tests/lib/QueryContext.test.QueryContext_should_construct_a_QueryContext_from_a_path.approved.json
+++ b/tests/lib/QueryContext.test.QueryContext_should_construct_a_QueryContext_from_a_path.approved.json
@@ -1,0 +1,7 @@
+{
+  "query": {
+    "file": {
+      "_path": "a/b/c.md"
+    }
+  }
+}

--- a/tests/lib/QueryContext.test.ts
+++ b/tests/lib/QueryContext.test.ts
@@ -1,0 +1,46 @@
+import { verifyAsJson } from 'approvals/lib/Providers/Jest/JestApprovals';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { FilenameField } from '../../src/Query/Filter/FilenameField';
+import { FolderField } from '../../src/Query/Filter/FolderField';
+import { PathField } from '../../src/Query/Filter/PathField';
+import { RootField } from '../../src/Query/Filter/RootField';
+import { makeQueryContextFromPath } from '../../src/lib/QueryContext';
+
+describe('QueryContext', () => {
+    it('should construct a QueryContext from a path', () => {
+        const path = 'a/b/c.md';
+        const queryContext = makeQueryContextFromPath(path);
+
+        verifyAsJson(queryContext);
+    });
+
+    describe('values should all match their corresponding filters', () => {
+        const path = 'a/b/c.md';
+        const task = new TaskBuilder().path(path).build();
+        const queryContext = makeQueryContextFromPath(path);
+
+        it('root', () => {
+            const instruction = `root includes ${queryContext.query.file.root}`;
+            const filter = new RootField().createFilterOrErrorMessage(instruction);
+            expect(filter).toMatchTask(task);
+        });
+
+        it('path', () => {
+            const instruction = `path includes ${queryContext.query.file.path}`;
+            const filter = new PathField().createFilterOrErrorMessage(instruction);
+            expect(filter).toMatchTask(task);
+        });
+
+        it('folder', () => {
+            const instruction = `folder includes ${queryContext.query.file.folder}`;
+            const filter = new FolderField().createFilterOrErrorMessage(instruction);
+            expect(filter).toMatchTask(task);
+        });
+
+        it('filename', () => {
+            const instruction = `filename includes ${queryContext.query.file.filename}`;
+            const filter = new FilenameField().createFilterOrErrorMessage(instruction);
+            expect(filter).toMatchTask(task);
+        });
+    });
+});

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -105,13 +105,17 @@ describe('query used for QueryRenderer', () => {
         const querySource = 'description includes world';
         const globalQuerySource = 'description includes hello';
         updateSettings({ globalQuery: globalQuerySource });
-        expect(getQueryForQueryRenderer(querySource).source).toEqual(`${globalQuerySource}\n${querySource}`);
+        const filePath = 'a/b/c.md';
+        const query = getQueryForQueryRenderer(querySource, filePath);
+        expect(query.source).toEqual(`${globalQuerySource}\n${querySource}`);
+        expect(query.filePath).toEqual(filePath);
     });
 
     it('should ignore the global query if "ignore global query" is set', () => {
         updateSettings({ globalQuery: 'path includes from_global_query' });
-        expect(getQueryForQueryRenderer('description includes from_block_query\nignore global query').source).toEqual(
-            'description includes from_block_query\nignore global query',
-        );
+        const filePath = 'a/b/c.md';
+        const query = getQueryForQueryRenderer('description includes from_block_query\nignore global query', filePath);
+        expect(query.source).toEqual('description includes from_block_query\nignore global query');
+        expect(query.filePath).toEqual(filePath);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,6 +1240,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/mustache@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-4.2.2.tgz#825bf5c214c3ab84d0b23fef2c8eb898f3ff8717"
+  integrity sha512-MUSpfpW0yZbTgjekDbH0shMYBUD+X/uJJJMm9LXN1d5yjl5lCY1vN/eWKD6D1tOtjA6206K0zcIPnUaFMurdNA==
+
 "@types/node@*":
   version "18.0.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.3.tgz#463fc47f13ec0688a33aec75d078a0541a447199"
@@ -4453,6 +4458,16 @@ ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+mustache-validator@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/mustache-validator/-/mustache-validator-0.2.0.tgz#b9ef770263fe560429a7f90cb5866331f4274cb1"
+  integrity sha512-L4RIboVYTXHFHNWv5Sac3Ru63SUMgDRSY1G7YapeasgMf7IqpYIO/h8f+/5GJJIwcCcfyQXDFffD+VO6/F5f+Q==
+
+mustache@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
 natives@^1.1.6:
   version "1.1.6"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add `query.file.root`, `query.file.folder`, `query.file.path` and `query.file.filename` templates.

## Motivation and Context

Provide a way to reference the query filename/root/folder/path without hardcoding it.

## How has this been tested?

New unit tests.

## Types of changes

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
