### PR TITLE
feat: Statuses report now shows a Status Settings table

### DIFF
--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -178,10 +178,7 @@ export class StatusSettings {
      */
     public static applyToStatusRegistry(statusSettings: StatusSettings, statusRegistry: StatusRegistry) {
         statusRegistry.clearStatuses();
-        statusSettings.coreStatuses.forEach((statusType) => {
-            statusRegistry.add(statusType);
-        });
-        statusSettings.customStatuses.forEach((statusType) => {
+        StatusSettings.allStatuses(statusSettings).forEach((statusType) => {
             statusRegistry.add(statusType);
         });
     }

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -164,6 +164,14 @@ export class StatusSettings {
     }
 
     /**
+     * Retun a list of all the statuses in the settings - first the core ones, then the custom ones.
+     * @param statusSettings
+     */
+    public static allStatuses(statusSettings: StatusSettings) {
+        return statusSettings.coreStatuses.concat(statusSettings.customStatuses);
+    }
+
+    /**
      * Apply the custom statuses in the statusSettings object to the statusRegistry.
      * @param statusSettings
      * @param statusRegistry

--- a/src/StatusRegistryReport.ts
+++ b/src/StatusRegistryReport.ts
@@ -23,3 +23,8 @@ You can delete this file any time.
 <!-- Switch to Live Preview or Reading Mode to see the diagram. -->
 ${mermaidText}`;
 }
+
+export function getPrintableSymbol(symbol: string) {
+    const result = symbol !== ' ' ? symbol : 'space';
+    return '`' + result + '`';
+}

--- a/src/StatusRegistryReport.ts
+++ b/src/StatusRegistryReport.ts
@@ -1,5 +1,25 @@
 import type { StatusRegistry } from './StatusRegistry';
 import type { StatusSettings } from './Config/StatusSettings';
+import { MarkdownTable } from './lib/MarkdownTable';
+import type { StatusConfiguration } from './StatusConfiguration';
+
+export function tabulateStatusSettings(statusSettings: StatusSettings) {
+    // Note: There is very similar code in verifyStatusesAsMarkdownTable() in DocsSamplesForStatuses.test.ts.
+    //       Maybe try unifying the common code one day?
+
+    const table = new MarkdownTable(['Status Symbol', 'Next Status Symbol', 'Status Name', 'Status Type']);
+
+    const statuses: StatusConfiguration[] = [];
+    statuses.push(...statusSettings.coreStatuses);
+    statuses.push(...statusSettings.customStatuses);
+    for (const status of statuses) {
+        const statusCharacter = getPrintableSymbol(status.symbol);
+        const nextStatusCharacter = getPrintableSymbol(status.nextStatusSymbol);
+        const type = getPrintableSymbol(status.type);
+        table.addRow([statusCharacter, nextStatusCharacter, status.name, type]);
+    }
+    return table.markdown;
+}
 
 export function createStatusRegistryReport(
     _statusSettings: StatusSettings,

--- a/src/StatusRegistryReport.ts
+++ b/src/StatusRegistryReport.ts
@@ -1,5 +1,5 @@
 import type { StatusRegistry } from './StatusRegistry';
-import type { StatusSettings } from './Config/StatusSettings';
+import { StatusSettings } from './Config/StatusSettings';
 import { MarkdownTable } from './lib/MarkdownTable';
 import type { StatusConfiguration } from './StatusConfiguration';
 
@@ -9,9 +9,7 @@ export function tabulateStatusSettings(statusSettings: StatusSettings) {
 
     const table = new MarkdownTable(['Status Symbol', 'Next Status Symbol', 'Status Name', 'Status Type']);
 
-    const statuses: StatusConfiguration[] = [];
-    statuses.push(...statusSettings.coreStatuses);
-    statuses.push(...statusSettings.customStatuses);
+    const statuses: StatusConfiguration[] = StatusSettings.allStatuses(statusSettings);
     for (const status of statuses) {
         table.addRow([
             getPrintableSymbol(status.symbol),

--- a/src/StatusRegistryReport.ts
+++ b/src/StatusRegistryReport.ts
@@ -52,7 +52,8 @@ You can delete this file any time.
 
 <!--
 Switch to Live Preview or Reading Mode to see the table.
-If there are any Markdown formatting characters in status names, such as '*' or '_' Obsidian may only render the table correctly in Reading Mode.
+If there are any Markdown formatting characters in status names, such as '*' or '_',
+Obsidian may only render the table correctly in Reading Mode.
 -->
 
 These are the status values in the Core and Custom statuses sections.

--- a/src/StatusRegistryReport.ts
+++ b/src/StatusRegistryReport.ts
@@ -37,16 +37,32 @@ export function createStatusRegistryReport(
     const mermaidText = statusRegistry.mermaidDiagram(detailed);
     return `# ${buttonName}
 
+## About this file
+
 This file was created by the Obsidian Tasks plugin (version ${versionString}) to help visualise the task statuses in this vault.
+
+If you change the Tasks status settings, you can get an updated report by:
+
+- Going to \`Settings\` -> \`Tasks\`.
+- Clicking on \`Review and check your Statuses\`.
 
 You can delete this file any time.
 
 ## Status Settings
 
+<!--
+Switch to Live Preview or Reading Mode to see the table.
+If there are any Markdown formatting characters in status names, such as '*' or '_' Obsidian may only render the table correctly in Reading Mode.
+-->
+
+These are the status values in the Core and Custom statuses sections.
+
 ${settingsTable}
 ## Loaded Settings
 
 <!-- Switch to Live Preview or Reading Mode to see the diagram. -->
+
+These are the settings actually used by Tasks.
 ${mermaidText}`;
 }
 

--- a/src/StatusRegistryReport.ts
+++ b/src/StatusRegistryReport.ts
@@ -13,10 +13,12 @@ export function tabulateStatusSettings(statusSettings: StatusSettings) {
     statuses.push(...statusSettings.coreStatuses);
     statuses.push(...statusSettings.customStatuses);
     for (const status of statuses) {
-        const statusCharacter = getPrintableSymbol(status.symbol);
-        const nextStatusCharacter = getPrintableSymbol(status.nextStatusSymbol);
-        const type = getPrintableSymbol(status.type);
-        table.addRow([statusCharacter, nextStatusCharacter, status.name, type]);
+        table.addRow([
+            getPrintableSymbol(status.symbol),
+            getPrintableSymbol(status.nextStatusSymbol),
+            status.name,
+            getPrintableSymbol(status.type),
+        ]);
     }
     return table.markdown;
 }

--- a/src/StatusRegistryReport.ts
+++ b/src/StatusRegistryReport.ts
@@ -22,7 +22,7 @@ export function tabulateStatusSettings(statusSettings: StatusSettings) {
 }
 
 export function createStatusRegistryReport(
-    _statusSettings: StatusSettings,
+    statusSettings: StatusSettings,
     statusRegistry: StatusRegistry,
     buttonName: string,
     versionString: string,
@@ -33,12 +33,18 @@ export function createStatusRegistryReport(
     // - Show any status transitions that won't work with recurring tasks currently, as DONE not followed by TODO.
 
     const detailed = true;
+    const settingsTable = tabulateStatusSettings(statusSettings);
     const mermaidText = statusRegistry.mermaidDiagram(detailed);
     return `# ${buttonName}
 
 This file was created by the Obsidian Tasks plugin (version ${versionString}) to help visualise the task statuses in this vault.
 
 You can delete this file any time.
+
+## Status Settings
+
+${settingsTable}
+## Loaded Settings
 
 <!-- Switch to Live Preview or Reading Mode to see the diagram. -->
 ${mermaidText}`;

--- a/tests/Config/StatusSettings.test.ts
+++ b/tests/Config/StatusSettings.test.ts
@@ -159,6 +159,18 @@ describe('StatusSettings', () => {
         `);
     });
 
+    it('should return a combined list of all statuses', () => {
+        // Arrange
+        const settings = new StatusSettings();
+
+        // Act
+        const allStatuses = StatusSettings.allStatuses(settings);
+
+        // Assert
+        const allSymbolsInOrder = allStatuses.map((status) => status.symbol).join('|');
+        expect(allSymbolsInOrder).toEqual(' |x|/|-');
+    });
+
     it('should apply settings to a StatusRegistry', () => {
         // Arrange
         const settings = new StatusSettings();

--- a/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
+++ b/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
@@ -21,6 +21,8 @@ import { MarkdownTable } from '../../src/lib/MarkdownTable';
 import { getPrintableSymbol } from '../../src/StatusRegistryReport';
 
 function verifyStatusesAsMarkdownTable(statuses: Status[], showQueryInstructions: boolean) {
+    // Note: There is very similar code in tabulateStatusSettings() in StatusRegistryReport.ts.
+    //       Maybe try unifying the common code one day?
     let statusName = 'Status Name';
     let statusType = 'Status Type';
     if (showQueryInstructions) {

--- a/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
+++ b/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
@@ -18,11 +18,7 @@ import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
 import { SearchInfo } from '../../src/Query/SearchInfo';
 import type { GrouperFunction } from '../../src/Query/Grouper';
 import { MarkdownTable } from '../../src/lib/MarkdownTable';
-
-function getPrintableSymbol(symbol: string) {
-    const result = symbol !== ' ' ? symbol : 'space';
-    return '`' + result + '`';
-}
+import { getPrintableSymbol } from '../../src/StatusRegistryReport';
 
 function verifyStatusesAsMarkdownTable(statuses: Status[], showQueryInstructions: boolean) {
     let statusName = 'Status Name';

--- a/tests/StatusRegistryReport.test.StatusRegistryReport_should_create_a_report.approved.md
+++ b/tests/StatusRegistryReport.test.StatusRegistryReport_should_create_a_report.approved.md
@@ -15,7 +15,8 @@ You can delete this file any time.
 
 <!--
 Switch to Live Preview or Reading Mode to see the table.
-If there are any Markdown formatting characters in status names, such as '*' or '_' Obsidian may only render the table correctly in Reading Mode.
+If there are any Markdown formatting characters in status names, such as '*' or '_',
+Obsidian may only render the table correctly in Reading Mode.
 -->
 
 These are the status values in the Core and Custom statuses sections.

--- a/tests/StatusRegistryReport.test.StatusRegistryReport_should_create_a_report.approved.md
+++ b/tests/StatusRegistryReport.test.StatusRegistryReport_should_create_a_report.approved.md
@@ -4,6 +4,19 @@ This file was created by the Obsidian Tasks plugin (version x.y.z) to help visua
 
 You can delete this file any time.
 
+## Status Settings
+
+| Status Symbol | Next Status Symbol | Status Name | Status Type |
+| ----- | ----- | ----- | ----- |
+| `space` | `x` | Todo | `TODO` |
+| `x` | `space` | Done | `DONE` |
+| `/` | `x` | In Progress | `IN_PROGRESS` |
+| `-` | `space` | Cancelled | `CANCELLED` |
+| `Q` | `A` | Question | `NON_TASK` |
+| `A` | `Q` | Answer | `NON_TASK` |
+
+## Loaded Settings
+
 <!-- Switch to Live Preview or Reading Mode to see the diagram. -->
 
 ```mermaid

--- a/tests/StatusRegistryReport.test.StatusRegistryReport_should_create_a_report.approved.md
+++ b/tests/StatusRegistryReport.test.StatusRegistryReport_should_create_a_report.approved.md
@@ -28,6 +28,7 @@ These are the status values in the Core and Custom statuses sections.
 | `-` | `space` | Cancelled | `CANCELLED` |
 | `Q` | `A` | Question | `NON_TASK` |
 | `A` | `Q` | Answer | `NON_TASK` |
+| `` | `` |  | `TODO` |
 
 ## Loaded Settings
 

--- a/tests/StatusRegistryReport.test.StatusRegistryReport_should_create_a_report.approved.md
+++ b/tests/StatusRegistryReport.test.StatusRegistryReport_should_create_a_report.approved.md
@@ -1,10 +1,24 @@
 # Review and check your Statuses
 
+## About this file
+
 This file was created by the Obsidian Tasks plugin (version x.y.z) to help visualise the task statuses in this vault.
+
+If you change the Tasks status settings, you can get an updated report by:
+
+- Going to `Settings` -> `Tasks`.
+- Clicking on `Review and check your Statuses`.
 
 You can delete this file any time.
 
 ## Status Settings
+
+<!--
+Switch to Live Preview or Reading Mode to see the table.
+If there are any Markdown formatting characters in status names, such as '*' or '_' Obsidian may only render the table correctly in Reading Mode.
+-->
+
+These are the status values in the Core and Custom statuses sections.
 
 | Status Symbol | Next Status Symbol | Status Name | Status Type |
 | ----- | ----- | ----- | ----- |
@@ -18,6 +32,8 @@ You can delete this file any time.
 ## Loaded Settings
 
 <!-- Switch to Live Preview or Reading Mode to see the diagram. -->
+
+These are the settings actually used by Tasks.
 
 ```mermaid
 flowchart LR

--- a/tests/StatusRegistryReport.test.StatusRegistryReport_should_tabulate_StatusSettings.approved.md
+++ b/tests/StatusRegistryReport.test.StatusRegistryReport_should_tabulate_StatusSettings.approved.md
@@ -1,0 +1,6 @@
+| Status Symbol | Next Status Symbol | Status Name | Status Type |
+| ----- | ----- | ----- | ----- |
+| `space` | `x` | Todo | `TODO` |
+| `x` | `space` | Done | `DONE` |
+| `/` | `x` | In Progress | `IN_PROGRESS` |
+| `-` | `space` | Cancelled | `CANCELLED` |

--- a/tests/StatusRegistryReport.test.ts
+++ b/tests/StatusRegistryReport.test.ts
@@ -1,4 +1,4 @@
-import { createStatusRegistryReport } from '../src/StatusRegistryReport';
+import { createStatusRegistryReport, tabulateStatusSettings } from '../src/StatusRegistryReport';
 import { StatusRegistry } from '../src/StatusRegistry';
 import { StatusSettings } from '../src/Config/StatusSettings';
 import type { StatusCollection, StatusCollectionEntry } from '../src/StatusCollection';
@@ -27,6 +27,12 @@ function createStatuses(
 }
 
 describe('StatusRegistryReport', function () {
+    it('should tabulate StatusSettings', () => {
+        const statusSettings = new StatusSettings();
+        const markdown = tabulateStatusSettings(statusSettings);
+        verifyWithFileExtension(markdown, '.md');
+    });
+
     it('should create a report', () => {
         // Arrange
 

--- a/tests/StatusRegistryReport.test.ts
+++ b/tests/StatusRegistryReport.test.ts
@@ -44,6 +44,7 @@ describe('StatusRegistryReport', function () {
         const customStatusesData: StatusCollection = [
             ['Q', 'Question', 'A', 'NON_TASK'],
             ['A', 'Answer', 'Q', 'NON_TASK'],
+            ['', '', '', 'TODO'], // A new, unedited status
         ];
         const { statusSettings, statusRegistry } = createStatuses(coreStatusesData, customStatusesData);
 

--- a/tests/StatusRegistryReport.test.ts
+++ b/tests/StatusRegistryReport.test.ts
@@ -16,6 +16,7 @@ function createStatuses(
     StatusSettings.replaceStatus(core, core[0], Status.createFromImportedValue(coreStatusesData[0]));
     StatusSettings.replaceStatus(core, core[1], Status.createFromImportedValue(coreStatusesData[1]));
 
+    StatusSettings.deleteAllCustomStatuses(statusSettings);
     customStatusesData.map((entry: StatusCollectionEntry) => {
         StatusSettings.addStatus(statusSettings.customStatuses, Status.createFromImportedValue(entry));
     });
@@ -42,6 +43,8 @@ describe('StatusRegistryReport', function () {
         ];
 
         const customStatusesData: StatusCollection = [
+            ['/', 'In Progress', 'x', 'IN_PROGRESS'],
+            ['-', 'Cancelled', ' ', 'CANCELLED'],
             ['Q', 'Question', 'A', 'NON_TASK'],
             ['A', 'Answer', 'Q', 'NON_TASK'],
             ['', '', '', 'TODO'], // A new, unedited status


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

The `Review and check your Statuses` button now shows a table of the statuses from the user's Tasks Status settings.

_Note: I'm planning on changing this some more, so am holding off writing the documentation for now._

## Motivation and Context

Builds on https://github.com/obsidian-tasks-group/obsidian-tasks/pull/2383 - showing more information.

A later step may add some error messages/feedback to the table.

## How has this been tested?

- By updating the test for the table output
- By repeated generating of the report in the Tasks-Demo vault.

## Screenshots (if appropriate)

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/a0e4c63a-c7f9-40e0-919a-dd9a2689f8d3)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
