### PR TITLE
docs: Finish Line Continuation and Inline Comments docs

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -13,6 +13,7 @@ _In recent [releases](https://github.com/obsidian-tasks-group/obsidian-tasks/rel
     Move the older ones down to the top of the comment block below...
 -->
 
+- X.Y.X: 🔥 Add [[Line Continuations|line continuations]]
 - X.Y.X: 🔥 Document [[Comments#Inline comments|inline comments]]
 - X.Y.Z: 🔥 Add new Help pages [[Known Limitations]] and [[Breaking Changes]].
 

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -13,6 +13,7 @@ _In recent [releases](https://github.com/obsidian-tasks-group/obsidian-tasks/rel
     Move the older ones down to the top of the comment block below...
 -->
 
+- X.Y.X: 🔥 Document [[Comments#Inline comments|inline comments]]
 - X.Y.Z: 🔥 Add new Help pages [[Known Limitations]] and [[Breaking Changes]].
 
 <!--

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -13,7 +13,8 @@ _In recent [releases](https://github.com/obsidian-tasks-group/obsidian-tasks/rel
     Move the older ones down to the top of the comment block below...
 -->
 
-- X.Y.X: 🔥 Add [[Line Continuations|line continuations]]
+- X.Y.X: 🔥 Add [[Line Continuations|line continuations]].
+  - **Warning**: This is a [[Line Continuations#Appendix Updating pre-X.Y.Z searches with trailing backslashes|potentially breaking change]] if you search for backslash (`\`) characters.
 - X.Y.X: 🔥 Document [[Comments#Inline comments|inline comments]]
 - X.Y.Z: 🔥 Add new Help pages [[Known Limitations]] and [[Breaking Changes]].
 

--- a/docs/Queries/Combining Filters.md
+++ b/docs/Queries/Combining Filters.md
@@ -36,7 +36,7 @@ The following rules apply:
 - The operators are case-sensitive: they must be capitalised.
 - The operators must be surrounded by spaces.
 - Use more `(` and `)` to nest further filters together.
-- A trailing backslash may be used to break a long filter over several lines, as described in [[Line Continuations]].
+- A trailing backslash (`\`) may be used to break a long filter over several lines, as described in [[Line Continuations]].
 - There is no practical limit to the number of filters combined on each line, nor the level of nesting of parentheses.
 
 Recommendations:

--- a/docs/Queries/Comments.md
+++ b/docs/Queries/Comments.md
@@ -28,5 +28,7 @@ line:
     short mode {{! This comment will be ignored }}
     ```
 
+Such comments will be removed when Tasks processes [[Placeholders]] in the query.
+
 Any text between the `{{!` and `}}` of a line will be ignored. Multiline comments are
 not supported (except perhaps in combination with [[Line Continuations|line continuations]]).

--- a/docs/Queries/Comments.md
+++ b/docs/Queries/Comments.md
@@ -29,4 +29,4 @@ line:
     ```
 
 Any text between the `{{!` and `}}` of a line will be ignored. Multiline comments are
-not supported (except perhaps in combination with [line continuations](Line Continuations)).
+not supported (except perhaps in combination with [[Line Continuations|line continuations]]).

--- a/docs/Queries/Explaining Queries.md
+++ b/docs/Queries/Explaining Queries.md
@@ -211,6 +211,8 @@ path includes {{query.file.path}}
 root includes {{query.file.root}}
 folder includes {{query.file.folder}}
 filename includes {{query.file.filename}}
+
+description includes Some Cryptic String {{! Inline comments are removed before search }}
 ```
 <!-- endSnippet -->
 
@@ -227,6 +229,8 @@ root includes some/
 folder includes some/sample/
 
 filename includes file path.md
+
+description includes Some Cryptic String
 ```
 <!-- endSnippet -->
 

--- a/docs/Queries/Line Continuations.md
+++ b/docs/Queries/Line Continuations.md
@@ -5,7 +5,9 @@ publish: true
 # Line Continuations
 
 > [!released]
-> Introduced in Tasks X.Y.Z.
+>
+> - Introduced in Tasks X.Y.Z.
+> - **Important**: This facility changed the meaning of a final backslash (`\`) character on a query line. See [[#Appendix Updating pre-X.Y.Z searches with trailing backslashes]] below to update queries.
 
 ## Wrap long lines in queries
 
@@ -80,3 +82,18 @@ Points to note:
   - This is risky though, as some editors and linters remove unnecessary trailing spaces.
   - So the **two backslashes option is safer**.
 - If in doubt, add the `explain` instruction to inspect how your code block is interpreted.
+
+## Appendix: Updating pre-X.Y.Z searches with trailing backslashes
+
+> [!Warning]
+> In Tasks X.Y.Z the meaning of a **final backslash (`\`) character** on a query line changed **from**:
+>
+> - `search for a backslash character`
+>
+> **to:**
+>
+> - `join the next query line to this one`
+>
+> To retain the previous search behaviour, use `\\` at the end of query lines instead of `\`.
+>
+> For details, see [[Line Continuations#Searches needing a trailing backslash|Searches needing a trailing backslash]] in [[Line Continuations]].

--- a/docs/Queries/Line Continuations.md
+++ b/docs/Queries/Line Continuations.md
@@ -3,24 +3,80 @@ publish: true
 ---
 
 # Line Continuations
+
 > [!released]
 > Introduced in Tasks X.Y.Z.
 
-Long queries can be organized across multiple lines using a trailing backslash:
+## Wrap long lines in queries
 
-    ```tasks
-    (priority is highest) OR \
-        (priority is lowest)
-    ```
+In Tasks code blocks, **a backslash (`\`)** is a 'line continuation character'. If a backslash is placed at the end of a line, the line is considered to continue on the next line.
 
-This can be helpful for long [[Combining Filters|combined filters]],  [[Custom Filters|custom filters]], and other queries that may be difficult to read on one line.
+This is useful for dividing up long queries across multiple lines, for better readability.
 
-Line continuations are treated as whitespace, and any extra indentation or whitespace around the backslash is compressed into a single space.
+For example this query:
 
-In the rare case that a trailing backslash is needed for a query, the trailing backslash may be escaped by adding a space at the end of the line, or by adding an extra backslash:
+<!-- snippet: DocsSamplesForExplain.test.explain_line_continuation_-_single_slash.approved.query.text -->
+```text
+(priority is highest) OR       \
+    (priority is lowest)
+explain
+```
+<!-- endSnippet -->
 
-    ```tasks
-    # Searches for a single backslash
-    description includes \\
-    explain
-    ```
+... runs this search:
+
+<!-- snippet: DocsSamplesForExplain.test.explain_line_continuation_-_single_slash.approved.explanation.text -->
+```text
+Explanation of this Tasks code block query:
+
+(priority is highest) OR (priority is lowest) =>
+  OR (At least one of):
+    priority is highest
+    priority is lowest
+```
+<!-- endSnippet -->
+
+This facility will be helpful for long [[Combining Filters]], [[Custom Filters]], and [[Custom Grouping]] lines, and other queries that may be difficult to read on one line.
+
+There are some more realistic examples towards the end of the [[Grouping#Due Date|Due date custom grouping examples]].
+
+Points to note:
+
+- To be a continuation character, the `\` must be the **very last character** on the line.
+- All the `\` and all whitespace around it is compressed down to a single space.
+- Consider indenting the second and subsequent lines, so the structure of the query immediately clear.
+- Consider aligning the `\` characters for readability.
+- If in doubt, add the `explain` instruction to inspect how your code block is interpreted.
+
+## Searches needing a trailing backslash
+
+In Tasks code blocks, **two backslashes (`\\`) at the very end of a line** are treated as a **single backslash**.
+
+This enables searching in the rare case that a trailing backslash is needed for a query.
+
+For example this query:
+
+<!-- snippet: DocsSamplesForExplain.test.explain_line_continuation_-_double_slash.approved.query.text -->
+```text
+# Search for a single backslash:
+description includes \\
+explain
+```
+<!-- endSnippet -->
+
+... runs this search:
+
+<!-- snippet: DocsSamplesForExplain.test.explain_line_continuation_-_double_slash.approved.explanation.text -->
+```text
+Explanation of this Tasks code block query:
+
+description includes \
+```
+<!-- endSnippet -->
+
+Points to note:
+
+- Alternatively, you can add one or more spaces after the trailing `\` to prevent it being continuation character.
+  - This is risky though, as some editors and linters remove unnecessary trailing spaces.
+  - So the **two backslashes option is safer**.
+- If in doubt, add the `explain` instruction to inspect how your code block is interpreted.

--- a/docs/Queries/Line Continuations.md
+++ b/docs/Queries/Line Continuations.md
@@ -46,7 +46,7 @@ Points to note:
 
 - To be a continuation character, the `\` must be the **very last character** on the line.
 - All the `\` and all whitespace around it is compressed down to a single space.
-- Consider indenting the second and subsequent lines, so the structure of the query immediately clear.
+- Consider indenting the second and subsequent lines, so the structure of the query is immediately clear.
 - Consider aligning the `\` characters for readability.
 - If in doubt, add the `explain` instruction to inspect how your code block is interpreted.
 

--- a/docs/Scripting/Placeholders.md
+++ b/docs/Scripting/Placeholders.md
@@ -17,6 +17,7 @@ publish: true
   - `{{query.file.path}}` might get expanded to
   - `some/sample/actions on my hobby.md` - for any Tasks queries inside that file.
 - The available values for use in placeholders are listed in [[Query Properties]].
+- Placeholders also provide the ability to write [[Comments#Inline comments|Inline comments]].
 
 ## Checking placeholder values
 
@@ -31,6 +32,8 @@ path includes {{query.file.path}}
 root includes {{query.file.root}}
 folder includes {{query.file.folder}}
 filename includes {{query.file.filename}}
+
+description includes Some Cryptic String {{! Inline comments are removed before search }}
 ```
 <!-- endSnippet -->
 
@@ -47,6 +50,8 @@ root includes some/
 folder includes some/sample/
 
 filename includes file path.md
+
+description includes Some Cryptic String
 ```
 <!-- endSnippet -->
 

--- a/docs/Support and Help/Breaking Changes.md
+++ b/docs/Support and Help/Breaking Changes.md
@@ -23,3 +23,5 @@ To help users updating across multiple Tasks releases, we collect here links to 
   - For example, see comment mentioning `3.0.0` in the CSS sample in [[How to style backlinks#Using CSS to replace the backlinks with icons|Using CSS to replace the backlinks with icons]].
 - Tasks [4.0.0](https://github.com/obsidian-tasks-group/obsidian-tasks/releases/tag/4.0.0) (15 June 2023):
   - The order of `group by urgency` [[Grouping#Urgency|was reversed]].
+- Tasks [X.Y.Z](https://github.com/obsidian-tasks-group/obsidian-tasks/releases/tag/X.Y.Z) (October 2023):
+  - The meaning of final backslash (`\`) characters on query lines [[Line Continuations#Appendix Updating pre-X.Y.Z searches with trailing backslashes|has changed]].

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_line_continuation_-_double_slash.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_line_continuation_-_double_slash.approved.explanation.text
@@ -1,0 +1,3 @@
+Explanation of this Tasks code block query:
+
+description includes \

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_line_continuation_-_double_slash.approved.query.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_line_continuation_-_double_slash.approved.query.text
@@ -1,0 +1,4 @@
+
+# Search for a single backslash:
+description includes \\
+explain

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_line_continuation_-_single_slash.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_line_continuation_-_single_slash.approved.explanation.text
@@ -1,0 +1,6 @@
+Explanation of this Tasks code block query:
+
+(priority is highest) OR (priority is lowest) =>
+  OR (At least one of):
+    priority is highest
+    priority is lowest

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_line_continuation_-_single_slash.approved.query.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_line_continuation_-_single_slash.approved.query.text
@@ -1,0 +1,4 @@
+
+(priority is highest) OR       \
+    (priority is lowest)
+explain

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_placeholders.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_placeholders.approved.explanation.text
@@ -7,3 +7,5 @@ root includes some/
 folder includes some/sample/
 
 filename includes file path.md
+
+description includes Some Cryptic String 

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_placeholders.approved.query.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_placeholders.approved.query.text
@@ -4,3 +4,5 @@ path includes {{query.file.path}}
 root includes {{query.file.root}}
 folder includes {{query.file.folder}}
 filename includes {{query.file.filename}}
+
+description includes Some Cryptic String {{! Inline comments are removed before search }}

--- a/tests/Query/Explain/DocsSamplesForExplain.test.ts
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.ts
@@ -126,4 +126,30 @@ filename includes {{query.file.fileName}}`;
         verifyQuery(instructions); // This does not have an explain, so does not call checkExplainPresentAndVerify()
         verifyTaskBlockExplanation(instructions, new GlobalFilter(), new GlobalQuery());
     });
+
+    it('line continuation - single slash', () => {
+        // Arrange
+        const instructions: string = `
+(priority is highest) OR       \\
+    (priority is lowest)
+explain
+`;
+
+        // Act, Assert
+        checkExplainPresentAndVerify(instructions);
+        verifyTaskBlockExplanation(instructions, new GlobalFilter(), new GlobalQuery());
+    });
+
+    it('line continuation - double slash', () => {
+        // Arrange
+        const instructions: string = `
+# Search for a single backslash:
+description includes \\\\
+explain
+`;
+
+        // Act, Assert
+        checkExplainPresentAndVerify(instructions);
+        verifyTaskBlockExplanation(instructions, new GlobalFilter(), new GlobalQuery());
+    });
 });

--- a/tests/Query/Explain/DocsSamplesForExplain.test.ts
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.ts
@@ -105,7 +105,10 @@ explain
 path includes {{query.file.path}}
 root includes {{query.file.root}}
 folder includes {{query.file.folder}}
-filename includes {{query.file.filename}}`;
+filename includes {{query.file.filename}}
+
+description includes Some Cryptic String {{! Inline comments are removed before search }}
+`;
 
         // Act, Assert
         checkExplainPresentAndVerify(instructions);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Add more description with before-and-after samples
- Document that Line Continuation is a potentially breaking change

## Motivation and Context

Want to release it!

## How has this been tested?

- Editing and viewing the docs in Obsidian
- Most sample text has been generated by tests, so proven to work

## Screenshots (if appropriate)

Example finished section:

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/50a4646c-db86-412f-b13f-b288c22ac721)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
