### PR TITLE
test: add tests for `shouldShowPostponeButton()` against Task dates

### DIFF
--- a/tests/Scripting/Postponer.test.ts
+++ b/tests/Scripting/Postponer.test.ts
@@ -86,6 +86,60 @@ describe('postpone - whether to show button', () => {
         checkPostponeButtonVisibility(StatusType.CANCELLED, false);
         checkPostponeButtonVisibility(StatusType.DONE, false);
     });
+
+    it('should show button for a task with no dates', () => {
+        const task = new TaskBuilder().build();
+
+        expect(shouldShowPostponeButton(task)).toEqual(true);
+    });
+
+    it('should show button for a task with a created date only', () => {
+        const task = new TaskBuilder().createdDate('2023-11-29').build();
+
+        expect(shouldShowPostponeButton(task)).toEqual(true);
+    });
+
+    it('should show button for a task with a done date only', () => {
+        const task = new TaskBuilder().doneDate('2023-11-30').build();
+
+        expect(shouldShowPostponeButton(task)).toEqual(true);
+    });
+
+    it('should show button for a task with a start date only', () => {
+        const task = new TaskBuilder().startDate('2023-12-01').build();
+
+        expect(shouldShowPostponeButton(task)).toEqual(true);
+    });
+
+    it('should show button for a task with an invalid start date', () => {
+        const task = new TaskBuilder().startDate('2023-13-01').build();
+
+        expect(shouldShowPostponeButton(task)).toEqual(true);
+    });
+
+    it('should show button for a task with a scheduled date only', () => {
+        const task = new TaskBuilder().scheduledDate('2023-12-02').build();
+
+        expect(shouldShowPostponeButton(task)).toEqual(true);
+    });
+
+    it('should show button for a task with an invalid scheduled date', () => {
+        const task = new TaskBuilder().scheduledDate('2023-12-36').build();
+
+        expect(shouldShowPostponeButton(task)).toEqual(true);
+    });
+
+    it('should show button for a task with a due date only', () => {
+        const task = new TaskBuilder().dueDate('2023-12-03').build();
+
+        expect(shouldShowPostponeButton(task)).toEqual(true);
+    });
+
+    it('should show button for a task with an invalid due date', () => {
+        const task = new TaskBuilder().dueDate('20233-12-03').build();
+
+        expect(shouldShowPostponeButton(task)).toEqual(true);
+    });
 });
 
 describe('postpone - postponement success message', () => {


### PR DESCRIPTION
# Description

Add tests to show the current behaviour of `shouldShowPostponeButton()` function depending on dates, present in the task - created, starts, due, scheduled & done.

## Motivation and Context

Prepare to change the behaviour of `shouldShowPostponeButton()` according to https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/2452

## How has this been tested?

Tried to break the new tests by putting wrong expected values =)

## Types of changes

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
