### PR TITLE
feat: 'group by backlink' headings link to location & show hover previews

### DIFF
--- a/docs/Queries/Grouping.md
+++ b/docs/Queries/Grouping.md
@@ -608,7 +608,7 @@ Since Tasks 4.7.0, the query's file name can be used in custom groups.
 
 ### Backlink
 
-- `group by backlink` (the text that would be shown in the task's [[Backlinks|backlink]], combining the task's file name and heading, but with no link added)
+- `group by backlink` (the text that would be shown in the task's [[Backlinks|backlink]], combining the task's file name and heading, with a link)
 
 ### Heading
 

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -37,7 +37,9 @@ export class BacklinkField extends TextField {
 
             // Only append the heading if it differs from the filename:
             const header = task.precedingHeader;
-            if (header !== null) {
+            if (header === null) {
+                /* empty */
+            } else {
                 if (header !== filename) {
                     return [`[[${filename}#${header}|${filename} > ${header}]]`];
                 }

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -40,6 +40,7 @@ export class BacklinkField extends TextField {
                 return ['[[' + filename + ']]'];
             }
 
+            // Always append the header, to ensure we navigate to the correct section of the file:
             return [`[[${filename}#${header}|${filename} > ${header}]]`];
         };
     }

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -38,7 +38,7 @@ export class BacklinkField extends TextField {
             // Only append the heading if it differs from the filename:
             const header = task.precedingHeader;
             if (header === null) {
-                /* empty */
+                return ['[[' + filename + ']]'];
             } else {
                 if (header !== filename) {
                     return [`[[${filename}#${header}|${filename} > ${header}]]`];

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -41,11 +41,7 @@ export class BacklinkField extends TextField {
                 return ['[[' + filename + ']]'];
             }
 
-            if (header !== filename) {
-                return [`[[${filename}#${header}|${filename} > ${header}]]`];
-            }
-
-            return ['[[' + filename + ']]'];
+            return [`[[${filename}#${header}|${filename} > ${header}]]`];
         };
     }
 }

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -40,9 +40,7 @@ export class BacklinkField extends TextField {
 
             // Only append the heading if it differs from the filename:
             if (task.precedingHeader && task.precedingHeader !== filename) {
-                result = `${result} > ${task.precedingHeader}`;
-
-                result = `${filename}#${task.precedingHeader}|${result}`;
+                result = `${filename}#${task.precedingHeader}|${result} > ${task.precedingHeader}`;
             }
             return ['[[' + result + ']]'];
         };

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -40,7 +40,7 @@ export class BacklinkField extends TextField {
 
             // Only append the heading if it differs from the filename:
             if (task.precedingHeader && task.precedingHeader !== filename) {
-                result += ' > ' + task.precedingHeader;
+                result = result + ` > ${task.precedingHeader}`;
 
                 result = `${filename}#${task.precedingHeader}|${result}`;
             }

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -40,7 +40,7 @@ export class BacklinkField extends TextField {
 
             // Only append the heading if it differs from the filename:
             if (task.precedingHeader && task.precedingHeader !== filename) {
-                result = result + ` > ${task.precedingHeader}`;
+                result = `${result} > ${task.precedingHeader}`;
 
                 result = `${filename}#${task.precedingHeader}|${result}`;
             }

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -39,10 +39,10 @@ export class BacklinkField extends TextField {
             const header = task.precedingHeader;
             if (header === null) {
                 return ['[[' + filename + ']]'];
-            } else {
-                if (header !== filename) {
-                    return [`[[${filename}#${header}|${filename} > ${header}]]`];
-                }
+            }
+
+            if (header !== filename) {
+                return [`[[${filename}#${header}|${filename} > ${header}]]`];
             }
 
             return ['[[' + filename + ']]'];

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -40,6 +40,7 @@ export class BacklinkField extends TextField {
             if (header && header !== filename) {
                 return [`[[${filename}#${header}|${filename} > ${header}]]`];
             }
+
             return ['[[' + filename + ']]'];
         };
     }

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -36,8 +36,9 @@ export class BacklinkField extends TextField {
             }
 
             // Only append the heading if it differs from the filename:
-            if (task.precedingHeader && task.precedingHeader !== filename) {
-                return [`[[${filename}#${task.precedingHeader}|${filename} > ${task.precedingHeader}]]`];
+            const header = task.precedingHeader;
+            if (header && header !== filename) {
+                return [`[[${filename}#${header}|${filename} > ${header}]]`];
             }
             return ['[[' + filename + ']]'];
         };

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -36,14 +36,15 @@ export class BacklinkField extends TextField {
             }
 
             // Always escape the filename, to prevent any underscores being interpreted as markdown:
-            let result = TextField.escapeMarkdownCharacters(filename);
+            let result = filename;
 
-            // Only append the heading if it differs from the un-escaped fileanme:
+            // Only append the heading if it differs from the filename:
             if (task.precedingHeader && task.precedingHeader !== filename) {
-                // We don't escape the heading, as any markdown characters in it really are markdown styling:
                 result += ' > ' + task.precedingHeader;
+
+                result = `${filename}#${task.precedingHeader}|${result}`;
             }
-            return [result];
+            return ['[[' + result + ']]'];
         };
     }
 }

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -1,7 +1,7 @@
 import type { Task } from '../../Task';
 import type { GrouperFunction } from '../Grouper';
-import { TextField } from './TextField';
 import { FilterOrErrorMessage } from './FilterOrErrorMessage';
+import { TextField } from './TextField';
 
 export class BacklinkField extends TextField {
     public fieldName(): string {
@@ -35,14 +35,11 @@ export class BacklinkField extends TextField {
                 return ['Unknown Location'];
             }
 
-            // Always escape the filename, to prevent any underscores being interpreted as markdown:
-            let result = filename;
-
             // Only append the heading if it differs from the filename:
             if (task.precedingHeader && task.precedingHeader !== filename) {
-                return [`[[${filename}#${task.precedingHeader}|${result} > ${task.precedingHeader}]]`];
+                return [`[[${filename}#${task.precedingHeader}|${filename} > ${task.precedingHeader}]]`];
             }
-            return ['[[' + result + ']]'];
+            return ['[[' + filename + ']]'];
         };
     }
 }

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -37,7 +37,7 @@ export class BacklinkField extends TextField {
 
             // Only append the heading if it differs from the filename:
             const header = task.precedingHeader;
-            if (header && header !== filename) {
+            if (header !== null && header !== filename) {
                 return [`[[${filename}#${header}|${filename} > ${header}]]`];
             }
 

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -40,7 +40,7 @@ export class BacklinkField extends TextField {
 
             // Only append the heading if it differs from the filename:
             if (task.precedingHeader && task.precedingHeader !== filename) {
-                result = `${filename}#${task.precedingHeader}|${result} > ${task.precedingHeader}`;
+                return [`[[${filename}#${task.precedingHeader}|${result} > ${task.precedingHeader}]]`];
             }
             return ['[[' + result + ']]'];
         };

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -35,7 +35,6 @@ export class BacklinkField extends TextField {
                 return ['Unknown Location'];
             }
 
-            // Only append the heading if it differs from the filename:
             const header = task.precedingHeader;
             if (header === null) {
                 return ['[[' + filename + ']]'];

--- a/src/Query/Filter/BacklinkField.ts
+++ b/src/Query/Filter/BacklinkField.ts
@@ -37,8 +37,10 @@ export class BacklinkField extends TextField {
 
             // Only append the heading if it differs from the filename:
             const header = task.precedingHeader;
-            if (header !== null && header !== filename) {
-                return [`[[${filename}#${header}|${filename} > ${header}]]`];
+            if (header !== null) {
+                if (header !== filename) {
+                    return [`[[${filename}#${header}|${filename} > ${header}]]`];
+                }
             }
 
             return ['[[' + filename + ']]'];

--- a/tests/Query/Filter/BacklinkField.test.ts
+++ b/tests/Query/Filter/BacklinkField.test.ts
@@ -38,22 +38,22 @@ describe('grouping by backlink', () => {
         ['', 'heading', ['Unknown Location']],
 
         // no heading supplied
-        ['a/b/c.md', null, ['c']],
+        ['a/b/c.md', null, ['[[c]]']],
 
         // File and heading, nominal case
-        ['a/b/c.md', 'heading', ['c > heading']],
+        ['a/b/c.md', 'heading', ['[[c#heading|c > heading]]']],
 
         // If file name and heading are identical, avoid duplication ('c > c')
-        ['a/b/c.md', 'c', ['c']],
+        ['a/b/c.md', 'c', ['[[c]]']],
 
         // If file name and heading are identical, avoid duplication, even if there are underscores in the file name
-        ['a_b_c.md', 'a_b_c', ['a\\_b\\_c']],
+        ['a_b_c.md', 'a_b_c', ['[[a_b_c]]']],
 
-        // Underscores in file name component are escaped
-        ['a/b/_c_.md', null, ['\\_c\\_']],
+        // Underscores in filename component are not escaped
+        ['a/b/_c_.md', null, ['[[_c_]]']],
 
-        // But underscores in the heading component are not
-        ['a/b/_c_.md', 'heading _italic text_', ['\\_c\\_ > heading _italic text_']],
+        // Underscores in the heading component are not escaped too
+        ['a/b/_c_.md', 'heading _italic text_', ['[[_c_#heading _italic text_|_c_ > heading _italic text_]]']],
     ])(
         'path "%s" and heading "%s" should have groups: %s',
         (path: string, heading: string | null, groups: string[]) => {
@@ -73,12 +73,12 @@ describe('grouping by backlink', () => {
 
         // Assert
         expect({ grouper, tasks }).groupHeadingsToBe([
-            '\\_c\\_',
-            '\\_c\\_ > heading _italic text_',
-            'a\\_b\\_c',
-            'b',
-            'c',
-            'c > heading',
+            '[[_c_]]',
+            '[[_c_#heading _italic text_|_c_ > heading _italic text_]]',
+            '[[a_b_c]]',
+            '[[b]]',
+            '[[c]]',
+            '[[c#heading|c > heading]]',
             'Unknown Location',
         ]);
     });

--- a/tests/Query/Filter/BacklinkField.test.ts
+++ b/tests/Query/Filter/BacklinkField.test.ts
@@ -44,10 +44,10 @@ describe('grouping by backlink', () => {
         ['a/b/c.md', 'heading', ['[[c#heading|c > heading]]']],
 
         // If file name and heading are identical, avoid duplication ('c > c')
-        ['a/b/c.md', 'c', ['[[c]]']],
+        ['a/b/c.md', 'c', ['[[c#c|c > c]]']],
 
         // If file name and heading are identical, avoid duplication, even if there are underscores in the file name
-        ['a_b_c.md', 'a_b_c', ['[[a_b_c]]']],
+        ['a_b_c.md', 'a_b_c', ['[[a_b_c#a_b_c|a_b_c > a_b_c]]']],
 
         // Underscores in filename component are not escaped
         ['a/b/_c_.md', null, ['[[_c_]]']],
@@ -75,9 +75,10 @@ describe('grouping by backlink', () => {
         expect({ grouper, tasks }).groupHeadingsToBe([
             '[[_c_]]',
             '[[_c_#heading _italic text_|_c_ > heading _italic text_]]',
-            '[[a_b_c]]',
+            '[[a_b_c#a_b_c|a_b_c > a_b_c]]',
             '[[b]]',
             '[[c]]',
+            '[[c#c|c > c]]',
             '[[c#heading|c > heading]]',
             'Unknown Location',
         ]);

--- a/tests/Query/Filter/BacklinkField.test.ts
+++ b/tests/Query/Filter/BacklinkField.test.ts
@@ -43,10 +43,10 @@ describe('grouping by backlink', () => {
         // File and heading, nominal case
         ['a/b/c.md', 'heading', ['[[c#heading|c > heading]]']],
 
-        // If file name and heading are identical, avoid duplication ('c > c')
+        // If file name and heading are identical, allow duplication ('c > c'), in order to link to correct section
         ['a/b/c.md', 'c', ['[[c#c|c > c]]']],
 
-        // If file name and heading are identical, avoid duplication, even if there are underscores in the file name
+        // If file name and heading are identical, allow duplication, even if there are underscores in the file name
         ['a_b_c.md', 'a_b_c', ['[[a_b_c#a_b_c|a_b_c > a_b_c]]']],
 
         // Underscores in filename component are not escaped

--- a/tests/Query/Filter/BacklinkField.test.ts
+++ b/tests/Query/Filter/BacklinkField.test.ts
@@ -52,7 +52,7 @@ describe('grouping by backlink', () => {
         // Underscores in filename component are not escaped
         ['a/b/_c_.md', null, ['[[_c_]]']],
 
-        // Underscores in the heading component are not escaped too
+        // Underscores in the heading component are not escaped either
         ['a/b/_c_.md', 'heading _italic text_', ['[[_c_#heading _italic text_|_c_ > heading _italic text_]]']],
     ])(
         'path "%s" and heading "%s" should have groups: %s',


### PR DESCRIPTION
# Description

`BacklinkField.grouper()` now generates links to the file/section instead of just a group header.

## Motivation and Context

When grouping by backlink, it's better to `hide backlink` since all the backlinks will be same in a given group. However in this way a clickable backlink is not available anymore. This adds a clickable backlink to the group header.

Fixes #1666:

- #1666

## How has this been tested?

Unit tests updated + smoke test:

query file:

````md
```tasks
tags include backlinktest
hide backlink
group by backlink
```
````

task file:

```md
- [ ] #task #backlinktest no header
# H1 header

- [ ] #task #backlinktest h1

## H2 header

- [ ] #task #backlinktest h2

### H3 header

- [ ] #task #backlinktest h3

###### H6 header under H3

- [ ] #task #backlinktest h6 under h3

#### H4 header

- [ ] #task #backlinktest h4

##### H5 header

- [ ] #task #backlinktest h5

###### H6 header

- [ ] #task #backlinktest h6
```

Group headers now have links:
![Снимок экрана 2023-09-24 в 16 22 40](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/e2c8b8dc-815f-43b4-a32e-bbba7d7e5f16)

Click on every group header and check that it leads to the clicked section. Example for `- [ ] #task #backlinktest h6 under h3`:
![Снимок экрана 2023-09-24 в 16 24 10](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/db4818d5-af89-4336-8978-66eb614478b7)
![Снимок экрана 2023-09-24 в 16 24 23](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/5b3b90c8-a4e6-4bf5-8be0-f6248b7ce3bb)

## Types of changes

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
