### PR TITLE
docs: Colour the code in custom filter & group samples

### DIFF
--- a/contributing/Building/Developing with WebStorm.md
+++ b/contributing/Building/Developing with WebStorm.md
@@ -32,3 +32,11 @@ Tell it to ignore `main.js`:
 - After you have built the plugin, find `main.js` in the `Project` view
 - Right-click on it and select `Override File Type`
 - Select `Plain Text`
+
+## Stop WebStorm complaining about invalid JavaScript in markdown
+
+We have started using JavaScript as the fenced code block language for some documentation, as it makes the published documentation easier to read. The syntax highlighting breaks up an otherwise long wall of text.  
+
+If using WebStorm IDE, it will complain very strongly about invalid JavaScript, as the code samples include things like `group by function` and line continuation characters.
+
+So turn off this checking, follow the steps in [Disable coding assistance in code blocks](https://www.jetbrains.com/help/webstorm/markdown.html#disable-injection-in-code-blocks).

--- a/docs/Queries/Filters.md
+++ b/docs/Queries/Filters.md
@@ -293,13 +293,13 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by status** is now poss
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.other_properties_task.isDone_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.isDone
 ```
 
 - Same as the `done` filter, but might be useful in conjunction with other expressions on the same line.
 
-```text
+```javascript
 filter by function ! task.isDone
 ```
 
@@ -329,7 +329,7 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by status names** is no
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.statuses_task.status.name_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.status.name === 'Unknown'
 ```
 
@@ -357,20 +357,20 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by status type** is now
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.statuses_task.status.type_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.status.type === 'NON_TASK'
 ```
 
 - Find tasks of type `NON_TASK`.
 
-```text
+```javascript
 filter by function 'TODO,IN_PROGRESS'.includes(task.status.type)
 ```
 
 - Find tasks that are either type `TODO` or type `IN_PROGRESS`.
 - This can be more convenient than doing Boolean `OR` searches.
 
-```text
+```javascript
 filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type)
 ```
 
@@ -386,19 +386,19 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by status symbol** is n
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.statuses_task.status.symbol_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.status.symbol === '-'
 ```
 
 - Find tasks with a checkbox `[-]`, which is conventionally used to mean "cancelled".
 
-```text
+```javascript
 filter by function task.status.symbol !== ' '
 ```
 
 - Find tasks with anything but the space character as their status symbol, that is, without the checkbox `[ ]`.
 
-```text
+```javascript
 filter by function \
     const symbol = task.status.symbol; \
     return symbol === 'P' || symbol === 'C' || symbol === 'Q' || symbol === 'A';
@@ -408,14 +408,14 @@ filter by function \
 - Find tasks with status symbol `P`, `C`, `Q` or `A`.
 - This can get quite verbose, the more symbols you want to search for.
 
-```text
+```javascript
 filter by function 'PCQA'.includes(task.status.symbol)
 ```
 
 - Find tasks with status symbol `P`, `C`, `Q` or `A`.
 - This is a convenient shortcut over a longer statement testing each allowed value independently.
 
-```text
+```javascript
 filter by function !' -x/'.includes(task.status.symbol)
 ```
 
@@ -431,7 +431,7 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by next status symbol**
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.statuses_task.status.nextSymbol_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.status.symbol === task.status.nextSymbol
 ```
 
@@ -479,7 +479,7 @@ Some of these examples use the [moment.js format characters](https://momentjs.co
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.dates_task.due_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.due.format('dddd') === 'Tuesday'
 ```
 
@@ -492,7 +492,7 @@ For users who are comfortable with JavaScript, these more complicated examples m
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.dates_task.due.advanced_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false
 ```
 
@@ -501,19 +501,19 @@ filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false
 - As the second parameter determines the precision, and not just a single value to check, using 'day' will check for year, month and day.
 - See the documentation of [isSameOrBefore](https://momentjscom.readthedocs.io/en/latest/moment/05-query/04-is-same-or-before/).
 
-```text
+```javascript
 filter by function task.due.moment?.isSameOrAfter(moment(), 'day') || false
 ```
 
 - Due today or later.
 
-```text
+```javascript
 filter by function task.due.moment?.isSame(moment('2023-05-31'), 'day') || false
 ```
 
 - Find all tasks due on 31 May 2023.
 
-```text
+```javascript
 filter by function task.due.moment?.isSame(moment('2023-05-31'), 'week') || false
 ```
 
@@ -546,7 +546,7 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by done date** is now p
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.dates_task.done_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.done.format('dddd') === 'Thursday'
 ```
 
@@ -582,7 +582,7 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by scheduled date** is 
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.dates_task.scheduled_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.scheduled.format('dddd') === 'Wednesday'
 ```
 
@@ -618,7 +618,7 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by start date** is now 
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.dates_task.start_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.start.format('dddd') === 'Sunday'
 ```
 
@@ -684,7 +684,7 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by created date** is no
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.dates_task.created_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.created.format('dddd') === 'Monday'
 ```
 
@@ -724,7 +724,7 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by happens date** is no
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.dates_task.happens_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.happens.format('dddd') === 'Friday'
 ```
 
@@ -805,7 +805,7 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by description** is now
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.other_properties_task.description_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.description.length > 100
 ```
 
@@ -845,7 +845,7 @@ Using the priority name:
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.other_properties_task.priorityName_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.priorityName !== 'Normal'
 ```
 
@@ -857,7 +857,7 @@ Using the priority number:
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.other_properties_task.priorityNumber_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.priorityNumber % 2 === 0
 ```
 
@@ -893,7 +893,7 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by urgency** is now pos
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.other_properties_task.urgency_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.urgency > 8.9999
 ```
 
@@ -901,13 +901,13 @@ filter by function task.urgency > 8.9999
 - Note that limiting value used is `8.9999`.
 - Searches that compare two urgency values for 'less than' or 'more than' (using one of `>`, `>=`, `<` or `<=`) **must adjust their values slightly to allow for rounding**.
 
-```text
+```javascript
 filter by function task.urgency > 7.9999 && task.urgency < 11.0001
 ```
 
 - Find tasks with an urgency score between `8.0` and `11.0`, inclusive.
 
-```text
+```javascript
 filter by function task.urgency.toFixed(2) === 1.95.toFixed(2)
 ```
 
@@ -916,13 +916,13 @@ filter by function task.urgency.toFixed(2) === 1.95.toFixed(2)
 - The `.toFixed(2)` on both sides of the `===` ensures that two numbers being compared are both rounded to the same number of decimal places (2).
 - This is important, to prevent being tripped up `10.29` being not exactly the same when comparing non-integer numbers.
 
-```text
+```javascript
 filter by function task.urgency.toFixed(2) !== 1.95.toFixed(2)
 ```
 
 - Find tasks with any urgency other than the default score of `1.95`.
 
-```text
+```javascript
 filter by function task.urgency === 10.29
 ```
 
@@ -964,21 +964,21 @@ Using `task.isRecurring`:
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.other_properties_task.isRecurring_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.isRecurring
 ```
 
 - This is identical to `is recurring`.
 - It can be used with `&&` (Boolean AND) or `||` (Boolean OR) in conjunction with other conditions.
 
-```text
+```javascript
 filter by function !task.isRecurring
 ```
 
 - This is identical to `is not recurring`.
 - It can be used with `&&` (Boolean AND) or `||` (Boolean OR) in conjunction with other conditions.
 
-```text
+```javascript
 filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁')
 ```
 
@@ -993,25 +993,25 @@ Using `task.recurrenceRule` - please read [[Task Properties#Values for Other Tas
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.other_properties_task.recurrenceRule_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.recurrenceRule.includes("every week")
 ```
 
 - Similar to `recurrence includes every week`, but case-sensitive.
 
-```text
+```javascript
 filter by function !task.recurrenceRule.includes("every week")
 ```
 
 - Similar to `recurrence does not include every week`, but case-sensitive.
 
-```text
+```javascript
 filter by function task.recurrenceRule.includes("every week") && task.recurrenceRule.includes("when done")
 ```
 
 - Find tasks that are due every week, and **do** contain `when done` in their recurrence rule.
 
-```text
+```javascript
 filter by function task.recurrenceRule.includes("every week") && !task.recurrenceRule.includes("when done")
 ```
 
@@ -1056,13 +1056,13 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by tags** is now possib
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.other_properties_task.tags_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.tags.length === 1
 ```
 
 - Find tasks with exactly 1 tag (other than any global filter).
 
-```text
+```javascript
 filter by function task.tags.length > 1
 ```
 
@@ -1074,13 +1074,13 @@ These are more complicated examples, which you might like to copy if you use tas
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.other_properties_task.tags.advanced_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.tags.find( (tag) => tag.includes('/') ) && true || false
 ```
 
 - Find all tasks that have at least one nested tag.
 
-```text
+```javascript
 filter by function task.tags.find( (tag) => tag.split('/').length >= 3 ) && true || false
 ```
 
@@ -1139,13 +1139,13 @@ In Tasks 4.8.0 `task.file.pathWithoutExtension` was added.
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.file_properties_task.file.path_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.file.path.includes('tasks releases/4.1.0 Release.md')
 ```
 
 - Like 'path includes', except that it is **case-sensitive**: capitalisation matters.
 
-```text
+```javascript
 filter by function task.file.path === 'tasks releases/4.1.0 Release.md'
 ```
 
@@ -1153,7 +1153,7 @@ filter by function task.file.path === 'tasks releases/4.1.0 Release.md'
 - Note that the file extension needs to be included too.
 - With built-in searches, this could only be done using a regular expression, with special characters `^` and `$`, and escaping any characters with special meaning such as `/`.
 
-```text
+```javascript
 filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase()
 ```
 
@@ -1183,14 +1183,14 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by root folder** is now
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.file_properties_task.file.root_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.file.root === '/'
 ```
 
 - Find tasks in files in the root of the vault.
 - Note that this is **case-sensitive**: capitalisation matters.
 
-```text
+```javascript
 filter by function task.file.root === 'Work/'
 ```
 
@@ -1221,33 +1221,33 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by folder** is now poss
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.file_properties_task.file.folder_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.file.folder === "Work/Projects/"
 ```
 
 - Find tasks in files in any file in the given folder **only**, and not any sub-folders.
 - The equality test, `===`, requires that the trailing slash (`/`) be included.
 
-```text
+```javascript
 filter by function task.file.folder.includes("Work/Projects/")
 ```
 
 - Find tasks in files in a specific folder **and any sub-folders**.
 
-```text
+```javascript
 filter by function task.file.folder.includes( '{{query.file.folder}}' )
 ```
 
 - Find tasks in files in the folder that contains the query **and any sub-folders**.
 - Note that the placeholder text is expanded to a raw string, so needs to be inside quotes.
 
-```text
+```javascript
 filter by function task.file.folder === '{{query.file.folder}}'
 ```
 
 - Find tasks in files in the folder that contains the query only (**not tasks in any sub-folders**).
 
-```text
+```javascript
 filter by function task.file.folder.includes("Work/Projects")
 ```
 
@@ -1281,14 +1281,14 @@ In Tasks 4.8.0 `task.file.filenameWithoutExtension` was added.
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.file_properties_task.file.filename_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.file.filename === "4.1.0 Release.md"
 ```
 
 - Find tasks in files with the exact file name, but in any folder.
 - The equality test, `===`, requires that the file extension `.md` be included.
 
-```text
+```javascript
 filter by function task.file.filename.includes("4.1.0 Release")
 ```
 
@@ -1325,7 +1325,7 @@ Since Tasks 4.2.0, **[[Custom Filters|custom filtering]] by heading** is now pos
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.file_properties_task.heading_docs.approved.md -->
 
-```text
+```javascript
 filter by function \
     const taskDate = task.due.moment; \
     const wanted = '2023-06-11'; \
@@ -1337,7 +1337,7 @@ filter by function \
   - **or** do not have a due date, and their preceding heading contains the same date as a string: `2023-06-11`.
 - Note that because we use variables to avoid repetition of values, we need to add `return`.
 
-```text
+```javascript
 filter by function \
     const taskDate = task.due.moment; \
     const now = moment(); \
@@ -1348,7 +1348,7 @@ filter by function \
   - **either** due on today's date,
   - **or** do not have a due date, and their preceding heading contains today's date as a string, formatted as `YYYY-MM-DD`.
 
-```text
+```javascript
 filter by function \
     const wanted = '#context/home'; \
     return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;

--- a/docs/Queries/Grouping.md
+++ b/docs/Queries/Grouping.md
@@ -60,7 +60,7 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by status** is now poss
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.isDone_docs.approved.md -->
 
-```text
+```javascript
 group by function task.isDone ? "Action Required" : "Nothing To Do"
 ```
 
@@ -80,13 +80,13 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by status names** is no
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.statuses_task.status.name_docs.approved.md -->
 
-```text
+```javascript
 group by function task.status.name
 ```
 
 - Identical to "group by status.name".
 
-```text
+```javascript
 group by function task.status.name.toUpperCase()
 ```
 
@@ -114,13 +114,13 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by status types** is no
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.statuses_task.status.type_docs.approved.md -->
 
-```text
+```javascript
 group by function task.status.type
 ```
 
 - Unlike "group by status.type", this sorts the status types in alphabetical order.
 
-```text
+```javascript
 group by function task.status.typeGroupText
 ```
 
@@ -136,7 +136,7 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by status symbol** is n
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.statuses_task.status.symbol_docs.approved.md -->
 
-```text
+```javascript
 group by function "Status symbol: " + task.status.symbol.replace(" ", "space")
 ```
 
@@ -152,7 +152,7 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by next status symbol**
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.statuses_task.status.nextSymbol_docs.approved.md -->
 
-```text
+```javascript
 group by function "Next status symbol: " + task.status.nextSymbol.replace(" ", "space")
 ```
 
@@ -179,7 +179,7 @@ Some of these examples use the [moment.js format characters](https://momentjs.co
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.dates_task.due_docs.approved.md -->
 
-```text
+```javascript
 group by function task.due.category.groupText
 ```
 
@@ -187,7 +187,7 @@ group by function task.due.category.groupText
 - Try this on a line before `group by due` if there are a lot of due date headings, and you would like them to be broken down in to some kind of structure.
 - The values `task.due.category.name` and `task.due.category.sortOrder` are also available.
 
-```text
+```javascript
 group by function task.due.fromNow.groupText
 ```
 
@@ -195,19 +195,19 @@ group by function task.due.fromNow.groupText
 - It users an empty string (so no heading) if there is no due date.
 - The values `task.due.fromNow.name` and `task.due.fromNow.sortOrder` are also available.
 
-```text
+```javascript
 group by function task.due.format("YYYY-MM-DD dddd")
 ```
 
 - Like "group by due", except it uses no heading, instead of a heading "No due date", if there is no due date.
 
-```text
+```javascript
 group by function task.due.formatAsDate()
 ```
 
 - Format date as YYYY-MM-DD or empty string (so no heading) if there is no due date.
 
-```text
+```javascript
 group by function task.due.formatAsDateAndTime()
 ```
 
@@ -217,7 +217,7 @@ group by function task.due.formatAsDateAndTime()
   - Currently the Tasks plugin does not support storing of times.
   - Do not add times to your tasks, as it will break the reading of task data.
 
-```text
+```javascript
 group by function task.due.format("YYYY[%%]-MM[%%] MMM", "no due date")
 ```
 
@@ -227,7 +227,7 @@ group by function task.due.format("YYYY[%%]-MM[%%] MMM", "no due date")
 - The hidden month number is added, commented-out between two `%%` strings, to control the sort order of headings.
 - To escape characters in format strings, you can wrap the characters in square brackets (here, `[%%]`).
 
-```text
+```javascript
 group by function task.due.format("YYYY[%%]-MM[%%] MMM [- Week] WW")
 ```
 
@@ -241,21 +241,21 @@ DON'T PANIC! For users who are comfortable with JavaScript, these more complicat
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.dates_task.due.advanced_docs.approved.md -->
 
-```text
+```javascript
 group by function task.due.format("dddd")
 ```
 
 - Group by day of the week (Monday, Tuesday, etc).
 - The day names are sorted alphabetically.
 
-```text
+```javascript
 group by function task.due.format("[%%]d[%%]dddd")
 ```
 
 - Group by day of the week (Sunday, Monday, Tuesday, etc).
 - The day names are sorted in date order, starting with Sunday.
 
-```text
+```javascript
 group by function                                   \
     const date = task.due;                          \
     if (!date.moment) {                             \
@@ -275,7 +275,7 @@ group by function                                   \
 - To add comments, we can use `{{! ... }}`
 - To make the expression more readable, we put a `\` at the end of several lines, to continue the expression on the next line.
 
-```text
+```javascript
 group by function \
     const date = task.due.moment; \
     return \
@@ -290,7 +290,7 @@ group by function \
 - Try this on a line before `group by due` if there are a lot of due date headings, and you would like them to be broken down in to some kind of structure.
 - Note that because we use variables to avoid repetition of values, we need to add `return`
 
-```text
+```javascript
 group by function \
     const date = task.due.moment; \
     return \
@@ -303,7 +303,7 @@ group by function \
 - As above, but the headings `Overdue`, `Today`, `Future` and `Undated` are highlighted.
 - See the sample screenshot below.
 
-```text
+```javascript
 group by function \
     const date = task.due.moment; \
     const now = moment(); \
@@ -335,7 +335,7 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by done date** is now p
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.dates_task.done_docs.approved.md -->
 
-```text
+```javascript
 group by function task.done.format("YYYY-MM-DD dddd")
 ```
 
@@ -358,7 +358,7 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by scheduled date** is 
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.dates_task.scheduled_docs.approved.md -->
 
-```text
+```javascript
 group by function task.scheduled.format("YYYY-MM-DD dddd")
 ```
 
@@ -381,7 +381,7 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by start date** is now 
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.dates_task.start_docs.approved.md -->
 
-```text
+```javascript
 group by function task.start.format("YYYY-MM-DD dddd")
 ```
 
@@ -403,7 +403,7 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by created date** is no
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.dates_task.created_docs.approved.md -->
 
-```text
+```javascript
 group by function task.created.format("YYYY-MM-DD dddd")
 ```
 
@@ -425,7 +425,7 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by happens date** is no
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.dates_task.happens_docs.approved.md -->
 
-```text
+```javascript
 group by function task.happens.format("YYYY-MM-DD dddd")
 ```
 
@@ -447,26 +447,26 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by description** is now
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.description_docs.approved.md -->
 
-```text
+```javascript
 group by function task.description
 ```
 
 - group by description.
 - This might be useful for finding completed recurrences of the same task.
 
-```text
+```javascript
 group by function task.description.toUpperCase()
 ```
 
 - Convert the description to capitals.
 
-```text
+```javascript
 group by function task.description.slice(0, 25)
 ```
 
 - Truncate descriptions to at most their first 25 characters, and group by that string.
 
-```text
+```javascript
 group by function task.description.replace('short', '==short==')
 ```
 
@@ -482,7 +482,7 @@ The value `task.descriptionWithoutTags` returns a copy of the description with a
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.descriptionWithoutTags_docs.approved.md -->
 
-```text
+```javascript
 group by function task.descriptionWithoutTags
 ```
 
@@ -514,7 +514,7 @@ Using the priority name:
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.priorityName_docs.approved.md -->
 
-```text
+```javascript
 group by function task.priorityName
 ```
 
@@ -522,7 +522,7 @@ group by function task.priorityName
 - The priority names are displayed in alphabetical order.
 - Note that the default priority is called 'Normal', as opposed to with `group by priority` which calls the default 'None'.
 
-```text
+```javascript
 group by function task.priorityNameGroupText
 ```
 
@@ -536,7 +536,7 @@ Using the priority number:
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.priorityNumber_docs.approved.md -->
 
-```text
+```javascript
 group by function task.priorityNumber
 ```
 
@@ -559,7 +559,7 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by urgency** is now pos
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.urgency_docs.approved.md -->
 
-```text
+```javascript
 group by function task.urgency.toFixed(3)
 ```
 
@@ -583,7 +583,7 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by recurrence** is now 
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.isRecurring_docs.approved.md -->
 
-```text
+```javascript
 group by function task.isRecurring ? "Recurring" : "Non-Recurring"
 ```
 
@@ -593,7 +593,7 @@ group by function task.isRecurring ? "Recurring" : "Non-Recurring"
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.recurrenceRule_docs.approved.md -->
 
-```text
+```javascript
 group by function task.recurrenceRule.replace('when done', '==when done==')
 ```
 
@@ -616,32 +616,32 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by tags** is now possib
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.tags_docs.approved.md -->
 
-```text
+```javascript
 group by function task.tags
 ```
 
 - Like "group by tags" except that tasks with no tags have no heading instead of "(No tags)".
 
-```text
+```javascript
 group by function task.tags.join(", ")
 ```
 
 - Tasks with multiple tags are listed once, with a heading that combines all the tags.
 - Separating with commas means the tags are clickable in the headings.
 
-```text
+```javascript
 group by function task.tags.sort().join(", ")
 ```
 
 - As above, but sorting the tags first ensures that the final headings are independent of order of tags in the tasks.
 
-```text
+```javascript
 group by function task.tags.filter( (tag) => tag.includes("#context/") )
 ```
 
 - Only create headings for tags that contain "#context/".
 
-```text
+```javascript
 group by function task.tags.filter( (tag) => ! tag.includes("#tag") )
 ```
 
@@ -653,49 +653,49 @@ These are more complicated examples, which you might like to copy if you use tas
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.tags.advanced_docs.approved.md -->
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[0].replace('#', '') )
 ```
 
 - `#tag/subtag/sub-sub-tag` gives **`tag`**.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[1] ? tag.split('/').slice(1, 2) : '')
 ```
 
 - `#tag/subtag/sub-sub-tag` gives **`subtag`**.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[2] ? tag.split('/').slice(2, 3) : '')
 ```
 
 - `#tag/subtag/sub-sub-tag` gives **`sub-sub-tag`**.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[3] ? tag.split('/').slice(3, 4) : '')
 ```
 
 - `#tag/subtag/sub-sub-tag` gives no heading, as there is no value at the 4th level.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[0] )
 ```
 
 - `#tag/subtag/sub-sub-tag` gives **`#tag`**.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[1] ? tag.split('/').slice(0, 2).join('/') : '')
 ```
 
 - `#tag/subtag/sub-sub-tag` gives **`#tag/subtag`**.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[2] ? tag.split('/').slice(0, 3).join('/') : '')
 ```
 
 - `#tag/subtag/sub-sub-tag` gives **`#tag/subtag/sub-sub-tag`**.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[3] ? tag.split('/').slice(0, 4).join('/') : '')
 ```
 
@@ -713,7 +713,7 @@ For example, this could be used to extract information from `task.originalMarkdo
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.originalMarkdown_docs.approved.md -->
 
-```text
+```javascript
 group by function '``' + task.originalMarkdown + '``'
 ```
 
@@ -721,7 +721,7 @@ group by function '``' + task.originalMarkdown + '``'
 - Note the pairs of backtick characters ('`'), to preserve even single backtick characters in the task line.
 - It's important to prevent the task checkbox (for example, '[ ]') from being rendered in the heading, as it gets very confusing if there are checkboxes on both headings and tasks.
 
-```text
+```javascript
 group by function task.originalMarkdown.replace(/^[^\[\]]+\[.\] */, '')
 ```
 
@@ -740,13 +740,13 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by file path** is now p
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.file_properties_task.file.path_docs.approved.md -->
 
-```text
+```javascript
 group by function task.file.path
 ```
 
 - Like 'group by path' but includes the file extension.
 
-```text
+```javascript
 group by function task.file.path.replace('{{query.file.folder}}', '')
 ```
 
@@ -776,7 +776,7 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by root folder** is now
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.file_properties_task.file.root_docs.approved.md -->
 
-```text
+```javascript
 group by function task.file.root
 ```
 
@@ -798,13 +798,13 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by folder** is now poss
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.file_properties_task.file.folder_docs.approved.md -->
 
-```text
+```javascript
 group by function task.file.folder
 ```
 
 - Same as 'group by folder'.
 
-```text
+```javascript
 group by function task.file.folder.slice(0, -1).split('/').pop() + '/'
 ```
 
@@ -832,13 +832,13 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by file name** is now p
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.file_properties_task.file.filename_docs.approved.md -->
 
-```text
+```javascript
 group by function task.file.filename
 ```
 
 - Like 'group by filename' but does not link to the file.
 
-```text
+```javascript
 group by function task.file.filename.filenameWithoutExtension + (task.hasHeading ? (' > ' + task.heading) : '')
 ```
 
@@ -866,7 +866,7 @@ Since Tasks 4.0.0, **[[Custom Grouping|custom grouping]] by heading** is now pos
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.file_properties_task.heading_docs.approved.md -->
 
-```text
+```javascript
 group by function (task.heading + '.md' === task.file.filename) ? '' : task.heading
 ```
 

--- a/docs/Scripting/Custom Filters.md
+++ b/docs/Scripting/Custom Filters.md
@@ -71,7 +71,7 @@ You can find many more examples by searching for `filter by function` in the [[F
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.other_properties_task.description_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.description.length > 100
 ```
 
@@ -83,7 +83,7 @@ filter by function task.description.length > 100
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.dates_task.due_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.due.format('dddd') === 'Tuesday'
 ```
 
@@ -96,7 +96,7 @@ For users who are comfortable with JavaScript, these more complicated examples m
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.dates_task.due.advanced_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false
 ```
 
@@ -105,19 +105,19 @@ filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false
 - As the second parameter determines the precision, and not just a single value to check, using 'day' will check for year, month and day.
 - See the documentation of [isSameOrBefore](https://momentjscom.readthedocs.io/en/latest/moment/05-query/04-is-same-or-before/).
 
-```text
+```javascript
 filter by function task.due.moment?.isSameOrAfter(moment(), 'day') || false
 ```
 
 - Due today or later.
 
-```text
+```javascript
 filter by function task.due.moment?.isSame(moment('2023-05-31'), 'day') || false
 ```
 
 - Find all tasks due on 31 May 2023.
 
-```text
+```javascript
 filter by function task.due.moment?.isSame(moment('2023-05-31'), 'week') || false
 ```
 
@@ -129,7 +129,7 @@ filter by function task.due.moment?.isSame(moment('2023-05-31'), 'week') || fals
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.other_properties_task.urgency_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.urgency > 8.9999
 ```
 
@@ -137,13 +137,13 @@ filter by function task.urgency > 8.9999
 - Note that limiting value used is `8.9999`.
 - Searches that compare two urgency values for 'less than' or 'more than' (using one of `>`, `>=`, `<` or `<=`) **must adjust their values slightly to allow for rounding**.
 
-```text
+```javascript
 filter by function task.urgency > 7.9999 && task.urgency < 11.0001
 ```
 
 - Find tasks with an urgency score between `8.0` and `11.0`, inclusive.
 
-```text
+```javascript
 filter by function task.urgency.toFixed(2) === 1.95.toFixed(2)
 ```
 
@@ -152,13 +152,13 @@ filter by function task.urgency.toFixed(2) === 1.95.toFixed(2)
 - The `.toFixed(2)` on both sides of the `===` ensures that two numbers being compared are both rounded to the same number of decimal places (2).
 - This is important, to prevent being tripped up `10.29` being not exactly the same when comparing non-integer numbers.
 
-```text
+```javascript
 filter by function task.urgency.toFixed(2) !== 1.95.toFixed(2)
 ```
 
 - Find tasks with any urgency other than the default score of `1.95`.
 
-```text
+```javascript
 filter by function task.urgency === 10.29
 ```
 
@@ -181,33 +181,33 @@ filter by function task.urgency === 10.29
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomFilteringExamples.test.file_properties_task.file.folder_docs.approved.md -->
 
-```text
+```javascript
 filter by function task.file.folder === "Work/Projects/"
 ```
 
 - Find tasks in files in any file in the given folder **only**, and not any sub-folders.
 - The equality test, `===`, requires that the trailing slash (`/`) be included.
 
-```text
+```javascript
 filter by function task.file.folder.includes("Work/Projects/")
 ```
 
 - Find tasks in files in a specific folder **and any sub-folders**.
 
-```text
+```javascript
 filter by function task.file.folder.includes( '{{query.file.folder}}' )
 ```
 
 - Find tasks in files in the folder that contains the query **and any sub-folders**.
 - Note that the placeholder text is expanded to a raw string, so needs to be inside quotes.
 
-```text
+```javascript
 filter by function task.file.folder === '{{query.file.folder}}'
 ```
 
 - Find tasks in files in the folder that contains the query only (**not tasks in any sub-folders**).
 
-```text
+```javascript
 filter by function task.file.folder.includes("Work/Projects")
 ```
 

--- a/docs/Scripting/Custom Grouping.md
+++ b/docs/Scripting/Custom Grouping.md
@@ -77,7 +77,7 @@ The `expression` must:
 > [!warning]
 > The strings returned are rendered as-is. This means, for example, that if the text you return has underscores in (`_`) that are not meant to indicate italics, you should escape them with backslashes ('\_') like this:
 >
-> ```text
+> ```javascript
 > group by function task.description.replaceAll('_', '\\_')
 >```
 
@@ -91,26 +91,26 @@ You can find many more examples by searching for `group by function` in the [[Gr
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.description_docs.approved.md -->
 
-```text
+```javascript
 group by function task.description
 ```
 
 - group by description.
 - This might be useful for finding completed recurrences of the same task.
 
-```text
+```javascript
 group by function task.description.toUpperCase()
 ```
 
 - Convert the description to capitals.
 
-```text
+```javascript
 group by function task.description.slice(0, 25)
 ```
 
 - Truncate descriptions to at most their first 25 characters, and group by that string.
 
-```text
+```javascript
 group by function task.description.replace('short', '==short==')
 ```
 
@@ -122,7 +122,7 @@ group by function task.description.replace('short', '==short==')
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.dates_task.due_docs.approved.md -->
 
-```text
+```javascript
 group by function task.due.category.groupText
 ```
 
@@ -130,7 +130,7 @@ group by function task.due.category.groupText
 - Try this on a line before `group by due` if there are a lot of due date headings, and you would like them to be broken down in to some kind of structure.
 - The values `task.due.category.name` and `task.due.category.sortOrder` are also available.
 
-```text
+```javascript
 group by function task.due.fromNow.groupText
 ```
 
@@ -138,19 +138,19 @@ group by function task.due.fromNow.groupText
 - It users an empty string (so no heading) if there is no due date.
 - The values `task.due.fromNow.name` and `task.due.fromNow.sortOrder` are also available.
 
-```text
+```javascript
 group by function task.due.format("YYYY-MM-DD dddd")
 ```
 
 - Like "group by due", except it uses no heading, instead of a heading "No due date", if there is no due date.
 
-```text
+```javascript
 group by function task.due.formatAsDate()
 ```
 
 - Format date as YYYY-MM-DD or empty string (so no heading) if there is no due date.
 
-```text
+```javascript
 group by function task.due.formatAsDateAndTime()
 ```
 
@@ -160,7 +160,7 @@ group by function task.due.formatAsDateAndTime()
   - Currently the Tasks plugin does not support storing of times.
   - Do not add times to your tasks, as it will break the reading of task data.
 
-```text
+```javascript
 group by function task.due.format("YYYY[%%]-MM[%%] MMM", "no due date")
 ```
 
@@ -170,7 +170,7 @@ group by function task.due.format("YYYY[%%]-MM[%%] MMM", "no due date")
 - The hidden month number is added, commented-out between two `%%` strings, to control the sort order of headings.
 - To escape characters in format strings, you can wrap the characters in square brackets (here, `[%%]`).
 
-```text
+```javascript
 group by function task.due.format("YYYY[%%]-MM[%%] MMM [- Week] WW")
 ```
 
@@ -186,7 +186,7 @@ There are many more date examples in [[Grouping#Due Date]].
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.other_properties_task.urgency_docs.approved.md -->
 
-```text
+```javascript
 group by function task.urgency.toFixed(3)
 ```
 
@@ -198,13 +198,13 @@ group by function task.urgency.toFixed(3)
 
 <!-- placeholder to force blank line before included text --><!-- include: CustomGroupingExamples.test.file_properties_task.file.folder_docs.approved.md -->
 
-```text
+```javascript
 group by function task.file.folder
 ```
 
 - Same as 'group by folder'.
 
-```text
+```javascript
 group by function task.file.folder.slice(0, -1).split('/').pop() + '/'
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.created_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.created_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.created.format('dddd') === 'Monday'
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.done_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.done_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.done.format('dddd') === 'Thursday'
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.due.advanced_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.due.advanced_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false
 ```
 
@@ -10,19 +10,19 @@ filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false
 - As the second parameter determines the precision, and not just a single value to check, using 'day' will check for year, month and day.
 - See the documentation of [isSameOrBefore](https://momentjscom.readthedocs.io/en/latest/moment/05-query/04-is-same-or-before/).
 
-```text
+```javascript
 filter by function task.due.moment?.isSameOrAfter(moment(), 'day') || false
 ```
 
 - Due today or later.
 
-```text
+```javascript
 filter by function task.due.moment?.isSame(moment('2023-05-31'), 'day') || false
 ```
 
 - Find all tasks due on 31 May 2023.
 
-```text
+```javascript
 filter by function task.due.moment?.isSame(moment('2023-05-31'), 'week') || false
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.due_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.due_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.due.format('dddd') === 'Tuesday'
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.happens_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.happens_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.happens.format('dddd') === 'Friday'
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.scheduled_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.scheduled_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.scheduled.format('dddd') === 'Wednesday'
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.start_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.dates_task.start_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.start.format('dddd') === 'Sunday'
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.file.filename_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.file.filename_docs.approved.md
@@ -1,14 +1,14 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.file.filename === "4.1.0 Release.md"
 ```
 
 - Find tasks in files with the exact file name, but in any folder.
 - The equality test, `===`, requires that the file extension `.md` be included.
 
-```text
+```javascript
 filter by function task.file.filename.includes("4.1.0 Release")
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.file.folder_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.file.folder_docs.approved.md
@@ -1,33 +1,33 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.file.folder === "Work/Projects/"
 ```
 
 - Find tasks in files in any file in the given folder **only**, and not any sub-folders.
 - The equality test, `===`, requires that the trailing slash (`/`) be included.
 
-```text
+```javascript
 filter by function task.file.folder.includes("Work/Projects/")
 ```
 
 - Find tasks in files in a specific folder **and any sub-folders**.
 
-```text
+```javascript
 filter by function task.file.folder.includes( '{{query.file.folder}}' )
 ```
 
 - Find tasks in files in the folder that contains the query **and any sub-folders**.
 - Note that the placeholder text is expanded to a raw string, so needs to be inside quotes.
 
-```text
+```javascript
 filter by function task.file.folder === '{{query.file.folder}}'
 ```
 
 - Find tasks in files in the folder that contains the query only (**not tasks in any sub-folders**).
 
-```text
+```javascript
 filter by function task.file.folder.includes("Work/Projects")
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.file.path_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.file.path_docs.approved.md
@@ -1,13 +1,13 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.file.path.includes('tasks releases/4.1.0 Release.md')
 ```
 
 - Like 'path includes', except that it is **case-sensitive**: capitalisation matters.
 
-```text
+```javascript
 filter by function task.file.path === 'tasks releases/4.1.0 Release.md'
 ```
 
@@ -15,7 +15,7 @@ filter by function task.file.path === 'tasks releases/4.1.0 Release.md'
 - Note that the file extension needs to be included too.
 - With built-in searches, this could only be done using a regular expression, with special characters `^` and `$`, and escaping any characters with special meaning such as `/`.
 
-```text
+```javascript
 filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase()
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.file.root_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.file.root_docs.approved.md
@@ -1,14 +1,14 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.file.root === '/'
 ```
 
 - Find tasks in files in the root of the vault.
 - Note that this is **case-sensitive**: capitalisation matters.
 
-```text
+```javascript
 filter by function task.file.root === 'Work/'
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.heading_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.heading_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function \
     const taskDate = task.due.moment; \
     const wanted = '2023-06-11'; \
@@ -13,7 +13,7 @@ filter by function \
   - **or** do not have a due date, and their preceding heading contains the same date as a string: `2023-06-11`.
 - Note that because we use variables to avoid repetition of values, we need to add `return`.
 
-```text
+```javascript
 filter by function \
     const taskDate = task.due.moment; \
     const now = moment(); \
@@ -24,7 +24,7 @@ filter by function \
   - **either** due on today's date,
   - **or** do not have a due date, and their preceding heading contains today's date as a string, formatted as `YYYY-MM-DD`.
 
-```text
+```javascript
 filter by function \
     const wanted = '#context/home'; \
     return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.description_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.description_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.description.length > 100
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.isDone_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.isDone_docs.approved.md
@@ -1,13 +1,13 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.isDone
 ```
 
 - Same as the `done` filter, but might be useful in conjunction with other expressions on the same line.
 
-```text
+```javascript
 filter by function ! task.isDone
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.isRecurring_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.isRecurring_docs.approved.md
@@ -1,21 +1,21 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.isRecurring
 ```
 
 - This is identical to `is recurring`.
 - It can be used with `&&` (Boolean AND) or `||` (Boolean OR) in conjunction with other conditions.
 
-```text
+```javascript
 filter by function !task.isRecurring
 ```
 
 - This is identical to `is not recurring`.
 - It can be used with `&&` (Boolean AND) or `||` (Boolean OR) in conjunction with other conditions.
 
-```text
+```javascript
 filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁')
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.priorityName_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.priorityName_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.priorityName !== 'Normal'
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.priorityNumber_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.priorityNumber_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.priorityNumber % 2 === 0
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.recurrenceRule_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.recurrenceRule_docs.approved.md
@@ -1,25 +1,25 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.recurrenceRule.includes("every week")
 ```
 
 - Similar to `recurrence includes every week`, but case-sensitive.
 
-```text
+```javascript
 filter by function !task.recurrenceRule.includes("every week")
 ```
 
 - Similar to `recurrence does not include every week`, but case-sensitive.
 
-```text
+```javascript
 filter by function task.recurrenceRule.includes("every week") && task.recurrenceRule.includes("when done")
 ```
 
 - Find tasks that are due every week, and **do** contain `when done` in their recurrence rule.
 
-```text
+```javascript
 filter by function task.recurrenceRule.includes("every week") && !task.recurrenceRule.includes("when done")
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.tags.advanced_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.tags.advanced_docs.approved.md
@@ -1,13 +1,13 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.tags.find( (tag) => tag.includes('/') ) && true || false
 ```
 
 - Find all tasks that have at least one nested tag.
 
-```text
+```javascript
 filter by function task.tags.find( (tag) => tag.split('/').length >= 3 ) && true || false
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.tags_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.tags_docs.approved.md
@@ -1,13 +1,13 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.tags.length === 1
 ```
 
 - Find tasks with exactly 1 tag (other than any global filter).
 
-```text
+```javascript
 filter by function task.tags.length > 1
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.urgency_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.other_properties_task.urgency_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.urgency > 8.9999
 ```
 
@@ -9,13 +9,13 @@ filter by function task.urgency > 8.9999
 - Note that limiting value used is `8.9999`.
 - Searches that compare two urgency values for 'less than' or 'more than' (using one of `>`, `>=`, `<` or `<=`) **must adjust their values slightly to allow for rounding**.
 
-```text
+```javascript
 filter by function task.urgency > 7.9999 && task.urgency < 11.0001
 ```
 
 - Find tasks with an urgency score between `8.0` and `11.0`, inclusive.
 
-```text
+```javascript
 filter by function task.urgency.toFixed(2) === 1.95.toFixed(2)
 ```
 
@@ -24,13 +24,13 @@ filter by function task.urgency.toFixed(2) === 1.95.toFixed(2)
 - The `.toFixed(2)` on both sides of the `===` ensures that two numbers being compared are both rounded to the same number of decimal places (2).
 - This is important, to prevent being tripped up `10.29` being not exactly the same when comparing non-integer numbers.
 
-```text
+```javascript
 filter by function task.urgency.toFixed(2) !== 1.95.toFixed(2)
 ```
 
 - Find tasks with any urgency other than the default score of `1.95`.
 
-```text
+```javascript
 filter by function task.urgency === 10.29
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.statuses_task.status.name_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.statuses_task.status.name_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.status.name === 'Unknown'
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.statuses_task.status.nextSymbol_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.statuses_task.status.nextSymbol_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.status.symbol === task.status.nextSymbol
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.statuses_task.status.symbol_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.statuses_task.status.symbol_docs.approved.md
@@ -1,19 +1,19 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.status.symbol === '-'
 ```
 
 - Find tasks with a checkbox `[-]`, which is conventionally used to mean "cancelled".
 
-```text
+```javascript
 filter by function task.status.symbol !== ' '
 ```
 
 - Find tasks with anything but the space character as their status symbol, that is, without the checkbox `[ ]`.
 
-```text
+```javascript
 filter by function \
     const symbol = task.status.symbol; \
     return symbol === 'P' || symbol === 'C' || symbol === 'Q' || symbol === 'A';
@@ -23,14 +23,14 @@ filter by function \
 - Find tasks with status symbol `P`, `C`, `Q` or `A`.
 - This can get quite verbose, the more symbols you want to search for.
 
-```text
+```javascript
 filter by function 'PCQA'.includes(task.status.symbol)
 ```
 
 - Find tasks with status symbol `P`, `C`, `Q` or `A`.
 - This is a convenient shortcut over a longer statement testing each allowed value independently.
 
-```text
+```javascript
 filter by function !' -x/'.includes(task.status.symbol)
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.statuses_task.status.type_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.statuses_task.status.type_docs.approved.md
@@ -1,20 +1,20 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 filter by function task.status.type === 'NON_TASK'
 ```
 
 - Find tasks of type `NON_TASK`.
 
-```text
+```javascript
 filter by function 'TODO,IN_PROGRESS'.includes(task.status.type)
 ```
 
 - Find tasks that are either type `TODO` or type `IN_PROGRESS`.
 - This can be more convenient than doing Boolean `OR` searches.
 
-```text
+```javascript
 filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type)
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.created_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.created_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.created.format("YYYY-MM-DD dddd")
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.done_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.done_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.done.format("YYYY-MM-DD dddd")
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.due.advanced_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.due.advanced_docs.approved.md
@@ -1,21 +1,21 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.due.format("dddd")
 ```
 
 - Group by day of the week (Monday, Tuesday, etc).
 - The day names are sorted alphabetically.
 
-```text
+```javascript
 group by function task.due.format("[%%]d[%%]dddd")
 ```
 
 - Group by day of the week (Sunday, Monday, Tuesday, etc).
 - The day names are sorted in date order, starting with Sunday.
 
-```text
+```javascript
 group by function                                   \
     const date = task.due;                          \
     if (!date.moment) {                             \
@@ -35,7 +35,7 @@ group by function                                   \
 - To add comments, we can use `{{! ... }}`
 - To make the expression more readable, we put a `\` at the end of several lines, to continue the expression on the next line.
 
-```text
+```javascript
 group by function \
     const date = task.due.moment; \
     return \
@@ -50,7 +50,7 @@ group by function \
 - Try this on a line before `group by due` if there are a lot of due date headings, and you would like them to be broken down in to some kind of structure.
 - Note that because we use variables to avoid repetition of values, we need to add `return`
 
-```text
+```javascript
 group by function \
     const date = task.due.moment; \
     return \
@@ -63,7 +63,7 @@ group by function \
 - As above, but the headings `Overdue`, `Today`, `Future` and `Undated` are highlighted.
 - See the sample screenshot below.
 
-```text
+```javascript
 group by function \
     const date = task.due.moment; \
     const now = moment(); \

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.due_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.due_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.due.category.groupText
 ```
 
@@ -9,7 +9,7 @@ group by function task.due.category.groupText
 - Try this on a line before `group by due` if there are a lot of due date headings, and you would like them to be broken down in to some kind of structure.
 - The values `task.due.category.name` and `task.due.category.sortOrder` are also available.
 
-```text
+```javascript
 group by function task.due.fromNow.groupText
 ```
 
@@ -17,19 +17,19 @@ group by function task.due.fromNow.groupText
 - It users an empty string (so no heading) if there is no due date.
 - The values `task.due.fromNow.name` and `task.due.fromNow.sortOrder` are also available.
 
-```text
+```javascript
 group by function task.due.format("YYYY-MM-DD dddd")
 ```
 
 - Like "group by due", except it uses no heading, instead of a heading "No due date", if there is no due date.
 
-```text
+```javascript
 group by function task.due.formatAsDate()
 ```
 
 - Format date as YYYY-MM-DD or empty string (so no heading) if there is no due date.
 
-```text
+```javascript
 group by function task.due.formatAsDateAndTime()
 ```
 
@@ -39,7 +39,7 @@ group by function task.due.formatAsDateAndTime()
     - Currently the Tasks plugin does not support storing of times.
     - Do not add times to your tasks, as it will break the reading of task data.
 
-```text
+```javascript
 group by function task.due.format("YYYY[%%]-MM[%%] MMM", "no due date")
 ```
 
@@ -49,7 +49,7 @@ group by function task.due.format("YYYY[%%]-MM[%%] MMM", "no due date")
 - The hidden month number is added, commented-out between two `%%` strings, to control the sort order of headings.
 - To escape characters in format strings, you can wrap the characters in square brackets (here, `[%%]`).
 
-```text
+```javascript
 group by function task.due.format("YYYY[%%]-MM[%%] MMM [- Week] WW")
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.happens_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.happens_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.happens.format("YYYY-MM-DD dddd")
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.scheduled_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.scheduled_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.scheduled.format("YYYY-MM-DD dddd")
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.start_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.dates_task.start_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.start.format("YYYY-MM-DD dddd")
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.file_properties_task.file.filename_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.file_properties_task.file.filename_docs.approved.md
@@ -1,13 +1,13 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.file.filename
 ```
 
 - Like 'group by filename' but does not link to the file.
 
-```text
+```javascript
 group by function task.file.filename.filenameWithoutExtension + (task.hasHeading ? (' > ' + task.heading) : '')
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.file_properties_task.file.folder_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.file_properties_task.file.folder_docs.approved.md
@@ -1,13 +1,13 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.file.folder
 ```
 
 - Same as 'group by folder'.
 
-```text
+```javascript
 group by function task.file.folder.slice(0, -1).split('/').pop() + '/'
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.file_properties_task.file.path_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.file_properties_task.file.path_docs.approved.md
@@ -1,13 +1,13 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.file.path
 ```
 
 - Like 'group by path' but includes the file extension.
 
-```text
+```javascript
 group by function task.file.path.replace('{{query.file.folder}}', '')
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.file_properties_task.file.root_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.file_properties_task.file.root_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.file.root
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.file_properties_task.heading_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.file_properties_task.heading_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function (task.heading + '.md' === task.file.filename) ? '' : task.heading
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.blockLink_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.blockLink_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.blockLink.replace(' ^', '')
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.descriptionWithoutTags_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.descriptionWithoutTags_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.descriptionWithoutTags
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.description_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.description_docs.approved.md
@@ -1,26 +1,26 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.description
 ```
 
 - group by description.
 - This might be useful for finding completed recurrences of the same task.
 
-```text
+```javascript
 group by function task.description.toUpperCase()
 ```
 
 - Convert the description to capitals.
 
-```text
+```javascript
 group by function task.description.slice(0, 25)
 ```
 
 - Truncate descriptions to at most their first 25 characters, and group by that string.
 
-```text
+```javascript
 group by function task.description.replace('short', '==short==')
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.isDone_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.isDone_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.isDone ? "Action Required" : "Nothing To Do"
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.isRecurring_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.isRecurring_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.isRecurring ? "Recurring" : "Non-Recurring"
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.originalMarkdown_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.originalMarkdown_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function '``' + task.originalMarkdown + '``'
 ```
 
@@ -9,7 +9,7 @@ group by function '``' + task.originalMarkdown + '``'
 - Note the pairs of backtick characters ('`'), to preserve even single backtick characters in the task line.
 - It's important to prevent the task checkbox (for example, '[ ]') from being rendered in the heading, as it gets very confusing if there are checkboxes on both headings and tasks.
 
-```text
+```javascript
 group by function task.originalMarkdown.replace(/^[^\[\]]+\[.\] */, '')
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.priorityName_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.priorityName_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.priorityName
 ```
 
@@ -9,7 +9,7 @@ group by function task.priorityName
 - The priority names are displayed in alphabetical order.
 - Note that the default priority is called 'Normal', as opposed to with `group by priority` which calls the default 'None'.
 
-```text
+```javascript
 group by function task.priorityNameGroupText
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.priorityNumber_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.priorityNumber_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.priorityNumber
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.recurrenceRule_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.recurrenceRule_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.recurrenceRule.replace('when done', '==when done==')
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.tags.advanced_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.tags.advanced_docs.approved.md
@@ -1,49 +1,49 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[0].replace('#', '') )
 ```
 
 - `#tag/subtag/sub-sub-tag` gives **`tag`**.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[1] ? tag.split('/').slice(1, 2) : '')
 ```
 
 - `#tag/subtag/sub-sub-tag` gives **`subtag`**.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[2] ? tag.split('/').slice(2, 3) : '')
 ```
 
 - `#tag/subtag/sub-sub-tag` gives **`sub-sub-tag`**.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[3] ? tag.split('/').slice(3, 4) : '')
 ```
 
 - `#tag/subtag/sub-sub-tag` gives no heading, as there is no value at the 4th level.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[0] )
 ```
 
 - `#tag/subtag/sub-sub-tag` gives **`#tag`**.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[1] ? tag.split('/').slice(0, 2).join('/') : '')
 ```
 
 - `#tag/subtag/sub-sub-tag` gives **`#tag/subtag`**.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[2] ? tag.split('/').slice(0, 3).join('/') : '')
 ```
 
 - `#tag/subtag/sub-sub-tag` gives **`#tag/subtag/sub-sub-tag`**.
 
-```text
+```javascript
 group by function task.tags.map( (tag) => tag.split('/')[3] ? tag.split('/').slice(0, 4).join('/') : '')
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.tags_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.tags_docs.approved.md
@@ -1,32 +1,32 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.tags
 ```
 
 - Like "group by tags" except that tasks with no tags have no heading instead of "(No tags)".
 
-```text
+```javascript
 group by function task.tags.join(", ")
 ```
 
 - Tasks with multiple tags are listed once, with a heading that combines all the tags.
 - Separating with commas means the tags are clickable in the headings.
 
-```text
+```javascript
 group by function task.tags.sort().join(", ")
 ```
 
 - As above, but sorting the tags first ensures that the final headings are independent of order of tags in the tasks.
 
-```text
+```javascript
 group by function task.tags.filter( (tag) => tag.includes("#context/") )
 ```
 
 - Only create headings for tags that contain "#context/".
 
-```text
+```javascript
 group by function task.tags.filter( (tag) => ! tag.includes("#tag") )
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.urgency_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.urgency_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.urgency.toFixed(3)
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.special_cases_formatting_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.special_cases_formatting_docs.approved.md
@@ -1,13 +1,13 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.due.format("YYYY %%MM%% MMMM [<mark style='background: var(--color-base-00); color: var(--color-base-40)'>- Week</mark>] WW", "Undated")
 ```
 
 - Show Year then Month, and then week number. Draw the fixed text paler, to de-emphasize it.
 
-```text
+```javascript
 group by function task.due.format("[%%]YYYY-MM-DD[%%]dddd [<mark style='background: var(--color-base-00); color: var(--color-base-40);'>](YYYY-MM-DD)[</mark>]")
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.statuses_task.status.name_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.statuses_task.status.name_docs.approved.md
@@ -1,13 +1,13 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.status.name
 ```
 
 - Identical to "group by status.name".
 
-```text
+```javascript
 group by function task.status.name.toUpperCase()
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.statuses_task.status.nextSymbol_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.statuses_task.status.nextSymbol_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function "Next status symbol: " + task.status.nextSymbol.replace(" ", "space")
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.statuses_task.status.symbol_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.statuses_task.status.symbol_docs.approved.md
@@ -1,7 +1,7 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function "Status symbol: " + task.status.symbol.replace(" ", "space")
 ```
 

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.statuses_task.status.type_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.statuses_task.status.type_docs.approved.md
@@ -1,13 +1,13 @@
 <!-- placeholder to force blank line before included text -->
 
 
-```text
+```javascript
 group by function task.status.type
 ```
 
 - Unlike "group by status.type", this sorts the status types in alphabetical order.
 
-```text
+```javascript
 group by function task.status.typeGroupText
 ```
 

--- a/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
+++ b/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
@@ -52,8 +52,16 @@ function formatQueryAndCommentsForDocs(filters: QueryInstructionLineAndDescripti
             const instruction = filter[0];
             const comments = filter.slice(1);
             const punctuatedComments: string[] = punctuateComments(comments);
+
+            // Using javascript as the fenced code block language makes the
+            // published documentation easier to read, as the syntax highlighting
+            // breaks up an otherwise long wall of text.
+            // If using WebStorm IDE, it will complain about invalid JavaScript.
+            // Turn off checking: https://www.jetbrains.com/help/webstorm/markdown.html#disable-injection-in-code-blocks
+            const language = 'javascript';
+
             markdown += `
-\`\`\`text
+\`\`\`${language}
 ${instruction}
 \`\`\`
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Tell Obsidian to render `group by function` and `filter by function` examples as JavaScript language, which means that symbols are colour-coded.

The patterns in the colours make the samples much easier to read.

See a new section in the Contributing Guide page [Developing with JetBrains WebStorm](https://publish.obsidian.md/tasks-contributing/Building/Developing+with+WebStorm) for how to stop WebStorm complaining because the samples are not strictly valid JS code.

## Motivation and Context

Try to make the samples easier to read at a glance - and make the structure of the longer ones easier to see.

## How has this been tested?

By viewing the updated docs in Obsidian.

## Screenshots (if appropriate)

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/244d7386-37c2-487a-bba3-ff2616092371)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [x] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
