### PR TITLE
refactor: remove destructured object and return in createTaskList()

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -214,13 +214,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         content.appendChild(explanationsBlock);
     }
 
-    private async createTasksList({
-        tasks,
-        content,
-    }: {
-        tasks: Task[];
-        content: HTMLDivElement;
-    }): Promise<HTMLUListElement> {
+    private async createTaskList2(tasks: Task[], content: HTMLDivElement) {
         const layout = new TaskLayout(this.query.layoutOptions);
         const taskList = content.createEl('ul');
         taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);
@@ -261,14 +255,6 @@ class QueryRenderChild extends MarkdownRenderChild {
             taskList.appendChild(listItem);
         }
 
-        return taskList;
-    }
-
-    private async createTaskList2(tasks: Task[], content: HTMLDivElement) {
-        const taskList = await this.createTasksList({
-            tasks: tasks,
-            content: content,
-        });
         content.appendChild(taskList);
     }
 

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -214,7 +214,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         content.appendChild(explanationsBlock);
     }
 
-    private async createTaskList2(tasks: Task[], content: HTMLDivElement) {
+    private async createTaskList(tasks: Task[], content: HTMLDivElement) {
         const layout = new TaskLayout(this.query.layoutOptions);
         const taskList = content.createEl('ul');
         taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);
@@ -294,7 +294,7 @@ class QueryRenderChild extends MarkdownRenderChild {
             this.addGroupHeadings(content, group.groupHeadings);
 
             const tasks = group.tasks;
-            await this.createTaskList2(tasks, content);
+            await this.createTaskList(tasks, content);
         }
     }
 

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -264,6 +264,14 @@ class QueryRenderChild extends MarkdownRenderChild {
         return taskList;
     }
 
+    private async createTaskList2(tasks: Task[], content: HTMLDivElement) {
+        const taskList = await this.createTasksList({
+            tasks: tasks,
+            content: content,
+        });
+        content.appendChild(taskList);
+    }
+
     private addEditButton(listItem: HTMLElement, task: Task) {
         const editTaskPencil = listItem.createEl('a', {
             cls: 'tasks-edit',
@@ -302,14 +310,6 @@ class QueryRenderChild extends MarkdownRenderChild {
             const tasks = group.tasks;
             await this.createTaskList2(tasks, content);
         }
-    }
-
-    private async createTaskList2(tasks: Task[], content: HTMLDivElement) {
-        const taskList = await this.createTasksList({
-            tasks: tasks,
-            content: content,
-        });
-        content.appendChild(taskList);
     }
 
     /**

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -293,8 +293,7 @@ class QueryRenderChild extends MarkdownRenderChild {
             // will be empty, and no headings will be added.
             this.addGroupHeadings(content, group.groupHeadings);
 
-            const tasks = group.tasks;
-            await this.createTaskList(tasks, content);
+            await this.createTaskList(group.tasks, content);
         }
     }
 

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -214,7 +214,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         content.appendChild(explanationsBlock);
     }
 
-    private async createTaskList(tasks: Task[], content: HTMLDivElement) {
+    private async createTaskList(tasks: Task[], content: HTMLDivElement): Promise<void> {
         const layout = new TaskLayout(this.query.layoutOptions);
         const taskList = content.createEl('ul');
         taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -300,12 +300,16 @@ class QueryRenderChild extends MarkdownRenderChild {
             this.addGroupHeadings(content, group.groupHeadings);
 
             const tasks = group.tasks;
-            const taskList = await this.createTasksList({
-                tasks: tasks,
-                content: content,
-            });
-            content.appendChild(taskList);
+            await this.createTaskList2(tasks, content);
         }
+    }
+
+    private async createTaskList2(tasks: Task[], content: HTMLDivElement) {
+        const taskList = await this.createTasksList({
+            tasks: tasks,
+            content: content,
+        });
+        content.appendChild(taskList);
     }
 
     /**

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -299,8 +299,9 @@ class QueryRenderChild extends MarkdownRenderChild {
             // will be empty, and no headings will be added.
             this.addGroupHeadings(content, group.groupHeadings);
 
+            const tasks = group.tasks;
             const taskList = await this.createTasksList({
-                tasks: group.tasks,
+                tasks: tasks,
                 content: content,
             });
             content.appendChild(taskList);


### PR DESCRIPTION
# Description

Change signature of createTaskList:

from
```ts
private async createTasksList({
        tasks,
        content,
    }: {
        tasks: Task[];
        content: HTMLDivElement;
    }): Promise<HTMLUListElement>
```

to 

```ts
private async createTaskList(tasks: Task[], content: HTMLDivElement): Promise<void>
```

## Motivation and Context

Shorter and cleaner code.

## How has this been tested?

Smoke tests (Unit tests are not testing this level).

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
