### PR TITLE
fix: Prevent default click behavior when jumping to a task

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -352,15 +352,12 @@ class QueryRenderChild extends MarkdownRenderChild {
             if (result) {
                 const [line, file] = result;
                 const leaf = this.app.workspace.getLeaf(Keymap.isModEvent(ev));
-                // This opens the file with the required line highlighted.
-                // It works for Edit and Reading mode, however, for some reason (maybe an Obsidian bug),
-                // when used in Reading mode, switching the result to Edit does not sync the scroll.
-                // A patch suggested over Discord to use leaf.setEphemeralState({scroll: line}) does not seem
-                // to make a difference.
-                // The issue is tracked here: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1879
-                await leaf.openFile(file, { eState: { line: line } });
-                // Suppress the default behavior of the event in this case.
+                // When the corresponding task has been found,
+                // suppress the default behavior of the mouse click event
+                // (which would interfere e.g. if the query is rendered inside a callout).
                 ev.preventDefault();
+                // Instead of the default behavior, open the file with the required line highlighted.
+                await leaf.openFile(file, { eState: { line: line } });
             }
         });
 
@@ -375,9 +372,8 @@ class QueryRenderChild extends MarkdownRenderChild {
                 if (result) {
                     const [line, file] = result;
                     const leaf = this.app.workspace.getLeaf('tab');
-                    await leaf.openFile(file, { eState: { line: line } });
-                    // Suppress the default behavior of the event in this case.
                     ev.preventDefault();
+                    await leaf.openFile(file, { eState: { line: line } });
                 }
             }
         });

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -359,6 +359,8 @@ class QueryRenderChild extends MarkdownRenderChild {
                 // to make a difference.
                 // The issue is tracked here: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1879
                 await leaf.openFile(file, { eState: { line: line } });
+                // Suppress the default behavior of the event in this case.
+                ev.preventDefault();
             }
         });
 
@@ -374,6 +376,8 @@ class QueryRenderChild extends MarkdownRenderChild {
                     const [line, file] = result;
                     const leaf = this.app.workspace.getLeaf('tab');
                     await leaf.openFile(file, { eState: { line: line } });
+                    // Suppress the default behavior of the event in this case.
+                    ev.preventDefault();
                 }
             }
         });


### PR DESCRIPTION
# Description

When jumping to a task using the backlink (a feature introduced in version 3.4), then the default behavior of the associated click event should be suppressed.

## Motivation and Context

If the task query appears in a callout, then clicking the backling will also trigger opening the callout for editing and selecting it. This default behavior interfers with our behavior of jumping to the task.

This PR should fix issue #2445.

_Confirmed: Fixes #2445_

## How has this been tested?

- Manual testing
- Obsidian 1.5.0 and Tasks 5.1.0
-  using the markdown shown in the issue
- also tested the case when the task and the query are located in different files.

## Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
