### PR TITLE
refactor: add data attributes in `TaskFieldRenderer` instead of returning them

### DIFF
--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -124,9 +124,7 @@ export class TaskFieldHTMLData {
         const dataAttribute: AttributesDictionary = {};
 
         if (this.attributeName !== TaskFieldHTMLData.noAttributeName) {
-            const key = this.attributeName;
-            const value = this.attributeValueCalculator(component, task);
-            element.dataset[key] = value;
+            element.dataset[this.attributeName] = this.attributeValueCalculator(component, task);
         }
 
         return dataAttribute;

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -121,13 +121,9 @@ export class TaskFieldHTMLData {
      * @param element
      */
     public dataAttribute(component: TaskLayoutComponent, task: Task, element: HTMLElement) {
-        const dataAttribute: AttributesDictionary = {};
-
         if (this.attributeName !== TaskFieldHTMLData.noAttributeName) {
             element.dataset[this.attributeName] = this.attributeValueCalculator(component, task);
         }
-
-        return dataAttribute;
     }
 }
 

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -3,8 +3,6 @@ import { PriorityTools } from './lib/PriorityTools';
 import type { Task } from './Task';
 import type { TaskLayoutComponent } from './TaskLayout';
 
-export type AttributesDictionary = { [key: string]: string };
-
 export class TaskFieldRenderer {
     private readonly data = taskFieldHTMLData;
 

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -14,14 +14,14 @@ export class TaskFieldRenderer {
      *
      * If no data was found for a component in a task, data attributes won't be added.
      *
-     * For detailed calculation see {@link TaskFieldHTMLData.dataAttribute}.
+     * For detailed calculation see {@link TaskFieldHTMLData.addDataAttribute}.
      *
      * @param component the component of the task for which the data attribute has to be added.
      * @param task the task from which the for the data attributes shall be taken.
      * @param element the HTML element to add the data attributes to.
      */
-    public dataAttribute(component: TaskLayoutComponent, task: Task, element: HTMLElement) {
-        this.data[component].dataAttribute(component, task, element);
+    public addDataAttribute(component: TaskLayoutComponent, task: Task, element: HTMLElement) {
+        this.data[component].addDataAttribute(component, task, element);
     }
 
     /**
@@ -118,7 +118,7 @@ export class TaskFieldHTMLData {
      * @param task the task from which the data shall be taken.
      * @param element the HTML element to add the data attributes to.
      */
-    public dataAttribute(component: TaskLayoutComponent, task: Task, element: HTMLElement) {
+    public addDataAttribute(component: TaskLayoutComponent, task: Task, element: HTMLElement) {
         if (this.attributeName !== TaskFieldHTMLData.noAttributeName) {
             element.dataset[this.attributeName] = this.attributeValueCalculator(component, task);
         }

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -16,12 +16,12 @@ export class TaskFieldRenderer {
      *
      * For detailed calculation see {@link TaskFieldHTMLData.addDataAttribute}.
      *
-     * @param component the component of the task for which the data attribute has to be added.
-     * @param task the task from which the for the data attributes shall be taken.
      * @param element the HTML element to add the data attributes to.
+     * @param task the task from which the for the data attributes shall be taken.
+     * @param component the component of the task for which the data attribute has to be added.
      */
-    public addDataAttribute(component: TaskLayoutComponent, task: Task, element: HTMLElement) {
-        this.data[component].addDataAttribute(component, task, element);
+    public addDataAttribute(element: HTMLElement, task: Task, component: TaskLayoutComponent) {
+        this.data[component].addDataAttribute(element, task, component);
     }
 
     /**
@@ -114,11 +114,11 @@ export class TaskFieldHTMLData {
      *
      * Calculation of the value is done with {@link TaskFieldHTMLData.attributeValueCalculator}.
      *
-     * @param component the component of the task for which the data attribute has to be added.
-     * @param task the task from which the data shall be taken.
      * @param element the HTML element to add the data attributes to.
+     * @param task the task from which the data shall be taken.
+     * @param component the component of the task for which the data attribute has to be added.
      */
-    public addDataAttribute(component: TaskLayoutComponent, task: Task, element: HTMLElement) {
+    public addDataAttribute(element: HTMLElement, task: Task, component: TaskLayoutComponent) {
         if (this.attributeName !== TaskFieldHTMLData.noAttributeName) {
             element.dataset[this.attributeName] = this.attributeValueCalculator(component, task);
         }

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -124,7 +124,9 @@ export class TaskFieldHTMLData {
         const dataAttribute: AttributesDictionary = {};
 
         if (this.attributeName !== TaskFieldHTMLData.noAttributeName) {
-            dataAttribute[this.attributeName] = this.attributeValueCalculator(component, task);
+            const key = this.attributeName;
+            const value = this.attributeValueCalculator(component, task);
+            dataAttribute[key] = value;
             for (const key in dataAttribute) element.dataset[key] = dataAttribute[key];
         }
 

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -23,7 +23,7 @@ export class TaskFieldRenderer {
      * @param element
      */
     public dataAttribute(component: TaskLayoutComponent, task: Task, element: HTMLElement) {
-        return this.data[component].dataAttribute(component, task, element);
+        this.data[component].dataAttribute(component, task, element);
     }
 
     /**

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -126,8 +126,7 @@ export class TaskFieldHTMLData {
         if (this.attributeName !== TaskFieldHTMLData.noAttributeName) {
             const key = this.attributeName;
             const value = this.attributeValueCalculator(component, task);
-            dataAttribute[key] = value;
-            for (const key in dataAttribute) element.dataset[key] = dataAttribute[key];
+            element.dataset[key] = value;
         }
 
         return dataAttribute;

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -20,10 +20,10 @@ export class TaskFieldRenderer {
      *
      * @param component the component of the task for which the data attribute has to be generated.
      * @param task the task from which the data shall be taken
-     * @param _element
+     * @param element
      */
-    public dataAttribute(component: TaskLayoutComponent, task: Task, _element: HTMLElement) {
-        return this.data[component].dataAttribute(component, task);
+    public dataAttribute(component: TaskLayoutComponent, task: Task, element: HTMLElement) {
+        return this.data[component].dataAttribute(component, task, element);
     }
 
     /**
@@ -118,8 +118,9 @@ export class TaskFieldHTMLData {
      *
      * @param component the component of the task for which the data attribute has to be generated.
      * @param task the task from which the data shall be taken
+     * @param _element
      */
-    public dataAttribute(component: TaskLayoutComponent, task: Task) {
+    public dataAttribute(component: TaskLayoutComponent, task: Task, _element: HTMLElement) {
         const dataAttribute: AttributesDictionary = {};
 
         if (this.attributeName !== TaskFieldHTMLData.noAttributeName) {

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -7,18 +7,18 @@ export class TaskFieldRenderer {
     private readonly data = taskFieldHTMLData;
 
     /**
-     * Searches for the component among the {@link taskFieldHTMLData} and gets its data attribute
-     * in a given task. The data attribute shall be added in the task's `<span>`.
-     * For example, a task with medium priority and done yesterday will have
-     * `data-task-priority="medium" data-task-due="past-1d" ` in its data attributes.
+     * Adds data attributes to an {@link HTMLElement} for a component. The data for the data attribute
+     * comes from {@link taskFieldHTMLData}.
+     * For example, a `<span>` describing a task with medium priority and done yesterday will have
+     * `data-task-priority="medium" data-task-due="past-1d"` in its data attributes.
      *
-     * If the data attribute is absent in the task, an empty {@link AttributesDictionary} is returned.
+     * If no data was found for a component in a task, data attributes won't be added.
      *
      * For detailed calculation see {@link TaskFieldHTMLData.dataAttribute}.
      *
-     * @param component the component of the task for which the data attribute has to be generated.
-     * @param task the task from which the data shall be taken
-     * @param element
+     * @param component the component of the task for which the data attribute has to be added.
+     * @param task the task from which the for the data attributes shall be taken.
+     * @param element the HTML element to add the data attributes to.
      */
     public dataAttribute(component: TaskLayoutComponent, task: Task, element: HTMLElement) {
         this.data[component].dataAttribute(component, task, element);
@@ -106,17 +106,17 @@ export class TaskFieldHTMLData {
     }
 
     /**
-     * Shall be called only by {@link TaskFieldRenderer}. Use that class if you need the data attributes.
+     * Shall be called only by {@link TaskFieldRenderer}. Use that class if you need to add the data attributes.
      *
-     * @returns the data attribute, associated to with a task's component, added in the task's `<span>`.
+     * Adds the data attribute, associated to with a task's component to an HTML element.
      * For example, a task with medium priority and done yesterday will have
      * `data-task-priority="medium" data-task-due="past-1d" ` in its data attributes.
      *
      * Calculation of the value is done with {@link TaskFieldHTMLData.attributeValueCalculator}.
      *
-     * @param component the component of the task for which the data attribute has to be generated.
-     * @param task the task from which the data shall be taken
-     * @param element
+     * @param component the component of the task for which the data attribute has to be added.
+     * @param task the task from which the data shall be taken.
+     * @param element the HTML element to add the data attributes to.
      */
     public dataAttribute(component: TaskLayoutComponent, task: Task, element: HTMLElement) {
         if (this.attributeName !== TaskFieldHTMLData.noAttributeName) {

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -7,16 +7,16 @@ export class TaskFieldRenderer {
     private readonly data = taskFieldHTMLData;
 
     /**
-     * Adds data attributes to an {@link element} for a component. For example,
+     * Adds data attribute to an {@link element} for a component. For example,
      * a `<span>` describing a task with medium priority and done yesterday will have
-     * `data-task-priority="medium" data-task-due="past-1d"` in its data attributes.
+     * `data-task-priority="medium" data-task-due="past-1d"` in its data attributes (One data attribute per component).
      *
-     * If no data was found for a component in a task, data attributes won't be added.
+     * If no data was found for a component in a task, data attribute won't be added.
      *
      * For detailed calculation see {@link TaskFieldHTMLData.addDataAttribute}.
      *
-     * @param element the HTML element to add the data attributes to.
-     * @param task the task from which the for the data attributes shall be taken.
+     * @param element the HTML element to add the data attribute to.
+     * @param task the task from which the for the data attribute shall be taken.
      * @param component the component of the task for which the data attribute has to be added.
      */
     public addDataAttribute(element: HTMLElement, task: Task, component: TaskLayoutComponent) {
@@ -105,15 +105,15 @@ export class TaskFieldHTMLData {
     }
 
     /**
-     * Shall be called only by {@link TaskFieldRenderer}. Use that class if you need to add the data attributes.
+     * Shall be called only by {@link TaskFieldRenderer}. Use that class if you need to add a data attribute.
      *
      * Adds the data attribute, associated to with a task's component to an HTML element.
      * For example, a task with medium priority and done yesterday will have
-     * `data-task-priority="medium" data-task-due="past-1d" ` in its data attributes.
+     * `data-task-priority="medium" data-task-due="past-1d" ` in its data attributes (One data attribute per component).
      *
      * Calculation of the value is done with {@link TaskFieldHTMLData.attributeValueCalculator}.
      *
-     * @param element the HTML element to add the data attributes to.
+     * @param element the HTML element to add the data attribute to.
      * @param task the task from which the data shall be taken.
      * @param component the component of the task for which the data attribute has to be added.
      */

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -20,8 +20,9 @@ export class TaskFieldRenderer {
      *
      * @param component the component of the task for which the data attribute has to be generated.
      * @param task the task from which the data shall be taken
+     * @param _element
      */
-    public dataAttribute(component: TaskLayoutComponent, task: Task) {
+    public dataAttribute(component: TaskLayoutComponent, task: Task, _element: HTMLElement) {
         return this.data[component].dataAttribute(component, task);
     }
 

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -7,9 +7,8 @@ export class TaskFieldRenderer {
     private readonly data = taskFieldHTMLData;
 
     /**
-     * Adds data attributes to an {@link HTMLElement} for a component. The data for the data attribute
-     * comes from {@link taskFieldHTMLData}.
-     * For example, a `<span>` describing a task with medium priority and done yesterday will have
+     * Adds data attributes to an {@link element} for a component. For example,
+     * a `<span>` describing a task with medium priority and done yesterday will have
      * `data-task-priority="medium" data-task-due="past-1d"` in its data attributes.
      *
      * If no data was found for a component in a task, data attributes won't be added.

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -118,13 +118,14 @@ export class TaskFieldHTMLData {
      *
      * @param component the component of the task for which the data attribute has to be generated.
      * @param task the task from which the data shall be taken
-     * @param _element
+     * @param element
      */
-    public dataAttribute(component: TaskLayoutComponent, task: Task, _element: HTMLElement) {
+    public dataAttribute(component: TaskLayoutComponent, task: Task, element: HTMLElement) {
         const dataAttribute: AttributesDictionary = {};
 
         if (this.attributeName !== TaskFieldHTMLData.noAttributeName) {
             dataAttribute[this.attributeName] = this.attributeValueCalculator(component, task);
+            for (const key in dataAttribute) element.dataset[key] = dataAttribute[key];
         }
 
         return dataAttribute;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -72,7 +72,7 @@ export class TaskLineRenderer {
      * configuration and a supplied TextRenderer (typically the Obsidian Markdown renderer, but for testing
      * purposes it can be a simpler one).
      *
-     * The element includes the task and its various components (description, priority, block link etc), the
+     * The element includes the task and its various components (description, priority, block link etc.), the
      * checkbox on the left with its event handling of completing the task, and the button for editing the task.
      *
      * @returns an HTML rendered List Item element (LI) for a task.
@@ -158,7 +158,7 @@ export class TaskLineRenderer {
                     // Inside that text span, we are creating another internal span, that will hold the text itself.
                     // This may seem redundant, and by default it indeed does nothing, but we do it to allow the CSS
                     // to differentiate between the container of the text and the text itself, so it will be possible
-                    // to do things like surrouding only the text (rather than its whole placeholder) with a highlight
+                    // to do things like surrounding only the text (rather than its whole placeholder) with a highlight
                     const internalSpan = document.createElement('span');
                     span.appendChild(internalSpan);
                     await this.renderComponentText(internalSpan, componentString, component, task);
@@ -180,7 +180,7 @@ export class TaskLineRenderer {
             fieldRenderer.addDataAttribute(li, task, component);
         }
 
-        // If a task has no priority field set, its priority will not be rendered as part of the loop above and
+        // If a task has no priority field set, its priority will not be rendered as part of the loop above, and
         // it will not be set a priority data attribute.
         // In such a case we want the upper task LI element to mark the task has a 'normal' priority.
         // So if the priority was not rendered, force it through the pipe of getting the component data for the
@@ -246,14 +246,14 @@ export class TaskLineRenderer {
      */
     private addInternalClasses(component: TaskLayoutComponent, internalSpan: HTMLSpanElement) {
         /*
-         * Sanitize tag names so they will be valid attribute values according to the HTML spec:
+         * Sanitize tag names, so they will be valid attribute values according to the HTML spec:
          * https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(double-quoted)-state
          */
         function tagToAttributeValue(tag: string) {
             // eslint-disable-next-line no-control-regex
             const illegalChars = /["&\x00\r\n]/g;
             let sanitizedTag = tag.replace(illegalChars, '-');
-            // And if after sanitazation the name starts with dashes or underscores, remove them.
+            // And if after sanitization the name starts with dashes or underscores, remove them.
             sanitizedTag = sanitizedTag.replace(/^[-_]+/, '');
             if (sanitizedTag.length > 0) return sanitizedTag;
             else return null;

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -169,15 +169,15 @@ export class TaskLineRenderer {
                     span.classList.add(...[componentClass]);
 
                     // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
-                    fieldRenderer.addDataAttribute(component, task, span);
-                    fieldRenderer.addDataAttribute(component, task, li);
+                    fieldRenderer.addDataAttribute(span, task, component);
+                    fieldRenderer.addDataAttribute(li, task, component);
                 }
             }
         }
 
         // Now build classes for the hidden task components without rendering them
         for (const component of taskLayout.hiddenTaskLayoutComponents) {
-            fieldRenderer.addDataAttribute(component, task, li);
+            fieldRenderer.addDataAttribute(li, task, component);
         }
 
         // If a task has no priority field set, its priority will not be rendered as part of the loop above and
@@ -186,7 +186,7 @@ export class TaskLineRenderer {
         // So if the priority was not rendered, force it through the pipe of getting the component data for the
         // priority field.
         if (li.dataset.taskPriority === undefined) {
-            fieldRenderer.addDataAttribute('priority', task, li);
+            fieldRenderer.addDataAttribute(li, task, 'priority');
         }
     }
 

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -169,7 +169,7 @@ export class TaskLineRenderer {
                     span.classList.add(...[componentClass]);
 
                     // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
-                    const componentDataAttribute = fieldRenderer.dataAttribute(component, task);
+                    const componentDataAttribute = fieldRenderer.dataAttribute(component, task, li);
                     for (const key in componentDataAttribute) span.dataset[key] = componentDataAttribute[key];
                     for (const key in componentDataAttribute) li.dataset[key] = componentDataAttribute[key];
                 }
@@ -178,7 +178,7 @@ export class TaskLineRenderer {
 
         // Now build classes for the hidden task components without rendering them
         for (const component of taskLayout.hiddenTaskLayoutComponents) {
-            const hiddenComponentDataAttribute = fieldRenderer.dataAttribute(component, task);
+            const hiddenComponentDataAttribute = fieldRenderer.dataAttribute(component, task, li);
             for (const key in hiddenComponentDataAttribute) li.dataset[key] = hiddenComponentDataAttribute[key];
         }
 
@@ -188,7 +188,7 @@ export class TaskLineRenderer {
         // So if the priority was not rendered, force it through the pipe of getting the component data for the
         // priority field.
         if (li.dataset.taskPriority === undefined) {
-            const priorityDataAttribute = fieldRenderer.dataAttribute('priority', task);
+            const priorityDataAttribute = fieldRenderer.dataAttribute('priority', task, li);
             for (const key in priorityDataAttribute) li.dataset[key] = priorityDataAttribute[key];
         }
     }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -169,17 +169,15 @@ export class TaskLineRenderer {
                     span.classList.add(...[componentClass]);
 
                     // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
-                    const componentDataAttribute = fieldRenderer.dataAttribute(component, task, li);
-                    for (const key in componentDataAttribute) span.dataset[key] = componentDataAttribute[key];
-                    for (const key in componentDataAttribute) li.dataset[key] = componentDataAttribute[key];
+                    fieldRenderer.dataAttribute(component, task, span);
+                    fieldRenderer.dataAttribute(component, task, li);
                 }
             }
         }
 
         // Now build classes for the hidden task components without rendering them
         for (const component of taskLayout.hiddenTaskLayoutComponents) {
-            const hiddenComponentDataAttribute = fieldRenderer.dataAttribute(component, task, li);
-            for (const key in hiddenComponentDataAttribute) li.dataset[key] = hiddenComponentDataAttribute[key];
+            fieldRenderer.dataAttribute(component, task, li);
         }
 
         // If a task has no priority field set, its priority will not be rendered as part of the loop above and
@@ -188,8 +186,7 @@ export class TaskLineRenderer {
         // So if the priority was not rendered, force it through the pipe of getting the component data for the
         // priority field.
         if (li.dataset.taskPriority === undefined) {
-            const priorityDataAttribute = fieldRenderer.dataAttribute('priority', task, li);
-            for (const key in priorityDataAttribute) li.dataset[key] = priorityDataAttribute[key];
+            fieldRenderer.dataAttribute('priority', task, li);
         }
     }
 

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -169,15 +169,15 @@ export class TaskLineRenderer {
                     span.classList.add(...[componentClass]);
 
                     // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
-                    fieldRenderer.dataAttribute(component, task, span);
-                    fieldRenderer.dataAttribute(component, task, li);
+                    fieldRenderer.addDataAttribute(component, task, span);
+                    fieldRenderer.addDataAttribute(component, task, li);
                 }
             }
         }
 
         // Now build classes for the hidden task components without rendering them
         for (const component of taskLayout.hiddenTaskLayoutComponents) {
-            fieldRenderer.dataAttribute(component, task, li);
+            fieldRenderer.addDataAttribute(component, task, li);
         }
 
         // If a task has no priority field set, its priority will not be rendered as part of the loop above and
@@ -186,7 +186,7 @@ export class TaskLineRenderer {
         // So if the priority was not rendered, force it through the pipe of getting the component data for the
         // priority field.
         if (li.dataset.taskPriority === undefined) {
-            fieldRenderer.dataAttribute('priority', task, li);
+            fieldRenderer.addDataAttribute('priority', task, li);
         }
     }
 

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -68,9 +68,7 @@ export class TaskLineRenderer {
     }
 
     /**
-     * Renders a given Task object into an HTML List Item (LI) element, using the given renderDetails
-     * configuration and a supplied TextRenderer (typically the Obsidian Markdown renderer, but for testing
-     * purposes it can be a simpler one).
+     * Renders a given Task object into an HTML List Item (LI) element.
      *
      * The element includes the task and its various components (description, priority, block link etc.), the
      * checkbox on the left with its event handling of completing the task, and the button for editing the task.

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -19,7 +19,7 @@ describe('Field Layouts Container tests', () => {
         jest.useRealTimers();
     });
 
-    it('should get the data attribute of an existing component (date)', () => {
+    it('should add a data attribute for an existing component (date)', () => {
         const task = new TaskBuilder().dueDate('2023-11-20').build();
         const span = document.createElement('span');
 
@@ -29,7 +29,7 @@ describe('Field Layouts Container tests', () => {
         expect(span.dataset['taskDue']).toEqual('future-1d');
     });
 
-    it('should get the data attribute of an existing component (not date)', () => {
+    it('should add a data attribute for an existing component (not date)', () => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const span = document.createElement('span');
 
@@ -38,7 +38,7 @@ describe('Field Layouts Container tests', () => {
         expect(Object.keys(span.dataset).length).toEqual(1);
         expect(span.dataset['taskPriority']).toEqual('medium');
     });
-    it('should return empty data attributes dictionary for a missing component', () => {
+    it('should not add any data attributes for a missing component', () => {
         const task = new TaskBuilder().build();
         const span = document.createElement('span');
 
@@ -49,14 +49,14 @@ describe('Field Layouts Container tests', () => {
 });
 
 describe('Field Layout Detail tests', () => {
-    it('should supply a class name and a data attribute name', () => {
+    it('should supply a class name', () => {
         const fieldLayoutDetail = new TaskFieldHTMLData('stuff', 'taskAttribute', () => {
             return '';
         });
         expect(fieldLayoutDetail.className).toEqual('stuff');
     });
 
-    it('should return a data attribute', () => {
+    it('should add a data attribute for an HTML element', () => {
         const fieldLayoutDetail = new TaskFieldHTMLData('dataAttributeTest', 'aKey', () => {
             return 'aValue';
         });

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -7,6 +7,8 @@ import { TaskBuilder } from './TestingTools/TaskBuilder';
 
 window.moment = moment;
 
+const fieldRenderer = new TaskFieldRenderer();
+
 describe('Field Layouts Container tests', () => {
     beforeEach(() => {
         jest.useFakeTimers();
@@ -18,33 +20,29 @@ describe('Field Layouts Container tests', () => {
     });
 
     it('should get the data attribute of an existing component (date)', () => {
-        const container = new TaskFieldRenderer();
         const task = new TaskBuilder().dueDate('2023-11-20').build();
         const span = document.createElement('span');
 
-        const dueDateDataAttribute = container.dataAttribute('dueDate', task, span);
+        const dueDateDataAttribute = fieldRenderer.dataAttribute('dueDate', task, span);
 
         expect(Object.keys(dueDateDataAttribute).length).toEqual(1);
         expect(dueDateDataAttribute['taskDue']).toEqual('future-1d');
     });
 
     it('should get the data attribute of an existing component (not date)', () => {
-        const container = new TaskFieldRenderer();
         const task = TaskBuilder.createFullyPopulatedTask();
         const span = document.createElement('span');
 
-        const dueDateDataAttribute = container.dataAttribute('priority', task, span);
+        const dueDateDataAttribute = fieldRenderer.dataAttribute('priority', task, span);
 
         expect(Object.keys(dueDateDataAttribute).length).toEqual(1);
         expect(dueDateDataAttribute['taskPriority']).toEqual('medium');
     });
-
     it('should return empty data attributes dictionary for a missing component', () => {
-        const container = new TaskFieldRenderer();
         const task = new TaskBuilder().build();
         const span = document.createElement('span');
 
-        const dueDateDataAttribute = container.dataAttribute('recurrenceRule', task, span);
+        const dueDateDataAttribute = fieldRenderer.dataAttribute('recurrenceRule', task, span);
 
         expect(Object.keys(dueDateDataAttribute).length).toEqual(0);
     });

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -23,7 +23,7 @@ describe('Field Layouts Container tests', () => {
         const task = new TaskBuilder().dueDate('2023-11-20').build();
         const span = document.createElement('span');
 
-        fieldRenderer.addDataAttribute('dueDate', task, span);
+        fieldRenderer.addDataAttribute(span, task, 'dueDate');
 
         expect(Object.keys(span.dataset).length).toEqual(1);
         expect(span.dataset['taskDue']).toEqual('future-1d');
@@ -33,7 +33,7 @@ describe('Field Layouts Container tests', () => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const span = document.createElement('span');
 
-        fieldRenderer.addDataAttribute('priority', task, span);
+        fieldRenderer.addDataAttribute(span, task, 'priority');
 
         expect(Object.keys(span.dataset).length).toEqual(1);
         expect(span.dataset['taskPriority']).toEqual('medium');
@@ -42,7 +42,7 @@ describe('Field Layouts Container tests', () => {
         const task = new TaskBuilder().build();
         const span = document.createElement('span');
 
-        fieldRenderer.addDataAttribute('recurrenceRule', task, span);
+        fieldRenderer.addDataAttribute(span, task, 'recurrenceRule');
 
         expect(Object.keys(span.dataset).length).toEqual(0);
     });
@@ -62,7 +62,7 @@ describe('Field Layout Detail tests', () => {
         });
         const span = document.createElement('span');
 
-        fieldLayoutDetail.addDataAttribute('description', new TaskBuilder().build(), span);
+        fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'description');
 
         expect(Object.keys(span.dataset).length).toEqual(1);
         expect(span.dataset['aKey']).toEqual('aValue');

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -23,28 +23,28 @@ describe('Field Layouts Container tests', () => {
         const task = new TaskBuilder().dueDate('2023-11-20').build();
         const span = document.createElement('span');
 
-        const dueDateDataAttribute = fieldRenderer.dataAttribute('dueDate', task, span);
+        fieldRenderer.dataAttribute('dueDate', task, span);
 
-        expect(Object.keys(dueDateDataAttribute).length).toEqual(1);
-        expect(dueDateDataAttribute['taskDue']).toEqual('future-1d');
+        expect(Object.keys(span.dataset).length).toEqual(1);
+        expect(span.dataset['taskDue']).toEqual('future-1d');
     });
 
     it('should get the data attribute of an existing component (not date)', () => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const span = document.createElement('span');
 
-        const dueDateDataAttribute = fieldRenderer.dataAttribute('priority', task, span);
+        fieldRenderer.dataAttribute('priority', task, span);
 
-        expect(Object.keys(dueDateDataAttribute).length).toEqual(1);
-        expect(dueDateDataAttribute['taskPriority']).toEqual('medium');
+        expect(Object.keys(span.dataset).length).toEqual(1);
+        expect(span.dataset['taskPriority']).toEqual('medium');
     });
     it('should return empty data attributes dictionary for a missing component', () => {
         const task = new TaskBuilder().build();
         const span = document.createElement('span');
 
-        const dueDateDataAttribute = fieldRenderer.dataAttribute('recurrenceRule', task, span);
+        fieldRenderer.dataAttribute('recurrenceRule', task, span);
 
-        expect(Object.keys(dueDateDataAttribute).length).toEqual(0);
+        expect(Object.keys(span.dataset).length).toEqual(0);
     });
 });
 

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -60,7 +60,8 @@ describe('Field Layout Detail tests', () => {
         const fieldLayoutDetail = new TaskFieldHTMLData('dataAttributeTest', 'aKey', () => {
             return 'aValue';
         });
-        const dataAttribute = fieldLayoutDetail.dataAttribute('description', new TaskBuilder().build());
+        const span = document.createElement('span');
+        const dataAttribute = fieldLayoutDetail.dataAttribute('description', new TaskBuilder().build(), span);
 
         expect(Object.keys(dataAttribute).length).toEqual(1);
         expect(dataAttribute['aKey']).toEqual('aValue');

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -23,7 +23,7 @@ describe('Field Layouts Container tests', () => {
         const task = new TaskBuilder().dueDate('2023-11-20').build();
         const span = document.createElement('span');
 
-        fieldRenderer.dataAttribute('dueDate', task, span);
+        fieldRenderer.addDataAttribute('dueDate', task, span);
 
         expect(Object.keys(span.dataset).length).toEqual(1);
         expect(span.dataset['taskDue']).toEqual('future-1d');
@@ -33,7 +33,7 @@ describe('Field Layouts Container tests', () => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const span = document.createElement('span');
 
-        fieldRenderer.dataAttribute('priority', task, span);
+        fieldRenderer.addDataAttribute('priority', task, span);
 
         expect(Object.keys(span.dataset).length).toEqual(1);
         expect(span.dataset['taskPriority']).toEqual('medium');
@@ -42,7 +42,7 @@ describe('Field Layouts Container tests', () => {
         const task = new TaskBuilder().build();
         const span = document.createElement('span');
 
-        fieldRenderer.dataAttribute('recurrenceRule', task, span);
+        fieldRenderer.addDataAttribute('recurrenceRule', task, span);
 
         expect(Object.keys(span.dataset).length).toEqual(0);
     });
@@ -62,7 +62,7 @@ describe('Field Layout Detail tests', () => {
         });
         const span = document.createElement('span');
 
-        fieldLayoutDetail.dataAttribute('description', new TaskBuilder().build(), span);
+        fieldLayoutDetail.addDataAttribute('description', new TaskBuilder().build(), span);
 
         expect(Object.keys(span.dataset).length).toEqual(1);
         expect(span.dataset['aKey']).toEqual('aValue');

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -20,8 +20,9 @@ describe('Field Layouts Container tests', () => {
     it('should get the data attribute of an existing component (date)', () => {
         const container = new TaskFieldRenderer();
         const task = new TaskBuilder().dueDate('2023-11-20').build();
+        const span = document.createElement('span');
 
-        const dueDateDataAttribute = container.dataAttribute('dueDate', task);
+        const dueDateDataAttribute = container.dataAttribute('dueDate', task, span);
 
         expect(Object.keys(dueDateDataAttribute).length).toEqual(1);
         expect(dueDateDataAttribute['taskDue']).toEqual('future-1d');
@@ -30,8 +31,9 @@ describe('Field Layouts Container tests', () => {
     it('should get the data attribute of an existing component (not date)', () => {
         const container = new TaskFieldRenderer();
         const task = TaskBuilder.createFullyPopulatedTask();
+        const span = document.createElement('span');
 
-        const dueDateDataAttribute = container.dataAttribute('priority', task);
+        const dueDateDataAttribute = container.dataAttribute('priority', task, span);
 
         expect(Object.keys(dueDateDataAttribute).length).toEqual(1);
         expect(dueDateDataAttribute['taskPriority']).toEqual('medium');
@@ -40,8 +42,9 @@ describe('Field Layouts Container tests', () => {
     it('should return empty data attributes dictionary for a missing component', () => {
         const container = new TaskFieldRenderer();
         const task = new TaskBuilder().build();
+        const span = document.createElement('span');
 
-        const dueDateDataAttribute = container.dataAttribute('recurrenceRule', task);
+        const dueDateDataAttribute = container.dataAttribute('recurrenceRule', task, span);
 
         expect(Object.keys(dueDateDataAttribute).length).toEqual(0);
     });

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -61,9 +61,10 @@ describe('Field Layout Detail tests', () => {
             return 'aValue';
         });
         const span = document.createElement('span');
-        const dataAttribute = fieldLayoutDetail.dataAttribute('description', new TaskBuilder().build(), span);
 
-        expect(Object.keys(dataAttribute).length).toEqual(1);
-        expect(dataAttribute['aKey']).toEqual('aValue');
+        fieldLayoutDetail.dataAttribute('description', new TaskBuilder().build(), span);
+
+        expect(Object.keys(span.dataset).length).toEqual(1);
+        expect(span.dataset['aKey']).toEqual('aValue');
     });
 });

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -8,7 +8,7 @@ import { resetSettings, updateSettings } from '../src/Config/Settings';
 import { DateParser } from '../src/Query/DateParser';
 import type { Task } from '../src/Task';
 import { TaskRegularExpressions } from '../src/Task';
-import { type AttributesDictionary, TaskFieldRenderer } from '../src/TaskFieldRenderer';
+import { TaskFieldRenderer } from '../src/TaskFieldRenderer';
 import { LayoutOptions } from '../src/TaskLayout';
 import type { TextRenderer } from '../src/TaskLineRenderer';
 import { TaskLineRenderer } from '../src/TaskLineRenderer';
@@ -18,6 +18,8 @@ import { TaskBuilder } from './TestingTools/TaskBuilder';
 
 jest.mock('obsidian');
 window.moment = moment;
+
+type AttributesDictionary = { [key: string]: string };
 
 const fieldRenderer = new TaskFieldRenderer();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- `TaskFieldRenderer` now adds the data attributes to an `HTMLelement` instead of returning them (At the end of the day, this is what we need the data attributes for)
- Reworked tests to show this behaviour
- `TaskLineRenderer` calls to get the data attributes are shorter, `taskToHtml` more readable and comprehensive
- `AttributeDictionary` now used only in `TaskFieldRenderer.test.ts`

## Motivation and Context

- Simpler code
- Prepare to for further refactoring to make rendering and layout code more flexible towards new features
- Get rid of `DataAttributes` in `src` (Possible in `test` as well, but need to update tests, probably good for another PR)

## How has this been tested?

Modified unit tests.

## Types of changes

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
