### PR TITLE
fix: Allow indenting tasks while suggest popup present

### DIFF
--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -14,6 +14,19 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
     constructor(app: App, settings: Settings) {
         super(app);
         this.settings = settings;
+
+        // EditorSuggestor swallows tabs while the suggestor popup is open
+        // This is a hack to support indenting while popup is open
+        app.scope.register([], 'Tab', () => {
+            const editor = this.context?.editor;
+            if (editor) {
+                editor.exec('indentMore');
+                // Returning false triggers preventDefault
+                // Should prevent double indent if tabs start to get passed through
+                return false;
+            }
+            return true;
+        });
     }
 
     onTrigger(cursor: EditorPosition, editor: Editor, _file: TFile): EditorSuggestTriggerInfo | null {
@@ -49,6 +62,7 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
 
     selectSuggestion(value: SuggestInfoWithContext, _evt: MouseEvent | KeyboardEvent) {
         const editor = value.context.editor;
+
         if (value.suggestionType === 'empty') {
             // Close the suggestion dialog and simulate an Enter press to the editor
             this.close();


### PR DESCRIPTION
# Description

Add a workaround addressing the fact that when the suggestion popup is open, pressing tab doesn't indent todo items.
Thanks to ush on the forums for the [suggestion](https://forum.obsidian.md/t/editorsuggest-eats-tabs-and-other-characters-probably-shouldnt/69728/2?u=camerallan)

## Motivation and Context

fixes #1578 #2187

This fix improves quality of life to users that maintain hierarchical task structures by removing the need to press `esc` to dismiss the popup in order to indent tasks.

## How has this been tested?

- Built the plugin locally and reproduced the issue
- Rebuilt the plugin after applying the fix and was unable to reproduce the issue
- Couldn't see a way to test this without introducing a new test suite
    - happy to take pointers though
- [x] Before merging, note the potential consequences of a fix for this going into obsidian core
    - This would result in double indentation when pressing tab - not great
    - Might be worth waiting until we hear whether this is intentional behaviour?

## Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [?] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
