### PR TITLE
docs: Add Recurring Tasks's 'Known Issues' to 'Known Limitations

### DIFF
--- a/docs/Getting Started/Recurring Tasks.md
+++ b/docs/Getting Started/Recurring Tasks.md
@@ -43,7 +43,7 @@ Alternatively, if you have enabled addition of [[Dates#Created date|created date
 - [x] take out the trash 🔁 every Sunday 📅 2021-04-25 ✅ 2023-03-10
 ```
 
-## Order of the new task
+### Order of the new task
 
 Use this setting to control where the recurring task is inserted. The default is to put the new task before the original one.
 

--- a/docs/Getting Started/Recurring Tasks.md
+++ b/docs/Getting Started/Recurring Tasks.md
@@ -43,35 +43,6 @@ Alternatively, if you have enabled addition of [[Dates#Created date|created date
 - [x] take out the trash 🔁 every Sunday 📅 2021-04-25 ✅ 2023-03-10
 ```
 
-### Limitations of Recurring Tasks
-
-> [!important]
-> A recurring task should have a due date. The due date and the recurrence rule must appear after the task's description.
-
-> [!important]
-> There are edge cases for tasks that recur monthly or yearly.
-For example, a task may be due `2022-01-31` and recur `every 3 months`.
-The next recurrence date of `2022-04-31` does not exist.
-
-In that case, Tasks moves the next occurrence **backwards** to the next valid date.
-In this case, that would be `2022-04-30`.
-
-From then on, the due date will be based on the 30th day of the month, unless changed manually.
-So the next occurrence would happen on `2022-07-30`, even though July has 31 days.
-
-> [!important]
-> With edge cases for tasks that recur monthly or yearly, **if the rule states the actual date of the next recurrence, Tasks will honour that instruction, skipping recurrence dates that do not exist**.
-
-For example, a task may be due `2022-01-31` and recur `every month on the 31st`.
-The next recurrence date of `2022-02-31` does not exist.
-
-In that case, Tasks moves the next occurrence **forwards** to the next valid date,
-skipping over recurrences with invalid dates.
-In this case, that would be `2022-03-31`.
-
-In the editor there is no direct feedback to whether your recurrence rule is valid.
-You can validate that tasks understands your rule by using the `Tasks: Create or edit` command when creating or editing a task.
-
 ## Order of the new task
 
 Use this setting to control where the recurring task is inserted. The default is to put the new task before the original one.
@@ -243,6 +214,35 @@ Examples of possible recurrence rules (mix and match as desired; these should be
 - `🔁 every February on the last`
 - `🔁 every April and December on the 1st and 24th` (meaning every _April 1st_ and _December 24th_)
 - `🔁 every year`
+
+## Limitations of Recurring Tasks
+
+> [!important]
+> A recurring task should have a due date. The due date and the recurrence rule must appear after the task's description.
+
+> [!important]
+> There are edge cases for tasks that recur monthly or yearly.
+For example, a task may be due `2022-01-31` and recur `every 3 months`.
+The next recurrence date of `2022-04-31` does not exist.
+
+In that case, Tasks moves the next occurrence **backwards** to the next valid date.
+In this case, that would be `2022-04-30`.
+
+From then on, the due date will be based on the 30th day of the month, unless changed manually.
+So the next occurrence would happen on `2022-07-30`, even though July has 31 days.
+
+> [!important]
+> With edge cases for tasks that recur monthly or yearly, **if the rule states the actual date of the next recurrence, Tasks will honour that instruction, skipping recurrence dates that do not exist**.
+
+For example, a task may be due `2022-01-31` and recur `every month on the 31st`.
+The next recurrence date of `2022-02-31` does not exist.
+
+In that case, Tasks moves the next occurrence **forwards** to the next valid date,
+skipping over recurrences with invalid dates.
+In this case, that would be `2022-03-31`.
+
+In the editor there is no direct feedback to whether your recurrence rule is valid.
+You can validate that tasks understands your rule by using the `Tasks: Create or edit` command when creating or editing a task.
 
 ## Known Issues
 

--- a/docs/Getting Started/Recurring Tasks.md
+++ b/docs/Getting Started/Recurring Tasks.md
@@ -223,12 +223,6 @@ The new task will have the due date advanced by two weeks and a scheduled date t
 -   [ ] Mow the lawn 🔁 every 2 weeks ⏳ 2021-11-11 📅 2021-11-13
 ```
 
-## Known Issues
-
-1. You can _not_ use rules where recurrence happens a certain number of times (`for x times`). Tasks doesn't link the tasks and doesn't know how often it occurred.
-2. You can _not_ use rules where recurrence ends on a specific date (`until "date"`). There is a bug in [`rrule`](https://github.com/jakubroztocil/rrule) where `until "date"` rules are not converted to the correct text. As a consequence, every subsequent task's "until" date will be one day earlier than the one before. We are tracking this in [issue #1818](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1818).
-3. If the highest priority date in a task does not exist (for example, due date is February 30th), when the task is completed the recurrence rule will disappear, and no new task will be created. This is detectable prior to completing the task by viewing the task in Live Preview: the recurrence rule will be hidden, and the date will be displayed as 'Invalid date'.
-
 ## Examples
 
 Examples of possible recurrence rules (mix and match as desired; these should be considered inspirational):
@@ -249,6 +243,12 @@ Examples of possible recurrence rules (mix and match as desired; these should be
 - `🔁 every February on the last`
 - `🔁 every April and December on the 1st and 24th` (meaning every _April 1st_ and _December 24th_)
 - `🔁 every year`
+
+## Known Issues
+
+1. You can _not_ use rules where recurrence happens a certain number of times (`for x times`). Tasks doesn't link the tasks and doesn't know how often it occurred.
+2. You can _not_ use rules where recurrence ends on a specific date (`until "date"`). There is a bug in [`rrule`](https://github.com/jakubroztocil/rrule) where `until "date"` rules are not converted to the correct text. As a consequence, every subsequent task's "until" date will be one day earlier than the one before. We are tracking this in [issue #1818](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1818).
+3. If the highest priority date in a task does not exist (for example, due date is February 30th), when the task is completed the recurrence rule will disappear, and no new task will be created. This is detectable prior to completing the task by viewing the task in Live Preview: the recurrence rule will be hidden, and the date will be displayed as 'Invalid date'.
 
 ## Technical Details
 

--- a/docs/Getting Started/Recurring Tasks.md
+++ b/docs/Getting Started/Recurring Tasks.md
@@ -244,7 +244,7 @@ In this case, that would be `2022-03-31`.
 In the editor there is no direct feedback to whether your recurrence rule is valid.
 You can validate that tasks understands your rule by using the `Tasks: Create or edit` command when creating or editing a task.
 
-## Known Issues
+### Known Issues
 
 1. You can _not_ use rules where recurrence happens a certain number of times (`for x times`). Tasks doesn't link the tasks and doesn't know how often it occurred.
 2. You can _not_ use rules where recurrence ends on a specific date (`until "date"`). There is a bug in [`rrule`](https://github.com/jakubroztocil/rrule) where `until "date"` rules are not converted to the correct text. As a consequence, every subsequent task's "until" date will be one day earlier than the one before. We are tracking this in [issue #1818](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1818).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This reorders the sections in 'Recurring Tasks' documentation page so that:

- The `Known Issues` section will be included in the [Recurring Tasks section of the Known Limitations page](https://publish.obsidian.md/tasks/Support+and+Help/Known+Limitations#Concepts+Recurring+Tasks) on next publish.
- All the limitations in the Recurring Tasks page are grouped together

## Motivation and Context

Preparation for further improvements in docs of recurring tasks.

## How has this been tested?

- By viewing the pages in Obisidian

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
