### PR TITLE
refactor: move to FieldLayoutDetail and linline 2 functions

### DIFF
--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -19,6 +19,9 @@ export class LayoutOptions {
     explainQuery: boolean = false;
 }
 
+/** TODO if this is migrated to `keyof Task` type, there will be no need
+ * to check whether FieldDetails[component] is resolved to a non null value.
+ */
 export type TaskLayoutComponent =
     | 'description'
     | 'priority'

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -19,9 +19,6 @@ export class LayoutOptions {
     explainQuery: boolean = false;
 }
 
-/** TODO if this is migrated to `keyof Task` type, there will be no need
- * to check whether FieldDetails[component] is resolved to a non null value.
- */
 export type TaskLayoutComponent =
     | 'description'
     | 'priority'

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -237,7 +237,7 @@ async function taskToHtml(
                 }
 
                 // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
-                const componentDataAttribute = getComponentDataAttribute(component, task);
+                const componentDataAttribute = FieldLayouts[component].getDataAttribute(component, task);
                 for (const key in componentDataAttribute) span.dataset[key] = componentDataAttribute[key];
                 allAttributes = { ...allAttributes, ...componentDataAttribute };
             }
@@ -246,7 +246,7 @@ async function taskToHtml(
 
     // Now build classes for the hidden task components without rendering them
     for (const component of taskLayout.hiddenTaskLayoutComponents) {
-        const hiddenComponentDataAttribute = getComponentDataAttribute(component, task);
+        const hiddenComponentDataAttribute = FieldLayouts[component].getDataAttribute(component, task);
         allAttributes = { ...allAttributes, ...hiddenComponentDataAttribute };
     }
 
@@ -256,7 +256,7 @@ async function taskToHtml(
     // So if the priority was not rendered, force it through the pipe of getting the component data for the
     // priority field.
     if (allAttributes.taskPriority === undefined) {
-        const priorityDataAttribute = getComponentDataAttribute('priority', task);
+        const priorityDataAttribute = FieldLayouts['priority'].getDataAttribute('priority', task);
         allAttributes = { ...allAttributes, ...priorityDataAttribute };
     }
 
@@ -311,16 +311,6 @@ async function renderComponentText(
     } else {
         span.innerHTML = componentString;
     }
-}
-
-/**
- * The data attribute describes the content of the component, e.g. `data-task-priority="medium"`, `data-task-due="past-1d"` etc.
- */
-function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
-    // If a TaskLayoutComponent needs a data attribute in the task's <span>, get the data attribute name (key) &
-    // data attribute value (value). Otherwise, just leave an empty string ('') as the value.
-    // The value is calculated based on FieldLayoutDetail.attributeValueCalculator
-    return FieldLayouts[component].getDataAttribute(component, task);
 }
 
 /*

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -325,7 +325,7 @@ function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
     // data attribute value (value). Otherwise, just leave an empty string ('') as the value.
     // The value is calculated based on FieldLayoutDetail.attributeValueCalculator
     const fieldLayoutDetail = FieldLayouts[component];
-    return extracted(fieldLayoutDetail, component, task);
+    return fieldLayoutDetail.getDataAttribute(component, task);
 }
 
 /*

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -58,9 +58,9 @@ export class FieldLayoutDetail {
 
     public getDataAttribute(component: TaskLayoutComponent, task: Task) {
         const dataAttribute: AttributesDictionary = {};
-        const attributeName = this.attributeName;
-        if (attributeName !== FieldLayoutDetail.noAttributeName) {
-            dataAttribute[attributeName] = this.attributeValueCalculator(component, task);
+
+        if (this.attributeName !== FieldLayoutDetail.noAttributeName) {
+            dataAttribute[this.attributeName] = this.attributeValueCalculator(component, task);
         }
 
         return dataAttribute;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -320,8 +320,7 @@ function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
     // If a TaskLayoutComponent needs a data attribute in the task's <span>, get the data attribute name (key) &
     // data attribute value (value). Otherwise, just leave an empty string ('') as the value.
     // The value is calculated based on FieldLayoutDetail.attributeValueCalculator
-    const fieldLayoutDetail = FieldLayouts[component];
-    return fieldLayoutDetail.getDataAttribute(component, task);
+    return FieldLayouts[component].getDataAttribute(component, task);
 }
 
 /*

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -55,6 +55,10 @@ export class FieldLayoutDetail {
         this.attributeName = attributeName;
         this.attributeValueCalculator = attributeValueCalculator;
     }
+
+    public getDataAttribute(component: TaskLayoutComponent, task: Task) {
+        return extracted(this, component, task);
+    }
 }
 
 const dateDataAttributeCalculator: AttributeValueCalculator = (component: TaskLayoutComponent, task: Task) => {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -220,11 +220,11 @@ async function taskToHtml(
                 addInternalClasses(component, internalSpan);
 
                 // Add the component's CSS class describing what this component is (priority, due date etc.)
-                //
-                //  It is important to ensure that the Task being rendered does actually have a value for this
-                //  field, that is, that `task[component]` has a value. Only call this if task has this value.
-                const componentClass = [FieldLayouts[component].className];
-                span.classList.add(...componentClass);
+                const fieldLayoutDetails = FieldLayouts[component];
+                if (fieldLayoutDetails) {
+                    const componentClass = [fieldLayoutDetails.className];
+                    span.classList.add(...componentClass);
+                }
 
                 // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
                 const componentDataAttribute = getComponentDataAttribute(component, task);

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -306,8 +306,7 @@ async function renderComponentText(
 function getTaskComponentClass(component: TaskLayoutComponent) {
     const componentClassContainer: string[] = [];
 
-    const fieldLayoutDetail = FieldLayouts[component];
-    componentClassContainer.push(fieldLayoutDetail.className);
+    componentClassContainer.push(FieldLayouts[component].className);
 
     return componentClassContainer;
 }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -56,6 +56,16 @@ export class FieldLayoutDetail {
         this.attributeValueCalculator = attributeValueCalculator;
     }
 
+    /**
+     * @returns the data attribute, associated to with a task's component, added in the task's `<span>`.
+     * For example, a task with medium priority and done yesterday will have
+     * `data-task-priority="medium" data-task-due="past-1d" ` in its data attributes.
+     *
+     * Calculation of the value is done with {@link FieldLayoutDetail.attributeValueCalculator}.
+     *
+     * @param component the component of the task for which the data attribute has to be generated.
+     * @param task the task from which the data shall be taken
+     */
     public getDataAttribute(component: TaskLayoutComponent, task: Task) {
         const dataAttribute: AttributesDictionary = {};
 

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -303,6 +303,16 @@ async function renderComponentText(
     }
 }
 
+function extracted(fieldLayoutDetail: FieldLayoutDetail, component: TaskLayoutComponent, task: Task) {
+    const dataAttribute: AttributesDictionary = {};
+    const attributeName = fieldLayoutDetail.attributeName;
+    if (attributeName !== FieldLayoutDetail.noAttributeName) {
+        dataAttribute[attributeName] = fieldLayoutDetail.attributeValueCalculator(component, task);
+    }
+
+    return dataAttribute;
+}
+
 /**
  * The data attribute describes the content of the component, e.g. `data-task-priority="medium"`, `data-task-due="past-1d"` etc.
  */
@@ -311,13 +321,7 @@ function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
     // data attribute value (value). Otherwise, just leave an empty string ('') as the value.
     // The value is calculated based on FieldLayoutDetail.attributeValueCalculator
     const fieldLayoutDetail = FieldLayouts[component];
-    const dataAttribute: AttributesDictionary = {};
-    const attributeName = fieldLayoutDetail.attributeName;
-    if (attributeName !== FieldLayoutDetail.noAttributeName) {
-        dataAttribute[attributeName] = fieldLayoutDetail.attributeValueCalculator(component, task);
-    }
-
-    return dataAttribute;
+    return extracted(fieldLayoutDetail, component, task);
 }
 
 /*

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -57,7 +57,13 @@ export class FieldLayoutDetail {
     }
 
     public getDataAttribute(component: TaskLayoutComponent, task: Task) {
-        return extracted(this, component, task);
+        const dataAttribute: AttributesDictionary = {};
+        const attributeName = this.attributeName;
+        if (attributeName !== FieldLayoutDetail.noAttributeName) {
+            dataAttribute[attributeName] = this.attributeValueCalculator(component, task);
+        }
+
+        return dataAttribute;
     }
 }
 
@@ -305,16 +311,6 @@ async function renderComponentText(
     } else {
         span.innerHTML = componentString;
     }
-}
-
-function extracted(fieldLayoutDetail: FieldLayoutDetail, component: TaskLayoutComponent, task: Task) {
-    const dataAttribute: AttributesDictionary = {};
-    const attributeName = fieldLayoutDetail.attributeName;
-    if (attributeName !== FieldLayoutDetail.noAttributeName) {
-        dataAttribute[attributeName] = fieldLayoutDetail.attributeValueCalculator(component, task);
-    }
-
-    return dataAttribute;
 }
 
 /**

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -304,9 +304,7 @@ async function renderComponentText(
  * that is, that `task[component]` has a value. Only call this if task has this value.
  */
 function getTaskComponentClass(component: TaskLayoutComponent) {
-    const componentClassContainer: string[] = [];
-
-    componentClassContainer.push(FieldLayouts[component].className);
+    const componentClassContainer: string[] = [FieldLayouts[component].className];
 
     return componentClassContainer;
 }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -307,12 +307,11 @@ async function renderComponentText(
  * The data attribute describes the content of the component, e.g. `data-task-priority="medium"`, `data-task-due="past-1d"` etc.
  */
 function getComponentDataAttribute(component: TaskLayoutComponent, task: Task) {
-    const dataAttribute: AttributesDictionary = {};
-
     // If a TaskLayoutComponent needs a data attribute in the task's <span>, get the data attribute name (key) &
     // data attribute value (value). Otherwise, just leave an empty string ('') as the value.
     // The value is calculated based on FieldLayoutDetail.attributeValueCalculator
     const fieldLayoutDetail = FieldLayouts[component];
+    const dataAttribute: AttributesDictionary = {};
     const attributeName = fieldLayoutDetail.attributeName;
     if (attributeName !== FieldLayoutDetail.noAttributeName) {
         dataAttribute[attributeName] = fieldLayoutDetail.attributeValueCalculator(component, task);

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -304,9 +304,7 @@ async function renderComponentText(
  * that is, that `task[component]` has a value. Only call this if task has this value.
  */
 function getTaskComponentClass(component: TaskLayoutComponent) {
-    const componentClassContainer: string[] = [FieldLayouts[component].className];
-
-    return componentClassContainer;
+    return [FieldLayouts[component].className];
 }
 
 /**

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -32,9 +32,12 @@ export class FieldLayoutDetail {
     };
 
     /**
-     * @param className CSS class of the component.
+     * @param className CSS class that describes what the component is, e.g. a due date or a priority,
+     * and is a value from FieldLayouts.
+     *
      * @param attributeName if the component needs data attribute (`data-key="value"`) this is the key.
      * Otherwise, set this to {@link FieldLayoutDetail.noAttributeName}.
+     *
      * @param attributeValueCalculator And this is the value.
      * Set to {@link FieldLayoutDetail.noAttributeValueCalculator} if shall be empty.
      *
@@ -217,7 +220,10 @@ async function taskToHtml(
                 addInternalClasses(component, internalSpan);
 
                 // Add the component's CSS class describing what this component is (priority, due date etc.)
-                const componentClass = getTaskComponentClass(component);
+                //
+                //  It is important to ensure that the Task being rendered does actually have a value for this
+                //  field, that is, that `task[component]` has a value. Only call this if task has this value.
+                const componentClass = [FieldLayouts[component].className];
                 span.classList.add(...componentClass);
 
                 // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
@@ -295,16 +301,6 @@ async function renderComponentText(
     } else {
         span.innerHTML = componentString;
     }
-}
-
-/**
- * The CSS class that describes what the component is, e.g. a due date or a priority, and is a value from FieldLayouts.
- *
- * **Important**: The caller is responsible for ensuring that the Task being rendered does actually have a value for this field,
- * that is, that `task[component]` has a value. Only call this if task has this value.
- */
-function getTaskComponentClass(component: TaskLayoutComponent) {
-    return [FieldLayouts[component].className];
 }
 
 /**

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -32,8 +32,7 @@ export class FieldLayoutDetail {
     };
 
     /**
-     * @param className CSS class that describes what the component is, e.g. a due date or a priority,
-     * and is a value from FieldLayouts.
+     * @param className CSS class that describes what the component is, e.g. a due date or a priority.
      *
      * @param attributeName if the component needs data attribute (`data-key="value"`) this is the key.
      * Otherwise, set this to {@link FieldLayoutDetail.noAttributeName}.

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -22,9 +22,9 @@ export type TaskLineRenderDetails = {
 type AttributeValueCalculator = (component: TaskLayoutComponent, task: Task) => string;
 
 export class FieldLayoutDetail {
-    className: string;
-    attributeName: string;
-    attributeValueCalculator: AttributeValueCalculator;
+    readonly className: string;
+    readonly attributeName: string;
+    readonly attributeValueCalculator: AttributeValueCalculator;
 
     public static noAttributeName = '';
     public static noAttributeValueCalculator: AttributeValueCalculator = () => {

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -44,8 +44,7 @@ async function createMockParentAndRender(task: Task, layoutOptions?: LayoutOptio
 
 function getTextSpan(parentElement: HTMLElement) {
     const li = parentElement.children[0];
-    const textSpan = li.children[1] as HTMLSpanElement;
-    return textSpan;
+    return li.children[1] as HTMLSpanElement;
 }
 
 function getDescriptionText(parentElement: HTMLElement) {

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -695,4 +695,14 @@ describe('Field Layout Detail tests', () => {
         const attributeValue = fieldLayoutDetail.attributeValueCalculator('createdDate', new TaskBuilder().build());
         expect(attributeValue).toEqual('someValue');
     });
+
+    it('should return a data attribute', () => {
+        const fieldLayoutDetail = new FieldLayoutDetail('dataAttributeTest', 'aKey', () => {
+            return 'aValue';
+        });
+        const dataAttribute = fieldLayoutDetail.getDataAttribute('description', new TaskBuilder().build());
+
+        expect(Object.keys(dataAttribute).length).toEqual(1);
+        expect(dataAttribute['aKey']).toEqual('aValue');
+    });
 });


### PR DESCRIPTION
# Description

Following #2403 now the getTaskComponentClass() and getComponentDataAttribute() from TaskLineRenderer.ts shall be refactored.

## Motivation and Context

Move behaviour towards the class that shall have it.

## How has this been tested?

Unit tests.

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
