### PR TITLE
refactor: fix async/await warnings in QueryRenderer.ts

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -280,8 +280,8 @@ class QueryRenderChild extends MarkdownRenderChild {
         editTaskPencil.onClickEvent((event: MouseEvent) => {
             event.preventDefault();
 
-            const onSubmit = (updatedTasks: Task[]): void => {
-                replaceTaskWithTasks({
+            const onSubmit = async (updatedTasks: Task[]): Promise<void> => {
+                await replaceTaskWithTasks({
                     originalTask: task,
                     newTasks: DateFallback.removeInferredStatusIfNeeded(task, updatedTasks),
                 });
@@ -306,7 +306,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         for (const group of tasksSortedLimitedGrouped.groups) {
             // If there were no 'group by' instructions, group.groupHeadings
             // will be empty, and no headings will be added.
-            this.addGroupHeadings(content, group.groupHeadings);
+            await this.addGroupHeadings(content, group.groupHeadings);
 
             await this.createTaskList(group.tasks, content);
         }
@@ -319,9 +319,9 @@ class QueryRenderChild extends MarkdownRenderChild {
      *                        in which case no headings will be added.
      * @private
      */
-    private addGroupHeadings(content: HTMLDivElement, groupHeadings: GroupDisplayHeading[]) {
+    private async addGroupHeadings(content: HTMLDivElement, groupHeadings: GroupDisplayHeading[]) {
         for (const heading of groupHeadings) {
-            this.addGroupHeading(content, heading);
+            await this.addGroupHeading(content, heading);
         }
     }
 

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -97,7 +97,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         this.source = source;
         this.filePath = filePath;
 
-        // The engine is chosen on the basis of the code block language. Currently
+        // The engine is chosen on the basis of the code block language. Currently,
         // there is only the main engine for the plugin, this allows others to be
         // added later.
         switch (this.containerEl.className) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add missing `async`, `await` and `Promise` keywords, missing comma in a comment.

## Motivation and Context

Have less distractions in WebStorm.

## How has this been tested?

Just checked that there are less warnings =)

_Edit: Also smoke-tested [Tasks-Demo-VerifyCommit-Build3823-Run1](https://github.com/obsidian-tasks-group/obsidian-tasks/suites/18698076888/artifacts/1088288283)._

## Types of changes

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
