### PR TITLE
feat: Enable postponing of start dates

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -483,7 +483,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         timeUnit: unitOfTime.DurationConstructor = 'days',
         amount = 1,
     ) {
-        const errorMessage = '⚠️ Postponement requires a happens date: start, due or scheduled.';
+        const errorMessage = '⚠️ Postponement requires a happens date: due, scheduled or start.';
         if (task.happens.moment === null) {
             return new Notice(errorMessage, 10000);
         }

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -483,7 +483,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         timeUnit: unitOfTime.DurationConstructor = 'days',
         amount = 1,
     ) {
-        const errorMessage = '⚠️ Postponement requires a happens date: due, scheduled or start.';
+        const errorMessage = '⚠️ Postponement requires a date: due, scheduled or start.';
         if (!task.startDate && !task.dueDate && !task.scheduledDate) {
             return new Notice(errorMessage, 10000);
         }

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -9,6 +9,7 @@ import { getTaskLineAndFile, replaceTaskWithTasks } from './File';
 
 import type { IQuery } from './IQuery';
 import {
+    type HappensDate,
     createPostponedTask,
     explainResults,
     getDateFieldToPostpone,
@@ -500,7 +501,7 @@ class QueryRenderChild extends MarkdownRenderChild {
 
     private onPostponeSuccessCallback(
         button: HTMLButtonElement,
-        updatedDateType: 'dueDate' | 'scheduledDate',
+        updatedDateType: HappensDate,
         postponedDateString: string,
     ) {
         // Disable the button to prevent update error due to the task not being reloaded yet.

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -483,8 +483,11 @@ class QueryRenderChild extends MarkdownRenderChild {
         timeUnit: unitOfTime.DurationConstructor = 'days',
         amount = 1,
     ) {
-        const errorMessage = '⚠️ Postponement requires a date: due or scheduled.';
-        if (!task.dueDate && !task.scheduledDate) return new Notice(errorMessage, 10000);
+        const errorMessage = '⚠️ Postponement requires a happens date: start, due or scheduled.';
+        if (task.happens.moment === null) {
+            return new Notice(errorMessage, 10000);
+        }
+
         const dateTypeToUpdate = getDateFieldToPostpone(task);
         if (dateTypeToUpdate === null) return;
 

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -484,7 +484,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         amount = 1,
     ) {
         const errorMessage = '⚠️ Postponement requires a happens date: due, scheduled or start.';
-        if (task.happens.moment === null) {
+        if (!task.startDate && !task.dueDate && !task.scheduledDate) {
             return new Notice(errorMessage, 10000);
         }
 

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -483,13 +483,11 @@ class QueryRenderChild extends MarkdownRenderChild {
         timeUnit: unitOfTime.DurationConstructor = 'days',
         amount = 1,
     ) {
-        const errorMessage = '⚠️ Postponement requires a date: due, scheduled or start.';
-        if (!task.startDate && !task.dueDate && !task.scheduledDate) {
+        const dateTypeToUpdate = getDateFieldToPostpone(task);
+        if (dateTypeToUpdate === null) {
+            const errorMessage = '⚠️ Postponement requires a date: due, scheduled or start.';
             return new Notice(errorMessage, 10000);
         }
-
-        const dateTypeToUpdate = getDateFieldToPostpone(task);
-        if (dateTypeToUpdate === null) return;
 
         const { postponedDate, newTasks } = createPostponedTask(task, dateTypeToUpdate, timeUnit, amount);
 

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -74,6 +74,12 @@ export function getQueryForQueryRenderer(source: string, globalQuery: GlobalQuer
 
 export type HappensDate = keyof Pick<Task, 'startDate' | 'scheduledDate' | 'dueDate'>;
 
+/**
+ * Gets a {@link HappensDate} field from a {@link Task} with the following priority: due > scheduled > start.
+ * If the task has no happens field {@link HappensDate}, null is returned.
+ *
+ * @param task
+ */
 export function getDateFieldToPostpone(task: Task): HappensDate | null {
     if (task.dueDate) {
         return 'dueDate';

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -75,9 +75,15 @@ export function getQueryForQueryRenderer(source: string, globalQuery: GlobalQuer
 export type HappensDate = keyof Pick<Task, 'scheduledDate' | 'dueDate'>;
 
 export function getDateFieldToPostpone(task: Task): HappensDate | null {
-    const scheduledDateOrNull = task.scheduledDate ? 'scheduledDate' : null;
-    const dateTypeToUpdate = task.dueDate ? 'dueDate' : scheduledDateOrNull;
-    return dateTypeToUpdate;
+    if (task.dueDate) {
+        return 'dueDate';
+    }
+
+    if (task.scheduledDate) {
+        return 'scheduledDate';
+    }
+
+    return null;
 }
 
 export function createPostponedTask(

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -72,7 +72,7 @@ export function getQueryForQueryRenderer(source: string, globalQuery: GlobalQuer
     return globalQuery.query(path).append(tasksBlockQuery);
 }
 
-export type HappensDate = keyof Pick<Task, 'scheduledDate' | 'dueDate'>;
+export type HappensDate = keyof Pick<Task, 'startDate' | 'scheduledDate' | 'dueDate'>;
 
 export function getDateFieldToPostpone(task: Task): HappensDate | null {
     if (task.dueDate) {

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -83,6 +83,10 @@ export function getDateFieldToPostpone(task: Task): HappensDate | null {
         return 'scheduledDate';
     }
 
+    if (task.startDate) {
+        return 'startDate';
+    }
+
     return null;
 }
 

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -72,7 +72,9 @@ export function getQueryForQueryRenderer(source: string, globalQuery: GlobalQuer
     return globalQuery.query(path).append(tasksBlockQuery);
 }
 
-export function getDateFieldToPostpone(task: Task) {
+export type HappensDate = keyof Pick<Task, 'scheduledDate' | 'dueDate'>;
+
+export function getDateFieldToPostpone(task: Task): HappensDate | null {
     const scheduledDateOrNull = task.scheduledDate ? 'scheduledDate' : null;
     const dateTypeToUpdate = task.dueDate ? 'dueDate' : scheduledDateOrNull;
     return dateTypeToUpdate;
@@ -80,7 +82,7 @@ export function getDateFieldToPostpone(task: Task) {
 
 export function createPostponedTask(
     task: Task,
-    dateTypeToUpdate: keyof Task,
+    dateTypeToUpdate: HappensDate,
     timeUnit: unitOfTime.DurationConstructor,
     amount: number,
 ) {

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -172,9 +172,9 @@ describe('postpone - date field choice', () => {
         checkPostponeField(taskBuilder, 'scheduledDate');
     });
 
-    it('should not postpone start date', () => {
+    it('should postpone start date', () => {
         const taskBuilder = new TaskBuilder().startDate(date);
-        checkDoesNotPostpone(taskBuilder);
+        checkPostponeField(taskBuilder, 'startDate');
     });
 
     it('should postpone due date in preference to start and scheduled dates', () => {

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -3,11 +3,15 @@
  */
 import moment from 'moment';
 import { Query } from '../../src/Query/Query';
-import { explainResults, getDateFieldToPostpone, getQueryForQueryRenderer } from '../../src/lib/QueryRendererHelper';
+import {
+    type HappensDate,
+    explainResults,
+    getDateFieldToPostpone,
+    getQueryForQueryRenderer,
+} from '../../src/lib/QueryRendererHelper';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { GlobalQuery } from '../../src/Config/GlobalQuery';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
-import type { Task } from '../../src/Task';
 
 window.moment = moment;
 
@@ -130,7 +134,7 @@ describe('query used for QueryRenderer', () => {
 });
 
 describe('postpone - date field choice', () => {
-    function checkPostponeField(taskBuilder: TaskBuilder, expected: keyof Task | null) {
+    function checkPostponeField(taskBuilder: TaskBuilder, expected: HappensDate | null) {
         const task = taskBuilder.build();
         expect(getDateFieldToPostpone(task)).toEqual(expected);
     }


### PR DESCRIPTION
# Description

Teach `getDateFieldToPostpone()` to postpone start date, treat it same as scheduled & due date.

## Motivation and Context

Expand postpone feature on happens date (start, due, scheduled).

## How has this been tested?

Modified existing unit tests, exploratory testing with vault from GitHub workflow.

## Types of changes

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
  - I guess we will need a separate PR to add the docs for the whole feature
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
