### PR TITLE
feat: 'show task count' now shows total, if 'limit' applied

### DIFF
--- a/docs/Queries/Limiting.md
+++ b/docs/Queries/Limiting.md
@@ -27,3 +27,11 @@ Shorthand is `limit groups <number>`.
 
 > [!released]
 > `limit groups to <number> tasks` was introduced in Tasks 3.8.0.
+
+## Seeing the total number of tasks found
+
+If either `limit` option prevents any tasks from being displayed in the results, the total number number will be shown, for example:
+
+```text
+50 of 686 tasks
+```

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -251,7 +251,7 @@ Problem line: "${line}"`;
                 taskGroups.applyTaskLimit(this._taskGroupLimit);
             }
 
-            return new QueryResult(taskGroups);
+            return new QueryResult(taskGroups, tasksSorted.length);
         } catch (e) {
             const description = 'Search failed';
             return QueryResult.fromError(errorMessageForException(description, e));

--- a/src/Query/QueryResult.ts
+++ b/src/Query/QueryResult.ts
@@ -1,6 +1,10 @@
 import { TaskGroups } from './TaskGroups';
 import type { TaskGroup } from './TaskGroup';
 
+function taskCountPluralised(tasksCount: number) {
+    return `task${tasksCount !== 1 ? 's' : ''}`;
+}
+
 export class QueryResult {
     public readonly taskGroups: TaskGroups;
     public readonly totalTasksCountBeforeLimit: number = 0;
@@ -28,7 +32,7 @@ export class QueryResult {
         const tasksCount = this.totalTasksCount;
         const tasksCountBeforeLimit = this.totalTasksCountBeforeLimit;
         if (tasksCount === tasksCountBeforeLimit) {
-            const pluralised = `task${tasksCount !== 1 ? 's' : ''}`;
+            const pluralised = taskCountPluralised(tasksCount);
             return `${tasksCount} ${pluralised}`;
         } else {
             return `${tasksCount} of ${tasksCountBeforeLimit} task${tasksCountBeforeLimit !== 1 ? 's' : ''}`;

--- a/src/Query/QueryResult.ts
+++ b/src/Query/QueryResult.ts
@@ -28,7 +28,8 @@ export class QueryResult {
         const tasksCount = this.totalTasksCount;
         const tasksCountBeforeLimit = this.totalTasksCountBeforeLimit;
         if (tasksCount === tasksCountBeforeLimit) {
-            return `${tasksCount} task${tasksCount !== 1 ? 's' : ''}`;
+            const pluralised = `task${tasksCount !== 1 ? 's' : ''}`;
+            return `${tasksCount} ${pluralised}`;
         } else {
             return `${tasksCount} of ${tasksCountBeforeLimit} task${tasksCountBeforeLimit !== 1 ? 's' : ''}`;
         }

--- a/src/Query/QueryResult.ts
+++ b/src/Query/QueryResult.ts
@@ -26,7 +26,11 @@ export class QueryResult {
 
     public totalTasksCountDisplayText() {
         const tasksCount = this.totalTasksCount;
-        return `${tasksCount} task${tasksCount !== 1 ? 's' : ''}`;
+        if (tasksCount === this.totalTasksCountBeforeLimit) {
+            return `${tasksCount} task${tasksCount !== 1 ? 's' : ''}`;
+        } else {
+            return `${tasksCount} of ${this.totalTasksCountBeforeLimit} task${tasksCount !== 1 ? 's' : ''}`;
+        }
     }
 
     public get groups(): TaskGroup[] {

--- a/src/Query/QueryResult.ts
+++ b/src/Query/QueryResult.ts
@@ -32,8 +32,7 @@ export class QueryResult {
         const tasksCount = this.totalTasksCount;
         const tasksCountBeforeLimit = this.totalTasksCountBeforeLimit;
         if (tasksCount === tasksCountBeforeLimit) {
-            const pluralised = taskCountPluralised(tasksCount);
-            return `${tasksCount} ${pluralised}`;
+            return `${tasksCount} ${taskCountPluralised(tasksCount)}`;
         } else {
             return `${tasksCount} of ${tasksCountBeforeLimit} task${tasksCountBeforeLimit !== 1 ? 's' : ''}`;
         }

--- a/src/Query/QueryResult.ts
+++ b/src/Query/QueryResult.ts
@@ -34,7 +34,7 @@ export class QueryResult {
         if (tasksCount === tasksCountBeforeLimit) {
             return `${tasksCount} ${taskCountPluralised(tasksCount)}`;
         } else {
-            return `${tasksCount} of ${tasksCountBeforeLimit} task${tasksCountBeforeLimit !== 1 ? 's' : ''}`;
+            return `${tasksCount} of ${tasksCountBeforeLimit} ${taskCountPluralised(tasksCountBeforeLimit)}`;
         }
     }
 

--- a/src/Query/QueryResult.ts
+++ b/src/Query/QueryResult.ts
@@ -26,10 +26,11 @@ export class QueryResult {
 
     public totalTasksCountDisplayText() {
         const tasksCount = this.totalTasksCount;
-        if (tasksCount === this.totalTasksCountBeforeLimit) {
+        const tasksCountBeforeLimit = this.totalTasksCountBeforeLimit;
+        if (tasksCount === tasksCountBeforeLimit) {
             return `${tasksCount} task${tasksCount !== 1 ? 's' : ''}`;
         } else {
-            return `${tasksCount} of ${this.totalTasksCountBeforeLimit} task${tasksCount !== 1 ? 's' : ''}`;
+            return `${tasksCount} of ${tasksCountBeforeLimit} task${tasksCountBeforeLimit !== 1 ? 's' : ''}`;
         }
     }
 

--- a/src/Query/QueryResult.ts
+++ b/src/Query/QueryResult.ts
@@ -3,10 +3,13 @@ import type { TaskGroup } from './TaskGroup';
 
 export class QueryResult {
     public readonly taskGroups: TaskGroups;
+    public readonly totalTasksCountBeforeLimit: number = 0;
+
     private _searchErrorMessage: string | undefined = undefined;
 
-    constructor(groups: TaskGroups) {
+    constructor(groups: TaskGroups, totalTasksCountBeforeLimit: number) {
         this.taskGroups = groups;
+        this.totalTasksCountBeforeLimit = totalTasksCountBeforeLimit;
     }
 
     public get searchErrorMessage(): string | undefined {
@@ -31,7 +34,7 @@ export class QueryResult {
     }
 
     static fromError(message: string): QueryResult {
-        const result = new QueryResult(new TaskGroups([], []));
+        const result = new QueryResult(new TaskGroups([], []), 0);
         result._searchErrorMessage = message;
         return result;
     }

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -1226,6 +1226,9 @@ At most 8 tasks per group (if any "group by" options are supplied).
 - [ ] Task 4 - will be sorted to 2nd place, so should pass limit
 `;
             expect('\n' + soleTaskGroup.tasksAsStringOfLines()).toStrictEqual(expectedTasks);
+
+            expect(queryResult.taskGroups.totalTasksCount()).toEqual(2);
+            expect(queryResult.totalTasksCountBeforeLimit).toEqual(6);
         });
 
         it('should apply group limit correctly, after sorting tasks', () => {
@@ -1270,6 +1273,9 @@ At most 8 tasks per group (if any "group by" options are supplied).
                 - [ ] Task 5 - will be sorted to 3nd place in the second group and pass the limit
                 "
             `);
+
+            expect(queryResult.taskGroups.totalTasksCount()).toEqual(5);
+            expect(queryResult.totalTasksCountBeforeLimit).toEqual(6);
         });
     });
 

--- a/tests/Query/QueryResult.test.ts
+++ b/tests/Query/QueryResult.test.ts
@@ -41,6 +41,7 @@ describe('QueryResult', () => {
     });
 
     describe('Text representation of tasks count', () => {
+        // Simple cases - where no limit was applied
         it('should pluralise "tasks" if 0 matches', () => {
             const tasks: Task[] = [];
             const queryResult = createUngroupedQueryResult(tasks);
@@ -60,6 +61,19 @@ describe('QueryResult', () => {
             ];
             const queryResult = createUngroupedQueryResult(tasks);
             expect(queryResult.totalTasksCountDisplayText()).toEqual('2 tasks');
+        });
+
+        // Cases where a limit was applied
+        // 0 of 1 tasks
+        // 1 of 2 tasks
+        // 2 of 9 tasks
+        it('should show original number of matching tasks if limit was applied', () => {
+            const tasks = [
+                fromLine({ line: '- [ ] Do something more complicated 1' }),
+                fromLine({ line: '- [ ] Do something more complicated 2' }),
+            ];
+            const queryResult = createUngroupedQueryResultWithLimit(tasks, 9);
+            expect(queryResult.totalTasksCountDisplayText()).toEqual('2 of 9 tasks');
         });
     });
 });

--- a/tests/Query/QueryResult.test.ts
+++ b/tests/Query/QueryResult.test.ts
@@ -42,6 +42,7 @@ describe('QueryResult', () => {
 
     describe('Text representation of tasks count', () => {
         // Simple cases - where no limit was applied
+
         it('should pluralise "tasks" if 0 matches', () => {
             const tasks: Task[] = [];
             const queryResult = createUngroupedQueryResult(tasks);
@@ -64,9 +65,19 @@ describe('QueryResult', () => {
         });
 
         // Cases where a limit was applied
-        // 0 of 1 tasks
-        // 1 of 2 tasks
-        // 2 of 9 tasks
+
+        it('should show original number of matching tasks if limit was applied', () => {
+            const tasks: Task[] = [];
+            const queryResult = createUngroupedQueryResultWithLimit(tasks, 1);
+            expect(queryResult.totalTasksCountDisplayText()).toEqual('0 of 1 task');
+        });
+
+        it('should show original number of matching tasks if limit was applied', () => {
+            const tasks = [fromLine({ line: '- [ ] Do something' })];
+            const queryResult = createUngroupedQueryResultWithLimit(tasks, 2);
+            expect(queryResult.totalTasksCountDisplayText()).toEqual('1 of 2 tasks');
+        });
+
         it('should show original number of matching tasks if limit was applied', () => {
             const tasks = [
                 fromLine({ line: '- [ ] Do something more complicated 1' }),

--- a/tests/Query/QueryResult.test.ts
+++ b/tests/Query/QueryResult.test.ts
@@ -6,8 +6,7 @@ import { fromLine } from '../TestHelpers';
 
 describe('QueryResult', () => {
     function createUngroupedQueryResult(tasks: Task[]) {
-        const totalTasksCountBeforeLimit = tasks.length;
-        return createUngroupedQueryResultWithLimit(tasks, totalTasksCountBeforeLimit);
+        return createUngroupedQueryResultWithLimit(tasks, tasks.length);
     }
 
     function createUngroupedQueryResultWithLimit(tasks: Task[], totalTasksCountBeforeLimit: number) {

--- a/tests/Query/QueryResult.test.ts
+++ b/tests/Query/QueryResult.test.ts
@@ -6,9 +6,14 @@ import { fromLine } from '../TestHelpers';
 
 describe('QueryResult', () => {
     function createUngroupedQueryResult(tasks: Task[]) {
+        const totalTasksCountBeforeLimit = tasks.length;
+        return createUngroupedQueryResultWithLimit(tasks, totalTasksCountBeforeLimit);
+    }
+
+    function createUngroupedQueryResultWithLimit(tasks: Task[], totalTasksCountBeforeLimit: number) {
         const groupers: Grouper[] = [];
         const groups = new TaskGroups(groupers, tasks);
-        return new QueryResult(groups, tasks.length);
+        return new QueryResult(groups, totalTasksCountBeforeLimit);
     }
 
     it('should create a QueryResult from TaskGroups', () => {

--- a/tests/Query/QueryResult.test.ts
+++ b/tests/Query/QueryResult.test.ts
@@ -8,7 +8,7 @@ describe('QueryResult', () => {
     function createUngroupedQueryResult(tasks: Task[]) {
         const groupers: Grouper[] = [];
         const groups = new TaskGroups(groupers, tasks);
-        return new QueryResult(groups);
+        return new QueryResult(groups, tasks.length);
     }
 
     it('should create a QueryResult from TaskGroups', () => {
@@ -18,7 +18,7 @@ describe('QueryResult', () => {
         const groups = new TaskGroups(groupers, tasks);
 
         // Act
-        const queryResult = new QueryResult(groups);
+        const queryResult = new QueryResult(groups, 0);
 
         // Assert
         expect(queryResult.totalTasksCount).toEqual(0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

- If there was a limit applied in the search, the results now show the total number of tasks that were found.
- For example, `50 of 686 tasks` instead of `50 tasks`

The original suggestion was to make this an optional feature, but it is so useful, and the time-cost of adding optional features is significant, so I've enabled it automatically.

Also update the user docs.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #2294:

- #2294

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/7132cf87-eead-421a-b107-2392735118d4)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
