### PR TITLE
fix: 'Create or edit task' now adds Created date if adding global filter

### DIFF
--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -23,13 +23,10 @@ function shouldUpdateCreatedDateForTask(task: Task) {
         return false;
     }
 
+    // If the task already had a description, treat it as new and add a creation date.
     const descriptionIsEmpty = task.description === '';
-    if (!descriptionIsEmpty) {
-        // The task already had a description, so had been created previously: don't change it.
-        return false;
-    }
 
-    return true;
+    return descriptionIsEmpty;
 }
 
 /**

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -24,7 +24,7 @@ function shouldUpdateCreatedDateForTask(task: Task) {
         return false;
     }
 
-    // If the task already had a description, treat it as new and add a creation date.
+    // If the description was empty, treat it as new and add a creation date.
     const descriptionIsEmpty = task.description === '';
 
     // If the global filter will be added when the task is saved, treat it as new and add a creation date.

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -23,7 +23,8 @@ function shouldUpdateCreatedDateForTask(task: Task) {
         return false;
     }
 
-    if (!(task.description === '')) {
+    const descriptionIsEmpty = task.description === '';
+    if (!descriptionIsEmpty) {
         // The task already had a description, so had been created previously: don't change it.
         return false;
     }

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -23,7 +23,7 @@ function shouldUpdateCreatedDateForTask(task: Task) {
         return false;
     }
 
-    if (task.description !== '') {
+    if (!(task.description === '')) {
         // The task already had a description, so had been created previously: don't change it.
         return false;
     }

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -4,6 +4,7 @@ import { DateFallback } from '../DateFallback';
 import { StatusRegistry } from '../StatusRegistry';
 import { TaskLocation } from '../TaskLocation';
 import { getSettings } from '../Config/Settings';
+import { GlobalFilter } from '../Config/GlobalFilter';
 
 function getDefaultCreatedDate() {
     const { setCreatedDate } = getSettings();
@@ -26,7 +27,13 @@ function shouldUpdateCreatedDateForTask(task: Task) {
     // If the task already had a description, treat it as new and add a creation date.
     const descriptionIsEmpty = task.description === '';
 
-    return descriptionIsEmpty;
+    // If the global filter will be added when the task is saved, treat it as new and add a creation date.
+    // See issue #2112.
+    const globalFilterEnabled = !GlobalFilter.isEmpty();
+    const taskDoesNotContainGlobalFilter = !GlobalFilter.includedIn(task.description);
+    const needsGlobalFilterToBeAdded = globalFilterEnabled && taskDoesNotContainGlobalFilter;
+
+    return descriptionIsEmpty || needsGlobalFilterToBeAdded;
 }
 
 /**

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -107,6 +107,7 @@ describe('CreateOrEditTaskParser - created date', () => {
     afterEach(() => {
         jest.useRealTimers();
         resetSettings();
+        GlobalFilter.reset();
     });
 
     it.each([
@@ -149,6 +150,19 @@ describe('CreateOrEditTaskParser - created date', () => {
         const task = taskFromLine({ line, path });
 
         expect(task.toFileLineString()).toStrictEqual('- [ ] hope created date will not be added');
+        expect(task.createdDate).toEqual(null);
+    });
+
+    it.failing('should add created date if adding the global filter', () => {
+        updateSettings({ setCreatedDate: true });
+        GlobalFilter.set('#task');
+        const path = 'a/b/c.md';
+        const line = '- [ ] did not have the global filter';
+
+        const task = taskFromLine({ line, path });
+
+        // The global filter doesn't get added until the Modal rewrites the line
+        expect(task.toFileLineString()).toStrictEqual('- [ ] did not have the global filter ➕ 2023-09-17');
         expect(task.createdDate).toEqual(null);
     });
 });

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -153,7 +153,7 @@ describe('CreateOrEditTaskParser - created date', () => {
         expect(task.createdDate).toEqual(null);
     });
 
-    it.failing('should add created date if adding the global filter', () => {
+    it('should add created date if adding the global filter', () => {
         updateSettings({ setCreatedDate: true });
         GlobalFilter.set('#task');
         const path = 'a/b/c.md';
@@ -163,6 +163,6 @@ describe('CreateOrEditTaskParser - created date', () => {
 
         // The global filter doesn't get added until the Modal rewrites the line
         expect(task.toFileLineString()).toStrictEqual('- [ ] did not have the global filter ➕ 2023-09-17');
-        expect(task.createdDate).toEqual(null);
+        expect(task.createdDate).toEqualMoment(moment('2023-09-17'));
     });
 });

--- a/tests/EditTask.test.Exhaustive_editing_Edit_and_save_All_inputs.approved.txt
+++ b/tests/EditTask.test.Exhaustive_editing_Edit_and_save_All_inputs.approved.txt
@@ -151,7 +151,7 @@ KEY: (globalFilter, set created date)
 
 ('#task', true)
     '- [ ] checkbox with initial description' =>
-    '- [ ] #task checkbox with initial description'
+    '- [ ] #task checkbox with initial description ➕ 2023-07-18'
 
 ('#task', true)
     '- [ ] checkbox with initial description and created date ➕ 2023-01-01' =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

When editing a task via the 'Edit task modal', if it didn't yet have the global filter, then treat it as a new task and add the Created date, if enabled.

<!--- Describe your changes in detail -->

## Motivation and Context

This fixes https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2112

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Added new test which failed before the bug was fixed
- Confirmed that 'exhaustive test' results are correctly updated
- Tested it manually in the sample vault

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
