### PR TITLE
fix: Editing a checkbox line with empty description now adds creation date, if enabled

### DIFF
--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -28,7 +28,7 @@ export const taskFromLine = ({ line, path }: { line: string; path: string }): Ta
     );
 
     const { setCreatedDate } = getSettings();
-    const createdDate = setCreatedDate ? window.moment().startOf('d') : null;
+    const createdDate = setCreatedDate ? window.moment() : null;
 
     if (task !== null) {
         if (task.description === '') {

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -28,9 +28,12 @@ export const taskFromLine = ({ line, path }: { line: string; path: string }): Ta
     );
 
     const { setCreatedDate } = getSettings();
-    const createdDate = setCreatedDate ? window.moment() : null;
+    const createdDate = setCreatedDate ? window.moment().startOf('d') : null;
 
     if (task !== null) {
+        if (setCreatedDate && task.createdDate === null) {
+            return new Task({ ...task, createdDate });
+        }
         return task;
     }
 

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -31,8 +31,10 @@ export const taskFromLine = ({ line, path }: { line: string; path: string }): Ta
     const createdDate = setCreatedDate ? window.moment().startOf('d') : null;
 
     if (task !== null) {
-        if (setCreatedDate && task.createdDate === null) {
-            return new Task({ ...task, createdDate });
+        if (task.description === '') {
+            if (setCreatedDate && task.createdDate === null) {
+                return new Task({ ...task, createdDate });
+            }
         }
         return task;
     }

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -27,12 +27,12 @@ export const taskFromLine = ({ line, path }: { line: string; path: string }): Ta
         DateFallback.fromPath(path), // set the scheduled date from the filename, so it can be displayed in the dialog
     );
 
+    const { setCreatedDate } = getSettings();
+    const createdDate = setCreatedDate ? window.moment() : null;
+
     if (task !== null) {
         return task;
     }
-
-    const { setCreatedDate } = getSettings();
-    const createdDate = setCreatedDate ? window.moment() : null;
 
     // If we are not on a line of a task, we take what we have.
     // The non-task line can still be a checklist, for example if it is lacking the global filter.

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -114,6 +114,28 @@ describe('CreateOrEditTaskParser - task recognition', () => {
         expect(task.createdDate).toEqualMoment(moment('2023-09-17'));
     });
 
+    it('should add Created Date to a task line without description when the setting is set', () => {
+        updateSettings({ setCreatedDate: true });
+        const line = '- [ ] ';
+        const path = 'a/b/c.md';
+
+        const task = taskFromLine({ line, path });
+
+        expect(task.toFileLineString()).toStrictEqual('- [ ]  ➕ 2023-09-17');
+        expect(task.createdDate).toEqualMoment(moment('2023-09-17'));
+    });
+
+    it('should add Created Date to a task line with just a bullet', () => {
+        updateSettings({ setCreatedDate: true });
+        const line = '-';
+        const path = 'a/b/c.md';
+
+        const task = taskFromLine({ line, path });
+
+        expect(task.toFileLineString()).toStrictEqual('- [ ]  ➕ 2023-09-17');
+        expect(task.createdDate).toEqualMoment(moment('2023-09-17'));
+    });
+
     it('should not change Created Date when it is already set', () => {
         updateSettings({ setCreatedDate: true });
         const line = '- [ ] without global filter and with ➕ 2023-01-20';

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -73,14 +73,8 @@ describe('CreateOrEditTaskParser - testing edited task if line is saved unchange
 });
 
 describe('CreateOrEditTaskParser - task recognition', () => {
-    beforeAll(() => {
-        jest.useFakeTimers();
-        jest.setSystemTime(new Date('2023-09-17'));
-    });
-
     afterEach(() => {
         GlobalFilter.reset();
-        jest.useRealTimers();
     });
 
     it('should recognize task details without global filter', () => {
@@ -101,6 +95,17 @@ describe('CreateOrEditTaskParser - task recognition', () => {
         expect(task.scheduledDate).toEqualMoment(moment('2023-06-13'));
         expect(task.dueDate).toEqualMoment(moment('2024-12-10'));
         expect(task.doneDate).toEqualMoment(moment('2023-06-22'));
+    });
+});
+
+describe('CreateOrEditTaskParser - created date', () => {
+    beforeAll(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2023-09-17'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
     });
 
     it.each([

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -99,7 +99,7 @@ describe('CreateOrEditTaskParser - task recognition', () => {
 });
 
 describe('CreateOrEditTaskParser - created date', () => {
-    beforeAll(() => {
+    beforeEach(() => {
         jest.useFakeTimers();
         jest.setSystemTime(new Date('2023-09-17'));
     });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
+import { updateSettings } from '../../src/Config/Settings';
 import { Priority } from '../../src/Task';
 import { taskFromLine } from '../../src/Commands/CreateOrEditTaskParser';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
@@ -72,8 +73,14 @@ describe('CreateOrEditTaskParser - testing edited task if line is saved unchange
 });
 
 describe('CreateOrEditTaskParser - task recognition', () => {
+    beforeAll(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2023-09-17'));
+    });
+
     afterEach(() => {
         GlobalFilter.reset();
+        jest.useRealTimers();
     });
 
     it('should recognize task details without global filter', () => {
@@ -94,5 +101,16 @@ describe('CreateOrEditTaskParser - task recognition', () => {
         expect(task.scheduledDate).toEqualMoment(moment('2023-06-13'));
         expect(task.dueDate).toEqualMoment(moment('2024-12-10'));
         expect(task.doneDate).toEqualMoment(moment('2023-06-22'));
+    });
+
+    it.failing('should add Created Date when the setting is set', () => {
+        updateSettings({ setCreatedDate: true });
+        const line = '- [ ] without global filter and without created date';
+        const path = 'a/b/c.md';
+
+        const task = taskFromLine({ line, path });
+
+        expect(task.toFileLineString()).toStrictEqual(`${line} ➕ 2023-09-17`);
+        expect(task.createdDate).toEqualMoment(moment('2023-09-17'));
     });
 });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -112,11 +112,6 @@ describe('CreateOrEditTaskParser - created date', () => {
         ['- ', '- [ ]  ➕ 2023-09-17', '2023-09-17'], // bullet point only
         ['- [ ] ', '- [ ]  ➕ 2023-09-17', '2023-09-17'], // bullet point and a checkbox
         [
-            '- [ ] without global filter and without created date', // nominal use-case
-            '- [ ] without global filter and without created date ➕ 2023-09-17',
-            '2023-09-17',
-        ],
-        [
             '- [ ] without global filter and with ➕ 2023-01-20', // with an existing created date
             '- [ ] without global filter and with ➕ 2023-01-20',
             '2023-01-20',
@@ -133,4 +128,15 @@ describe('CreateOrEditTaskParser - created date', () => {
             expect(task.createdDate).toEqualMoment(moment(expectedCreatedDate));
         },
     );
+
+    it('should not add created date to a task line with description', () => {
+        updateSettings({ setCreatedDate: true });
+        const path = 'a/b/c.md';
+        const line = '- [ ] hope created date will not be added';
+
+        const task = taskFromLine({ line, path });
+
+        expect(task.toFileLineString()).toStrictEqual('- [ ] hope created date will not be added');
+        expect(task.createdDate).toEqual(null);
+    });
 });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -103,16 +103,24 @@ describe('CreateOrEditTaskParser - task recognition', () => {
         expect(task.doneDate).toEqualMoment(moment('2023-06-22'));
     });
 
-    it('should add Created Date when the setting is set', () => {
-        updateSettings({ setCreatedDate: true });
-        const line = '- [ ] without global filter and without created date';
-        const path = 'a/b/c.md';
+    it.each([
+        [
+            '- [ ] without global filter and without created date',
+            '- [ ] without global filter and without created date ➕ 2023-09-17',
+            '2023-09-17',
+        ],
+    ])(
+        'line loaded into "Create or edit task" command: "%s"',
+        (line: string, expectedResult: string, createdDate: string) => {
+            updateSettings({ setCreatedDate: true });
+            const path = 'a/b/c.md';
 
-        const task = taskFromLine({ line, path });
+            const task = taskFromLine({ line, path });
 
-        expect(task.toFileLineString()).toStrictEqual(`${line} ➕ 2023-09-17`);
-        expect(task.createdDate).toEqualMoment(moment('2023-09-17'));
-    });
+            expect(task.toFileLineString()).toStrictEqual(expectedResult);
+            expect(task.createdDate).toEqualMoment(moment(createdDate));
+        },
+    );
 
     it('should add Created Date to a task line without description when the setting is set', () => {
         updateSettings({ setCreatedDate: true });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -109,6 +109,13 @@ describe('CreateOrEditTaskParser - task recognition', () => {
             '- [ ] without global filter and without created date ➕ 2023-09-17',
             '2023-09-17',
         ],
+        ['- [ ] ', '- [ ]  ➕ 2023-09-17', '2023-09-17'],
+        ['- ', '- [ ]  ➕ 2023-09-17', '2023-09-17'],
+        [
+            '- [ ] without global filter and with ➕ 2023-01-20',
+            '- [ ] without global filter and with ➕ 2023-01-20',
+            '2023-01-20',
+        ],
     ])(
         'line loaded into "Create or edit task" command: "%s"',
         (line: string, expectedResult: string, createdDate: string) => {
@@ -121,37 +128,4 @@ describe('CreateOrEditTaskParser - task recognition', () => {
             expect(task.createdDate).toEqualMoment(moment(createdDate));
         },
     );
-
-    it('should add Created Date to a task line without description when the setting is set', () => {
-        updateSettings({ setCreatedDate: true });
-        const line = '- [ ] ';
-        const path = 'a/b/c.md';
-
-        const task = taskFromLine({ line, path });
-
-        expect(task.toFileLineString()).toStrictEqual('- [ ]  ➕ 2023-09-17');
-        expect(task.createdDate).toEqualMoment(moment('2023-09-17'));
-    });
-
-    it('should add Created Date to a task line with just a bullet', () => {
-        updateSettings({ setCreatedDate: true });
-        const line = '-';
-        const path = 'a/b/c.md';
-
-        const task = taskFromLine({ line, path });
-
-        expect(task.toFileLineString()).toStrictEqual('- [ ]  ➕ 2023-09-17');
-        expect(task.createdDate).toEqualMoment(moment('2023-09-17'));
-    });
-
-    it('should not change Created Date when it is already set', () => {
-        updateSettings({ setCreatedDate: true });
-        const line = '- [ ] without global filter and with ➕ 2023-01-20';
-        const path = 'a/b/c.md';
-
-        const task = taskFromLine({ line, path });
-
-        expect(task.toFileLineString()).toStrictEqual(line);
-        expect(task.createdDate).toEqualMoment(moment('2023-01-20'));
-    });
 });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
-import { updateSettings } from '../../src/Config/Settings';
+import { resetSettings, updateSettings } from '../../src/Config/Settings';
 import { Priority } from '../../src/Task';
 import { taskFromLine } from '../../src/Commands/CreateOrEditTaskParser';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
@@ -106,6 +106,7 @@ describe('CreateOrEditTaskParser - created date', () => {
 
     afterEach(() => {
         jest.useRealTimers();
+        resetSettings();
     });
 
     it.each([

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -110,14 +110,14 @@ describe('CreateOrEditTaskParser - created date', () => {
 
     it.each([
         [
-            '- [ ] without global filter and without created date',
+            '- [ ] without global filter and without created date', // nominal use-case
             '- [ ] without global filter and without created date ➕ 2023-09-17',
             '2023-09-17',
         ],
-        ['- [ ] ', '- [ ]  ➕ 2023-09-17', '2023-09-17'],
-        ['- ', '- [ ]  ➕ 2023-09-17', '2023-09-17'],
+        ['- [ ] ', '- [ ]  ➕ 2023-09-17', '2023-09-17'], // bullet point and a checkbox
+        ['- ', '- [ ]  ➕ 2023-09-17', '2023-09-17'], // bullet point only
         [
-            '- [ ] without global filter and with ➕ 2023-01-20',
+            '- [ ] without global filter and with ➕ 2023-01-20', // with an existing created date
             '- [ ] without global filter and with ➕ 2023-01-20',
             '2023-01-20',
         ],

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -103,7 +103,7 @@ describe('CreateOrEditTaskParser - task recognition', () => {
         expect(task.doneDate).toEqualMoment(moment('2023-06-22'));
     });
 
-    it.failing('should add Created Date when the setting is set', () => {
+    it('should add Created Date when the setting is set', () => {
         updateSettings({ setCreatedDate: true });
         const line = '- [ ] without global filter and without created date';
         const path = 'a/b/c.md';

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -118,14 +118,14 @@ describe('CreateOrEditTaskParser - task recognition', () => {
         ],
     ])(
         'line loaded into "Create or edit task" command: "%s"',
-        (line: string, expectedResult: string, createdDate: string) => {
+        (line: string, expectedTaskLine: string, expectedCreatedDate: string) => {
             updateSettings({ setCreatedDate: true });
             const path = 'a/b/c.md';
 
             const task = taskFromLine({ line, path });
 
-            expect(task.toFileLineString()).toStrictEqual(expectedResult);
-            expect(task.createdDate).toEqualMoment(moment(createdDate));
+            expect(task.toFileLineString()).toStrictEqual(expectedTaskLine);
+            expect(task.createdDate).toEqualMoment(moment(expectedCreatedDate));
         },
     );
 });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -113,4 +113,15 @@ describe('CreateOrEditTaskParser - task recognition', () => {
         expect(task.toFileLineString()).toStrictEqual(`${line} ➕ 2023-09-17`);
         expect(task.createdDate).toEqualMoment(moment('2023-09-17'));
     });
+
+    it('should not change Created Date when it is already set', () => {
+        updateSettings({ setCreatedDate: true });
+        const line = '- [ ] without global filter and with ➕ 2023-01-20';
+        const path = 'a/b/c.md';
+
+        const task = taskFromLine({ line, path });
+
+        expect(task.toFileLineString()).toStrictEqual(line);
+        expect(task.createdDate).toEqualMoment(moment('2023-01-20'));
+    });
 });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -109,13 +109,13 @@ describe('CreateOrEditTaskParser - created date', () => {
     });
 
     it.each([
+        ['- ', '- [ ]  ➕ 2023-09-17', '2023-09-17'], // bullet point only
+        ['- [ ] ', '- [ ]  ➕ 2023-09-17', '2023-09-17'], // bullet point and a checkbox
         [
             '- [ ] without global filter and without created date', // nominal use-case
             '- [ ] without global filter and without created date ➕ 2023-09-17',
             '2023-09-17',
         ],
-        ['- [ ] ', '- [ ]  ➕ 2023-09-17', '2023-09-17'], // bullet point and a checkbox
-        ['- ', '- [ ]  ➕ 2023-09-17', '2023-09-17'], // bullet point only
         [
             '- [ ] without global filter and with ➕ 2023-01-20', // with an existing created date
             '- [ ] without global filter and with ➕ 2023-01-20',

--- a/tests/EditTask.test.Exhaustive_editing_Edit_and_save_All_inputs.approved.txt
+++ b/tests/EditTask.test.Exhaustive_editing_Edit_and_save_All_inputs.approved.txt
@@ -59,11 +59,11 @@ KEY: (globalFilter, set created date)
 
 ('', true)
     '- [ ]' =>
-    '- [ ] simulate user typing text in to empty description field'
+    '- [ ] simulate user typing text in to empty description field ➕ 2023-07-18'
 
 ('', true)
     '- [ ] ' =>
-    '- [ ] simulate user typing text in to empty description field'
+    '- [ ] simulate user typing text in to empty description field ➕ 2023-07-18'
 
 ('', true)
     '- list item, but no checkbox' =>
@@ -139,11 +139,11 @@ KEY: (globalFilter, set created date)
 
 ('#task', true)
     '- [ ]' =>
-    '- [ ] #task simulate user typing text in to empty description field'
+    '- [ ] #task simulate user typing text in to empty description field ➕ 2023-07-18'
 
 ('#task', true)
     '- [ ] ' =>
-    '- [ ] #task simulate user typing text in to empty description field'
+    '- [ ] #task simulate user typing text in to empty description field ➕ 2023-07-18'
 
 ('#task', true)
     '- list item, but no checkbox' =>


### PR DESCRIPTION
# Description

When a task line has been parsed, check whether the created date shall be appended to it.

In https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2025#issuecomment-1616420079 you wrote:

> So the fix will be to add some code at line 29 that says
> 
> * if it was a task already - with a checkbox
> * and if the description is empty,
> * and it does not already have a creation date....
> * then add the creation date before returning the task on line 31.

## Motivation and Context

Fixes #2025 

## How has this been tested?

New unit tests added.

Smoke test in demo vault:

Global Filter set to `#task`, Add creation date option enabled. On each of the following lines execute `Create or Edit task` command, put something (`blablabla`) into description, click apply:

```
-
- [ ]
```

Both the lines gain the global filter, the description that was set and the created date. The first line gains the checkbox.

Before the fix: only the first line got the created date.

## Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
