### PR TITLE
test: include description and tags in Visualise HTML tests

### DIFF
--- a/tests/TaskLineRenderer.test.Visualise_HTML_Full_task_-_full_mode.approved.html
+++ b/tests/TaskLineRenderer.test.Visualise_HTML_Full_task_-_full_mode.approved.html
@@ -16,7 +16,7 @@
     data-line="0">
         <span class="tasks-list-text">
         <span class="task-description">
-        <span></span></span>
+        <span>Do exercises #todo #health</span></span>
         <span class="task-priority"
     data-task-priority="medium">
         <span> 🔼</span></span>

--- a/tests/TaskLineRenderer.test.Visualise_HTML_Full_task_-_short_mode.approved.html
+++ b/tests/TaskLineRenderer.test.Visualise_HTML_Full_task_-_short_mode.approved.html
@@ -16,7 +16,7 @@
     data-line="0">
         <span class="tasks-list-text">
         <span class="task-description">
-        <span></span></span>
+        <span>Do exercises #todo #health</span></span>
         <span class="task-priority"
     data-task-priority="medium">
         <span> 🔼</span></span>

--- a/tests/TaskLineRenderer.test.Visualise_HTML_Minimal_task_-_full_mode.approved.html
+++ b/tests/TaskLineRenderer.test.Visualise_HTML_Minimal_task_-_full_mode.approved.html
@@ -11,4 +11,4 @@
     data-line="0">
         <span class="tasks-list-text">
         <span class="task-description">
-        <span></span></span></span></li>
+        <span>empty</span></span></span></li>

--- a/tests/TaskLineRenderer.test.Visualise_HTML_Minimal_task_-_short_mode.approved.html
+++ b/tests/TaskLineRenderer.test.Visualise_HTML_Minimal_task_-_short_mode.approved.html
@@ -11,4 +11,4 @@
     data-line="0">
         <span class="tasks-list-text">
         <span class="task-description">
-        <span></span></span></span></li>
+        <span>empty</span></span></span></li>

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -601,7 +601,14 @@ describe('task line rendering', () => {
 
 describe('Visualise HTML', () => {
     async function renderAndVerifyHTML(task: Task, layoutOptions: LayoutOptions) {
-        const parentRender = await createMockParentAndRender(task, layoutOptions);
+        const mockHTMLRenderer = async (text: string, element: HTMLSpanElement, _path: string) => {
+            // Contrary to the default mockTextRenderer() in createMockParentAndRender(),
+            // instead of the rendered HTMLSpanElement.innerText,
+            // we need the plain HTML here like in TaskLineRenderer.renderComponentText().
+            element.innerHTML = text;
+        };
+
+        const parentRender = await createMockParentAndRender(task, layoutOptions, mockHTMLRenderer);
         const taskAsMarkdown = `<!--
 ${task.toFileLineString()}
 -->\n\n`;

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -626,6 +626,9 @@ ${task.toFileLineString()}
         const layoutOptions = new LayoutOptions();
 
         // Show every Task field, disable short mode, do not explain the query
+        // Also note that urgency, backlinks and edit button are rendered in QueryRender.createTaskList(),
+        // so they won't be visible in this test it is using TaskLineRenderer.renderTaskLine().
+        // See also comments in TaskLayout.applyOptions().
         Object.keys(layoutOptions).forEach((key) => {
             const key2 = key as keyof LayoutOptions;
             layoutOptions[key2] = false;


### PR DESCRIPTION
# Description

Add an HTML mock renderer for the HTML visualisation tests.

Continuation of #2405 

## Motivation and Context

Improve tests for safer refactorings.

## How has this been tested?

Approval tests.

## Types of changes

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
