### PR TITLE
refactor: extract data attribute names dictionary from `getComponentDataAttribute()`

### DIFF
--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -312,9 +312,10 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         case 'dueDate':
         case 'startDate':
         case 'scheduledDate':
-        case 'doneDate':
+        case 'doneDate': {
             addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;
+        }
     }
     return dataAttributes;
 }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -312,8 +312,6 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         case 'dueDate':
         case 'startDate':
         case 'scheduledDate':
-            addDateDataAttributes(task[component], dataAttributeNames[component]);
-            break;
         case 'doneDate':
             addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -329,7 +329,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'scheduledDate': {
-            addDateDataAttributes(task.scheduledDate, scheduledDateAttributeName);
+            addDateDataAttributes(task.scheduledDate, dataAttributeNames[component]);
             break;
         }
         case 'doneDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -289,18 +289,18 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         }
     }
 
+    const createdDateAttributeName = 'taskCreated';
     // Update data attributes
     switch (component) {
-        case 'description':
-        case 'recurrenceRule': {
-            break;
-        }
         case 'priority': {
             dataAttributes['taskPriority'] = PriorityTools.priorityNameUsingNormal(task.priority).toLocaleLowerCase();
             break;
         }
+        case 'description':
+        case 'recurrenceRule': {
+            break;
+        }
         case 'createdDate': {
-            const createdDateAttributeName = 'taskCreated';
             addDateDataAttributes(task.createdDate, createdDateAttributeName);
             break;
         }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -300,7 +300,8 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'createdDate': {
-            addDateDataAttributes(task.createdDate, 'taskCreated');
+            const createdDateAttributeName = 'taskCreated';
+            addDateDataAttributes(task.createdDate, createdDateAttributeName);
             break;
         }
         case 'dueDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -289,14 +289,13 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         }
     }
 
-    const startDateAttributeName = 'taskStart';
     const scheduledDateAttributeName = 'taskScheduled';
     const doneDateAttributeName = 'taskDone';
 
     const dataAttributeNames: { [c in TaskLayoutComponent]: string } = {
         createdDate: 'taskCreated',
         dueDate: 'taskDue',
-        startDate: startDateAttributeName,
+        startDate: 'taskStart',
         scheduledDate: scheduledDateAttributeName,
         doneDate: doneDateAttributeName,
         priority: '',

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -280,6 +280,11 @@ function getTaskComponentClass(component: TaskLayoutComponent, task: Task) {
 function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
     const dataAttribute: AttributesDictionary = {};
 
+    // If a TaskLayoutComponent needs a data attribute in the task's <span>, add the data attribute name
+    // to this dictionary: key is the component, value is the data attribute name.
+    // Otherwise, just leave an empty string ('') as the value.
+    // Also add the new component to the switch-case below in this function. This is where
+    // the data attribute value shall be calculated and set in the returned dictionary.
     const DataAttributeNames: { [c in TaskLayoutComponent]: string } = {
         createdDate: 'taskCreated',
         dueDate: 'taskDue',

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -289,14 +289,13 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         }
     }
 
-    const createdDateAttributeName = 'taskCreated';
     const dueDateAttributeName = 'taskDue';
     const startDateAttributeName = 'taskStart';
     const scheduledDateAttributeName = 'taskScheduled';
     const doneDateAttributeName = 'taskDone';
 
     const dataAttributeNames: { [c in TaskLayoutComponent]: string } = {
-        createdDate: createdDateAttributeName,
+        createdDate: 'taskCreated',
         dueDate: dueDateAttributeName,
         startDate: startDateAttributeName,
         scheduledDate: scheduledDateAttributeName,

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -319,7 +319,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'startDate': {
-            addDateDataAttributes(task.startDate, dataAttributeNames[component]);
+            addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;
         }
         case 'scheduledDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -325,7 +325,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'startDate': {
-            addDateDataAttributes(task.startDate, startDateAttributeName);
+            addDateDataAttributes(task.startDate, dataAttributeNames[component]);
             break;
         }
         case 'scheduledDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -298,7 +298,8 @@ function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
         case 'blockLink':
             break;
         case 'priority': {
-            dataAttribute['taskPriority'] = PriorityTools.priorityNameUsingNormal(task.priority).toLocaleLowerCase();
+            const attributeName = 'taskPriority';
+            dataAttribute[attributeName] = PriorityTools.priorityNameUsingNormal(task.priority).toLocaleLowerCase();
             break;
         }
         case 'createdDate':

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -289,14 +289,12 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         }
     }
 
-    const doneDateAttributeName = 'taskDone';
-
     const dataAttributeNames: { [c in TaskLayoutComponent]: string } = {
         createdDate: 'taskCreated',
         dueDate: 'taskDue',
         startDate: 'taskStart',
         scheduledDate: 'taskScheduled',
-        doneDate: doneDateAttributeName,
+        doneDate: 'taskDone',
         priority: '',
         description: '',
         recurrenceRule: '',

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -315,7 +315,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'dueDate': {
-            addDateDataAttributes(task.dueDate, dataAttributeNames[component]);
+            addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;
         }
         case 'startDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -333,7 +333,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'doneDate': {
-            addDateDataAttributes(task.doneDate, doneDateAttributeName);
+            addDateDataAttributes(task.doneDate, dataAttributeNames[component]);
             break;
         }
     }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -31,7 +31,7 @@ export const LayoutClasses: { [c in TaskLayoutComponent]: string } = {
     blockLink: '',
 };
 
-const dataAttributeNames: { [c in TaskLayoutComponent]: string } = {
+const DataAttributeNames: { [c in TaskLayoutComponent]: string } = {
     createdDate: 'taskCreated',
     dueDate: 'taskDue',
     startDate: 'taskStart',
@@ -298,7 +298,7 @@ function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
         case 'blockLink':
             break;
         case 'priority': {
-            const attributeName = dataAttributeNames[component];
+            const attributeName = DataAttributeNames[component];
             dataAttribute[attributeName] = PriorityTools.priorityNameUsingNormal(task.priority).toLocaleLowerCase();
             break;
         }
@@ -311,7 +311,7 @@ function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
             if (date) {
                 const attributeValue = dateToAttribute(date);
                 if (attributeValue) {
-                    const attributeName = dataAttributeNames[component];
+                    const attributeName = DataAttributeNames[component];
                     dataAttribute[attributeName] = attributeValue;
                 }
             }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -306,10 +306,10 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         case 'doneDate': {
             const date = task[component];
             if (date) {
-                const dateValue = dateToAttribute(date);
-                if (dateValue) {
+                const attributeValue = dateToAttribute(date);
+                if (attributeValue) {
                     const dataAttributeName = dataAttributeNames[component];
-                    dataAttributes[dataAttributeName] = dateValue;
+                    dataAttributes[dataAttributeName] = attributeValue;
                 }
             }
             break;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -320,7 +320,8 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'doneDate': {
-            addDateDataAttributes(task.doneDate, 'taskDone');
+            const doneDateAttributeName = 'taskDone';
+            addDateDataAttributes(task.doneDate, doneDateAttributeName);
             break;
         }
     }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -278,7 +278,7 @@ function getTaskComponentClass(component: TaskLayoutComponent, task: Task) {
  * The data attribute describes the content of the component, e.g. `data-task-priority="medium"`, `data-task-due="past-1d"` etc.
  */
 function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
-    const dataAttributes: AttributesDictionary = {};
+    const dataAttribute: AttributesDictionary = {};
 
     const dataAttributeNames: { [c in TaskLayoutComponent]: string } = {
         createdDate: 'taskCreated',
@@ -298,7 +298,7 @@ function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
         case 'blockLink':
             break;
         case 'priority':
-            dataAttributes['taskPriority'] = PriorityTools.priorityNameUsingNormal(task.priority).toLocaleLowerCase();
+            dataAttribute['taskPriority'] = PriorityTools.priorityNameUsingNormal(task.priority).toLocaleLowerCase();
             break;
         case 'createdDate':
         case 'dueDate':
@@ -310,13 +310,13 @@ function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
                 const attributeValue = dateToAttribute(date);
                 if (attributeValue) {
                     const attributeName = dataAttributeNames[component];
-                    dataAttributes[attributeName] = attributeValue;
+                    dataAttribute[attributeName] = attributeValue;
                 }
             }
             break;
         }
     }
-    return dataAttributes;
+    return dataAttribute;
 }
 
 /*

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -302,34 +302,27 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
     };
     // Update data attributes
     switch (component) {
-        case 'priority': {
+        case 'priority':
             dataAttributes['taskPriority'] = PriorityTools.priorityNameUsingNormal(task.priority).toLocaleLowerCase();
             break;
-        }
         case 'description':
-        case 'recurrenceRule': {
+        case 'recurrenceRule':
             break;
-        }
-        case 'createdDate': {
+        case 'createdDate':
             addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;
-        }
-        case 'dueDate': {
+        case 'dueDate':
             addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;
-        }
-        case 'startDate': {
+        case 'startDate':
             addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;
-        }
-        case 'scheduledDate': {
+        case 'scheduledDate':
             addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;
-        }
-        case 'doneDate': {
+        case 'doneDate':
             addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;
-        }
     }
     return dataAttributes;
 }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -165,7 +165,7 @@ async function taskToHtml(
                 const componentClass = getTaskComponentClass(component, task);
                 span.classList.add(...componentClass);
 
-                // Add the attributes to the component ('priority-medium', 'due-past-1d' etc)
+                // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
                 const componentDataAttribute = getComponentDataAttribute(component, task);
                 for (const key in componentDataAttribute) span.dataset[key] = componentDataAttribute[key];
                 allAttributes = { ...allAttributes, ...componentDataAttribute };

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -317,7 +317,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'createdDate': {
-            addDateDataAttributes(task.createdDate, createdDateAttributeName);
+            addDateDataAttributes(task.createdDate, dataAttributeNames[component]);
             break;
         }
         case 'dueDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -305,10 +305,10 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         case 'scheduledDate':
         case 'doneDate': {
             const date = task[component];
-            const dataAttributeName = dataAttributeNames[component];
             if (date) {
                 const dateValue = dateToAttribute(date);
                 if (dateValue) {
+                    const dataAttributeName = dataAttributeNames[component];
                     dataAttributes[dataAttributeName] = dateValue;
                 }
             }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -185,8 +185,8 @@ async function taskToHtml(
     // So if the priority was not rendered, force it through the pipe of getting the component data for the
     // priority field.
     if (allAttributes.taskPriority === undefined) {
-        const dataAttributes = getComponentDataAttribute('priority', task);
-        allAttributes = { ...allAttributes, ...dataAttributes };
+        const priorityDataAttribute = getComponentDataAttribute('priority', task);
+        allAttributes = { ...allAttributes, ...priorityDataAttribute };
     }
 
     return allAttributes;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -166,9 +166,9 @@ async function taskToHtml(
                 span.classList.add(...componentClass);
 
                 // Add the attributes to the component ('priority-medium', 'due-past-1d' etc)
-                const dataAttributes = getComponentDataAttribute(component, task);
-                for (const key in dataAttributes) span.dataset[key] = dataAttributes[key];
-                allAttributes = { ...allAttributes, ...dataAttributes };
+                const componentDataAttribute = getComponentDataAttribute(component, task);
+                for (const key in componentDataAttribute) span.dataset[key] = componentDataAttribute[key];
+                allAttributes = { ...allAttributes, ...componentDataAttribute };
             }
         }
     }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -280,15 +280,6 @@ function getTaskComponentClass(component: TaskLayoutComponent, task: Task) {
 function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
     const dataAttributes: AttributesDictionary = {};
 
-    function addDateDataAttributes(date: moment.Moment | null, attributeName: string) {
-        if (date) {
-            const dateValue = dateToAttribute(date);
-            if (dateValue) {
-                dataAttributes[attributeName] = dateValue;
-            }
-        }
-    }
-
     const dataAttributeNames: { [c in TaskLayoutComponent]: string } = {
         createdDate: 'taskCreated',
         dueDate: 'taskDue',
@@ -315,7 +306,12 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         case 'doneDate': {
             const date = task[component];
             const dataAttributeName = dataAttributeNames[component];
-            addDateDataAttributes(date, dataAttributeName);
+            if (date) {
+                const dateValue = dateToAttribute(date);
+                if (dateValue) {
+                    dataAttributes[dataAttributeName] = dateValue;
+                }
+            }
             break;
         }
     }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -31,18 +31,6 @@ export const LayoutClasses: { [c in TaskLayoutComponent]: string } = {
     blockLink: '',
 };
 
-const DataAttributeNames: { [c in TaskLayoutComponent]: string } = {
-    createdDate: 'taskCreated',
-    dueDate: 'taskDue',
-    startDate: 'taskStart',
-    scheduledDate: 'taskScheduled',
-    doneDate: 'taskDone',
-    priority: 'taskPriority',
-    description: '',
-    recurrenceRule: '',
-    blockLink: '',
-};
-
 const MAX_DAY_VALUE_RANGE = 7;
 const DAY_VALUE_OVER_RANGE_POSTFIX = 'far';
 
@@ -291,6 +279,18 @@ function getTaskComponentClass(component: TaskLayoutComponent, task: Task) {
  */
 function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
     const dataAttribute: AttributesDictionary = {};
+
+    const DataAttributeNames: { [c in TaskLayoutComponent]: string } = {
+        createdDate: 'taskCreated',
+        dueDate: 'taskDue',
+        startDate: 'taskStart',
+        scheduledDate: 'taskScheduled',
+        doneDate: 'taskDone',
+        priority: 'taskPriority',
+        description: '',
+        recurrenceRule: '',
+        blockLink: '',
+    };
 
     switch (component) {
         case 'description':

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -298,7 +298,6 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         case 'description':
         case 'recurrenceRule':
-            break;
         case 'blockLink':
             break;
         case 'createdDate':

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -315,7 +315,8 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'scheduledDate': {
-            addDateDataAttributes(task.scheduledDate, 'taskScheduled');
+            const scheduledDateAttributeName = 'taskScheduled';
+            addDateDataAttributes(task.scheduledDate, scheduledDateAttributeName);
             break;
         }
         case 'doneDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -314,7 +314,8 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         case 'scheduledDate':
         case 'doneDate': {
             const date = task[component];
-            addDateDataAttributes(date, dataAttributeNames[component]);
+            const dataAttributeName = dataAttributeNames[component];
+            addDateDataAttributes(date, dataAttributeName);
             break;
         }
     }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -289,14 +289,13 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         }
     }
 
-    const dueDateAttributeName = 'taskDue';
     const startDateAttributeName = 'taskStart';
     const scheduledDateAttributeName = 'taskScheduled';
     const doneDateAttributeName = 'taskDone';
 
     const dataAttributeNames: { [c in TaskLayoutComponent]: string } = {
         createdDate: 'taskCreated',
-        dueDate: dueDateAttributeName,
+        dueDate: 'taskDue',
         startDate: startDateAttributeName,
         scheduledDate: scheduledDateAttributeName,
         doneDate: doneDateAttributeName,

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -294,6 +294,18 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
     const startDateAttributeName = 'taskStart';
     const scheduledDateAttributeName = 'taskScheduled';
     const doneDateAttributeName = 'taskDone';
+
+    const dataAttributeNames: { [c in TaskLayoutComponent]: string } = {
+        createdDate: createdDateAttributeName,
+        dueDate: dueDateAttributeName,
+        startDate: startDateAttributeName,
+        scheduledDate: scheduledDateAttributeName,
+        doneDate: doneDateAttributeName,
+        priority: '',
+        description: '',
+        recurrenceRule: '',
+        blockLink: '',
+    };
     // Update data attributes
     switch (component) {
         case 'priority': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -292,6 +292,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
     const createdDateAttributeName = 'taskCreated';
     const dueDateAttributeName = 'taskDue';
     const startDateAttributeName = 'taskStart';
+    const scheduledDateAttributeName = 'taskScheduled';
     // Update data attributes
     switch (component) {
         case 'priority': {
@@ -315,7 +316,6 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'scheduledDate': {
-            const scheduledDateAttributeName = 'taskScheduled';
             addDateDataAttributes(task.scheduledDate, scheduledDateAttributeName);
             break;
         }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -31,6 +31,18 @@ export const LayoutClasses: { [c in TaskLayoutComponent]: string } = {
     blockLink: '',
 };
 
+const dataAttributeNames: { [c in TaskLayoutComponent]: string } = {
+    createdDate: 'taskCreated',
+    dueDate: 'taskDue',
+    startDate: 'taskStart',
+    scheduledDate: 'taskScheduled',
+    doneDate: 'taskDone',
+    priority: 'taskPriority',
+    description: '',
+    recurrenceRule: '',
+    blockLink: '',
+};
+
 const MAX_DAY_VALUE_RANGE = 7;
 const DAY_VALUE_OVER_RANGE_POSTFIX = 'far';
 
@@ -279,18 +291,6 @@ function getTaskComponentClass(component: TaskLayoutComponent, task: Task) {
  */
 function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
     const dataAttribute: AttributesDictionary = {};
-
-    const dataAttributeNames: { [c in TaskLayoutComponent]: string } = {
-        createdDate: 'taskCreated',
-        dueDate: 'taskDue',
-        startDate: 'taskStart',
-        scheduledDate: 'taskScheduled',
-        doneDate: 'taskDone',
-        priority: 'taskPriority',
-        description: '',
-        recurrenceRule: '',
-        blockLink: '',
-    };
 
     switch (component) {
         case 'description':

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -293,12 +293,12 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
     };
 
     switch (component) {
-        case 'priority':
-            dataAttributes['taskPriority'] = PriorityTools.priorityNameUsingNormal(task.priority).toLocaleLowerCase();
-            break;
         case 'description':
         case 'recurrenceRule':
         case 'blockLink':
+            break;
+        case 'priority':
+            dataAttributes['taskPriority'] = PriorityTools.priorityNameUsingNormal(task.priority).toLocaleLowerCase();
             break;
         case 'createdDate':
         case 'dueDate':

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -309,8 +309,6 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         case 'recurrenceRule':
             break;
         case 'createdDate':
-            addDateDataAttributes(task[component], dataAttributeNames[component]);
-            break;
         case 'dueDate':
             addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -299,6 +299,8 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         case 'description':
         case 'recurrenceRule':
             break;
+        case 'blockLink':
+            break;
         case 'createdDate':
         case 'dueDate':
         case 'startDate':

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -175,8 +175,8 @@ async function taskToHtml(
 
     // Now build classes for the hidden task components without rendering them
     for (const component of taskLayout.hiddenTaskLayoutComponents) {
-        const dataAttributes = getComponentDataAttribute(component, task);
-        allAttributes = { ...allAttributes, ...dataAttributes };
+        const hiddenComponentDataAttribute = getComponentDataAttribute(component, task);
+        allAttributes = { ...allAttributes, ...hiddenComponentDataAttribute };
     }
 
     // If a task has no priority field set, its priority will not be rendered as part of the loop above and

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -308,8 +308,8 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             if (date) {
                 const attributeValue = dateToAttribute(date);
                 if (attributeValue) {
-                    const dataAttributeName = dataAttributeNames[component];
-                    dataAttributes[dataAttributeName] = attributeValue;
+                    const attributeName = dataAttributeNames[component];
+                    dataAttributes[attributeName] = attributeValue;
                 }
             }
             break;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -166,7 +166,7 @@ async function taskToHtml(
                 span.classList.add(...componentClass);
 
                 // Add the attributes to the component ('priority-medium', 'due-past-1d' etc)
-                const dataAttributes = getTaskDataAttributes(component, task);
+                const dataAttributes = getComponentDataAttribute(component, task);
                 for (const key in dataAttributes) span.dataset[key] = dataAttributes[key];
                 allAttributes = { ...allAttributes, ...dataAttributes };
             }
@@ -175,7 +175,7 @@ async function taskToHtml(
 
     // Now build classes for the hidden task components without rendering them
     for (const component of taskLayout.hiddenTaskLayoutComponents) {
-        const dataAttributes = getTaskDataAttributes(component, task);
+        const dataAttributes = getComponentDataAttribute(component, task);
         allAttributes = { ...allAttributes, ...dataAttributes };
     }
 
@@ -185,7 +185,7 @@ async function taskToHtml(
     // So if the priority was not rendered, force it through the pipe of getting the component data for the
     // priority field.
     if (allAttributes.taskPriority === undefined) {
-        const dataAttributes = getTaskDataAttributes('priority', task);
+        const dataAttributes = getComponentDataAttribute('priority', task);
         allAttributes = { ...allAttributes, ...dataAttributes };
     }
 
@@ -277,7 +277,7 @@ function getTaskComponentClass(component: TaskLayoutComponent, task: Task) {
 /**
  * The dataAttributes describe the content of the component, e.g. `data-task-priority="medium"`, `data-task-due="past-1d"` etc.
  */
-function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
+function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
     const dataAttributes: AttributesDictionary = {};
 
     const dataAttributeNames: { [c in TaskLayoutComponent]: string } = {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -289,14 +289,13 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         }
     }
 
-    const scheduledDateAttributeName = 'taskScheduled';
     const doneDateAttributeName = 'taskDone';
 
     const dataAttributeNames: { [c in TaskLayoutComponent]: string } = {
         createdDate: 'taskCreated',
         dueDate: 'taskDue',
         startDate: 'taskStart',
-        scheduledDate: scheduledDateAttributeName,
+        scheduledDate: 'taskScheduled',
         doneDate: doneDateAttributeName,
         priority: '',
         description: '',

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -275,7 +275,7 @@ function getTaskComponentClass(component: TaskLayoutComponent, task: Task) {
 }
 
 /**
- * The dataAttributes describe the content of the component, e.g. `data-task-priority="medium"`, `data-task-due="past-1d"` etc.
+ * The data attribute describes the content of the component, e.g. `data-task-priority="medium"`, `data-task-due="past-1d"` etc.
  */
 function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
     const dataAttributes: AttributesDictionary = {};

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -323,7 +323,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'scheduledDate': {
-            addDateDataAttributes(task.scheduledDate, dataAttributeNames[component]);
+            addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;
         }
         case 'doneDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -305,7 +305,8 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'dueDate': {
-            addDateDataAttributes(task.dueDate, 'taskDue');
+            const dueDateAttributeName = 'taskDue';
+            addDateDataAttributes(task.dueDate, dueDateAttributeName);
             break;
         }
         case 'startDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -321,7 +321,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'dueDate': {
-            addDateDataAttributes(task.dueDate, dueDateAttributeName);
+            addDateDataAttributes(task.dueDate, dataAttributeNames[component]);
             break;
         }
         case 'startDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -293,6 +293,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
     const dueDateAttributeName = 'taskDue';
     const startDateAttributeName = 'taskStart';
     const scheduledDateAttributeName = 'taskScheduled';
+    const doneDateAttributeName = 'taskDone';
     // Update data attributes
     switch (component) {
         case 'priority': {
@@ -320,7 +321,6 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'doneDate': {
-            const doneDateAttributeName = 'taskDone';
             addDateDataAttributes(task.doneDate, doneDateAttributeName);
             break;
         }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -310,7 +310,8 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'startDate': {
-            addDateDataAttributes(task.startDate, 'taskStart');
+            const startDateAttributeName = 'taskStart';
+            addDateDataAttributes(task.startDate, startDateAttributeName);
             break;
         }
         case 'scheduledDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -310,8 +310,6 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         case 'createdDate':
         case 'dueDate':
-            addDateDataAttributes(task[component], dataAttributeNames[component]);
-            break;
         case 'startDate':
             addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -311,8 +311,6 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         case 'createdDate':
         case 'dueDate':
         case 'startDate':
-            addDateDataAttributes(task[component], dataAttributeNames[component]);
-            break;
         case 'scheduledDate':
             addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -313,7 +313,8 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         case 'startDate':
         case 'scheduledDate':
         case 'doneDate': {
-            addDateDataAttributes(task[component], dataAttributeNames[component]);
+            const date = task[component];
+            addDateDataAttributes(date, dataAttributeNames[component]);
             break;
         }
     }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -290,6 +290,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
     }
 
     const createdDateAttributeName = 'taskCreated';
+    const dueDateAttributeName = 'taskDue';
     // Update data attributes
     switch (component) {
         case 'priority': {
@@ -305,7 +306,6 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'dueDate': {
-            const dueDateAttributeName = 'taskDue';
             addDateDataAttributes(task.dueDate, dueDateAttributeName);
             break;
         }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -286,7 +286,7 @@ function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
         startDate: 'taskStart',
         scheduledDate: 'taskScheduled',
         doneDate: 'taskDone',
-        priority: '',
+        priority: 'taskPriority',
         description: '',
         recurrenceRule: '',
         blockLink: '',
@@ -298,7 +298,7 @@ function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
         case 'blockLink':
             break;
         case 'priority': {
-            const attributeName = 'taskPriority';
+            const attributeName = dataAttributeNames[component];
             dataAttribute[attributeName] = PriorityTools.priorityNameUsingNormal(task.priority).toLocaleLowerCase();
             break;
         }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -297,9 +297,10 @@ function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
         case 'recurrenceRule':
         case 'blockLink':
             break;
-        case 'priority':
+        case 'priority': {
             dataAttribute['taskPriority'] = PriorityTools.priorityNameUsingNormal(task.priority).toLocaleLowerCase();
             break;
+        }
         case 'createdDate':
         case 'dueDate':
         case 'startDate':

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -125,6 +125,8 @@ export async function renderTaskLine(
     return li;
 }
 
+export type AttributesDictionary = { [key: string]: string };
+
 async function taskToHtml(
     task: Task,
     renderDetails: TaskLineRenderDetails,
@@ -241,8 +243,6 @@ async function renderComponentText(
         span.innerHTML = componentString;
     }
 }
-
-export type AttributesDictionary = { [key: string]: string };
 
 /**
  * The CSS class that describes what the component is, e.g. a due date or a priority, and is a value from LayoutClasses.

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -291,6 +291,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
 
     const createdDateAttributeName = 'taskCreated';
     const dueDateAttributeName = 'taskDue';
+    const startDateAttributeName = 'taskStart';
     // Update data attributes
     switch (component) {
         case 'priority': {
@@ -310,7 +311,6 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'startDate': {
-            const startDateAttributeName = 'taskStart';
             addDateDataAttributes(task.startDate, startDateAttributeName);
             break;
         }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -311,7 +311,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'createdDate': {
-            addDateDataAttributes(task.createdDate, dataAttributeNames[component]);
+            addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;
         }
         case 'dueDate': {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -327,7 +327,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
             break;
         }
         case 'doneDate': {
-            addDateDataAttributes(task.doneDate, dataAttributeNames[component]);
+            addDateDataAttributes(task[component], dataAttributeNames[component]);
             break;
         }
     }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -291,7 +291,7 @@ function getTaskDataAttributes(component: TaskLayoutComponent, task: Task) {
         recurrenceRule: '',
         blockLink: '',
     };
-    // Update data attributes
+
     switch (component) {
         case 'priority':
             dataAttributes['taskPriority'] = PriorityTools.priorityNameUsingNormal(task.priority).toLocaleLowerCase();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Refactor - remove code duplication and extract hard coded values to a dictionary. Continuation of #2235.

## Motivation and Context

Prepare for #2198 and maybe for an abstraction for `LayoutOptions`.

## How has this been tested?

Unit testing.

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
