### PR TITLE
test: Prevent IDEs from stripping spaces from test

### DIFF
--- a/tests/Scanner.test.ts
+++ b/tests/Scanner.test.ts
@@ -1,6 +1,3 @@
-/* Note: some tests are sensitive to whitespace changes. Ensure your editor preserves
- * trailing whitespace.
- */
 import { continue_lines, scan } from '../src/Query/Scanner';
 
 describe('continue_lines', () => {
@@ -18,23 +15,38 @@ continued`;
         const text = String.raw`line1 \\
 
 line2`;
-        expect(continue_lines(text)).toEqual(String.raw`line1 \ 
-line2`);
+        expect(continue_lines(text)).toEqual(
+            [
+                // force linebreak
+                String.raw`line1 \ `,
+                'line2',
+            ].join('\n'),
+        );
     });
     it('preserves non-final backslashes', () => {
         const text = String.raw`line\1 \
 continued \\\
 
 line2`;
-        expect(continue_lines(text)).toEqual(String.raw`line\1 continued \\ 
-line2`);
+        expect(continue_lines(text)).toEqual(
+            [
+                // force linebreak
+                String.raw`line\1 continued \\ `,
+                'line2',
+            ].join('\n'),
+        );
     });
     it('ignores interleaved continuations', () => {
         const text = String.raw`line1\\
 
 line2`;
-        expect(continue_lines(text)).toEqual(String.raw`line1\ 
-line2`);
+        expect(continue_lines(text)).toEqual(
+            [
+                // force linebreak
+                String.raw`line1\ `,
+                'line2',
+            ].join('\n'),
+        );
     });
     it('compresses surrounding spaces', () => {
         const text = String.raw`line1    \
@@ -46,8 +58,13 @@ line2`);
 \t\tcontinued\\
 
 line2`;
-        expect(continue_lines(text)).toEqual(String.raw`line1 continued 
-line2`);
+        expect(continue_lines(text)).toEqual(
+            [
+                // force linebreak
+                'line1 continued ',
+                'line2',
+            ].join('\n'),
+        );
     });
 });
 
@@ -58,11 +75,14 @@ due this week`;
         expect(scan(text)).toEqual(['not done', 'due this week']);
     });
     it('strips whitespace', () => {
-        const text = String.raw` not done   
-        due this week
-
-        
-        `;
+        const text = [
+            // force line break
+            ' not done   ',
+            '        due this week',
+            '',
+            '        ',
+            '        ',
+        ].join('\n');
         expect(scan(text)).toEqual(['not done', 'due this week']);
     });
     it('supports line continuation', () => {
@@ -71,13 +91,16 @@ due this week`;
         expect(scan(text)).toEqual(['( property1 ) AND (property2)']);
     });
     it('drops empty lines', () => {
-        const text = String.raw`line1    
- line2 
-
- 
-  line3
-  
-  `;
+        const text = [
+            // force line break
+            'line1    ',
+            ' line2 ',
+            '',
+            ' ',
+            '  line3',
+            '  ',
+            '  ',
+        ].join('\n');
         expect(scan(text)).toEqual(['line1', 'line2', 'line3']);
     });
 });

--- a/tests/Scanner.test.ts
+++ b/tests/Scanner.test.ts
@@ -84,10 +84,11 @@ describe('continue_lines', () => {
 
     it('compresses surrounding tabs', () => {
         const text = [
-            `line1\t\\
-\t\tcontinued\\
-
-line2`,
+            // force linebreak
+            'line1\t\\',
+            '\t\tcontinued\\',
+            '',
+            'line2',
         ].join('\n');
         expect(continue_lines(text)).toEqual(
             [
@@ -102,8 +103,9 @@ line2`,
 describe('scan', () => {
     it('works on an easy case', () => {
         const text = [
-            String.raw`not done
-due this week`,
+            // force line break
+            'not done',
+            'due this week',
         ].join('\n');
         expect(scan(text)).toEqual(['not done', 'due this week']);
     });

--- a/tests/Scanner.test.ts
+++ b/tests/Scanner.test.ts
@@ -1,5 +1,10 @@
 import { continue_lines, scan } from '../src/Query/Scanner';
 
+// There is no way to have a literal \ at the end of a raw string.
+// In such cases, we use substitution instead.
+// Context: https://stackoverflow.com/questions/42604680/string-raw-when-last-character-is
+const bs = '\\';
+
 describe('continue_lines', () => {
     it('keeps non-continued text the same', () => {
         const text = [
@@ -11,7 +16,7 @@ due this week`,
 
     it('removes backslashed newlines', () => {
         const text = [
-            String.raw`line1 \
+            String.raw`line1 ${bs}
 continued`,
         ].join('\n');
         expect(continue_lines(text)).toEqual('line1 continued');
@@ -19,7 +24,7 @@ continued`,
 
     it('only consumes one backslash', () => {
         const text = [
-            String.raw`line1 \\
+            String.raw`line1 ${bs}${bs}
 
 line2`,
         ].join('\n');
@@ -34,8 +39,8 @@ line2`,
 
     it('preserves non-final backslashes', () => {
         const text = [
-            String.raw`line\1 \
-continued \\\
+            String.raw`line\1 ${bs}
+continued ${bs}${bs}${bs}
 
 line2`,
         ].join('\n');
@@ -50,7 +55,7 @@ line2`,
 
     it('ignores interleaved continuations', () => {
         const text = [
-            String.raw`line1\\
+            String.raw`line1${bs}${bs}
 
 line2`,
         ].join('\n');
@@ -65,7 +70,7 @@ line2`,
 
     it('compresses surrounding spaces', () => {
         const text = [
-            String.raw`line1    \
+            String.raw`line1    ${bs}
             continued`,
         ].join('\n');
         expect(continue_lines(text)).toEqual(String.raw`line1 continued`);

--- a/tests/Scanner.test.ts
+++ b/tests/Scanner.test.ts
@@ -6,11 +6,13 @@ describe('continue_lines', () => {
 due this week`;
         expect(continue_lines(text)).toEqual(text);
     });
+
     it('removes backslashed newlines', () => {
         const text = String.raw`line1 \
 continued`;
         expect(continue_lines(text)).toEqual('line1 continued');
     });
+
     it('only consumes one backslash', () => {
         const text = String.raw`line1 \\
 
@@ -23,6 +25,7 @@ line2`;
             ].join('\n'),
         );
     });
+
     it('preserves non-final backslashes', () => {
         const text = String.raw`line\1 \
 continued \\\
@@ -36,6 +39,7 @@ line2`;
             ].join('\n'),
         );
     });
+
     it('ignores interleaved continuations', () => {
         const text = String.raw`line1\\
 
@@ -48,11 +52,13 @@ line2`;
             ].join('\n'),
         );
     });
+
     it('compresses surrounding spaces', () => {
         const text = String.raw`line1    \
             continued`;
         expect(continue_lines(text)).toEqual(String.raw`line1 continued`);
     });
+
     it('compresses surrounding tabs', () => {
         const text = `line1\t\\
 \t\tcontinued\\
@@ -74,6 +80,7 @@ describe('scan', () => {
 due this week`;
         expect(scan(text)).toEqual(['not done', 'due this week']);
     });
+
     it('strips whitespace', () => {
         const text = [
             // force line break
@@ -85,11 +92,13 @@ due this week`;
         ].join('\n');
         expect(scan(text)).toEqual(['not done', 'due this week']);
     });
+
     it('supports line continuation', () => {
         const text = String.raw`( property1 ) AND \
  (property2)`;
         expect(scan(text)).toEqual(['( property1 ) AND (property2)']);
     });
+
     it('drops empty lines', () => {
         const text = [
             // force line break

--- a/tests/Scanner.test.ts
+++ b/tests/Scanner.test.ts
@@ -83,10 +83,12 @@ describe('continue_lines', () => {
     });
 
     it('compresses surrounding tabs', () => {
-        const text = `line1\t\\
+        const text = [
+            `line1\t\\
 \t\tcontinued\\
 
-line2`;
+line2`,
+        ].join('\n');
         expect(continue_lines(text)).toEqual(
             [
                 // force linebreak

--- a/tests/Scanner.test.ts
+++ b/tests/Scanner.test.ts
@@ -2,21 +2,27 @@ import { continue_lines, scan } from '../src/Query/Scanner';
 
 describe('continue_lines', () => {
     it('keeps non-continued text the same', () => {
-        const text = String.raw`not done
-due this week`;
+        const text = [
+            String.raw`not done
+due this week`,
+        ].join('\n');
         expect(continue_lines(text)).toEqual(text);
     });
 
     it('removes backslashed newlines', () => {
-        const text = String.raw`line1 \
-continued`;
+        const text = [
+            String.raw`line1 \
+continued`,
+        ].join('\n');
         expect(continue_lines(text)).toEqual('line1 continued');
     });
 
     it('only consumes one backslash', () => {
-        const text = String.raw`line1 \\
+        const text = [
+            String.raw`line1 \\
 
-line2`;
+line2`,
+        ].join('\n');
         expect(continue_lines(text)).toEqual(
             [
                 // force linebreak
@@ -27,10 +33,12 @@ line2`;
     });
 
     it('preserves non-final backslashes', () => {
-        const text = String.raw`line\1 \
+        const text = [
+            String.raw`line\1 \
 continued \\\
 
-line2`;
+line2`,
+        ].join('\n');
         expect(continue_lines(text)).toEqual(
             [
                 // force linebreak
@@ -41,9 +49,11 @@ line2`;
     });
 
     it('ignores interleaved continuations', () => {
-        const text = String.raw`line1\\
+        const text = [
+            String.raw`line1\\
 
-line2`;
+line2`,
+        ].join('\n');
         expect(continue_lines(text)).toEqual(
             [
                 // force linebreak
@@ -54,8 +64,10 @@ line2`;
     });
 
     it('compresses surrounding spaces', () => {
-        const text = String.raw`line1    \
-            continued`;
+        const text = [
+            String.raw`line1    \
+            continued`,
+        ].join('\n');
         expect(continue_lines(text)).toEqual(String.raw`line1 continued`);
     });
 
@@ -76,8 +88,10 @@ line2`;
 
 describe('scan', () => {
     it('works on an easy case', () => {
-        const text = String.raw`not done
-due this week`;
+        const text = [
+            String.raw`not done
+due this week`,
+        ].join('\n');
         expect(scan(text)).toEqual(['not done', 'due this week']);
     });
 
@@ -94,8 +108,10 @@ due this week`;
     });
 
     it('supports line continuation', () => {
-        const text = String.raw`( property1 ) AND \
- (property2)`;
+        const text = [
+            String.raw`( property1 ) AND \
+ (property2)`,
+        ].join('\n');
         expect(scan(text)).toEqual(['( property1 ) AND (property2)']);
     });
 

--- a/tests/Scanner.test.ts
+++ b/tests/Scanner.test.ts
@@ -8,25 +8,28 @@ const bs = '\\';
 describe('continue_lines', () => {
     it('keeps non-continued text the same', () => {
         const text = [
-            String.raw`not done
-due this week`,
+            // force linebreak
+            'not done',
+            'due this week',
         ].join('\n');
         expect(continue_lines(text)).toEqual(text);
     });
 
     it('removes backslashed newlines', () => {
         const text = [
-            String.raw`line1 ${bs}
-continued`,
+            // force linebreak
+            String.raw`line1 ${bs}`,
+            'continued',
         ].join('\n');
         expect(continue_lines(text)).toEqual('line1 continued');
     });
 
     it('only consumes one backslash', () => {
         const text = [
-            String.raw`line1 ${bs}${bs}
-
-line2`,
+            // force linebreak
+            String.raw`line1 ${bs}${bs}`,
+            '',
+            'line2',
         ].join('\n');
         expect(continue_lines(text)).toEqual(
             [
@@ -39,10 +42,11 @@ line2`,
 
     it('preserves non-final backslashes', () => {
         const text = [
-            String.raw`line\1 ${bs}
-continued ${bs}${bs}${bs}
-
-line2`,
+            // force linebreak
+            String.raw`line\1 ${bs}`,
+            `continued ${bs}${bs}${bs}`,
+            '',
+            'line2',
         ].join('\n');
         expect(continue_lines(text)).toEqual(
             [
@@ -55,9 +59,10 @@ line2`,
 
     it('ignores interleaved continuations', () => {
         const text = [
-            String.raw`line1${bs}${bs}
-
-line2`,
+            // force linebreak
+            String.raw`line1${bs}${bs}`,
+            '',
+            'line2',
         ].join('\n');
         expect(continue_lines(text)).toEqual(
             [
@@ -70,8 +75,9 @@ line2`,
 
     it('compresses surrounding spaces', () => {
         const text = [
-            String.raw`line1    ${bs}
-            continued`,
+            // force linebreak
+            String.raw`line1    ${bs}`,
+            'continued',
         ].join('\n');
         expect(continue_lines(text)).toEqual(String.raw`line1 continued`);
     });

--- a/tests/Scanner.test.ts
+++ b/tests/Scanner.test.ts
@@ -124,8 +124,9 @@ describe('scan', () => {
 
     it('supports line continuation', () => {
         const text = [
-            String.raw`( property1 ) AND \
- (property2)`,
+            // force line break
+            String.raw`( property1 ) AND ${bs}`,
+            ' (property2)',
         ].join('\n');
         expect(scan(text)).toEqual(['( property1 ) AND (property2)']);
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This is a follow-up from #2330. See discussion in https://github.com/obsidian-tasks-group/obsidian-tasks/pull/2330#discussion_r1359794459.

It stops IDEs from breaking tests by stripping trailing whitespace from the end of strings in source file `Scanner.test.ts`.

## How has this been tested?

It updates existing tests. So by running them repeatedly.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
