### PR TITLE
recfactor: SearchInfo now contains list of tasks being searched

### DIFF
--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -13,6 +13,7 @@ import type { Grouper } from './Grouper';
 import type { Filter } from './Filter/Filter';
 import { QueryResult } from './QueryResult';
 import { scan } from './Scanner';
+import { SearchInfo } from './SearchInfo';
 
 export class Query implements IQuery {
     /** Note: source is the raw source, before expanding any placeholders */
@@ -232,9 +233,10 @@ Problem line: "${line}"`;
     }
 
     public applyQueryToTasks(tasks: Task[]): QueryResult {
+        const allTasks = tasks;
         try {
             this.filters.forEach((filter) => {
-                tasks = tasks.filter(filter.filterFunction);
+                tasks = tasks.filter((task) => filter.filterFunction(task, new SearchInfo(allTasks)));
             });
 
             const { debugSettings } = getSettings();

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -233,10 +233,10 @@ Problem line: "${line}"`;
     }
 
     public applyQueryToTasks(tasks: Task[]): QueryResult {
-        const allTasks = tasks;
+        const searchInfo = new SearchInfo(tasks);
         try {
             this.filters.forEach((filter) => {
-                tasks = tasks.filter((task) => filter.filterFunction(task, new SearchInfo(allTasks)));
+                tasks = tasks.filter((task) => filter.filterFunction(task, searchInfo));
             });
 
             const { debugSettings } = getSettings();

--- a/src/Query/SearchInfo.ts
+++ b/src/Query/SearchInfo.ts
@@ -1,7 +1,7 @@
 import type { Task } from '../Task';
 
 /**
- * SearchInfo will soon contain selected data passed in from the {@link Query} being executed.
+ * SearchInfo contains selected data passed in from the {@link Query} being executed.
  *
  * This is the Parameter Object pattern: it is a container for information that needs
  * to be passed down through multiple levels of code, without having to update

--- a/src/Query/SearchInfo.ts
+++ b/src/Query/SearchInfo.ts
@@ -1,9 +1,17 @@
+import type { Task } from '../Task';
+
 /**
  * SearchInfo will soon contain selected data passed in from the {@link Query} being executed.
  *
- * This is the Parameter Object pattern: it is a container for information that will
- * be passed down through multiple levels of code, in order to be able to in future
- * pass through more data, without having to update the function signatures of all
- * the layers in between.
+ * This is the Parameter Object pattern: it is a container for information that needs
+ * to be passed down through multiple levels of code, without having to update
+ * the function signatures of all the layers in between.
  */
-export class SearchInfo {}
+export class SearchInfo {
+    // TODO This needs to be really Readonly
+    public readonly allTasks: Task[];
+
+    public constructor(allTasks: Task[]) {
+        this.allTasks = allTasks;
+    }
+}

--- a/src/Query/SearchInfo.ts
+++ b/src/Query/SearchInfo.ts
@@ -13,6 +13,6 @@ export class SearchInfo {
     public readonly allTasks: Readonly<Task[]>;
 
     public constructor(allTasks: Task[]) {
-        this.allTasks = allTasks;
+        this.allTasks = [...allTasks];
     }
 }

--- a/src/Query/SearchInfo.ts
+++ b/src/Query/SearchInfo.ts
@@ -8,8 +8,7 @@ import type { Task } from '../Task';
  * the function signatures of all the layers in between.
  */
 export class SearchInfo {
-    // TODO This needs to be really Readonly
-    public readonly allTasks: Task[];
+    public readonly allTasks: Readonly<Task[]>;
 
     public constructor(allTasks: Task[]) {
         this.allTasks = allTasks;

--- a/src/Query/SearchInfo.ts
+++ b/src/Query/SearchInfo.ts
@@ -8,6 +8,8 @@ import type { Task } from '../Task';
  * the function signatures of all the layers in between.
  */
 export class SearchInfo {
+    /** The list of tasks being searched.
+     */
     public readonly allTasks: Readonly<Task[]>;
 
     public constructor(allTasks: Task[]) {

--- a/tests/CustomMatchers/CustomMatchersForFilters.test.ts
+++ b/tests/CustomMatchers/CustomMatchersForFilters.test.ts
@@ -8,7 +8,8 @@ import { Explanation } from '../../src/Query/Explain/Explanation';
 describe('CustomMatchersForFilters', () => {
     it('should check filter with supplied SearchInfo', () => {
         // Arrange
-        const initialSearchInfo = new SearchInfo();
+        const task = new TaskBuilder().build();
+        const initialSearchInfo = new SearchInfo([task]);
         const checkSearchInfoPassedThrough = (_task: Task, searchInfo: SearchInfo) => {
             return Object.is(initialSearchInfo, searchInfo);
         };
@@ -17,6 +18,6 @@ describe('CustomMatchersForFilters', () => {
         );
 
         // Act, Assert
-        expect(filter).toMatchTaskWithSearchInfo(new TaskBuilder().build(), initialSearchInfo);
+        expect(filter).toMatchTaskWithSearchInfo(task, initialSearchInfo);
     });
 });

--- a/tests/CustomMatchers/CustomMatchersForFilters.ts
+++ b/tests/CustomMatchers/CustomMatchersForFilters.ts
@@ -171,7 +171,7 @@ with filter: "${filter.instruction}"`,
 }
 
 export function toMatchTask(filter: FilterOrErrorMessage, task: Task) {
-    return toMatchTaskWithSearchInfo(filter, task, new SearchInfo());
+    return toMatchTaskWithSearchInfo(filter, task, new SearchInfo([task]));
 }
 
 export function toMatchTaskFromLine(filter: FilterOrErrorMessage, line: string) {

--- a/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
+++ b/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
@@ -228,7 +228,7 @@ function verifyTransitionsAsMarkdownTable(statuses: Status[]) {
     function filterAllStatuses(filter: FilterOrErrorMessage) {
         const cells: string[] = [`Matches \`${filter!.instruction}\``];
         tasks.forEach((task) => {
-            const matchedText = filter!.filter?.filterFunction(task, new SearchInfo()) ? 'YES' : 'no';
+            const matchedText = filter!.filter?.filterFunction(task, new SearchInfo([task])) ? 'YES' : 'no';
             cells.push(matchedText);
         });
         table.addRow(cells);

--- a/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
+++ b/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
@@ -227,8 +227,9 @@ function verifyTransitionsAsMarkdownTable(statuses: Status[]) {
 
     function filterAllStatuses(filter: FilterOrErrorMessage) {
         const cells: string[] = [`Matches \`${filter!.instruction}\``];
+        const searchInfo = new SearchInfo(tasks);
         tasks.forEach((task) => {
-            const matchedText = filter!.filter?.filterFunction(task, new SearchInfo([task])) ? 'YES' : 'no';
+            const matchedText = filter!.filter?.filterFunction(task, searchInfo) ? 'YES' : 'no';
             cells.push(matchedText);
         });
         table.addRow(cells);

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -44,7 +44,8 @@ describe('FunctionField - filtering', () => {
         // Assert
         expect(filter).toBeValid();
         const t = () => {
-            filter.filterFunction!(new TaskBuilder().build(), new SearchInfo());
+            const task = new TaskBuilder().build();
+            filter.filterFunction!(task, new SearchInfo([task]));
         };
         expect(t).toThrow(Error);
         expect(t).toThrowError('filtering function must return true or false. This returned "undefined".');

--- a/tests/Query/SearchInfo.test.ts
+++ b/tests/Query/SearchInfo.test.ts
@@ -1,0 +1,16 @@
+import { SearchInfo } from '../../src/Query/SearchInfo';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
+
+describe('SearchInfo', () => {
+    it('should not be able to modify the tasks in SearchInfo.allTasks', () => {
+        const tasks = [new TaskBuilder().build()];
+        const searchInfo = new SearchInfo(tasks);
+        expect(searchInfo.allTasks.length).toEqual(1);
+
+        // Success: Does not compile
+        // searchInfo.allTasks.push(new TaskBuilder().description('I should not be allowed').build());
+
+        // Success: Does not compile
+        // searchInfo.allTasks[0] = new TaskBuilder().description('cannot replace a task').build();
+    });
+});

--- a/tests/Query/SearchInfo.test.ts
+++ b/tests/Query/SearchInfo.test.ts
@@ -2,7 +2,7 @@ import { SearchInfo } from '../../src/Query/SearchInfo';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 
 describe('SearchInfo', () => {
-    it('should not be able to modify the tasks in SearchInfo.allTasks directly', () => {
+    it('should not be able to modify SearchInfo.allTasks directly', () => {
         const tasks = [new TaskBuilder().build()];
         const searchInfo = new SearchInfo(tasks);
         expect(searchInfo.allTasks.length).toEqual(1);
@@ -14,7 +14,7 @@ describe('SearchInfo', () => {
         // searchInfo.allTasks[0] = new TaskBuilder().description('cannot replace a task').build();
     });
 
-    it.failing('should not be able to modify the tasks in SearchInfo.allTasks indirectly', () => {
+    it('should not be able to modify SearchInfo.allTasks indirectly', () => {
         const tasks = [new TaskBuilder().build()];
         const searchInfo = new SearchInfo(tasks);
 

--- a/tests/Query/SearchInfo.test.ts
+++ b/tests/Query/SearchInfo.test.ts
@@ -2,7 +2,7 @@ import { SearchInfo } from '../../src/Query/SearchInfo';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 
 describe('SearchInfo', () => {
-    it('should not be able to modify the tasks in SearchInfo.allTasks', () => {
+    it('should not be able to modify the tasks in SearchInfo.allTasks directly', () => {
         const tasks = [new TaskBuilder().build()];
         const searchInfo = new SearchInfo(tasks);
         expect(searchInfo.allTasks.length).toEqual(1);
@@ -12,5 +12,14 @@ describe('SearchInfo', () => {
 
         // Success: Does not compile
         // searchInfo.allTasks[0] = new TaskBuilder().description('cannot replace a task').build();
+    });
+
+    it.failing('should not be able to modify the tasks in SearchInfo.allTasks indirectly', () => {
+        const tasks = [new TaskBuilder().build()];
+        const searchInfo = new SearchInfo(tasks);
+
+        // Check that updating the original list of tasks does not change the tasks saved in searchInfo.allTasks
+        tasks.push(new TaskBuilder().description('I should not be added to searchInfo.allTasks').build());
+        expect(searchInfo.allTasks.length).toEqual(1);
     });
 });

--- a/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
+++ b/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
@@ -91,8 +91,9 @@ export function verifyFunctionFieldFilterSamplesOnTasks(filters: QueryInstructio
 
         const filterFunction = filterOrErrorMessage.filterFunction!;
         const matchingTasks: string[] = [];
+        const searchInfo = new SearchInfo(tasks);
         for (const task of tasks) {
-            const matches = filterFunction(task, new SearchInfo());
+            const matches = filterFunction(task, searchInfo);
             if (matches) {
                 matchingTasks.push(task.toFileLineString());
             }

--- a/tests/TestingTools/FilterTestHelpers.ts
+++ b/tests/TestingTools/FilterTestHelpers.ts
@@ -28,7 +28,7 @@ export function testFilter(filter: FilterOrErrorMessage, taskBuilder: TaskBuilde
 export function testTaskFilter(filter: FilterOrErrorMessage, task: Task, expected: boolean) {
     expect(filter.filterFunction).toBeDefined();
     expect(filter.error).toBeUndefined();
-    expect(filter.filterFunction!(task, new SearchInfo())).toEqual(expected);
+    expect(filter.filterFunction!(task, new SearchInfo([task]))).toEqual(expected);
 }
 
 /**
@@ -50,8 +50,9 @@ export function testTaskFilterViaQuery(filter: string, task: Task, expected: boo
 
     // Act
     let filteredTasks = [...tasks];
+    const searchInfo = new SearchInfo(tasks);
     query.filters.forEach((filter) => {
-        filteredTasks = filteredTasks.filter(filter.filterFunction);
+        filteredTasks = filteredTasks.filter((task) => filter.filterFunction(task, searchInfo));
     });
     const matched = filteredTasks.length === 1;
 
@@ -84,8 +85,9 @@ export function shouldSupportFiltering(
 
     // Act
     let filteredTasks = [...tasks];
+    const searchInfo = new SearchInfo(tasks);
     query.filters.forEach((filter) => {
-        filteredTasks = filteredTasks.filter(filter.filterFunction);
+        filteredTasks = filteredTasks.filter((task) => filter.filterFunction(task, searchInfo));
     });
 
     // Assert


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add to `SearchInfo` the tasks being searched.

## Motivation and Context

This will be needed by the work on implementing task dependencies.

## How has this been tested?

- Adding tests and updating existing ones
- Check some of the Tasks code blocks in the demo vault

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
