### PR TITLE
perf: Do not index attachments after plugin has loaded

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -217,7 +217,8 @@ export class Cache {
         }
 
         if (!file.path.endsWith('.md')) {
-            this.logger.warn('indexFile: WARNING: indexing non-markdown file: ' + file.path);
+            this.logger.debug('indexFile: skipping non-markdown file: ' + file.path);
+            return;
         }
 
         this.logger.debug('Cache.indexFile: ' + file.path);


### PR DESCRIPTION




<!--- Provide a general summary of your changes in the Title above -->

# Description

Do not index attachments after plugin has loaded.

Non-markdown files that were added, renamed or deleted after the plugin had loaded were being passed to Cache.indexFile() which was then reading them.

This could cause wasted work, and when deleting non-markdown files, would trigger Tasks search results to be needlessly redrawn.

It also generated warning messages for users who had the console open.

## Motivation and Context

Fixes #2464

## How has this been tested?

Exploratory testing in the Tasks-Demo vault.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
