### PR TITLE
refactor: Add getInstance() to GlobalFilter & make all else non-static

### DIFF
--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -29,7 +29,7 @@ function shouldUpdateCreatedDateForTask(task: Task) {
 
     // If the global filter will be added when the task is saved, treat it as new and add a creation date.
     // See issue #2112.
-    const globalFilterEnabled = !GlobalFilter.isEmpty();
+    const globalFilterEnabled = !GlobalFilter.getInstance().isEmpty();
     const taskDoesNotContainGlobalFilter = !GlobalFilter.includedIn(task.description);
     const needsGlobalFilterToBeAdded = globalFilterEnabled && taskDoesNotContainGlobalFilter;
 

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -30,7 +30,7 @@ function shouldUpdateCreatedDateForTask(task: Task) {
     // If the global filter will be added when the task is saved, treat it as new and add a creation date.
     // See issue #2112.
     const globalFilterEnabled = !GlobalFilter.getInstance().isEmpty();
-    const taskDoesNotContainGlobalFilter = !GlobalFilter.includedIn(task.description);
+    const taskDoesNotContainGlobalFilter = !GlobalFilter.getInstance().includedIn(task.description);
     const needsGlobalFilterToBeAdded = globalFilterEnabled && taskDoesNotContainGlobalFilter;
 
     return descriptionIsEmpty || needsGlobalFilterToBeAdded;

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -105,7 +105,7 @@ export class GlobalFilter {
         return description;
     }
 
-    static removeAsSubstringFrom(description: string): string {
+    removeAsSubstringFrom(description: string): string {
         const globalFilter = GlobalFilter.getInstance().get();
         return description.replace(globalFilter, '').trim();
     }

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -11,9 +11,23 @@ import * as RegExpTools from '../lib/RegExpTools';
  *     - These static methods will be made non-static in a future change.
  */
 export class GlobalFilter {
+    private static instance: GlobalFilter;
+
     static empty = '';
     static _globalFilter = '';
     static _removeGlobalFilter = false;
+
+    /**
+     * Provides access to the single global instance of GlobalFilter.
+     * This should eventually only be used in the plugin code.
+     */
+    public static getInstance(): GlobalFilter {
+        if (!GlobalFilter.instance) {
+            GlobalFilter.instance = new GlobalFilter();
+        }
+
+        return GlobalFilter.instance;
+    }
 
     static get(): string {
         return GlobalFilter._globalFilter;

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -30,38 +30,38 @@ export class GlobalFilter {
     }
 
     get(): string {
-        return GlobalFilter.getInstance()._globalFilter;
+        return this._globalFilter;
     }
 
     set(value: string) {
-        GlobalFilter.getInstance()._globalFilter = value;
+        this._globalFilter = value;
     }
 
     reset() {
-        GlobalFilter.getInstance().set(GlobalFilter.empty);
+        this.set(GlobalFilter.empty);
     }
 
     isEmpty(): boolean {
-        return GlobalFilter.getInstance().get() === GlobalFilter.empty;
+        return this.get() === GlobalFilter.empty;
     }
 
     equals(tag: string): boolean {
-        return GlobalFilter.getInstance().get() === tag;
+        return this.get() === tag;
     }
 
     includedIn(description: string): boolean {
-        const globalFilter = GlobalFilter.getInstance().get();
+        const globalFilter = this.get();
         return description.includes(globalFilter);
     }
 
     prependTo(description: string): string {
-        return GlobalFilter.getInstance().get() + ' ' + description;
+        return this.get() + ' ' + description;
     }
 
     removeAsWordFromDependingOnSettings(description: string): string {
-        const removeGlobalFilter = GlobalFilter.getInstance().getRemoveGlobalFilter();
+        const removeGlobalFilter = this.getRemoveGlobalFilter();
         if (removeGlobalFilter) {
-            return GlobalFilter.getInstance().removeAsWordFrom(description);
+            return this.removeAsWordFrom(description);
         }
 
         return description;
@@ -71,14 +71,14 @@ export class GlobalFilter {
      * @see setRemoveGlobalFilter
      */
     getRemoveGlobalFilter() {
-        return GlobalFilter.getInstance()._removeGlobalFilter;
+        return this._removeGlobalFilter;
     }
 
     /**
      * @see getRemoveGlobalFilter
      */
     setRemoveGlobalFilter(removeGlobalFilter: boolean) {
-        GlobalFilter.getInstance()._removeGlobalFilter = removeGlobalFilter;
+        this._removeGlobalFilter = removeGlobalFilter;
     }
 
     /**
@@ -88,15 +88,12 @@ export class GlobalFilter {
      * If the global filter exists as part of a nested tag, we keep it untouched.
      */
     removeAsWordFrom(description: string): string {
-        if (GlobalFilter.getInstance().isEmpty()) {
+        if (this.isEmpty()) {
             return description;
         }
 
         // This matches the global filter (after escaping it) only when it's a complete word
-        const theRegExp = RegExp(
-            '(^|\\s)' + RegExpTools.escapeRegExp(GlobalFilter.getInstance().get()) + '($|\\s)',
-            'ug',
-        );
+        const theRegExp = RegExp('(^|\\s)' + RegExpTools.escapeRegExp(this.get()) + '($|\\s)', 'ug');
 
         if (description.search(theRegExp) > -1) {
             description = description.replace(theRegExp, '$1$2').replace('  ', ' ').trim();
@@ -106,7 +103,7 @@ export class GlobalFilter {
     }
 
     removeAsSubstringFrom(description: string): string {
-        const globalFilter = GlobalFilter.getInstance().get();
+        const globalFilter = this.get();
         return description.replace(globalFilter, '').trim();
     }
 }

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -41,7 +41,7 @@ export class GlobalFilter {
         GlobalFilter.getInstance().set(GlobalFilter.empty);
     }
 
-    static isEmpty(): boolean {
+    isEmpty(): boolean {
         return GlobalFilter.getInstance().get() === GlobalFilter.empty;
     }
 
@@ -88,7 +88,7 @@ export class GlobalFilter {
      * If the global filter exists as part of a nested tag, we keep it untouched.
      */
     static removeAsWordFrom(description: string): string {
-        if (GlobalFilter.isEmpty()) {
+        if (GlobalFilter.getInstance().isEmpty()) {
             return description;
         }
 

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -14,8 +14,8 @@ export class GlobalFilter {
     private static instance: GlobalFilter;
 
     static empty = '';
-    _globalFilter = '';
-    _removeGlobalFilter = false;
+    private _globalFilter = '';
+    private _removeGlobalFilter = false;
 
     /**
      * Provides access to the single global instance of GlobalFilter.

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -54,7 +54,7 @@ export class GlobalFilter {
         return description.includes(globalFilter);
     }
 
-    static prependTo(description: string): string {
+    prependTo(description: string): string {
         return GlobalFilter.getInstance().get() + ' ' + description;
     }
 

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -37,7 +37,7 @@ export class GlobalFilter {
         GlobalFilter.getInstance()._globalFilter = value;
     }
 
-    static reset() {
+    reset() {
         GlobalFilter.getInstance().set(GlobalFilter.empty);
     }
 

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -14,8 +14,8 @@ export class GlobalFilter {
     private static instance: GlobalFilter;
 
     static empty = '';
-    static _globalFilter = '';
-    static _removeGlobalFilter = false;
+    _globalFilter = '';
+    _removeGlobalFilter = false;
 
     /**
      * Provides access to the single global instance of GlobalFilter.
@@ -30,11 +30,11 @@ export class GlobalFilter {
     }
 
     static get(): string {
-        return GlobalFilter._globalFilter;
+        return GlobalFilter.getInstance()._globalFilter;
     }
 
     static set(value: string) {
-        GlobalFilter._globalFilter = value;
+        GlobalFilter.getInstance()._globalFilter = value;
     }
 
     static reset() {
@@ -71,14 +71,14 @@ export class GlobalFilter {
      * @see setRemoveGlobalFilter
      */
     static getRemoveGlobalFilter() {
-        return GlobalFilter._removeGlobalFilter;
+        return GlobalFilter.getInstance()._removeGlobalFilter;
     }
 
     /**
      * @see getRemoveGlobalFilter
      */
     static setRemoveGlobalFilter(removeGlobalFilter: boolean) {
-        GlobalFilter._removeGlobalFilter = removeGlobalFilter;
+        GlobalFilter.getInstance()._removeGlobalFilter = removeGlobalFilter;
     }
 
     /**

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -49,7 +49,7 @@ export class GlobalFilter {
         return GlobalFilter.getInstance().get() === tag;
     }
 
-    static includedIn(description: string): boolean {
+    includedIn(description: string): boolean {
         const globalFilter = GlobalFilter.getInstance().get();
         return description.includes(globalFilter);
     }

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -59,7 +59,7 @@ export class GlobalFilter {
     }
 
     removeAsWordFromDependingOnSettings(description: string): string {
-        const removeGlobalFilter = GlobalFilter.getRemoveGlobalFilter();
+        const removeGlobalFilter = GlobalFilter.getInstance().getRemoveGlobalFilter();
         if (removeGlobalFilter) {
             return GlobalFilter.removeAsWordFrom(description);
         }
@@ -70,7 +70,7 @@ export class GlobalFilter {
     /**
      * @see setRemoveGlobalFilter
      */
-    static getRemoveGlobalFilter() {
+    getRemoveGlobalFilter() {
         return GlobalFilter.getInstance()._removeGlobalFilter;
     }
 

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -29,36 +29,36 @@ export class GlobalFilter {
         return GlobalFilter.instance;
     }
 
-    get(): string {
+    public get(): string {
         return this._globalFilter;
     }
 
-    set(value: string) {
+    public set(value: string) {
         this._globalFilter = value;
     }
 
-    reset() {
+    public reset() {
         this.set(GlobalFilter.empty);
     }
 
-    isEmpty(): boolean {
+    public isEmpty(): boolean {
         return this.get() === GlobalFilter.empty;
     }
 
-    equals(tag: string): boolean {
+    public equals(tag: string): boolean {
         return this.get() === tag;
     }
 
-    includedIn(description: string): boolean {
+    public includedIn(description: string): boolean {
         const globalFilter = this.get();
         return description.includes(globalFilter);
     }
 
-    prependTo(description: string): string {
+    public prependTo(description: string): string {
         return this.get() + ' ' + description;
     }
 
-    removeAsWordFromDependingOnSettings(description: string): string {
+    public removeAsWordFromDependingOnSettings(description: string): string {
         const removeGlobalFilter = this.getRemoveGlobalFilter();
         if (removeGlobalFilter) {
             return this.removeAsWordFrom(description);
@@ -70,14 +70,14 @@ export class GlobalFilter {
     /**
      * @see setRemoveGlobalFilter
      */
-    getRemoveGlobalFilter() {
+    public getRemoveGlobalFilter() {
         return this._removeGlobalFilter;
     }
 
     /**
      * @see getRemoveGlobalFilter
      */
-    setRemoveGlobalFilter(removeGlobalFilter: boolean) {
+    public setRemoveGlobalFilter(removeGlobalFilter: boolean) {
         this._removeGlobalFilter = removeGlobalFilter;
     }
 
@@ -87,7 +87,7 @@ export class GlobalFilter {
      * or a space), because we don't want to cut-off nested tags like #task/subtag.
      * If the global filter exists as part of a nested tag, we keep it untouched.
      */
-    removeAsWordFrom(description: string): string {
+    public removeAsWordFrom(description: string): string {
         if (this.isEmpty()) {
             return description;
         }
@@ -102,7 +102,7 @@ export class GlobalFilter {
         return description;
     }
 
-    removeAsSubstringFrom(description: string): string {
+    public removeAsSubstringFrom(description: string): string {
         const globalFilter = this.get();
         return description.replace(globalFilter, '').trim();
     }

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -58,7 +58,7 @@ export class GlobalFilter {
         return GlobalFilter.getInstance().get() + ' ' + description;
     }
 
-    static removeAsWordFromDependingOnSettings(description: string): string {
+    removeAsWordFromDependingOnSettings(description: string): string {
         const removeGlobalFilter = GlobalFilter.getRemoveGlobalFilter();
         if (removeGlobalFilter) {
             return GlobalFilter.removeAsWordFrom(description);

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -45,7 +45,7 @@ export class GlobalFilter {
         return GlobalFilter.getInstance().get() === GlobalFilter.empty;
     }
 
-    static equals(tag: string): boolean {
+    equals(tag: string): boolean {
         return GlobalFilter.getInstance().get() === tag;
     }
 

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -33,12 +33,12 @@ export class GlobalFilter {
         return GlobalFilter.getInstance()._globalFilter;
     }
 
-    static set(value: string) {
+    set(value: string) {
         GlobalFilter.getInstance()._globalFilter = value;
     }
 
     static reset() {
-        GlobalFilter.set(GlobalFilter.empty);
+        GlobalFilter.getInstance().set(GlobalFilter.empty);
     }
 
     static isEmpty(): boolean {

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -77,7 +77,7 @@ export class GlobalFilter {
     /**
      * @see getRemoveGlobalFilter
      */
-    static setRemoveGlobalFilter(removeGlobalFilter: boolean) {
+    setRemoveGlobalFilter(removeGlobalFilter: boolean) {
         GlobalFilter.getInstance()._removeGlobalFilter = removeGlobalFilter;
     }
 

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -61,7 +61,7 @@ export class GlobalFilter {
     removeAsWordFromDependingOnSettings(description: string): string {
         const removeGlobalFilter = GlobalFilter.getInstance().getRemoveGlobalFilter();
         if (removeGlobalFilter) {
-            return GlobalFilter.removeAsWordFrom(description);
+            return GlobalFilter.getInstance().removeAsWordFrom(description);
         }
 
         return description;
@@ -87,7 +87,7 @@ export class GlobalFilter {
      * or a space), because we don't want to cut-off nested tags like #task/subtag.
      * If the global filter exists as part of a nested tag, we keep it untouched.
      */
-    static removeAsWordFrom(description: string): string {
+    removeAsWordFrom(description: string): string {
         if (GlobalFilter.getInstance().isEmpty()) {
             return description;
         }

--- a/src/Config/GlobalFilter.ts
+++ b/src/Config/GlobalFilter.ts
@@ -29,7 +29,7 @@ export class GlobalFilter {
         return GlobalFilter.instance;
     }
 
-    static get(): string {
+    get(): string {
         return GlobalFilter.getInstance()._globalFilter;
     }
 
@@ -42,20 +42,20 @@ export class GlobalFilter {
     }
 
     static isEmpty(): boolean {
-        return GlobalFilter.get() === GlobalFilter.empty;
+        return GlobalFilter.getInstance().get() === GlobalFilter.empty;
     }
 
     static equals(tag: string): boolean {
-        return GlobalFilter.get() === tag;
+        return GlobalFilter.getInstance().get() === tag;
     }
 
     static includedIn(description: string): boolean {
-        const globalFilter = GlobalFilter.get();
+        const globalFilter = GlobalFilter.getInstance().get();
         return description.includes(globalFilter);
     }
 
     static prependTo(description: string): string {
-        return GlobalFilter.get() + ' ' + description;
+        return GlobalFilter.getInstance().get() + ' ' + description;
     }
 
     static removeAsWordFromDependingOnSettings(description: string): string {
@@ -93,7 +93,10 @@ export class GlobalFilter {
         }
 
         // This matches the global filter (after escaping it) only when it's a complete word
-        const theRegExp = RegExp('(^|\\s)' + RegExpTools.escapeRegExp(GlobalFilter.get()) + '($|\\s)', 'ug');
+        const theRegExp = RegExp(
+            '(^|\\s)' + RegExpTools.escapeRegExp(GlobalFilter.getInstance().get()) + '($|\\s)',
+            'ug',
+        );
 
         if (description.search(theRegExp) > -1) {
             description = description.replace(theRegExp, '$1$2').replace('  ', ' ').trim();
@@ -103,7 +106,7 @@ export class GlobalFilter {
     }
 
     static removeAsSubstringFrom(description: string): string {
-        const globalFilter = GlobalFilter.get();
+        const globalFilter = GlobalFilter.getInstance().get();
         return description.replace(globalFilter, '').trim();
     }
 }

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -119,7 +119,7 @@ export class SettingsTab extends PluginSettingTab {
 
                 toggle.setValue(settings.removeGlobalFilter).onChange(async (value) => {
                     updateSettings({ removeGlobalFilter: value });
-                    GlobalFilter.setRemoveGlobalFilter(value);
+                    GlobalFilter.getInstance().setRemoveGlobalFilter(value);
                     await this.plugin.saveSettings();
                 });
             });

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -104,7 +104,7 @@ export class SettingsTab extends PluginSettingTab {
                     .setValue(GlobalFilter.getInstance().get())
                     .onChange(async (value) => {
                         updateSettings({ globalFilter: value });
-                        GlobalFilter.set(value);
+                        GlobalFilter.getInstance().set(value);
                         await this.plugin.saveSettings();
                     });
             });

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -101,7 +101,7 @@ export class SettingsTab extends PluginSettingTab {
                 // but wasn't able to figure out how to make the text box
                 // wide enough for the whole string to be visible.
                 text.setPlaceholder('e.g. #task or TODO')
-                    .setValue(GlobalFilter.get())
+                    .setValue(GlobalFilter.getInstance().get())
                     .onChange(async (value) => {
                         updateSettings({ globalFilter: value });
                         GlobalFilter.set(value);

--- a/src/File.ts
+++ b/src/File.ts
@@ -345,7 +345,7 @@ function tryFindingLineNumberFromTaskSectionInfo(
         }
 
         const line = fileLines[listItemLineNumber];
-        if (GlobalFilter.includedIn(line)) {
+        if (GlobalFilter.getInstance().includedIn(line)) {
             if (sectionIndex === originalTask.taskLocation.sectionIndex) {
                 if (line === originalTask.originalMarkdown) {
                     taskLineNumber = listItemLineNumber;

--- a/src/InlineRenderer.ts
+++ b/src/InlineRenderer.ts
@@ -46,7 +46,7 @@ export class InlineRenderer {
                 return false;
             }
 
-            return GlobalFilter.includedIn(firstLineText);
+            return GlobalFilter.getInstance().includedIn(firstLineText);
         });
         if (renderedElements.length === 0) {
             // No tasks means nothing to do.

--- a/src/Query/Filter/DescriptionField.ts
+++ b/src/Query/Filter/DescriptionField.ts
@@ -25,7 +25,7 @@ export class DescriptionField extends TextField {
         // Remove global filter from description match if present.
         // This is necessary to match only on the content of the task, not
         // the global filter.
-        return GlobalFilter.removeAsSubstringFrom(task.description);
+        return GlobalFilter.getInstance().removeAsSubstringFrom(task.description);
     }
 
     public supportsSorting(): boolean {
@@ -55,7 +55,7 @@ export class DescriptionField extends TextField {
      * Properly reads links [[like this|one]] (note pipe).
      */
     public static cleanDescription(description: string): string {
-        description = GlobalFilter.removeAsSubstringFrom(description);
+        description = GlobalFilter.getInstance().removeAsSubstringFrom(description);
 
         const startsWithLinkRegex = /^\[\[?([^\]]*)]]?/;
         const linkRegexMatch = description.match(startsWithLinkRegex);

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -414,7 +414,7 @@ export function onlySuggestIfBracketOpen(fn: SuggestionBuilder, brackets: [strin
  *                          See 'ch' in https://docs.obsidian.md/Reference/TypeScript+API/EditorPosition/EditorPosition
  */
 export function canSuggestForLine(line: string, cursorPosition: number) {
-    return GlobalFilter.includedIn(line) && cursorIsInTaskLineDescription(line, cursorPosition);
+    return GlobalFilter.getInstance().includedIn(line) && cursorIsInTaskLineDescription(line, cursorPosition);
 }
 
 /**

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -286,7 +286,7 @@ export class Task {
         taskInfo.tags = taskInfo.tags.map((tag) => tag.trim());
 
         // Remove the Global Filter if it is there
-        taskInfo.tags = taskInfo.tags.filter((tag) => !GlobalFilter.equals(tag));
+        taskInfo.tags = taskInfo.tags.filter((tag) => !GlobalFilter.getInstance().equals(tag));
 
         return new Task({
             ...taskComponents,

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -239,7 +239,7 @@ export class Task {
 
         // return if the line does not have the global filter. Do this before
         // any other processing to improve performance.
-        if (!GlobalFilter.includedIn(taskComponents.body)) {
+        if (!GlobalFilter.getInstance().includedIn(taskComponents.body)) {
             return null;
         }
 

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -139,7 +139,7 @@ async function taskToHtml(
         let componentString = emojiSerializer.componentToString(task, taskLayout, component);
         if (componentString) {
             if (component === 'description') {
-                componentString = GlobalFilter.removeAsWordFromDependingOnSettings(componentString);
+                componentString = GlobalFilter.getInstance().removeAsWordFromDependingOnSettings(componentString);
             }
             // Create the text span that will hold the rendered component
             const span = document.createElement('span');

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -26,7 +26,7 @@ import { Query } from '../Query/Query';
 export function explainResults(source: string, globalQuery: GlobalQuery, path: string | undefined = undefined): string {
     let result = '';
 
-    if (!GlobalFilter.isEmpty()) {
+    if (!GlobalFilter.getInstance().isEmpty()) {
         result += `Only tasks containing the global filter '${GlobalFilter.getInstance().get()}'.\n\n`;
     }
 

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -27,7 +27,7 @@ export function explainResults(source: string, globalQuery: GlobalQuery, path: s
     let result = '';
 
     if (!GlobalFilter.isEmpty()) {
-        result += `Only tasks containing the global filter '${GlobalFilter.get()}'.\n\n`;
+        result += `Only tasks containing the global filter '${GlobalFilter.getInstance().get()}'.\n\n`;
     }
 
     const tasksBlockQuery = new Query({ source }, path);

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ export default class TasksPlugin extends Plugin {
         const newSettings = await this.loadData();
         updateSettings(newSettings);
         GlobalFilter.getInstance().set(newSettings.globalFilter);
-        GlobalFilter.setRemoveGlobalFilter(newSettings.removeGlobalFilter);
+        GlobalFilter.getInstance().setRemoveGlobalFilter(newSettings.removeGlobalFilter);
         GlobalQuery.getInstance().set(newSettings.globalQuery);
         await this.loadTaskStatuses();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,7 +70,7 @@ export default class TasksPlugin extends Plugin {
     async loadSettings() {
         const newSettings = await this.loadData();
         updateSettings(newSettings);
-        GlobalFilter.set(newSettings.globalFilter);
+        GlobalFilter.getInstance().set(newSettings.globalFilter);
         GlobalFilter.setRemoveGlobalFilter(newSettings.removeGlobalFilter);
         GlobalQuery.getInstance().set(newSettings.globalQuery);
         await this.loadTaskStatuses();

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -231,7 +231,7 @@
     onMount(() => {
         const { provideAccessKeys } = getSettings();
         withAccessKeys = provideAccessKeys;
-        const description = GlobalFilter.removeAsWordFrom(task.description);
+        const description = GlobalFilter.getInstance().removeAsWordFrom(task.description);
         // If we're displaying to the user the description without the global filter (i.e. it was removed in the method
         // above), or if the description did not include a global filter in the first place, we'll add the global filter
         // when saving the task.

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -299,7 +299,7 @@
     const _onSubmit = () => {
         let description = editableTask.description.trim();
         if (addGlobalFilterOnSave) {
-            description = GlobalFilter.prependTo(description);
+            description = GlobalFilter.getInstance().prependTo(description);
         }
 
         const startDate = parseTypedDateForSaving(editableTask.startDate);

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -235,7 +235,7 @@
         // If we're displaying to the user the description without the global filter (i.e. it was removed in the method
         // above), or if the description did not include a global filter in the first place, we'll add the global filter
         // when saving the task.
-        if (description != task.description || !GlobalFilter.includedIn(task.description)) {
+        if (description != task.description || !GlobalFilter.getInstance().includedIn(task.description)) {
             addGlobalFilterOnSave = true;
         }
         let priority: typeof editableTask.priority = 'none';

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -11,7 +11,7 @@ window.moment = moment;
 
 describe('CreateOrEditTaskParser - testing edited task if line is saved unchanged', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it.each([
@@ -74,7 +74,7 @@ describe('CreateOrEditTaskParser - testing edited task if line is saved unchange
 
 describe('CreateOrEditTaskParser - task recognition', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('should recognize task details without global filter', () => {
@@ -107,7 +107,7 @@ describe('CreateOrEditTaskParser - created date', () => {
     afterEach(() => {
         jest.useRealTimers();
         resetSettings();
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it.each([

--- a/tests/Commands/CreateOrEditTaskParser.test.ts
+++ b/tests/Commands/CreateOrEditTaskParser.test.ts
@@ -63,7 +63,7 @@ describe('CreateOrEditTaskParser - testing edited task if line is saved unchange
     ])(
         'line loaded into "Create or edit task" command: "%s"',
         (line: string, expectedResult: string, globalFilter: string) => {
-            GlobalFilter.set(globalFilter);
+            GlobalFilter.getInstance().set(globalFilter);
             const path = 'a/b/c.md';
             const task = taskFromLine({ line, path });
             expect(task.toFileLineString()).toStrictEqual(expectedResult);
@@ -78,7 +78,7 @@ describe('CreateOrEditTaskParser - task recognition', () => {
     });
 
     it('should recognize task details without global filter', () => {
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
         const taskLine =
             '- [ ] without global filter but with all the info ⏬ 🔁 every 2 days ➕ 2022-03-10 🛫 2022-01-31 ⏳ 2023-06-13 📅 2024-12-10 ✅ 2023-06-22';
         const path = 'a/b/c.md';
@@ -155,7 +155,7 @@ describe('CreateOrEditTaskParser - created date', () => {
 
     it('should add created date if adding the global filter', () => {
         updateSettings({ setCreatedDate: true });
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
         const path = 'a/b/c.md';
         const line = '- [ ] did not have the global filter';
 

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -93,7 +93,7 @@ describe('ToggleDone', () => {
         testToggleLine('|', '- |');
         testToggleLine('foo|bar', '- foobar|');
 
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         testToggleLine('|', '- |');
         testToggleLine('foo|bar', '- foobar|');
@@ -104,7 +104,7 @@ describe('ToggleDone', () => {
         testToggleLine('- |', '- [ ] |');
         testToggleLine('- |foobar', '- [ ] foobar|');
 
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         testToggleLine('|- ', '- [ ] |');
         testToggleLine('- |', '- [ ] |');
@@ -118,7 +118,7 @@ describe('ToggleDone', () => {
         // Issue #449 - cursor jumped 13 characters to the right on completion
         testToggleLine('- [ ] I have a |proper description', '- [x] I have a |proper description ✅ 2022-09-04');
 
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         testToggleLine('|- [ ] ', '|- [x] ');
         testToggleLine('- [ ] |', '- [x] |');
@@ -134,7 +134,7 @@ describe('ToggleDone', () => {
         // Issue #449 - cursor jumped 13 characters to the left on un-completion
         testToggleLine('- [x] I have a proper description| ✅ 2022-09-04', '- [ ] I have a proper description|');
 
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         // Done date is not removed if task does not match global filter
         testToggleLine('|- [x]  ✅ 2022-09-04', '|- [ ] ✅ 2022-09-04');
@@ -162,7 +162,7 @@ describe('ToggleDone', () => {
 - [x] I am a recurring task| 🔁 every day 📅 2022-09-04 ✅ 2022-09-04`,
         );
 
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         // Tasks do not recur, and no done-date added, if not matching global filter
         testToggleLine(
@@ -201,7 +201,7 @@ describe('ToggleDone', () => {
         });
 
         it('when there is a global filter and task with global filter is toggled', () => {
-            GlobalFilter.set('#task');
+            GlobalFilter.getInstance().set('#task');
 
             const line1 = '- [C] #task this is a task starting at Con';
 
@@ -214,7 +214,7 @@ describe('ToggleDone', () => {
         });
 
         it('when there is a global filter and task without global filter is toggled', () => {
-            GlobalFilter.set('#task');
+            GlobalFilter.getInstance().set('#task');
 
             const line1 = '- [P] this is a task starting at Pro, not matching the global filter';
 

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -78,7 +78,7 @@ function testToggleLineForOutOfRangeCursorPositions(
 
 describe('ToggleDone', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     const todaySpy = jest.spyOn(Date, 'now').mockReturnValue(moment('2022-09-04').valueOf());
@@ -180,7 +180,7 @@ describe('ToggleDone', () => {
 
     describe('should honour next status character', () => {
         afterEach(() => {
-            GlobalFilter.reset();
+            GlobalFilter.getInstance().reset();
         });
 
         // Arrange

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -118,29 +118,29 @@ describe('Task rendering', () => {
     });
 
     it('should display task description without non-tag Global Filter)', () => {
-        GlobalFilter.set('filter');
+        GlobalFilter.getInstance().set('filter');
         testDescriptionRender('filter important thing', 'important thing');
     });
 
     it('should display task description with complex non-tag Global Filter)', () => {
-        GlobalFilter.set('filter');
+        GlobalFilter.getInstance().set('filter');
         // This behavior is inconsistent with Obsidian's tag definition which includes nested tags
         testDescriptionRender('filter/important thing', 'filter/important thing');
     });
 
     it('should display task description without tag-like Global Filter', () => {
-        GlobalFilter.set('#todo');
+        GlobalFilter.getInstance().set('#todo');
         testDescriptionRender('#todo another plan', 'another plan');
     });
 
     it('should display task description with complex tag-like Global Filter', () => {
-        GlobalFilter.set('#todo');
+        GlobalFilter.getInstance().set('#todo');
         // This behavior is inconsistent with Obsidian's tag definition which includes nested tags
         testDescriptionRender('#todo/important another plan', '#todo/important another plan');
     });
 
     it('should display task description with emoji removed, when global filter is in initial line', () => {
-        GlobalFilter.set('#todo');
+        GlobalFilter.getInstance().set('#todo');
         testDescriptionRender(
             '#todo with global filter and with scheduled date ⏳ 2023-06-13',
             'with global filter and with scheduled date',
@@ -148,7 +148,7 @@ describe('Task rendering', () => {
     });
 
     it('should display task description with emoji removed, even if the global filter is missing from initial line (bug 2037)', () => {
-        GlobalFilter.set('#todo');
+        GlobalFilter.getInstance().set('#todo');
         // When written, this was a demonstration of the behaviour logged in
         // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2037
         testDescriptionRender(
@@ -181,7 +181,7 @@ describe('Task editing', () => {
     it('should not change the description if the task was not edited and keep Global Filter', async () => {
         const globalFilter = '#remember';
         const description = 'simple task';
-        GlobalFilter.set(globalFilter);
+        GlobalFilter.getInstance().set(globalFilter);
         await testDescriptionEdit(`${globalFilter} ${description}`, description, `${globalFilter} ${description}`);
     });
 
@@ -189,7 +189,7 @@ describe('Task editing', () => {
         const globalFilter = '#remember';
         const oldDescription = 'simple task';
         const newDescription = 'new plan';
-        GlobalFilter.set(globalFilter);
+        GlobalFilter.getInstance().set(globalFilter);
         await testDescriptionEdit(
             `${globalFilter} ${oldDescription}`,
             newDescription,
@@ -247,7 +247,7 @@ describe('Exhaustive editing', () => {
             name,
             title,
             async (globalFilter, setCreatedDate, initialTaskLine) => {
-                GlobalFilter.set(globalFilter as string);
+                GlobalFilter.getInstance().set(globalFilter as string);
 
                 // @ts-expect-error: TS2322: Type 'T2' is not assignable to type 'boolean | undefined'.
                 updateSettings({ setCreatedDate });

--- a/tests/EditTask.test.ts
+++ b/tests/EditTask.test.ts
@@ -100,7 +100,7 @@ async function editTaskLine(line: string, newDescription: string | undefined) {
 
 describe('Task rendering', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     function testDescriptionRender(taskDescription: string, expectedDescription: string) {
@@ -160,7 +160,7 @@ describe('Task rendering', () => {
 
 describe('Task editing', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     async function testDescriptionEdit(taskDescription: string, newDescription: string, expectedDescription: string) {
@@ -211,7 +211,7 @@ describe('Exhaustive editing', () => {
     });
 
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
         resetSettings();
         jest.useRealTimers();
     });

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -22,7 +22,7 @@ describe('Global Filter tests', () => {
         const testValue = 'newGlobalFilter';
 
         // Act
-        GlobalFilter.set(testValue);
+        GlobalFilter.getInstance().set(testValue);
 
         // Assert
         expect(GlobalFilter.getInstance().get()).toEqual(testValue);
@@ -31,7 +31,7 @@ describe('Global Filter tests', () => {
     it('Should reset the Global Filter', () => {
         // Arrange
         const testValue = '#important';
-        GlobalFilter.set(testValue);
+        GlobalFilter.getInstance().set(testValue);
 
         // Act
         GlobalFilter.reset();
@@ -47,7 +47,7 @@ describe('Global Filter tests', () => {
 
     it('Should indicate non-empty Global Filter after setting one', () => {
         // Arrange
-        GlobalFilter.set('newGlobalFilter');
+        GlobalFilter.getInstance().set('newGlobalFilter');
 
         // Assert
         expect(GlobalFilter.isEmpty()).toEqual(false);
@@ -55,7 +55,7 @@ describe('Global Filter tests', () => {
 
     it('Should match a string with Global Filter', () => {
         // Arrange
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         // Assert
         expect(GlobalFilter.includedIn('Important #task inside')).toEqual(true);
@@ -63,7 +63,7 @@ describe('Global Filter tests', () => {
 
     it('Should check equality correctly', () => {
         // Arrange
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         // Assert
         expect(GlobalFilter.equals('#task')).toEqual(true);
@@ -73,7 +73,7 @@ describe('Global Filter tests', () => {
 
     it('Should not match a string without Global Filter', () => {
         // Arrange
-        GlobalFilter.set('testValue');
+        GlobalFilter.getInstance().set('testValue');
 
         // Assert
         expect(GlobalFilter.includedIn('Without Global Filter')).toEqual(false);
@@ -92,7 +92,7 @@ describe('Global Filter tests', () => {
         const testValue = '#end';
         const testStringBefore = 'Important thing to do #end';
         const testStringAfter = 'Important thing to do';
-        GlobalFilter.set(testValue);
+        GlobalFilter.getInstance().set(testValue);
 
         // Assert
         expect(GlobalFilter.removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
@@ -103,7 +103,7 @@ describe('Global Filter tests', () => {
         const testValue = '#beginning';
         const testStringBefore = '#beginning another important thing';
         const testStringAfter = 'another important thing';
-        GlobalFilter.set(testValue);
+        GlobalFilter.getInstance().set(testValue);
 
         // Assert
         expect(GlobalFilter.removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
@@ -115,7 +115,7 @@ describe('Global Filter tests', () => {
         const testStringBefore = 'With the GF in the #middle of the string';
         // Note the 2 spaces where the 'newGlobalFilter' was
         const testStringAfter = 'With the GF in the  of the string';
-        GlobalFilter.set(testValue);
+        GlobalFilter.getInstance().set(testValue);
 
         // Assert
         expect(GlobalFilter.removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
@@ -130,7 +130,7 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
 
     it('Should remove Global Filter from a string when Setting is set to false', () => {
         // Arrange
-        GlobalFilter.set('todo');
+        GlobalFilter.getInstance().set('todo');
         GlobalFilter.setRemoveGlobalFilter(false);
 
         // Assert
@@ -141,7 +141,7 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
 
     it('Should remove Global Filter from a string when Setting is set to true', () => {
         // Arrange
-        GlobalFilter.set('todo');
+        GlobalFilter.getInstance().set('todo');
         GlobalFilter.setRemoveGlobalFilter(true);
 
         // Assert
@@ -164,7 +164,7 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
         'should not remove Global Filter (%s) if it is in a substring for a task "- [ ] %s"',
         async (globalFilter: string, description: string) => {
             GlobalFilter.setRemoveGlobalFilter(true);
-            GlobalFilter.set(globalFilter);
+            GlobalFilter.getInstance().set(globalFilter);
 
             expect(GlobalFilter.removeAsWordFrom(description)).toEqual(description);
         },
@@ -296,7 +296,7 @@ describe('check removal of the global filter', () => {
         'should parse "$inputDescription" and extract "$expectedDescription"',
         ({ globalFilter, inputDescription, expectedDescription }) => {
             // Arrange
-            GlobalFilter.set(globalFilter);
+            GlobalFilter.getInstance().set(globalFilter);
 
             // Assert
             expect(GlobalFilter.removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
@@ -345,7 +345,7 @@ describe('check removal of the global filter exhaustively', () => {
         '\\',
     ])('should parse global filter "%s" edge cases correctly', (globalFilter) => {
         // Arrange
-        GlobalFilter.set(globalFilter);
+        GlobalFilter.getInstance().set(globalFilter);
 
         // global filter removed at beginning, middle and end
         let inputDescription = `${globalFilter} 1 ${globalFilter} 2 ${globalFilter}`;
@@ -374,7 +374,7 @@ describe('GlobalFilter.prepend() tests', () => {
         const globalFilter = 'awesome';
         const description = 'blossom';
 
-        GlobalFilter.set(globalFilter);
+        GlobalFilter.getInstance().set(globalFilter);
         expect(GlobalFilter.prependTo(description)).toEqual(`${globalFilter} ${description}`);
     });
 

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -162,9 +162,9 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
         ['TODO', 'at the end TODO/maybe'],
     ])(
         'should not remove Global Filter (%s) if it is in a substring for a task "- [ ] %s"',
-        async (globalFilter: string, description: string) => {
+        async (globalFilterValue: string, description: string) => {
             GlobalFilter.getInstance().setRemoveGlobalFilter(true);
-            GlobalFilter.getInstance().set(globalFilter);
+            GlobalFilter.getInstance().set(globalFilterValue);
 
             expect(GlobalFilter.getInstance().removeAsWordFrom(description)).toEqual(description);
         },
@@ -177,126 +177,126 @@ describe('check removal of the global filter', () => {
     });
 
     type GlobalFilterRemovalExpectation = {
-        globalFilter: string;
+        globalFilterValue: string;
         inputDescription: string;
         expectedDescription: string;
     };
 
     test.each<GlobalFilterRemovalExpectation>([
         {
-            globalFilter: '#task',
+            globalFilterValue: '#task',
             inputDescription: '#task this is a very simple task',
             expectedDescription: 'this is a very simple task',
         },
         {
-            globalFilter: '',
+            globalFilterValue: '',
             inputDescription: '#task this is a very simple task',
             expectedDescription: '#task this is a very simple task',
         },
         {
-            globalFilter: '🞋',
+            globalFilterValue: '🞋',
             inputDescription: 'task with emoji 🞋 global filter',
             expectedDescription: 'task with emoji global filter',
         },
         {
-            globalFilter: '#t',
+            globalFilterValue: '#t',
             inputDescription: 'task with #t global filter in the middle',
             expectedDescription: 'task with global filter in the middle',
         },
         {
-            globalFilter: '#t',
+            globalFilterValue: '#t',
             inputDescription: 'task with global filter in the end #t',
             expectedDescription: 'task with global filter in the end',
         },
         {
-            globalFilter: '#t',
+            globalFilterValue: '#t',
             inputDescription: 'task #t with #t several global #t filters #t',
             // Trailing spaces present after the first removal
             expectedDescription: 'task with  several global  filters',
         },
         {
-            globalFilter: '#t',
+            globalFilterValue: '#t',
             inputDescription: 'task with global filter in the end and some spaces  #t  ',
             expectedDescription: 'task with global filter in the end and some spaces',
         },
         {
-            globalFilter: '#complex/global/filter',
+            globalFilterValue: '#complex/global/filter',
             inputDescription: 'task with #complex/global/filter in the middle',
             expectedDescription: 'task with in the middle',
         },
         {
-            globalFilter: '#task',
+            globalFilterValue: '#task',
             inputDescription: 'task with an extension of the global filter #task/with/extension',
             expectedDescription: 'task with an extension of the global filter #task/with/extension',
         },
         {
-            globalFilter: '#t',
+            globalFilterValue: '#t',
             inputDescription: 'task with #t multiple global filters #t',
             expectedDescription: 'task with multiple global filters',
         },
         {
-            globalFilter: '#t',
+            globalFilterValue: '#t',
             inputDescription: '#t', // confirm behaviour when the description is empty
             expectedDescription: '',
         },
         {
-            globalFilter: '#t',
+            globalFilterValue: '#t',
             inputDescription: '#t #t',
             // Wrong behaviour - the expected should be empty
             expectedDescription: '#t',
         },
         {
-            globalFilter: '#t',
+            globalFilterValue: '#t',
             inputDescription: '#t #t #t',
             // Wrong behaviour - the expected should be empty
             expectedDescription: '#t',
         },
         {
-            globalFilter: '#t',
+            globalFilterValue: '#t',
             inputDescription: '#t #t #t #t',
             // Wrong behaviour - the expected should be empty
             expectedDescription: '#t #t',
         },
         {
-            globalFilter: '#t',
+            globalFilterValue: '#t',
             inputDescription: '#t #t #t #t #t',
             // Wrong behaviour - the expected should be empty
             expectedDescription: '#t #t',
         },
         {
-            globalFilter: 'some',
+            globalFilterValue: 'some',
             inputDescription: 'some', // confirm behaviour when the description is empty
             expectedDescription: '',
         },
         {
-            globalFilter: 'some',
+            globalFilterValue: 'some',
             inputDescription: 'some some',
             // Wrong behaviour - the expected should be empty
             expectedDescription: 'some',
         },
         {
-            globalFilter: 'some',
+            globalFilterValue: 'some',
             inputDescription: 'some some some',
             // Wrong behaviour - the expected should be empty
             expectedDescription: 'some',
         },
         {
-            globalFilter: 'some',
+            globalFilterValue: 'some',
             inputDescription: 'some some some some',
             // Wrong behaviour - the expected should be empty
             expectedDescription: 'some some',
         },
         {
-            globalFilter: 'some',
+            globalFilterValue: 'some',
             inputDescription: 'some some some some some',
             // Wrong behaviour - the expected should be empty
             expectedDescription: 'some some',
         },
     ])(
         'should parse "$inputDescription" and extract "$expectedDescription"',
-        ({ globalFilter, inputDescription, expectedDescription }) => {
+        ({ globalFilterValue, inputDescription, expectedDescription }) => {
             // Arrange
-            GlobalFilter.getInstance().set(globalFilter);
+            GlobalFilter.getInstance().set(globalFilterValue);
 
             // Assert
             expect(GlobalFilter.getInstance().removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
@@ -343,24 +343,24 @@ describe('check removal of the global filter exhaustively', () => {
         // Failed attempt at creating a failing test for when / was not escaped
         '///',
         '\\',
-    ])('should parse global filter "%s" edge cases correctly', (globalFilter) => {
+    ])('should parse global filter "%s" edge cases correctly', (globalFilterValue) => {
         // Arrange
-        GlobalFilter.getInstance().set(globalFilter);
+        GlobalFilter.getInstance().set(globalFilterValue);
 
         // global filter removed at beginning, middle and end
-        let inputDescription = `${globalFilter} 1 ${globalFilter} 2 ${globalFilter}`;
+        let inputDescription = `${globalFilterValue} 1 ${globalFilterValue} 2 ${globalFilterValue}`;
         let expectedDescription = '1 2';
         expect(GlobalFilter.getInstance().removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
 
         // global filter not removed if non-empty non-tag characters before or after it
-        inputDescription = `${globalFilter}x 1 x${globalFilter} ${globalFilter}x 2 x${globalFilter}`;
-        expectedDescription = `${globalFilter}x 1 x${globalFilter} ${globalFilter}x 2 x${globalFilter}`;
+        inputDescription = `${globalFilterValue}x 1 x${globalFilterValue} ${globalFilterValue}x 2 x${globalFilterValue}`;
+        expectedDescription = `${globalFilterValue}x 1 x${globalFilterValue} ${globalFilterValue}x 2 x${globalFilterValue}`;
         expect(GlobalFilter.getInstance().removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
 
         // global filter not removed if non-empty sub-tag characters after it.
         // Include at least one occurrence of global filter, so we don't pass by luck.
-        inputDescription = `${globalFilter}/x 1 x${globalFilter} ${globalFilter}/x 2 ${globalFilter} ${globalFilter}/x`;
-        expectedDescription = `${globalFilter}/x 1 x${globalFilter} ${globalFilter}/x 2 ${globalFilter}/x`;
+        inputDescription = `${globalFilterValue}/x 1 x${globalFilterValue} ${globalFilterValue}/x 2 ${globalFilterValue} ${globalFilterValue}/x`;
+        expectedDescription = `${globalFilterValue}/x 1 x${globalFilterValue} ${globalFilterValue}/x 2 ${globalFilterValue}/x`;
         expect(GlobalFilter.getInstance().removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
     });
 });
@@ -371,11 +371,11 @@ describe('GlobalFilter.prepend() tests', () => {
     });
 
     it('Should prepend Global Filter', () => {
-        const globalFilter = 'awesome';
+        const globalFilterValue = 'awesome';
         const description = 'blossom';
 
-        GlobalFilter.getInstance().set(globalFilter);
-        expect(GlobalFilter.getInstance().prependTo(description)).toEqual(`${globalFilter} ${description}`);
+        GlobalFilter.getInstance().set(globalFilterValue);
+        expect(GlobalFilter.getInstance().prependTo(description)).toEqual(`${globalFilterValue} ${description}`);
     });
 
     it('Should prepend not prepend empty Global Filter', () => {

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -14,7 +14,7 @@ describe('Global Filter tests', () => {
     });
 
     it('Should provide Global Filter with the default value with get()', () => {
-        expect(GlobalFilter.get()).toEqual('');
+        expect(GlobalFilter.getInstance().get()).toEqual('');
     });
 
     it('Should set new Global Filter', () => {
@@ -25,7 +25,7 @@ describe('Global Filter tests', () => {
         GlobalFilter.set(testValue);
 
         // Assert
-        expect(GlobalFilter.get()).toEqual(testValue);
+        expect(GlobalFilter.getInstance().get()).toEqual(testValue);
     });
 
     it('Should reset the Global Filter', () => {
@@ -37,7 +37,7 @@ describe('Global Filter tests', () => {
         GlobalFilter.reset();
 
         // Assert
-        expect(GlobalFilter.get()).toEqual('');
+        expect(GlobalFilter.getInstance().get()).toEqual('');
     });
 
     it('Should indicate empty Global Filter by default', () => {

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -134,7 +134,7 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
         GlobalFilter.setRemoveGlobalFilter(false);
 
         // Assert
-        expect(GlobalFilter.removeAsWordFromDependingOnSettings('This is absolutely todo')).toEqual(
+        expect(GlobalFilter.getInstance().removeAsWordFromDependingOnSettings('This is absolutely todo')).toEqual(
             'This is absolutely todo',
         );
     });
@@ -145,7 +145,7 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
         GlobalFilter.setRemoveGlobalFilter(true);
 
         // Assert
-        expect(GlobalFilter.removeAsWordFromDependingOnSettings('This is absolutely todo')).toEqual(
+        expect(GlobalFilter.getInstance().removeAsWordFromDependingOnSettings('This is absolutely todo')).toEqual(
             'This is absolutely',
         );
     });

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -1,4 +1,3 @@
-import { resetSettings } from '../src/Config/Settings';
 import { GlobalFilter } from '../src/Config/GlobalFilter';
 
 describe('Global Filter tests', () => {
@@ -146,29 +145,26 @@ describe('Global Filter tests', () => {
 });
 
 describe('Global Filter tests with Remove Global Filter Setting', () => {
-    afterEach(() => {
-        GlobalFilter.getInstance().reset();
-        resetSettings();
-    });
-
     it('Should remove Global Filter from a string when Setting is set to false', () => {
         // Arrange
-        GlobalFilter.getInstance().set('todo');
-        GlobalFilter.getInstance().setRemoveGlobalFilter(false);
+        const globalFilter = new GlobalFilter();
+        globalFilter.set('todo');
+        globalFilter.setRemoveGlobalFilter(false);
 
         // Assert
-        expect(GlobalFilter.getInstance().removeAsWordFromDependingOnSettings('This is absolutely todo')).toEqual(
+        expect(globalFilter.removeAsWordFromDependingOnSettings('This is absolutely todo')).toEqual(
             'This is absolutely todo',
         );
     });
 
     it('Should remove Global Filter from a string when Setting is set to true', () => {
         // Arrange
-        GlobalFilter.getInstance().set('todo');
-        GlobalFilter.getInstance().setRemoveGlobalFilter(true);
+        const globalFilter = new GlobalFilter();
+        globalFilter.set('todo');
+        globalFilter.setRemoveGlobalFilter(true);
 
         // Assert
-        expect(GlobalFilter.getInstance().removeAsWordFromDependingOnSettings('This is absolutely todo')).toEqual(
+        expect(globalFilter.removeAsWordFromDependingOnSettings('This is absolutely todo')).toEqual(
             'This is absolutely',
         );
     });
@@ -186,10 +182,11 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
     ])(
         'should not remove Global Filter (%s) if it is in a substring for a task "- [ ] %s"',
         async (globalFilterValue: string, description: string) => {
-            GlobalFilter.getInstance().setRemoveGlobalFilter(true);
-            GlobalFilter.getInstance().set(globalFilterValue);
+            const globalFilter = new GlobalFilter();
+            globalFilter.setRemoveGlobalFilter(true);
+            globalFilter.set(globalFilterValue);
 
-            expect(GlobalFilter.getInstance().removeAsWordFrom(description)).toEqual(description);
+            expect(globalFilter.removeAsWordFrom(description)).toEqual(description);
         },
     );
 });

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -42,7 +42,7 @@ describe('Global Filter tests', () => {
 
     it('Should indicate empty Global Filter by default', () => {
         // Assert
-        expect(GlobalFilter.isEmpty()).toEqual(true);
+        expect(GlobalFilter.getInstance().isEmpty()).toEqual(true);
     });
 
     it('Should indicate non-empty Global Filter after setting one', () => {
@@ -50,7 +50,7 @@ describe('Global Filter tests', () => {
         GlobalFilter.getInstance().set('newGlobalFilter');
 
         // Assert
-        expect(GlobalFilter.isEmpty()).toEqual(false);
+        expect(GlobalFilter.getInstance().isEmpty()).toEqual(false);
     });
 
     it('Should match a string with Global Filter', () => {

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -2,10 +2,6 @@ import { resetSettings } from '../src/Config/Settings';
 import { GlobalFilter } from '../src/Config/GlobalFilter';
 
 describe('Global Filter tests', () => {
-    afterEach(() => {
-        GlobalFilter.getInstance().reset();
-    });
-
     it('getInstance() should return the same object', () => {
         const globalFilter1 = GlobalFilter.getInstance();
         const globalFilter2 = GlobalFilter.getInstance();
@@ -14,18 +10,20 @@ describe('Global Filter tests', () => {
     });
 
     it('Should provide Global Filter with the default value with get()', () => {
-        expect(GlobalFilter.getInstance().get()).toEqual('');
+        const globalFilter = new GlobalFilter();
+        expect(globalFilter.get()).toEqual('');
     });
 
     it('Should set new Global Filter', () => {
         // Arrange
         const testValue = 'newGlobalFilter';
+        const globalFilter = new GlobalFilter();
 
         // Act
-        GlobalFilter.getInstance().set(testValue);
+        globalFilter.set(testValue);
 
         // Assert
-        expect(GlobalFilter.getInstance().get()).toEqual(testValue);
+        expect(globalFilter.get()).toEqual(testValue);
     });
 
     it('Should allow independent values for independent instances', () => {
@@ -45,60 +43,68 @@ describe('Global Filter tests', () => {
     it('Should reset the Global Filter', () => {
         // Arrange
         const testValue = '#important';
-        GlobalFilter.getInstance().set(testValue);
+        const globalFilter = new GlobalFilter();
+        globalFilter.set(testValue);
 
         // Act
-        GlobalFilter.getInstance().reset();
+        globalFilter.reset();
 
         // Assert
-        expect(GlobalFilter.getInstance().get()).toEqual('');
+        expect(globalFilter.get()).toEqual('');
     });
 
     it('Should indicate empty Global Filter by default', () => {
         // Assert
-        expect(GlobalFilter.getInstance().isEmpty()).toEqual(true);
+        const globalFilter = new GlobalFilter();
+        expect(globalFilter.isEmpty()).toEqual(true);
     });
 
     it('Should indicate non-empty Global Filter after setting one', () => {
         // Arrange
-        GlobalFilter.getInstance().set('newGlobalFilter');
+        const globalFilter = new GlobalFilter();
+        globalFilter.set('newGlobalFilter');
 
         // Assert
-        expect(GlobalFilter.getInstance().isEmpty()).toEqual(false);
+        expect(globalFilter.isEmpty()).toEqual(false);
     });
 
     it('Should match a string with Global Filter', () => {
         // Arrange
-        GlobalFilter.getInstance().set('#task');
+        const globalFilter = new GlobalFilter();
+        globalFilter.set('#task');
 
         // Assert
-        expect(GlobalFilter.getInstance().includedIn('Important #task inside')).toEqual(true);
+        expect(globalFilter.includedIn('Important #task inside')).toEqual(true);
     });
 
     it('Should check equality correctly', () => {
         // Arrange
-        GlobalFilter.getInstance().set('#task');
+        const globalFilter = new GlobalFilter();
+        globalFilter.set('#task');
 
         // Assert
-        expect(GlobalFilter.getInstance().equals('#task')).toEqual(true);
-        expect(GlobalFilter.getInstance().equals('#tasks')).toEqual(false);
-        expect(GlobalFilter.getInstance().equals('#TODO')).toEqual(false);
+        expect(globalFilter.equals('#task')).toEqual(true);
+        expect(globalFilter.equals('#tasks')).toEqual(false);
+        expect(globalFilter.equals('#TODO')).toEqual(false);
     });
 
     it('Should not match a string without Global Filter', () => {
         // Arrange
-        GlobalFilter.getInstance().set('testValue');
+        const globalFilter = new GlobalFilter();
+        globalFilter.set('testValue');
 
         // Assert
-        expect(GlobalFilter.getInstance().includedIn('Without Global Filter')).toEqual(false);
+        expect(globalFilter.includedIn('Without Global Filter')).toEqual(false);
     });
 
     it('Should control whether to remove the global filter from displayed tasks', () => {
-        GlobalFilter.getInstance().setRemoveGlobalFilter(false);
-        expect(GlobalFilter.getInstance().getRemoveGlobalFilter()).toEqual(false);
+        const globalFilter = new GlobalFilter();
 
-        GlobalFilter.getInstance().setRemoveGlobalFilter(true);
-        expect(GlobalFilter.getInstance().getRemoveGlobalFilter()).toEqual(true);
+        globalFilter.setRemoveGlobalFilter(false);
+        expect(globalFilter.getRemoveGlobalFilter()).toEqual(false);
+
+        globalFilter.setRemoveGlobalFilter(true);
+        expect(globalFilter.getRemoveGlobalFilter()).toEqual(true);
     });
 
     it('Should remove Global Filter from the beginning of a string', () => {
@@ -106,10 +112,11 @@ describe('Global Filter tests', () => {
         const testValue = '#end';
         const testStringBefore = 'Important thing to do #end';
         const testStringAfter = 'Important thing to do';
-        GlobalFilter.getInstance().set(testValue);
+        const globalFilter = new GlobalFilter();
+        globalFilter.set(testValue);
 
         // Assert
-        expect(GlobalFilter.getInstance().removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
+        expect(globalFilter.removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
     });
 
     it('Should remove Global Filter from the end of a string', () => {
@@ -117,10 +124,11 @@ describe('Global Filter tests', () => {
         const testValue = '#beginning';
         const testStringBefore = '#beginning another important thing';
         const testStringAfter = 'another important thing';
-        GlobalFilter.getInstance().set(testValue);
+        const globalFilter = new GlobalFilter();
+        globalFilter.set(testValue);
 
         // Assert
-        expect(GlobalFilter.getInstance().removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
+        expect(globalFilter.removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
     });
 
     it('Should remove Global Filter in the middle of a string', () => {
@@ -129,10 +137,11 @@ describe('Global Filter tests', () => {
         const testStringBefore = 'With the GF in the #middle of the string';
         // Note the 2 spaces where the 'newGlobalFilter' was
         const testStringAfter = 'With the GF in the  of the string';
-        GlobalFilter.getInstance().set(testValue);
+        const globalFilter = new GlobalFilter();
+        globalFilter.set(testValue);
 
         // Assert
-        expect(GlobalFilter.getInstance().removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
+        expect(globalFilter.removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
     });
 });
 

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -20,6 +20,8 @@ describe('Global Filter tests', () => {
     it('Should set new Global Filter', () => {
         // Arrange
         const testValue = 'newGlobalFilter';
+
+        // Act
         GlobalFilter.set(testValue);
 
         // Assert
@@ -30,6 +32,8 @@ describe('Global Filter tests', () => {
         // Arrange
         const testValue = '#important';
         GlobalFilter.set(testValue);
+
+        // Act
         GlobalFilter.reset();
 
         // Assert

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -375,12 +375,12 @@ describe('GlobalFilter.prepend() tests', () => {
         const description = 'blossom';
 
         GlobalFilter.getInstance().set(globalFilter);
-        expect(GlobalFilter.prependTo(description)).toEqual(`${globalFilter} ${description}`);
+        expect(GlobalFilter.getInstance().prependTo(description)).toEqual(`${globalFilter} ${description}`);
     });
 
     it('Should prepend not prepend empty Global Filter', () => {
         // Note that an empty space is currently prepended in case the Global Filter is empty
         // Not fixing this for now in a refactoring PR
-        expect(GlobalFilter.prependTo('description')).toEqual(' description');
+        expect(GlobalFilter.getInstance().prependTo('description')).toEqual(' description');
     });
 });

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -322,10 +322,6 @@ describe('check removal of the global filter', () => {
 });
 
 describe('check removal of the global filter exhaustively', () => {
-    afterEach(() => {
-        GlobalFilter.getInstance().reset();
-    });
-
     test.each<string>([
         '#t',
         // The characters listed below are the ones that are - or were - escaped by
@@ -362,23 +358,24 @@ describe('check removal of the global filter exhaustively', () => {
         '\\',
     ])('should parse global filter "%s" edge cases correctly', (globalFilterValue) => {
         // Arrange
-        GlobalFilter.getInstance().set(globalFilterValue);
+        const globalFilter = new GlobalFilter();
+        globalFilter.set(globalFilterValue);
 
         // global filter removed at beginning, middle and end
         let inputDescription = `${globalFilterValue} 1 ${globalFilterValue} 2 ${globalFilterValue}`;
         let expectedDescription = '1 2';
-        expect(GlobalFilter.getInstance().removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
+        expect(globalFilter.removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
 
         // global filter not removed if non-empty non-tag characters before or after it
         inputDescription = `${globalFilterValue}x 1 x${globalFilterValue} ${globalFilterValue}x 2 x${globalFilterValue}`;
         expectedDescription = `${globalFilterValue}x 1 x${globalFilterValue} ${globalFilterValue}x 2 x${globalFilterValue}`;
-        expect(GlobalFilter.getInstance().removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
+        expect(globalFilter.removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
 
         // global filter not removed if non-empty sub-tag characters after it.
         // Include at least one occurrence of global filter, so we don't pass by luck.
         inputDescription = `${globalFilterValue}/x 1 x${globalFilterValue} ${globalFilterValue}/x 2 ${globalFilterValue} ${globalFilterValue}/x`;
         expectedDescription = `${globalFilterValue}/x 1 x${globalFilterValue} ${globalFilterValue}/x 2 ${globalFilterValue}/x`;
-        expect(GlobalFilter.getInstance().removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
+        expect(globalFilter.removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
     });
 });
 

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -3,7 +3,7 @@ import { GlobalFilter } from '../src/Config/GlobalFilter';
 
 describe('Global Filter tests', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('getInstance() should return the same object', () => {
@@ -34,7 +34,7 @@ describe('Global Filter tests', () => {
         GlobalFilter.getInstance().set(testValue);
 
         // Act
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
 
         // Assert
         expect(GlobalFilter.getInstance().get()).toEqual('');
@@ -124,7 +124,7 @@ describe('Global Filter tests', () => {
 
 describe('Global Filter tests with Remove Global Filter Setting', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
         resetSettings();
     });
 
@@ -173,7 +173,7 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
 
 describe('check removal of the global filter', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     type GlobalFilterRemovalExpectation = {
@@ -306,7 +306,7 @@ describe('check removal of the global filter', () => {
 
 describe('check removal of the global filter exhaustively', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     test.each<string>([
@@ -367,7 +367,7 @@ describe('check removal of the global filter exhaustively', () => {
 
 describe('GlobalFilter.prepend() tests', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('Should prepend Global Filter', () => {

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -95,7 +95,7 @@ describe('Global Filter tests', () => {
         GlobalFilter.getInstance().set(testValue);
 
         // Assert
-        expect(GlobalFilter.removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
+        expect(GlobalFilter.getInstance().removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
     });
 
     it('Should remove Global Filter from the end of a string', () => {
@@ -106,7 +106,7 @@ describe('Global Filter tests', () => {
         GlobalFilter.getInstance().set(testValue);
 
         // Assert
-        expect(GlobalFilter.removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
+        expect(GlobalFilter.getInstance().removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
     });
 
     it('Should remove Global Filter in the middle of a string', () => {
@@ -118,7 +118,7 @@ describe('Global Filter tests', () => {
         GlobalFilter.getInstance().set(testValue);
 
         // Assert
-        expect(GlobalFilter.removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
+        expect(GlobalFilter.getInstance().removeAsSubstringFrom(testStringBefore)).toEqual(testStringAfter);
     });
 });
 

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -166,7 +166,7 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
             GlobalFilter.getInstance().setRemoveGlobalFilter(true);
             GlobalFilter.getInstance().set(globalFilter);
 
-            expect(GlobalFilter.removeAsWordFrom(description)).toEqual(description);
+            expect(GlobalFilter.getInstance().removeAsWordFrom(description)).toEqual(description);
         },
     );
 });
@@ -299,7 +299,7 @@ describe('check removal of the global filter', () => {
             GlobalFilter.getInstance().set(globalFilter);
 
             // Assert
-            expect(GlobalFilter.removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
+            expect(GlobalFilter.getInstance().removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
         },
     );
 });
@@ -350,18 +350,18 @@ describe('check removal of the global filter exhaustively', () => {
         // global filter removed at beginning, middle and end
         let inputDescription = `${globalFilter} 1 ${globalFilter} 2 ${globalFilter}`;
         let expectedDescription = '1 2';
-        expect(GlobalFilter.removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
+        expect(GlobalFilter.getInstance().removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
 
         // global filter not removed if non-empty non-tag characters before or after it
         inputDescription = `${globalFilter}x 1 x${globalFilter} ${globalFilter}x 2 x${globalFilter}`;
         expectedDescription = `${globalFilter}x 1 x${globalFilter} ${globalFilter}x 2 x${globalFilter}`;
-        expect(GlobalFilter.removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
+        expect(GlobalFilter.getInstance().removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
 
         // global filter not removed if non-empty sub-tag characters after it.
         // Include at least one occurrence of global filter, so we don't pass by luck.
         inputDescription = `${globalFilter}/x 1 x${globalFilter} ${globalFilter}/x 2 ${globalFilter} ${globalFilter}/x`;
         expectedDescription = `${globalFilter}/x 1 x${globalFilter} ${globalFilter}/x 2 ${globalFilter}/x`;
-        expect(GlobalFilter.removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
+        expect(GlobalFilter.getInstance().removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
     });
 });
 

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -192,10 +192,6 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
 });
 
 describe('check removal of the global filter', () => {
-    afterEach(() => {
-        GlobalFilter.getInstance().reset();
-    });
-
     type GlobalFilterRemovalExpectation = {
         globalFilterValue: string;
         inputDescription: string;
@@ -316,10 +312,11 @@ describe('check removal of the global filter', () => {
         'should parse "$inputDescription" and extract "$expectedDescription"',
         ({ globalFilterValue, inputDescription, expectedDescription }) => {
             // Arrange
-            GlobalFilter.getInstance().set(globalFilterValue);
+            const globalFilter = new GlobalFilter();
+            globalFilter.set(globalFilterValue);
 
             // Assert
-            expect(GlobalFilter.getInstance().removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
+            expect(globalFilter.removeAsWordFrom(inputDescription)).toEqual(expectedDescription);
         },
     );
 });

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -6,6 +6,13 @@ describe('Global Filter tests', () => {
         GlobalFilter.reset();
     });
 
+    it('getInstance() should return the same object', () => {
+        const globalFilter1 = GlobalFilter.getInstance();
+        const globalFilter2 = GlobalFilter.getInstance();
+
+        expect(Object.is(globalFilter1, globalFilter2)).toEqual(true);
+    });
+
     it('Should provide Global Filter with the default value with get()', () => {
         expect(GlobalFilter.get()).toEqual('');
     });

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -66,9 +66,9 @@ describe('Global Filter tests', () => {
         GlobalFilter.getInstance().set('#task');
 
         // Assert
-        expect(GlobalFilter.equals('#task')).toEqual(true);
-        expect(GlobalFilter.equals('#tasks')).toEqual(false);
-        expect(GlobalFilter.equals('#TODO')).toEqual(false);
+        expect(GlobalFilter.getInstance().equals('#task')).toEqual(true);
+        expect(GlobalFilter.getInstance().equals('#tasks')).toEqual(false);
+        expect(GlobalFilter.getInstance().equals('#TODO')).toEqual(false);
     });
 
     it('Should not match a string without Global Filter', () => {

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -58,7 +58,7 @@ describe('Global Filter tests', () => {
         GlobalFilter.getInstance().set('#task');
 
         // Assert
-        expect(GlobalFilter.includedIn('Important #task inside')).toEqual(true);
+        expect(GlobalFilter.getInstance().includedIn('Important #task inside')).toEqual(true);
     });
 
     it('Should check equality correctly', () => {
@@ -76,7 +76,7 @@ describe('Global Filter tests', () => {
         GlobalFilter.getInstance().set('testValue');
 
         // Assert
-        expect(GlobalFilter.includedIn('Without Global Filter')).toEqual(false);
+        expect(GlobalFilter.getInstance().includedIn('Without Global Filter')).toEqual(false);
     });
 
     it('Should control whether to remove the global filter from displayed tasks', () => {

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -28,6 +28,20 @@ describe('Global Filter tests', () => {
         expect(GlobalFilter.getInstance().get()).toEqual(testValue);
     });
 
+    it.failing('Should allow independent values for independent instances', () => {
+        // Arrange
+        const globalFilter1 = new GlobalFilter();
+        const globalFilter2 = new GlobalFilter();
+
+        // Act
+        globalFilter1.set('1');
+        globalFilter2.set('2');
+
+        // Assert
+        expect(globalFilter1.get()).toEqual('1');
+        expect(globalFilter2.get()).toEqual('2');
+    });
+
     it('Should reset the Global Filter', () => {
         // Arrange
         const testValue = '#important';

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -380,21 +380,19 @@ describe('check removal of the global filter exhaustively', () => {
 });
 
 describe('GlobalFilter.prepend() tests', () => {
-    afterEach(() => {
-        GlobalFilter.getInstance().reset();
-    });
-
     it('Should prepend Global Filter', () => {
         const globalFilterValue = 'awesome';
         const description = 'blossom';
 
-        GlobalFilter.getInstance().set(globalFilterValue);
-        expect(GlobalFilter.getInstance().prependTo(description)).toEqual(`${globalFilterValue} ${description}`);
+        const globalFilter = new GlobalFilter();
+        globalFilter.set(globalFilterValue);
+        expect(globalFilter.prependTo(description)).toEqual(`${globalFilterValue} ${description}`);
     });
 
     it('Should prepend not prepend empty Global Filter', () => {
         // Note that an empty space is currently prepended in case the Global Filter is empty
         // Not fixing this for now in a refactoring PR
-        expect(GlobalFilter.getInstance().prependTo('description')).toEqual(' description');
+        const globalFilter = new GlobalFilter();
+        expect(globalFilter.prependTo('description')).toEqual(' description');
     });
 });

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -80,10 +80,10 @@ describe('Global Filter tests', () => {
     });
 
     it('Should control whether to remove the global filter from displayed tasks', () => {
-        GlobalFilter.setRemoveGlobalFilter(false);
+        GlobalFilter.getInstance().setRemoveGlobalFilter(false);
         expect(GlobalFilter.getInstance().getRemoveGlobalFilter()).toEqual(false);
 
-        GlobalFilter.setRemoveGlobalFilter(true);
+        GlobalFilter.getInstance().setRemoveGlobalFilter(true);
         expect(GlobalFilter.getInstance().getRemoveGlobalFilter()).toEqual(true);
     });
 
@@ -131,7 +131,7 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
     it('Should remove Global Filter from a string when Setting is set to false', () => {
         // Arrange
         GlobalFilter.getInstance().set('todo');
-        GlobalFilter.setRemoveGlobalFilter(false);
+        GlobalFilter.getInstance().setRemoveGlobalFilter(false);
 
         // Assert
         expect(GlobalFilter.getInstance().removeAsWordFromDependingOnSettings('This is absolutely todo')).toEqual(
@@ -142,7 +142,7 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
     it('Should remove Global Filter from a string when Setting is set to true', () => {
         // Arrange
         GlobalFilter.getInstance().set('todo');
-        GlobalFilter.setRemoveGlobalFilter(true);
+        GlobalFilter.getInstance().setRemoveGlobalFilter(true);
 
         // Assert
         expect(GlobalFilter.getInstance().removeAsWordFromDependingOnSettings('This is absolutely todo')).toEqual(
@@ -163,7 +163,7 @@ describe('Global Filter tests with Remove Global Filter Setting', () => {
     ])(
         'should not remove Global Filter (%s) if it is in a substring for a task "- [ ] %s"',
         async (globalFilter: string, description: string) => {
-            GlobalFilter.setRemoveGlobalFilter(true);
+            GlobalFilter.getInstance().setRemoveGlobalFilter(true);
             GlobalFilter.getInstance().set(globalFilter);
 
             expect(GlobalFilter.removeAsWordFrom(description)).toEqual(description);

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -28,7 +28,7 @@ describe('Global Filter tests', () => {
         expect(GlobalFilter.getInstance().get()).toEqual(testValue);
     });
 
-    it.failing('Should allow independent values for independent instances', () => {
+    it('Should allow independent values for independent instances', () => {
         // Arrange
         const globalFilter1 = new GlobalFilter();
         const globalFilter2 = new GlobalFilter();

--- a/tests/GlobalFilter.test.ts
+++ b/tests/GlobalFilter.test.ts
@@ -81,10 +81,10 @@ describe('Global Filter tests', () => {
 
     it('Should control whether to remove the global filter from displayed tasks', () => {
         GlobalFilter.setRemoveGlobalFilter(false);
-        expect(GlobalFilter.getRemoveGlobalFilter()).toEqual(false);
+        expect(GlobalFilter.getInstance().getRemoveGlobalFilter()).toEqual(false);
 
         GlobalFilter.setRemoveGlobalFilter(true);
-        expect(GlobalFilter.getRemoveGlobalFilter()).toEqual(true);
+        expect(GlobalFilter.getInstance().getRemoveGlobalFilter()).toEqual(true);
     });
 
     it('Should remove Global Filter from the beginning of a string', () => {

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -1055,7 +1055,7 @@ describe('Query', () => {
 
     describe('explanations', () => {
         afterEach(() => {
-            GlobalFilter.reset();
+            GlobalFilter.getInstance().reset();
         });
 
         it('should explain 0 filters', () => {

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -43,7 +43,7 @@ describe('description should strip signifiers, some duplicate spaces and trailin
 
     it('with tag as global filter - all tags included', () => {
         // Arrange
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         const task = fromLine({
             line: '- [ ] #task Initial  description  ⏫  #tag1 ✅ 2022-08-12 #tag2/sub-tag ',
@@ -59,7 +59,7 @@ describe('description should strip signifiers, some duplicate spaces and trailin
 
     it('with non-tag as global filter - all tags included', () => {
         // Arrange
-        GlobalFilter.set('global-filter');
+        GlobalFilter.getInstance().set('global-filter');
 
         const task = fromLine({
             line: '- [ ] global-filter Initial  description  ⏫  #tag1 ✅ 2022-08-12 #tag2/sub-tag ',
@@ -77,7 +77,7 @@ describe('description should strip signifiers, some duplicate spaces and trailin
 describe('description', () => {
     it('ignores the global filter when filtering', () => {
         // Arrange
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
         const filter = new DescriptionField().createFilterOrErrorMessage('description includes task');
 
         // Act, Assert
@@ -95,7 +95,7 @@ describe('description', () => {
 
     it('works without a global filter', () => {
         // Arrange
-        GlobalFilter.set('');
+        GlobalFilter.getInstance().set('');
         const filter = new DescriptionField().createFilterOrErrorMessage('description includes task');
 
         // Act, Assert

--- a/tests/Query/Filter/DescriptionField.test.ts
+++ b/tests/Query/Filter/DescriptionField.test.ts
@@ -54,7 +54,7 @@ describe('description should strip signifiers, some duplicate spaces and trailin
         expect(field.value(task)).toStrictEqual('Initial  description #tag1 #tag2/sub-tag');
 
         // Cleanup
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('with non-tag as global filter - all tags included', () => {
@@ -70,7 +70,7 @@ describe('description should strip signifiers, some duplicate spaces and trailin
         expect(field.value(task)).toStrictEqual('Initial  description #tag1 #tag2/sub-tag');
 
         // Cleanup
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 });
 
@@ -90,7 +90,7 @@ describe('description', () => {
         testDescriptionFilter(filter, '- [ ] #task this does: task', true);
 
         // Cleanup
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('works without a global filter', () => {
@@ -106,7 +106,7 @@ describe('description', () => {
         testDescriptionFilter(filter, '- [ ] #task this does: task', true);
 
         // Cleanup
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('works with regex', () => {

--- a/tests/Query/Filter/TagsField.test.ts
+++ b/tests/Query/Filter/TagsField.test.ts
@@ -51,7 +51,7 @@ describe('tag presence & absence', () => {
         expect(filter).toMatchTaskFromLine('- [ ] #task stuff #one #two ');
         expect(filter).not.toMatchTaskFromLine('- [ ] #task global filter is not a tag');
 
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('should filter together with the global filter ("no tags")', () => {
@@ -68,7 +68,7 @@ describe('tag presence & absence', () => {
         expect(filter).not.toMatchTaskFromLine('- [ ] #task stuff #one #two ');
         expect(filter).toMatchTaskFromLine('- [ ] #task global filter is not a tag');
 
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 });
 
@@ -241,7 +241,7 @@ describe('tag/tags', () => {
                 shouldSupportFiltering(filters, allTaskLines, expectedResult);
 
                 // Cleanup
-                GlobalFilter.reset();
+                GlobalFilter.getInstance().reset();
             },
         );
 
@@ -283,7 +283,7 @@ describe('tag/tags', () => {
             shouldSupportFiltering(filters, defaultTasksWithTags, []);
 
             // Cleanup
-            GlobalFilter.reset();
+            GlobalFilter.getInstance().reset();
         });
     });
 
@@ -499,7 +499,7 @@ describe('Sort by tags', () => {
         ).toEqual(expectedOrder);
 
         // Cleanup
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('should sort correctly reversed by tag defaulting to first with global filter', () => {
@@ -531,7 +531,7 @@ describe('Sort by tags', () => {
         ).toEqual(expectedOrder);
 
         // Cleanup
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('should sort correctly by second tag with global filter', () => {
@@ -558,7 +558,7 @@ describe('Sort by tags', () => {
         expect(result).toEqual(expectedOrder);
 
         // Cleanup
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('should sort correctly reversed by second tag with global filter', () => {
@@ -585,7 +585,7 @@ describe('Sort by tags', () => {
         expect(result).toEqual(expectedOrder);
 
         // Cleanup
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     // Issue #1407 - Multiple 'sort by tag' lines ignored all but last one

--- a/tests/Query/Filter/TagsField.test.ts
+++ b/tests/Query/Filter/TagsField.test.ts
@@ -38,7 +38,7 @@ describe('tag presence & absence', () => {
     });
 
     it('should filter together with the global filter ("has tags")', () => {
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         // Arrange
         const filter = new TagsField().createFilterOrErrorMessage('has tags');
@@ -55,7 +55,7 @@ describe('tag presence & absence', () => {
     });
 
     it('should filter together with the global filter ("no tags")', () => {
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         // Arrange
         const filter = new TagsField().createFilterOrErrorMessage('no tags');
@@ -221,7 +221,7 @@ describe('tag/tags', () => {
             'should filter tag with globalFilter %s',
             (_, { tasks: allTaskLines, filters, expectedResult }) => {
                 // Arrange
-                GlobalFilter.set('#task');
+                GlobalFilter.getInstance().set('#task');
 
                 // Run on the plural version of the filter first.
                 shouldSupportFiltering(filters, allTaskLines, expectedResult);
@@ -276,7 +276,7 @@ describe('tag/tags', () => {
 
         it('should ignore the tag which is the global filter', () => {
             // Arrange
-            GlobalFilter.set('#task');
+            GlobalFilter.getInstance().set('#task');
             const filters: Array<string> = ['tags include task'];
 
             // Act, Assert
@@ -472,7 +472,7 @@ describe('Sort by tags', () => {
 
     it('should sort correctly by tag defaulting to first with global filter', () => {
         // Arrange
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         const t1 = fromLine({ line: '- [ ] #task a #aaa #jjj' });
         const t2 = fromLine({ line: '- [ ] #task a #aaaa #aaaa' });
@@ -504,7 +504,7 @@ describe('Sort by tags', () => {
 
     it('should sort correctly reversed by tag defaulting to first with global filter', () => {
         // Arrange
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         const t1 = fromLine({ line: '- [ ] #task a #aaa #jjj' });
         const t2 = fromLine({ line: '- [ ] #task a #aaaa #aaaa' });
@@ -536,7 +536,7 @@ describe('Sort by tags', () => {
 
     it('should sort correctly by second tag with global filter', () => {
         // Arrange
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         const t1 = fromLine({ line: '- [ ] #task a #fff #aaa' });
         const t2 = fromLine({ line: '- [ ] #task a #aaaa #aaaa' });
@@ -563,7 +563,7 @@ describe('Sort by tags', () => {
 
     it('should sort correctly reversed by second tag with global filter', () => {
         // Arrange
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         const t1 = fromLine({ line: '- [ ] #task a #fff #aaa' });
         const t2 = fromLine({ line: '- [ ] #task a #aaaa #aaaa' });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -248,12 +248,12 @@ describe('canSuggestForLine', () => {
     });
 
     it('should suggest if global filter missing from line', () => {
-        GlobalFilter.set('#todo');
+        GlobalFilter.getInstance().set('#todo');
         expect(canSuggestForLineWithCursor('- [ ] #todo has global filter|')).toEqual(true);
     });
 
     it('should not suggest if global filter missing from line', () => {
-        GlobalFilter.set('#todo');
+        GlobalFilter.getInstance().set('#todo');
         expect(canSuggestForLineWithCursor('- [ ] no global filter|')).toEqual(false);
     });
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -230,7 +230,7 @@ describe('onlySuggestIfBracketOpen', () => {
 
 describe('canSuggestForLine', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     function canSuggestForLineWithCursor(line: string) {
@@ -238,12 +238,12 @@ describe('canSuggestForLine', () => {
     }
 
     it('should not suggest if there is no checkbox', () => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
         expect(canSuggestForLineWithCursor('- not a task line|')).toEqual(false);
     });
 
     it('should suggest if there is no global filter and cursor is in the description', () => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
         expect(canSuggestForLineWithCursor('- [ ] global filter is not set|')).toEqual(true);
     });
 

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -406,7 +406,7 @@ describe('parsing tags', () => {
         ({ markdownTask, expectedDescription, extractedTags, globalFilter }) => {
             // Arrange
             if (globalFilter != '') {
-                GlobalFilter.set(globalFilter);
+                GlobalFilter.getInstance().set(globalFilter);
             }
 
             // Act
@@ -436,7 +436,7 @@ describe('task parsing VS global filter', () => {
 
     it('returns null when task does not have global filter', () => {
         // Arrange
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
         const line = '- [x] this is a done task 🗓 2021-09-12 ✅ 2021-06-20';
 
         // Act
@@ -455,7 +455,7 @@ describe('task parsing VS global filter', () => {
         '- [ #task ] this is a task 🗓 2021-09-12',
     ])('should not parse task with global filter outside of the description: "%s"', (line: string) => {
         // Arrange
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         // Act
         const task = fromLine({
@@ -468,7 +468,7 @@ describe('task parsing VS global filter', () => {
 
     it('should not consider task status when searching for global filter', () => {
         // Arrange
-        GlobalFilter.set('@');
+        GlobalFilter.getInstance().set('@');
 
         // Act
         const task = fromLine({
@@ -673,7 +673,7 @@ describe('to string', () => {
     it('retains the global filter', () => {
         // Arrange
         const line = '- [ ] This is a task with #t as a global filter and also #t/some tags';
-        GlobalFilter.set('#t');
+        GlobalFilter.getInstance().set('#t');
 
         // Act
         const task: Task = fromLine({

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -423,7 +423,7 @@ describe('parsing tags', () => {
 
             // Cleanup
             if (globalFilter != '') {
-                GlobalFilter.reset();
+                GlobalFilter.getInstance().reset();
             }
         },
     );
@@ -431,7 +431,7 @@ describe('parsing tags', () => {
 
 describe('task parsing VS global filter', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('returns null when task does not have global filter', () => {
@@ -684,7 +684,7 @@ describe('to string', () => {
         const expectedLine = 'This is a task with #t as a global filter and also #t/some tags';
         expect(task.toString()).toStrictEqual(expectedLine);
         resetSettings();
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 });
 
@@ -1159,7 +1159,7 @@ describe('created dates on recurring task', () => {
     afterEach(() => {
         jest.useRealTimers();
         resetSettings();
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('should not set created date with disabled setting', () => {
@@ -1216,13 +1216,13 @@ describe('order of recurring tasks', () => {
         jest.useFakeTimers();
         jest.setSystemTime(new Date(2023, 5 - 1, 16));
         resetSettings();
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     afterAll(() => {
         jest.useRealTimers();
         resetSettings();
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('should put new task before old, by default', () => {

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -121,7 +121,7 @@ describe('task line rendering', () => {
 
     it('should render Global Filter when the Remove Global Filter is off', async () => {
         GlobalFilter.setRemoveGlobalFilter(false);
-        GlobalFilter.set('#global');
+        GlobalFilter.getInstance().set('#global');
 
         const taskLine = '- [ ] This is a simple task with a #global filter';
         const descriptionWithFilter = await getDescriptionTest(taskLine);
@@ -131,7 +131,7 @@ describe('task line rendering', () => {
 
     it('should not render Global Filter when the Remove Global Filter is on', async () => {
         GlobalFilter.setRemoveGlobalFilter(true);
-        GlobalFilter.set('#global');
+        GlobalFilter.getInstance().set('#global');
 
         const taskLine = '- [ ] #global/subtag-shall-stay This is a simple task with a #global filter';
         const descriptionWithoutFilter = await getDescriptionTest(taskLine);

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -68,7 +68,7 @@ describe('task line rendering', () => {
     afterEach(() => {
         resetSettings();
         GlobalFilter.getInstance().reset();
-        GlobalFilter.setRemoveGlobalFilter(false);
+        GlobalFilter.getInstance().setRemoveGlobalFilter(false);
     });
 
     it('creates the correct span structure for a basic task', async () => {
@@ -120,7 +120,7 @@ describe('task line rendering', () => {
     };
 
     it('should render Global Filter when the Remove Global Filter is off', async () => {
-        GlobalFilter.setRemoveGlobalFilter(false);
+        GlobalFilter.getInstance().setRemoveGlobalFilter(false);
         GlobalFilter.getInstance().set('#global');
 
         const taskLine = '- [ ] This is a simple task with a #global filter';
@@ -130,7 +130,7 @@ describe('task line rendering', () => {
     });
 
     it('should not render Global Filter when the Remove Global Filter is on', async () => {
-        GlobalFilter.setRemoveGlobalFilter(true);
+        GlobalFilter.getInstance().setRemoveGlobalFilter(true);
         GlobalFilter.getInstance().set('#global');
 
         const taskLine = '- [ ] #global/subtag-shall-stay This is a simple task with a #global filter';

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -67,7 +67,7 @@ function getOtherLayoutComponents(parentElement: HTMLElement): string[] {
 describe('task line rendering', () => {
     afterEach(() => {
         resetSettings();
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
         GlobalFilter.setRemoveGlobalFilter(false);
     });
 

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -11,7 +11,7 @@ window.moment = moment;
 
 describe('explain', () => {
     afterEach(() => {
-        GlobalFilter.reset();
+        GlobalFilter.getInstance().reset();
     });
 
     it('should explain a task', () => {

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -26,7 +26,7 @@ No filters supplied. All tasks will match the query.`;
     });
 
     it('should explain a task with global filter active', () => {
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         const source = '';
         const query = new Query({ source });
@@ -58,7 +58,7 @@ No filters supplied. All tasks will match the query.`;
 
     it('should explain a task with global query and global filter active', () => {
         const globalQuery = new GlobalQuery('description includes hello');
-        GlobalFilter.set('#task');
+        GlobalFilter.getInstance().set('#task');
 
         const source = '';
         const query = new Query({ source });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Outside of tests, all access to `GlobalFilter` is now via `GlobalFilter.getInstance()`
- All other data and methods are now non-static

This is a step on the way to making `GlobalFilter` behave like `GlobalQuery`.

/CC @ilandikov for info.

## Motivation and Context

This is part 1 of #2281

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

- Running existing tests
- Adding new tests
- Running the smoke tests

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
