### PR TITLE
fix: Prevent crash at startup if user never previously edited settings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -68,11 +68,16 @@ export default class TasksPlugin extends Plugin {
     }
 
     async loadSettings() {
-        const newSettings = await this.loadData();
+        let newSettings = await this.loadData();
         updateSettings(newSettings);
+
+        // Fetch the updated settings, in case the user has not yet edited the settings,
+        // in which case newSettings is currently empty.
+        newSettings = getSettings();
         GlobalFilter.getInstance().set(newSettings.globalFilter);
         GlobalFilter.getInstance().setRemoveGlobalFilter(newSettings.removeGlobalFilter);
         GlobalQuery.getInstance().set(newSettings.globalQuery);
+
         await this.loadTaskStatuses();
     }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

Prevent a crash if there is no Tasks plugin `data.json` settings file at startup.

## Motivation and Context

Fixes #2302.

## How has this been tested?

On my Mac.

- Confirmed that Tasks now does start up correctly if there is no settings file.
- Also confirmed if there is a settings file, its values are loaded correctly.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
