### PR TITLE
docs: Wrap long lines in custom filter and group samples

### DIFF
--- a/docs/Queries/Filters.md
+++ b/docs/Queries/Filters.md
@@ -399,7 +399,9 @@ filter by function task.status.symbol !== ' '
 - Find tasks with anything but the space character as their status symbol, that is, without the checkbox `[ ]`.
 
 ```text
-filter by function const symbol = task.status.symbol; return symbol === 'P' || symbol === 'C' || symbol === 'Q' || symbol === 'A'
+filter by function \
+    const symbol = task.status.symbol; \
+    return symbol === 'P' || symbol === 'C' || symbol === 'Q' || symbol === 'A';
 ```
 
 - Note that because we use a variable to avoid repetition, we need to add `return`
@@ -1324,27 +1326,35 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by heading** is now pos
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.file_properties_task.heading_docs.approved.md -->
 
 ```text
-filter by function const taskDate = task.due.moment; const wanted = '2023-06-11'; return taskDate?.isSame(wanted, 'day') || ( !taskDate && task.heading?.includes(wanted)) || false
+filter by function \
+    const taskDate = task.due.moment; \
+    const wanted = '2023-06-11'; \
+    return taskDate?.isSame(wanted, 'day') || ( !taskDate && task.heading?.includes(wanted)) || false
 ```
 
-- Find takes that:
+- Find tasks that:
   - **either** due on the date `2023-06-11`,
   - **or** do not have a due date, and their preceding heading contains the same date as a string: `2023-06-11`.
 - Note that because we use variables to avoid repetition of values, we need to add `return`.
 
 ```text
-filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false
+filter by function \
+    const taskDate = task.due.moment; \
+    const now = moment(); \
+    return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false
 ```
 
-- Find takes that:
+- Find tasks that:
   - **either** due on today's date,
   - **or** do not have a due date, and their preceding heading contains today's date as a string, formatted as `YYYY-MM-DD`.
 
 ```text
-filter by function task.heading?.includes('#context/home') || task.tags.find( (tag) => tag === '#context/home' ) && true || false
+filter by function \
+    const wanted = '#context/home'; \
+    return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;
 ```
 
-- Find takes that:
+- Find tasks that:
   - **either** have a tag exactly matching `#context/home` on the task line,
   - **or** their preceding heading contains the text `#context/home` anywhere.
     - For demonstration purposes, this is slightly imprecise, in that it would also match nested tasks, such as `#context/home/ground-floor`.

--- a/docs/Queries/Grouping.md
+++ b/docs/Queries/Grouping.md
@@ -256,35 +256,62 @@ group by function task.due.format("[%%]d[%%]dddd")
 - The day names are sorted in date order, starting with Sunday.
 
 ```text
-group by function const date = task.due; return date.moment ? ( date.moment.day() === 0 ? date.format("[%%][8][%%]dddd") : date.format("[%%]d[%%]dddd") ) : "Undated"
+group by function                                   \
+    const date = task.due;                          \
+    if (!date.moment) {                             \
+        return "Undated";                           \
+    }                                               \
+    if (date.moment.day() === 0) {                  \
+        {{! Put the Sunday group last: }}           \
+        return date.format("[%%][8][%%]dddd");      \
+    }                                               \
+    return date.format("[%%]d[%%]dddd");
 ```
 
 - Group by day of the week (Monday, Tuesday, etc).
 - The day names are sorted in date order, starting with Monday.
 - Tasks without due dates are displayed at the end, under a heading "Undated".
-- This is best understood by pasting it in to a Tasks block in Obsidian and then deleting parts of the expression.
 - The key technique is to say that if the day is Sunday (`0`), then force it to be displayed as date number `8`, so it comes after the other days of the week.
-- Note that because we use variables to avoid repetition of values, we need to add `return`
+- To add comments, we can use `{{! ... }}`
+- To make the expression more readable, we put a `\` at the end of several lines, to continue the expression on the next line.
 
 ```text
-group by function const date = task.due.moment; return (!date) ? '%%4%% Undated' : date.isBefore(moment(), 'day') ? '%%1%% Overdue' : date.isSame(moment(), 'day') ? '%%2%% Today' : '%%3%% Future'
+group by function \
+    const date = task.due.moment; \
+    return \
+        (!date)                           ? '%%4%% Undated' : \
+        date.isBefore(moment(), 'day')    ? '%%1%% Overdue' : \
+        date.isSame(moment(), 'day')      ? '%%2%% Today'   : \
+        '%%3%% Future';
 ```
 
 - This gives exactly the same output as `group by function task.due.category.groupText`, and is shown here in case you want to customise the behaviour in some way.
 - Group task due dates in to 4 broad categories: `Overdue`, `Today`, `Future` and `Undated`, displayed in that order.
 - Try this on a line before `group by due` if there are a lot of due date headings, and you would like them to be broken down in to some kind of structure.
-- A limitation of Tasks expressions is that they each need to fit on a single line, so this uses nested ternary operators, making it powerful but very hard to read.
-- In fact, for ease of development and testing, it was written in a full-fledged development environment as a series of if/else blocks, and then automatically refactored in these nested ternary operators.
+- Note that because we use variables to avoid repetition of values, we need to add `return`
 
 ```text
-group by function const date = task.due.moment; return (!date) ? '%%4%% ==Undated==' : date.isBefore(moment(), 'day') ? '%%1%% ==Overdue==' : date.isSame(moment(), 'day') ? '%%2%% ==Today==' : '%%3%% ==Future=='
+group by function \
+    const date = task.due.moment; \
+    return \
+        (!date)                           ? '%%4%% ==Undated==' : \
+        date.isBefore(moment(), 'day')    ? '%%1%% ==Overdue==' : \
+        date.isSame(moment(), 'day')      ? '%%2%% ==Today=='   : \
+        '%%3%% ==Future==';
 ```
 
 - As above, but the headings `Overdue`, `Today`, `Future` and `Undated` are highlighted.
 - See the sample screenshot below.
 
 ```text
-group by function const date = task.due.moment; const now = moment(); const label = (order, name) => `%%${order}%% ==${name}==`; if (!date) return label(4, 'Undated'); if (date.isBefore(now, 'day')) return label(1, 'Overdue'); if (date.isSame(now, 'day')) return label(2, 'Today'); return label(3, 'Future');
+group by function \
+    const date = task.due.moment; \
+    const now = moment(); \
+    const label = (order, name) => `%%${order}%% ==${name}==`; \
+    if (!date)                      return label(4, 'Undated'); \
+    if (date.isBefore(now, 'day'))  return label(1, 'Overdue'); \
+    if (date.isSame(now, 'day'))    return label(2, 'Today'); \
+    return label(3, 'Future');
 ```
 
 - As above, but using a local function, and `if` statements.

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.heading_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.heading_docs.approved.md
@@ -2,27 +2,35 @@
 
 
 ```text
-filter by function const taskDate = task.due.moment; const wanted = '2023-06-11'; return taskDate?.isSame(wanted, 'day') || ( !taskDate && task.heading?.includes(wanted)) || false
+filter by function \
+    const taskDate = task.due.moment; \
+    const wanted = '2023-06-11'; \
+    return taskDate?.isSame(wanted, 'day') || ( !taskDate && task.heading?.includes(wanted)) || false
 ```
 
-- Find takes that:
+- Find tasks that:
   - **either** due on the date `2023-06-11`,
   - **or** do not have a due date, and their preceding heading contains the same date as a string: `2023-06-11`.
 - Note that because we use variables to avoid repetition of values, we need to add `return`.
 
 ```text
-filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false
+filter by function \
+    const taskDate = task.due.moment; \
+    const now = moment(); \
+    return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false
 ```
 
-- Find takes that:
+- Find tasks that:
   - **either** due on today's date,
   - **or** do not have a due date, and their preceding heading contains today's date as a string, formatted as `YYYY-MM-DD`.
 
 ```text
-filter by function task.heading?.includes('#context/home') || task.tags.find( (tag) => tag === '#context/home' ) && true || false
+filter by function \
+    const wanted = '#context/home'; \
+    return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;
 ```
 
-- Find takes that:
+- Find tasks that:
   - **either** have a tag exactly matching `#context/home` on the task line,
   - **or** their preceding heading contains the text `#context/home` anywhere.
     - For demonstration purposes, this is slightly imprecise, in that it would also match nested tasks, such as `#context/home/ground-floor`.

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.heading_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.heading_results.approved.txt
@@ -2,8 +2,11 @@ Results of custom filters
 
 
 
-filter by function const taskDate = task.due.moment; const wanted = '2023-06-11'; return taskDate?.isSame(wanted, 'day') || ( !taskDate && task.heading?.includes(wanted)) || false
-Find takes that:
+filter by function \
+    const taskDate = task.due.moment; \
+    const wanted = '2023-06-11'; \
+    return taskDate?.isSame(wanted, 'day') || ( !taskDate && task.heading?.includes(wanted)) || false
+Find tasks that:
   **either** due on the date `2023-06-11`,
   **or** do not have a due date, and their preceding heading contains the same date as a string: `2023-06-11`.
 Note that because we use variables to avoid repetition of values, we need to add `return`.
@@ -13,8 +16,11 @@ Note that because we use variables to avoid repetition of values, we need to add
 ====================================================================================
 
 
-filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false
-Find takes that:
+filter by function \
+    const taskDate = task.due.moment; \
+    const now = moment(); \
+    return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false
+Find tasks that:
   **either** due on today's date,
   **or** do not have a due date, and their preceding heading contains today's date as a string, formatted as `YYYY-MM-DD`.
 =>
@@ -23,8 +29,10 @@ Find takes that:
 ====================================================================================
 
 
-filter by function task.heading?.includes('#context/home') || task.tags.find( (tag) => tag === '#context/home' ) && true || false
-Find takes that:
+filter by function \
+    const wanted = '#context/home'; \
+    return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;
+Find tasks that:
   **either** have a tag exactly matching `#context/home` on the task line,
   **or** their preceding heading contains the text `#context/home` anywhere.
     For demonstration purposes, this is slightly imprecise, in that it would also match nested tasks, such as `#context/home/ground-floor`.

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.statuses_task.status.symbol_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.statuses_task.status.symbol_docs.approved.md
@@ -14,7 +14,9 @@ filter by function task.status.symbol !== ' '
 - Find tasks with anything but the space character as their status symbol, that is, without the checkbox `[ ]`.
 
 ```text
-filter by function const symbol = task.status.symbol; return symbol === 'P' || symbol === 'C' || symbol === 'Q' || symbol === 'A'
+filter by function \
+    const symbol = task.status.symbol; \
+    return symbol === 'P' || symbol === 'C' || symbol === 'Q' || symbol === 'A';
 ```
 
 - Note that because we use a variable to avoid repetition, we need to add `return`

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.statuses_task.status.symbol_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.statuses_task.status.symbol_results.approved.txt
@@ -25,7 +25,9 @@ Find tasks with anything but the space character as their status symbol, that is
 ====================================================================================
 
 
-filter by function const symbol = task.status.symbol; return symbol === 'P' || symbol === 'C' || symbol === 'Q' || symbol === 'A'
+filter by function \
+    const symbol = task.status.symbol; \
+    return symbol === 'P' || symbol === 'C' || symbol === 'Q' || symbol === 'A';
 Note that because we use a variable to avoid repetition, we need to add `return`
 Find tasks with status symbol `P`, `C`, `Q` or `A`.
 This can get quite verbose, the more symbols you want to search for.

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.ts
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.ts
@@ -274,21 +274,29 @@ describe('file properties', () => {
             'task.heading',
             [
                 [
-                    "filter by function const taskDate = task.due.moment; const wanted = '2023-06-11'; return taskDate?.isSame(wanted, 'day') || ( !taskDate && task.heading?.includes(wanted)) || false",
-                    'Find takes that:',
+                    `filter by function \\
+    const taskDate = task.due.moment; \\
+    const wanted = '2023-06-11'; \\
+    return taskDate?.isSame(wanted, 'day') || ( !taskDate && task.heading?.includes(wanted)) || false`,
+                    'Find tasks that:',
                     '  **either** due on the date `2023-06-11`,',
                     '  **or** do not have a due date, and their preceding heading contains the same date as a string: `2023-06-11`.',
                     'Note that because we use variables to avoid repetition of values, we need to add `return`.',
                 ],
                 [
-                    "filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false",
-                    'Find takes that:',
+                    `filter by function \\
+    const taskDate = task.due.moment; \\
+    const now = moment(); \\
+    return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false`,
+                    'Find tasks that:',
                     "  **either** due on today's date,",
                     "  **or** do not have a due date, and their preceding heading contains today's date as a string, formatted as `YYYY-MM-DD`.",
                 ],
                 [
-                    "filter by function task.heading?.includes('#context/home') || task.tags.find( (tag) => tag === '#context/home' ) && true || false",
-                    'Find takes that:',
+                    `filter by function \\
+    const wanted = '#context/home'; \\
+    return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;`,
+                    'Find tasks that:',
                     '  **either** have a tag exactly matching `#context/home` on the task line,',
                     '  **or** their preceding heading contains the text `#context/home` anywhere.',
                     '    For demonstration purposes, this is slightly imprecise, in that it would also match nested tasks, such as `#context/home/ground-floor`.',
@@ -300,15 +308,15 @@ describe('file properties', () => {
 
     /*
 - ```filter by function task.due.moment?.isSame('2023-06-11', 'day') || ( !task.due.moment && task.heading?.includes('2023-06-11')) || false```
-"Find takes that:",
+"Find tasks that:",
 "  **either** due on the date `2023-06-11`,",
 "  **or** do not have a due date, and their preceding heading contains the same date as a string: `2023-06-11`.",
 - ```filter by function task.due.moment?.isSame(moment(), 'day') || ( !task.due.moment && task.heading?.includes(moment().format('YYYY-MM-DD')) ) || false```
-"Find takes that:",
+"Find tasks that:",
 "  **either** due on today's date,",
 "  **or** do not have a due date, and their preceding heading contains today's date as a string, formatted as `YYYY-MM-DD`.",
 - ```filter by function task.heading?.includes('#context/home') || task.tags.find( (tag) => tag === '#context/home' ) && true || false```
-"Find takes that:",
+"Find tasks that:",
 "  **either** have a tag exactly matching `#context/home` on the task line",
 "  **or** their preceding heading contains the text `#context/home` anywhere",
 "    For demonstration purposes, this is slightly imprecise, in that it would also match nested tasks, such as `#context/home/ground-floor`",
@@ -382,7 +390,9 @@ describe('statuses', () => {
                     'Find tasks with anything but the space character as their status symbol, that is, without the checkbox `[ ]`.',
                 ],
                 [
-                    "filter by function const symbol = task.status.symbol; return symbol === 'P' || symbol === 'C' || symbol === 'Q' || symbol === 'A'",
+                    `filter by function \\
+    const symbol = task.status.symbol; \\
+    return symbol === 'P' || symbol === 'C' || symbol === 'Q' || symbol === 'A';`,
                     'Note that because we use a variable to avoid repetition, we need to add `return`',
                     'Find tasks with status symbol `P`, `C`, `Q` or `A`.',
                     'This can get quite verbose, the more symbols you want to search for.',

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.due.advanced_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.due.advanced_docs.approved.md
@@ -16,35 +16,62 @@ group by function task.due.format("[%%]d[%%]dddd")
 - The day names are sorted in date order, starting with Sunday.
 
 ```text
-group by function const date = task.due; return date.moment ? ( date.moment.day() === 0 ? date.format("[%%][8][%%]dddd") : date.format("[%%]d[%%]dddd") ) : "Undated"
+group by function                                   \
+    const date = task.due;                          \
+    if (!date.moment) {                             \
+        return "Undated";                           \
+    }                                               \
+    if (date.moment.day() === 0) {                  \
+        {{! Put the Sunday group last: }}           \
+        return date.format("[%%][8][%%]dddd");      \
+    }                                               \
+    return date.format("[%%]d[%%]dddd");
 ```
 
 - Group by day of the week (Monday, Tuesday, etc).
 - The day names are sorted in date order, starting with Monday.
 - Tasks without due dates are displayed at the end, under a heading "Undated".
-- This is best understood by pasting it in to a Tasks block in Obsidian and then deleting parts of the expression.
 - The key technique is to say that if the day is Sunday (`0`), then force it to be displayed as date number `8`, so it comes after the other days of the week.
-- Note that because we use variables to avoid repetition of values, we need to add `return`
+- To add comments, we can use `{{! ... }}`
+- To make the expression more readable, we put a `\` at the end of several lines, to continue the expression on the next line.
 
 ```text
-group by function const date = task.due.moment; return (!date) ? '%%4%% Undated' : date.isBefore(moment(), 'day') ? '%%1%% Overdue' : date.isSame(moment(), 'day') ? '%%2%% Today' : '%%3%% Future'
+group by function \
+    const date = task.due.moment; \
+    return \
+        (!date)                           ? '%%4%% Undated' : \
+        date.isBefore(moment(), 'day')    ? '%%1%% Overdue' : \
+        date.isSame(moment(), 'day')      ? '%%2%% Today'   : \
+        '%%3%% Future';
 ```
 
 - This gives exactly the same output as `group by function task.due.category.groupText`, and is shown here in case you want to customise the behaviour in some way.
 - Group task due dates in to 4 broad categories: `Overdue`, `Today`, `Future` and `Undated`, displayed in that order.
 - Try this on a line before `group by due` if there are a lot of due date headings, and you would like them to be broken down in to some kind of structure.
-- A limitation of Tasks expressions is that they each need to fit on a single line, so this uses nested ternary operators, making it powerful but very hard to read.
-- In fact, for ease of development and testing, it was written in a full-fledged development environment as a series of if/else blocks, and then automatically refactored in these nested ternary operators.
+- Note that because we use variables to avoid repetition of values, we need to add `return`
 
 ```text
-group by function const date = task.due.moment; return (!date) ? '%%4%% ==Undated==' : date.isBefore(moment(), 'day') ? '%%1%% ==Overdue==' : date.isSame(moment(), 'day') ? '%%2%% ==Today==' : '%%3%% ==Future=='
+group by function \
+    const date = task.due.moment; \
+    return \
+        (!date)                           ? '%%4%% ==Undated==' : \
+        date.isBefore(moment(), 'day')    ? '%%1%% ==Overdue==' : \
+        date.isSame(moment(), 'day')      ? '%%2%% ==Today=='   : \
+        '%%3%% ==Future==';
 ```
 
 - As above, but the headings `Overdue`, `Today`, `Future` and `Undated` are highlighted.
 - See the sample screenshot below.
 
 ```text
-group by function const date = task.due.moment; const now = moment(); const label = (order, name) => `%%${order}%% ==${name}==`; if (!date) return label(4, 'Undated'); if (date.isBefore(now, 'day')) return label(1, 'Overdue'); if (date.isSame(now, 'day')) return label(2, 'Today'); return label(3, 'Future');
+group by function \
+    const date = task.due.moment; \
+    const now = moment(); \
+    const label = (order, name) => `%%${order}%% ==${name}==`; \
+    if (!date)                      return label(4, 'Undated'); \
+    if (date.isBefore(now, 'day'))  return label(1, 'Overdue'); \
+    if (date.isSame(now, 'day'))    return label(2, 'Today'); \
+    return label(3, 'Future');
 ```
 
 - As above, but using a local function, and `if` statements.

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.due.advanced_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.due.advanced_results.approved.txt
@@ -24,13 +24,22 @@ Invalid date
 ====================================================================================
 
 
-group by function const date = task.due; return date.moment ? ( date.moment.day() === 0 ? date.format("[%%][8][%%]dddd") : date.format("[%%]d[%%]dddd") ) : "Undated"
+group by function                                   \
+    const date = task.due;                          \
+    if (!date.moment) {                             \
+        return "Undated";                           \
+    }                                               \
+    if (date.moment.day() === 0) {                  \
+        {{! Put the Sunday group last: }}           \
+        return date.format("[%%][8][%%]dddd");      \
+    }                                               \
+    return date.format("[%%]d[%%]dddd");
 Group by day of the week (Monday, Tuesday, etc).
 The day names are sorted in date order, starting with Monday.
 Tasks without due dates are displayed at the end, under a heading "Undated".
-This is best understood by pasting it in to a Tasks block in Obsidian and then deleting parts of the expression.
 The key technique is to say that if the day is Sunday (`0`), then force it to be displayed as date number `8`, so it comes after the other days of the week.
-Note that because we use variables to avoid repetition of values, we need to add `return`
+To add comments, we can use `{{! ... }}`
+To make the expression more readable, we put a `\` at the end of several lines, to continue the expression on the next line.
 =>
 %%2%%Tuesday
 %%3%%Wednesday
@@ -40,12 +49,17 @@ Undated
 ====================================================================================
 
 
-group by function const date = task.due.moment; return (!date) ? '%%4%% Undated' : date.isBefore(moment(), 'day') ? '%%1%% Overdue' : date.isSame(moment(), 'day') ? '%%2%% Today' : '%%3%% Future'
+group by function \
+    const date = task.due.moment; \
+    return \
+        (!date)                           ? '%%4%% Undated' : \
+        date.isBefore(moment(), 'day')    ? '%%1%% Overdue' : \
+        date.isSame(moment(), 'day')      ? '%%2%% Today'   : \
+        '%%3%% Future';
 This gives exactly the same output as `group by function task.due.category.groupText`, and is shown here in case you want to customise the behaviour in some way.
 Group task due dates in to 4 broad categories: `Overdue`, `Today`, `Future` and `Undated`, displayed in that order.
 Try this on a line before `group by due` if there are a lot of due date headings, and you would like them to be broken down in to some kind of structure.
-A limitation of Tasks expressions is that they each need to fit on a single line, so this uses nested ternary operators, making it powerful but very hard to read.
-In fact, for ease of development and testing, it was written in a full-fledged development environment as a series of if/else blocks, and then automatically refactored in these nested ternary operators.
+Note that because we use variables to avoid repetition of values, we need to add `return`
 =>
 %%1%% Overdue
 %%2%% Today
@@ -54,7 +68,13 @@ In fact, for ease of development and testing, it was written in a full-fledged d
 ====================================================================================
 
 
-group by function const date = task.due.moment; return (!date) ? '%%4%% ==Undated==' : date.isBefore(moment(), 'day') ? '%%1%% ==Overdue==' : date.isSame(moment(), 'day') ? '%%2%% ==Today==' : '%%3%% ==Future=='
+group by function \
+    const date = task.due.moment; \
+    return \
+        (!date)                           ? '%%4%% ==Undated==' : \
+        date.isBefore(moment(), 'day')    ? '%%1%% ==Overdue==' : \
+        date.isSame(moment(), 'day')      ? '%%2%% ==Today=='   : \
+        '%%3%% ==Future==';
 As above, but the headings `Overdue`, `Today`, `Future` and `Undated` are highlighted.
 See the sample screenshot below.
 =>
@@ -65,7 +85,14 @@ See the sample screenshot below.
 ====================================================================================
 
 
-group by function const date = task.due.moment; const now = moment(); const label = (order, name) => `%%${order}%% ==${name}==`; if (!date) return label(4, 'Undated'); if (date.isBefore(now, 'day')) return label(1, 'Overdue'); if (date.isSame(now, 'day')) return label(2, 'Today'); return label(3, 'Future');
+group by function \
+    const date = task.due.moment; \
+    const now = moment(); \
+    const label = (order, name) => `%%${order}%% ==${name}==`; \
+    if (!date)                      return label(4, 'Undated'); \
+    if (date.isBefore(now, 'day'))  return label(1, 'Overdue'); \
+    if (date.isSame(now, 'day'))    return label(2, 'Today'); \
+    return label(3, 'Future');
 As above, but using a local function, and `if` statements.
 =>
 %%1%% ==Overdue==

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.ts
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.ts
@@ -115,29 +115,56 @@ describe('dates', () => {
                     'The day names are sorted in date order, starting with Sunday',
                 ],
                 [
-                    'group by function const date = task.due; return date.moment ? ( date.moment.day() === 0 ? date.format("[%%][8][%%]dddd") : date.format("[%%]d[%%]dddd") ) : "Undated"',
+                    `group by function                                   \\
+    const date = task.due;                          \\
+    if (!date.moment) {                             \\
+        return "Undated";                           \\
+    }                                               \\
+    if (date.moment.day() === 0) {                  \\
+        {{! Put the Sunday group last: }}           \\
+        return date.format("[%%][8][%%]dddd");      \\
+    }                                               \\
+    return date.format("[%%]d[%%]dddd");`,
                     'Group by day of the week (Monday, Tuesday, etc).',
                     'The day names are sorted in date order, starting with Monday.',
                     'Tasks without due dates are displayed at the end, under a heading "Undated".',
-                    'This is best understood by pasting it in to a Tasks block in Obsidian and then deleting parts of the expression.',
                     'The key technique is to say that if the day is Sunday (`0`), then force it to be displayed as date number `8`, so it comes after the other days of the week',
-                    'Note that because we use variables to avoid repetition of values, we need to add `return`',
+                    'To add comments, we can use `{{! ... }}`',
+                    'To make the expression more readable, we put a `\\` at the end of several lines, to continue the expression on the next line.',
                 ],
                 [
-                    "group by function const date = task.due.moment; return (!date) ? '%%4%% Undated' : date.isBefore(moment(), 'day') ? '%%1%% Overdue' : date.isSame(moment(), 'day') ? '%%2%% Today' : '%%3%% Future'",
+                    `group by function \\
+    const date = task.due.moment; \\
+    return \\
+        (!date)                           ? '%%4%% Undated' : \\
+        date.isBefore(moment(), 'day')    ? '%%1%% Overdue' : \\
+        date.isSame(moment(), 'day')      ? '%%2%% Today'   : \\
+        '%%3%% Future';`,
                     'This gives exactly the same output as `group by function task.due.category.groupText`, and is shown here in case you want to customise the behaviour in some way',
                     'Group task due dates in to 4 broad categories: `Overdue`, `Today`, `Future` and `Undated`, displayed in that order.',
                     'Try this on a line before `group by due` if there are a lot of due date headings, and you would like them to be broken down in to some kind of structure.',
-                    'A limitation of Tasks expressions is that they each need to fit on a single line, so this uses nested ternary operators, making it powerful but very hard to read.',
-                    'In fact, for ease of development and testing, it was written in a full-fledged development environment as a series of if/else blocks, and then automatically refactored in these nested ternary operators',
+                    'Note that because we use variables to avoid repetition of values, we need to add `return`',
                 ],
                 [
-                    "group by function const date = task.due.moment; return (!date) ? '%%4%% ==Undated==' : date.isBefore(moment(), 'day') ? '%%1%% ==Overdue==' : date.isSame(moment(), 'day') ? '%%2%% ==Today==' : '%%3%% ==Future=='",
+                    `group by function \\
+    const date = task.due.moment; \\
+    return \\
+        (!date)                           ? '%%4%% ==Undated==' : \\
+        date.isBefore(moment(), 'day')    ? '%%1%% ==Overdue==' : \\
+        date.isSame(moment(), 'day')      ? '%%2%% ==Today=='   : \\
+        '%%3%% ==Future==';`,
                     'As above, but the headings `Overdue`, `Today`, `Future` and `Undated` are highlighted.',
                     'See the sample screenshot below',
                 ],
                 [
-                    "group by function const date = task.due.moment; const now = moment(); const label = (order, name) => `%%${order}%% ==${name}==`; if (!date) return label(4, 'Undated'); if (date.isBefore(now, 'day')) return label(1, 'Overdue'); if (date.isSame(now, 'day')) return label(2, 'Today'); return label(3, 'Future');",
+                    `group by function \\
+    const date = task.due.moment; \\
+    const now = moment(); \\
+    const label = (order, name) => \`%%\${order}%% ==\${name}==\`; \\
+    if (!date)                      return label(4, 'Undated'); \\
+    if (date.isBefore(now, 'day'))  return label(1, 'Overdue'); \\
+    if (date.isSame(now, 'day'))    return label(2, 'Today'); \\
+    return label(3, 'Future');`,
                     'As above, but using a local function, and `if` statements',
                 ],
             ],

--- a/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
+++ b/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
@@ -5,6 +5,7 @@ import { groupHeadingsForTask } from '../../CustomMatchers/CustomMatchersForGrou
 import { verifyMarkdownForDocs } from '../../TestingTools/VerifyMarkdownTable';
 import { expandPlaceholders } from '../../../src/Scripting/ExpandPlaceholders';
 import { makeQueryContext } from '../../../src/Scripting/QueryContext';
+import { scan } from '../../../src/Query/Scanner';
 
 /** For example, 'task.due' */
 type TaskPropertyName = string;
@@ -14,6 +15,12 @@ export type CustomPropertyDocsTestData = [TaskPropertyName, QueryInstructionLine
 // -----------------------------------------------------------------------------------------------------------------
 // Helper functions
 // -----------------------------------------------------------------------------------------------------------------
+
+function preprocessSingleInstruction(instruction: string, path: string) {
+    const instructions = scan(instruction);
+    expect(instructions.length).toEqual(1);
+    return expandPlaceholders(instructions[0], makeQueryContext(path));
+}
 
 function punctuateComments(comments: string[]) {
     return comments.map((comment) => {
@@ -69,7 +76,7 @@ export function verifyFunctionFieldFilterSamplesOnTasks(filters: QueryInstructio
         const instruction = filter[0];
         const comment = filter.slice(1);
 
-        const expandedInstruction = expandPlaceholders(instruction, makeQueryContext('a/b.md'));
+        const expandedInstruction = preprocessSingleInstruction(instruction, 'a/b.md');
         const filterOrErrorMessage = new FunctionField().createFilterOrErrorMessage(expandedInstruction);
         expect(filterOrErrorMessage).toBeValid();
 
@@ -112,7 +119,7 @@ export function verifyFunctionFieldGrouperSamplesOnTasks(
         const instruction = group[0];
         const comment = group.slice(1);
 
-        const expandedInstruction = expandPlaceholders(instruction, makeQueryContext('a/b.md'));
+        const expandedInstruction = preprocessSingleInstruction(instruction, 'a/b.md');
         const grouper = new FunctionField().createGrouperFromLine(expandedInstruction);
         expect(grouper).not.toBeNull();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Make some of the custom filter and custom grouping examples more readable, by wrapping longer lines, and in one case, introducing an inline comment.

## Motivation and Context

- Advertise continuation lines
- Make the longer samples a bit less head-hurty... 🤯

## How has this been tested?

- By running the tests that confirm that the code samples still give the same results
- By viewing the changed documentation files in Obsidian

## Screenshots (if appropriate)

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/dcd46fcf-ef86-472e-a7de-ed0af16f8afb)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
