### PR TITLE
refactor: remove `AttributesDictionary` from `TaskLineRenderer.ts`

### DIFF
--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -156,28 +156,26 @@ export class TaskLineRenderer {
                 // Create the text span that will hold the rendered component
                 const span = document.createElement('span');
                 textSpan.appendChild(span);
-                if (span) {
-                    // Inside that text span, we are creating another internal span, that will hold the text itself.
-                    // This may seem redundant, and by default it indeed does nothing, but we do it to allow the CSS
-                    // to differentiate between the container of the text and the text itself, so it will be possible
-                    // to do things like surrouding only the text (rather than its whole placeholder) with a highlight
-                    const internalSpan = document.createElement('span');
-                    span.appendChild(internalSpan);
-                    await this.renderComponentText(internalSpan, componentString, component, task);
-                    this.addInternalClasses(component, internalSpan);
+                // Inside that text span, we are creating another internal span, that will hold the text itself.
+                // This may seem redundant, and by default it indeed does nothing, but we do it to allow the CSS
+                // to differentiate between the container of the text and the text itself, so it will be possible
+                // to do things like surrouding only the text (rather than its whole placeholder) with a highlight
+                const internalSpan = document.createElement('span');
+                span.appendChild(internalSpan);
+                await this.renderComponentText(internalSpan, componentString, component, task);
+                this.addInternalClasses(component, internalSpan);
 
-                    // Add the component's CSS class describing what this component is (priority, due date etc.)
-                    const fieldLayoutDetails = FieldLayoutDetails[component];
-                    if (fieldLayoutDetails) {
-                        const componentClass = [fieldLayoutDetails.className];
-                        span.classList.add(...componentClass);
-                    }
-
-                    // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
-                    const componentDataAttribute = fieldLayouts.dataAttribute(component, task);
-                    for (const key in componentDataAttribute) span.dataset[key] = componentDataAttribute[key];
-                    taskAttributes = { ...taskAttributes, ...componentDataAttribute };
+                // Add the component's CSS class describing what this component is (priority, due date etc.)
+                const fieldLayoutDetails = FieldLayoutDetails[component];
+                if (fieldLayoutDetails) {
+                    const componentClass = [fieldLayoutDetails.className];
+                    span.classList.add(...componentClass);
                 }
+
+                // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
+                const componentDataAttribute = fieldLayouts.dataAttribute(component, task);
+                for (const key in componentDataAttribute) span.dataset[key] = componentDataAttribute[key];
+                taskAttributes = { ...taskAttributes, ...componentDataAttribute };
             }
         }
 

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -142,13 +142,13 @@ export class TaskLineRenderer {
         const textSpan = document.createElement('span');
         li.appendChild(textSpan);
         textSpan.classList.add('tasks-list-text');
-        const attributes = await this.taskToHtml(task, textSpan);
-        for (const key in attributes) li.dataset[key] = attributes[key];
+        const taskAttributes = await this.taskToHtml(task, textSpan);
+        for (const key in taskAttributes) li.dataset[key] = taskAttributes[key];
         return textSpan;
     }
 
     private async taskToHtml(task: Task, parentElement: HTMLElement): Promise<AttributesDictionary> {
-        let allAttributes: AttributesDictionary = {};
+        let taskAttributes: AttributesDictionary = {};
         const taskLayout = new TaskLayout(this.layoutOptions);
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
         // Render and build classes for all the task's visible components
@@ -181,7 +181,7 @@ export class TaskLineRenderer {
                     // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
                     const componentDataAttribute = fieldLayouts.dataAttribute(component, task);
                     for (const key in componentDataAttribute) span.dataset[key] = componentDataAttribute[key];
-                    allAttributes = { ...allAttributes, ...componentDataAttribute };
+                    taskAttributes = { ...taskAttributes, ...componentDataAttribute };
                 }
             }
         }
@@ -189,7 +189,7 @@ export class TaskLineRenderer {
         // Now build classes for the hidden task components without rendering them
         for (const component of taskLayout.hiddenTaskLayoutComponents) {
             const hiddenComponentDataAttribute = fieldLayouts.dataAttribute(component, task);
-            allAttributes = { ...allAttributes, ...hiddenComponentDataAttribute };
+            taskAttributes = { ...taskAttributes, ...hiddenComponentDataAttribute };
         }
 
         // If a task has no priority field set, its priority will not be rendered as part of the loop above and
@@ -197,12 +197,12 @@ export class TaskLineRenderer {
         // In such a case we want the upper task LI element to mark the task has a 'normal' priority.
         // So if the priority was not rendered, force it through the pipe of getting the component data for the
         // priority field.
-        if (allAttributes.taskPriority === undefined) {
+        if (taskAttributes.taskPriority === undefined) {
             const priorityDataAttribute = fieldLayouts.dataAttribute('priority', task);
-            allAttributes = { ...allAttributes, ...priorityDataAttribute };
+            taskAttributes = { ...taskAttributes, ...priorityDataAttribute };
         }
 
-        return allAttributes;
+        return taskAttributes;
     }
 
     /*

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -142,12 +142,7 @@ export class TaskLineRenderer {
         const textSpan = document.createElement('span');
         li.appendChild(textSpan);
         textSpan.classList.add('tasks-list-text');
-        const taskAttributes = await this.taskToHtml(task, textSpan);
-        for (const key in taskAttributes) li.dataset[key] = taskAttributes[key];
-        return textSpan;
-    }
 
-    private async taskToHtml(task: Task, textSpan: HTMLElement): Promise<AttributesDictionary> {
         let taskAttributes: AttributesDictionary = {};
         const taskLayout = new TaskLayout(this.layoutOptions);
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
@@ -202,7 +197,8 @@ export class TaskLineRenderer {
             taskAttributes = { ...taskAttributes, ...priorityDataAttribute };
         }
 
-        return taskAttributes;
+        for (const key in taskAttributes) li.dataset[key] = taskAttributes[key];
+        return textSpan;
     }
 
     /*

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -5,7 +5,7 @@ import { TASK_FORMATS, getSettings } from './Config/Settings';
 import { replaceTaskWithTasks } from './File';
 import type { Task } from './Task';
 import * as taskModule from './Task';
-import { type AttributesDictionary, FieldLayoutDetails, FieldLayouts } from './TaskFieldRenderer';
+import { FieldLayoutDetails, FieldLayouts } from './TaskFieldRenderer';
 import type { LayoutOptions, TaskLayoutComponent } from './TaskLayout';
 import { TaskLayout } from './TaskLayout';
 
@@ -143,7 +143,6 @@ export class TaskLineRenderer {
         li.appendChild(textSpan);
         textSpan.classList.add('tasks-list-text');
 
-        let taskAttributes: AttributesDictionary = {};
         const taskLayout = new TaskLayout(this.layoutOptions);
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
         // Render and build classes for all the task's visible components
@@ -175,14 +174,14 @@ export class TaskLineRenderer {
                 // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
                 const componentDataAttribute = fieldLayouts.dataAttribute(component, task);
                 for (const key in componentDataAttribute) span.dataset[key] = componentDataAttribute[key];
-                taskAttributes = { ...taskAttributes, ...componentDataAttribute };
+                for (const key in componentDataAttribute) li.dataset[key] = componentDataAttribute[key];
             }
         }
 
         // Now build classes for the hidden task components without rendering them
         for (const component of taskLayout.hiddenTaskLayoutComponents) {
             const hiddenComponentDataAttribute = fieldLayouts.dataAttribute(component, task);
-            taskAttributes = { ...taskAttributes, ...hiddenComponentDataAttribute };
+            for (const key in hiddenComponentDataAttribute) li.dataset[key] = hiddenComponentDataAttribute[key];
         }
 
         // If a task has no priority field set, its priority will not be rendered as part of the loop above and
@@ -190,12 +189,11 @@ export class TaskLineRenderer {
         // In such a case we want the upper task LI element to mark the task has a 'normal' priority.
         // So if the priority was not rendered, force it through the pipe of getting the component data for the
         // priority field.
-        if (taskAttributes.taskPriority === undefined) {
+        if (li.dataset.taskPriority === undefined) {
             const priorityDataAttribute = fieldLayouts.dataAttribute('priority', task);
-            taskAttributes = { ...taskAttributes, ...priorityDataAttribute };
+            for (const key in priorityDataAttribute) li.dataset[key] = priorityDataAttribute[key];
         }
 
-        for (const key in taskAttributes) li.dataset[key] = taskAttributes[key];
         return textSpan;
     }
 

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -147,7 +147,7 @@ export class TaskLineRenderer {
         return textSpan;
     }
 
-    private async taskToHtml(task: Task, parentElement: HTMLElement): Promise<AttributesDictionary> {
+    private async taskToHtml(task: Task, textSpan: HTMLElement): Promise<AttributesDictionary> {
         let taskAttributes: AttributesDictionary = {};
         const taskLayout = new TaskLayout(this.layoutOptions);
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
@@ -160,7 +160,7 @@ export class TaskLineRenderer {
                 }
                 // Create the text span that will hold the rendered component
                 const span = document.createElement('span');
-                parentElement.appendChild(span);
+                textSpan.appendChild(span);
                 if (span) {
                     // Inside that text span, we are creating another internal span, that will hold the text itself.
                     // This may seem redundant, and by default it indeed does nothing, but we do it to allow the CSS

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -89,16 +89,7 @@ export class TaskLineRenderer {
 
         li.classList.add('task-list-item', 'plugin-tasks-list-item');
 
-        // Maintenance note:
-        //  We don't use the Obsidian convenience function li.createEl() here, because we don't have it available
-        //  when running tests, and we want the tests to be able to create the full div and span structure,
-        //  so had to convert all of these to the equivalent but more elaborate document.createElement() and
-        //  appendChild() calls.
-        const textSpan = document.createElement('span');
-        li.appendChild(textSpan);
-        textSpan.classList.add('tasks-list-text');
-        const attributes = await this.taskToHtml(task, textSpan);
-        for (const key in attributes) li.dataset[key] = attributes[key];
+        const textSpan = await this.renderTaskText(li, task);
 
         // NOTE: this area is mentioned in `CONTRIBUTING.md` under "How does Tasks handle status changes". When
         // moving the code, remember to update that reference too.
@@ -140,6 +131,20 @@ export class TaskLineRenderer {
         }
 
         return li;
+    }
+
+    private async renderTaskText(li: HTMLLIElement, task: Task) {
+        // Maintenance note:
+        //  We don't use the Obsidian convenience function li.createEl() here, because we don't have it available
+        //  when running tests, and we want the tests to be able to create the full div and span structure,
+        //  so had to convert all of these to the equivalent but more elaborate document.createElement() and
+        //  appendChild() calls.
+        const textSpan = document.createElement('span');
+        li.appendChild(textSpan);
+        textSpan.classList.add('tasks-list-text');
+        const attributes = await this.taskToHtml(task, textSpan);
+        for (const key in attributes) li.dataset[key] = attributes[key];
+        return textSpan;
     }
 
     private async taskToHtml(task: Task, parentElement: HTMLElement): Promise<AttributesDictionary> {


### PR DESCRIPTION
# Description

Remove`AttributesDictionary` from `TaskLineRenderer.ts` (imported from `TaskFieldRenderer.ts`.

## Motivation and Context

Separate concerns of rendering the task and its components.

## How has this been tested?

Unit tests.

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
