### PR TITLE
docs: Remove duplicate "path includes" in current file How To

### DIFF
--- a/docs/How To/How to get tasks in current file.md
+++ b/docs/How To/How to get tasks in current file.md
@@ -28,7 +28,7 @@ We can use the `path` instruction with the placeholder text `{{query.file.path}}
 
     ```tasks
     not done
-    path includes path includes {{query.file.path}}
+    path includes {{query.file.path}}
     ```
 
 The following placeholders are available:


### PR DESCRIPTION

## Description

There is a duplicate "path includes" in one of the code blocks in "docs/How To/How to get tasks in current file.md".  This PR removes that duplicate.

## Motivation and Context

When copying the current task code block, no tasks show up. That is because there is a duplicate "path includes".

## How has this been tested?

Copying the code block into my Obsidian vault.

## Types of changes

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
