### PR TITLE
refactor: remove cyclic dependencies & optional parameter in `TaskLineRenderer.ts`

### DIFF
--- a/src/InlineRenderer.ts
+++ b/src/InlineRenderer.ts
@@ -2,6 +2,7 @@ import type { MarkdownPostProcessorContext, Plugin } from 'obsidian';
 import { MarkdownRenderChild } from 'obsidian';
 import { GlobalFilter } from './Config/GlobalFilter';
 import { Task } from './Task';
+import { taskToLi } from './TaskLineRenderer';
 import { TaskLocation } from './TaskLocation';
 
 export class InlineRenderer {
@@ -99,7 +100,7 @@ export class InlineRenderer {
 
             const dataLine: string = renderedElement.getAttr('data-line') ?? '0';
             const listIndex: number = Number.parseInt(dataLine, 10);
-            const taskElement = await task.toLi({
+            const taskElement = await taskToLi(task, {
                 parentUlElement: element,
                 listIndex,
                 obsidianComponent: childComponent,

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -6,6 +6,7 @@ import type { IQuery } from './IQuery';
 import { State } from './Cache';
 import { getTaskLineAndFile, replaceTaskWithTasks } from './File';
 import type { GroupDisplayHeading } from './Query/GroupDisplayHeading';
+import { taskToLi } from './TaskLineRenderer';
 import { TaskModal } from './TaskModal';
 import type { TasksEvents } from './TasksEvents';
 import type { Task } from './Task';
@@ -223,7 +224,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         for (const [i, task] of tasks.entries()) {
             const isFilenameUnique = this.isFilenameUnique({ task });
 
-            const listItem = await task.toLi({
+            const listItem = await taskToLi(task, {
                 parentUlElement: taskList,
                 listIndex: i,
                 layoutOptions: this.query.layoutOptions,

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -111,6 +111,10 @@ interface TaskComponents {
     blockLink: string;
 }
 
+function taskToLi(task: Task, renderDetails: TaskLineRenderDetails) {
+    return renderTaskLine(task, renderDetails);
+}
+
 /**
  * Task encapsulates the properties of the MarkDown task along with
  * the extensions provided by this plugin. This is used to parse and
@@ -337,7 +341,7 @@ export class Task {
      */
     public async toLi(renderDetails: TaskLineRenderDetails): Promise<HTMLLIElement> {
         const task = this;
-        return renderTaskLine(task, renderDetails);
+        return taskToLi(task, renderDetails);
     }
 
     /**

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -336,7 +336,8 @@ export class Task {
      * @param renderDetails
      */
     public async toLi(renderDetails: TaskLineRenderDetails): Promise<HTMLLIElement> {
-        return renderTaskLine(this, renderDetails);
+        const task = this;
+        return renderTaskLine(task, renderDetails);
     }
 
     /**

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -340,8 +340,7 @@ export class Task {
      * @param renderDetails
      */
     public async toLi(renderDetails: TaskLineRenderDetails): Promise<HTMLLIElement> {
-        const task = this;
-        return taskToLi(task, renderDetails);
+        return taskToLi(this, renderDetails);
     }
 
     /**

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -1,4 +1,5 @@
 import type { Moment } from 'moment';
+import { taskToLi } from './TaskLineRenderer';
 import type { TaskLocation } from './TaskLocation';
 import type { Recurrence } from './Recurrence';
 import { getSettings, getUserSelectedTaskFormat } from './Config/Settings';
@@ -6,7 +7,6 @@ import { GlobalFilter } from './Config/GlobalFilter';
 import { StatusRegistry } from './StatusRegistry';
 import type { Status } from './Status';
 import { Urgency } from './Urgency';
-import { renderTaskLine } from './TaskLineRenderer';
 import type { TaskLineRenderDetails } from './TaskLineRenderer';
 import { DateFallback } from './DateFallback';
 import { compareByDate } from './lib/DateTools';
@@ -109,10 +109,6 @@ interface TaskComponents {
     status: Status;
     body: string;
     blockLink: string;
-}
-
-function taskToLi(task: Task, renderDetails: TaskLineRenderDetails) {
-    return renderTaskLine(task, renderDetails);
 }
 
 /**

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -1,5 +1,4 @@
 import type { Moment } from 'moment';
-import { taskToLi } from './TaskLineRenderer';
 import type { TaskLocation } from './TaskLocation';
 import type { Recurrence } from './Recurrence';
 import { getSettings, getUserSelectedTaskFormat } from './Config/Settings';
@@ -7,7 +6,6 @@ import { GlobalFilter } from './Config/GlobalFilter';
 import { StatusRegistry } from './StatusRegistry';
 import type { Status } from './Status';
 import { Urgency } from './Urgency';
-import type { TaskLineRenderDetails } from './TaskLineRenderer';
 import { DateFallback } from './DateFallback';
 import { compareByDate } from './lib/DateTools';
 import { TasksDate } from './Scripting/TasksDate';
@@ -329,16 +327,6 @@ export class Task {
         }
         return { indentation, listMarker, status, body, blockLink };
     }
-
-    /**
-     * Create an HTML rendered List Item element (LI) for the current task.
-     * @note Output is based on the {@link DefaultTaskSerializer}'s format, with default (emoji) symbols
-     * @param renderDetails
-     */
-    public async toLi(renderDetails: TaskLineRenderDetails): Promise<HTMLLIElement> {
-        return taskToLi(this, renderDetails);
-    }
-
     /**
      * Flatten the task as a string that includes all its components.
      *

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -443,6 +443,6 @@ function toTooltipDate({ signifier, date }: { signifier: string; date: Moment })
  * @param task
  * @param renderDetails
  */
-export function taskToLi(task: Task, renderDetails: TaskLineRenderDetails) {
+export function taskToLi(task: Task, renderDetails: TaskLineRenderDetails): Promise<HTMLLIElement> {
     return renderTaskLine(task, renderDetails);
 }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -64,9 +64,8 @@ async function obsidianMarkdownRenderer(
 export async function renderTaskLine(
     task: Task,
     renderDetails: TaskLineRenderDetails,
-    textRenderer: TextRenderer | null = null,
+    textRenderer: TextRenderer,
 ): Promise<HTMLLIElement> {
-    if (!textRenderer) textRenderer = obsidianMarkdownRenderer;
     const li: HTMLLIElement = document.createElement('li');
     renderDetails.parentUlElement.appendChild(li);
 
@@ -444,5 +443,5 @@ function toTooltipDate({ signifier, date }: { signifier: string; date: Moment })
  * @param renderDetails
  */
 export function taskToLi(task: Task, renderDetails: TaskLineRenderDetails): Promise<HTMLLIElement> {
-    return renderTaskLine(task, renderDetails);
+    return renderTaskLine(task, renderDetails, obsidianMarkdownRenderer);
 }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -44,16 +44,6 @@ export type TextRenderer = (
     obsidianComponent: Component | null, // null is allowed here only for tests
 ) => Promise<void>;
 
-async function obsidianMarkdownRenderer(
-    text: string,
-    element: HTMLSpanElement,
-    path: string,
-    obsidianComponent: Component | null,
-) {
-    if (!obsidianComponent) throw new Error('Must call the Obsidian renderer with an Obsidian Component object');
-    await MarkdownRenderer.renderMarkdown(text, element, path, obsidianComponent);
-}
-
 /**
  * Renders a given Task object into an HTML List Item (LI) element, using the given renderDetails
  * configuration and a supplied TextRenderer (typically the Obsidian Markdown renderer, but for testing
@@ -443,5 +433,15 @@ function toTooltipDate({ signifier, date }: { signifier: string; date: Moment })
  * @param renderDetails
  */
 export function taskToLi(task: Task, renderDetails: TaskLineRenderDetails): Promise<HTMLLIElement> {
+    async function obsidianMarkdownRenderer(
+        text: string,
+        element: HTMLSpanElement,
+        path: string,
+        obsidianComponent: Component | null,
+    ) {
+        if (!obsidianComponent) throw new Error('Must call the Obsidian renderer with an Obsidian Component object');
+        await MarkdownRenderer.renderMarkdown(text, element, path, obsidianComponent);
+    }
+
     return renderTaskLine(task, renderDetails, obsidianMarkdownRenderer);
 }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -436,3 +436,7 @@ function toTooltipDate({ signifier, date }: { signifier: string; date: Moment })
         window.moment().startOf('day'),
     )})`;
 }
+
+export function taskToLi(task: Task, renderDetails: TaskLineRenderDetails) {
+    return renderTaskLine(task, renderDetails);
+}

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -437,6 +437,12 @@ function toTooltipDate({ signifier, date }: { signifier: string; date: Moment })
     )})`;
 }
 
+/**
+ * Create an HTML rendered List Item element (LI) for a task.
+ * @note Output is based on the {@link DefaultTaskSerializer}'s format, with default (emoji) symbols
+ * @param task
+ * @param renderDetails
+ */
 export function taskToLi(task: Task, renderDetails: TaskLineRenderDetails) {
     return renderTaskLine(task, renderDetails);
 }


### PR DESCRIPTION
# Description

1. Remove `Task.ts` & `TaskLineRenderer.ts` cyclic dependencies
2. Remove optional in `renderTaskLine()`

Before:
```
1) Config/Settings.ts > Suggestor/Suggestor.ts
2) Task.ts > Config/Settings.ts > Suggestor/Suggestor.ts
3) Task.ts > Config/Settings.ts > Suggestor/Suggestor.ts > TaskSerializer/DefaultTaskSerializer.ts
4) Task.ts > Config/Settings.ts > TaskSerializer/DataviewTaskSerializer.ts
5) Task.ts > DateFallback.ts
6) Task.ts > Scripting/TasksDate.ts
7) Task.ts > TaskLineRenderer.ts > File.ts
8) Task.ts > TaskLineRenderer.ts > File.ts > lib/MockDataCreator.ts
9) Task.ts > TaskLineRenderer.ts
10) Task.ts > TaskLineRenderer.ts > lib/PriorityTools.ts
11) Task.ts > Urgency.ts
12) Cache.ts > TasksEvents.ts
13) Query/FilterParser.ts > Query/Filter/BooleanField.ts
14) Config/SettingsTab.ts > main.ts
```

After:

```
1) Config/Settings.ts > Suggestor/Suggestor.ts
2) Task.ts > Config/Settings.ts > Suggestor/Suggestor.ts
3) Task.ts > Config/Settings.ts > Suggestor/Suggestor.ts > TaskSerializer/DefaultTaskSerializer.ts
4) Task.ts > Config/Settings.ts > TaskSerializer/DataviewTaskSerializer.ts
5) Task.ts > DateFallback.ts
6) Task.ts > Scripting/TasksDate.ts
7) Task.ts > Urgency.ts
8) Task.ts > lib/PriorityTools.ts
9) Cache.ts > TasksEvents.ts
10) Query/FilterParser.ts > Query/Filter/BooleanField.ts
11) Config/SettingsTab.ts > main.ts
```

## Motivation and Context

Cleaner code, less branches, less cyclic deps.

## How has this been tested?

Smoke tests.

Unit tests do nothing at this level: former `Task.toLi()` now `TaskLineRenderer.taskToLi()` are called by `InlineRenderer` & `QueryRenderer.ts`

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
