### PR TITLE
refactor: Rename postpone symbols and standardise parameter order

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -496,11 +496,11 @@ class QueryRenderChild extends MarkdownRenderChild {
             newTasks,
         });
         this.query.debug('[postpone]: postponeOnClickCallback() - after  call to replaceTaskWithTasks()');
-        this.onPostponeSuccessCallback(button, dateTypeToUpdate, postponedDate);
+        this.postponeSuccessCallback(button, dateTypeToUpdate, postponedDate);
     }
 
-    private onPostponeSuccessCallback(button: HTMLButtonElement, updatedDateType: HappensDate, postponedDate: Moment) {
-        this.query.debug('[postpone]: onPostponeSuccessCallback() entered');
+    private postponeSuccessCallback(button: HTMLButtonElement, updatedDateType: HappensDate, postponedDate: Moment) {
+        this.query.debug('[postpone]: postponeSuccessCallback() entered');
         // Disable the button to prevent update error due to the task not being reloaded yet.
         button.disabled = true;
         button.setAttr('title', 'You can perform this action again after reloading the file.');
@@ -508,6 +508,6 @@ class QueryRenderChild extends MarkdownRenderChild {
         const successMessage = postponementSuccessMessage(postponedDate, updatedDateType);
         new Notice(successMessage, 5000);
         this.events.triggerRequestCacheUpdate(this.render.bind(this));
-        this.query.debug('[postpone]: onPostponeSuccessCallback() exiting');
+        this.query.debug('[postpone]: postponeSuccessCallback() exiting');
     }
 }

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -415,7 +415,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         button.addClasses(classNames);
         button.setText(' ⏩');
 
-        button.addEventListener('click', () => this.postponeOnClickCallback(task, button, 'days', 1));
+        button.addEventListener('click', () => this.postponeOnClickCallback(button, task, 1, 'days'));
 
         /** Open a context menu on right-click.
          * Give a choice of postponing for a week, month, or quarter.
@@ -427,7 +427,7 @@ class QueryRenderChild extends MarkdownRenderChild {
             const postponeMenuItemCallback = (item: MenuItem, timeUnit: unitOfTime.DurationConstructor, amount = 1) => {
                 const amountOrArticle = amount > 1 ? amount : 'a';
                 item.setTitle(`${commonTitle} ${amountOrArticle} ${timeUnit}`).onClick(() =>
-                    this.postponeOnClickCallback(task, button, timeUnit, amount),
+                    this.postponeOnClickCallback(button, task, amount, timeUnit),
                 );
             };
 
@@ -477,10 +477,10 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private async postponeOnClickCallback(
-        task: Task,
         button: HTMLButtonElement,
-        timeUnit: unitOfTime.DurationConstructor,
+        task: Task,
         amount: number,
+        timeUnit: moment.unitOfTime.DurationConstructor,
     ) {
         const dateTypeToUpdate = getDateFieldToPostpone(task);
         if (dateTypeToUpdate === null) {

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -415,7 +415,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         button.addClasses(classNames);
         button.setText(' ⏩');
 
-        button.addEventListener('click', () => this.postponeOnClickCallback(task, button, 'days'));
+        button.addEventListener('click', () => this.postponeOnClickCallback(task, button, 'days', 1));
 
         /** Open a context menu on right-click.
          * Give a choice of postponing for a week, month, or quarter.
@@ -479,8 +479,8 @@ class QueryRenderChild extends MarkdownRenderChild {
     private async postponeOnClickCallback(
         task: Task,
         button: HTMLButtonElement,
-        timeUnit: unitOfTime.DurationConstructor = 'days',
-        amount = 1,
+        timeUnit: unitOfTime.DurationConstructor,
+        amount: number,
     ) {
         const dateTypeToUpdate = getDateFieldToPostpone(task);
         if (dateTypeToUpdate === null) {

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -415,7 +415,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         button.addClasses(classNames);
         button.setText(' ⏩');
 
-        button.addEventListener('click', () => this.getOnClickCallback(task, button, 'days'));
+        button.addEventListener('click', () => this.postponeOnClickCallback(task, button, 'days'));
 
         /** Open a context menu on right-click.
          * Give a choice of postponing for a week, month, or quarter.
@@ -427,7 +427,7 @@ class QueryRenderChild extends MarkdownRenderChild {
             const getMenuItemCallback = (item: MenuItem, timeUnit: unitOfTime.DurationConstructor, amount = 1) => {
                 const amountOrArticle = amount > 1 ? amount : 'a';
                 item.setTitle(`${commonTitle} ${amountOrArticle} ${timeUnit}`).onClick(() =>
-                    this.getOnClickCallback(task, button, timeUnit, amount),
+                    this.postponeOnClickCallback(task, button, timeUnit, amount),
                 );
             };
 
@@ -476,7 +476,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         return groupingRules.join(',');
     }
 
-    private async getOnClickCallback(
+    private async postponeOnClickCallback(
         task: Task,
         button: HTMLButtonElement,
         timeUnit: unitOfTime.DurationConstructor = 'days',
@@ -490,12 +490,12 @@ class QueryRenderChild extends MarkdownRenderChild {
 
         const { postponedDate, newTasks } = createPostponedTask(task, dateTypeToUpdate, timeUnit, amount);
 
-        this.query.debug('[postpone]: getOnClickCallback() - before call to replaceTaskWithTasks()');
+        this.query.debug('[postpone]: postponeOnClickCallback() - before call to replaceTaskWithTasks()');
         await replaceTaskWithTasks({
             originalTask: task,
             newTasks,
         });
-        this.query.debug('[postpone]: getOnClickCallback() - after  call to replaceTaskWithTasks()');
+        this.query.debug('[postpone]: postponeOnClickCallback() - after  call to replaceTaskWithTasks()');
         this.onPostponeSuccessCallback(button, dateTypeToUpdate, postponedDate);
     }
 

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -424,18 +424,18 @@ class QueryRenderChild extends MarkdownRenderChild {
             const menu = new Menu();
             const commonTitle = 'Postpone for';
 
-            const getMenuItemCallback = (item: MenuItem, timeUnit: unitOfTime.DurationConstructor, amount = 1) => {
+            const postponeMenuItemCallback = (item: MenuItem, timeUnit: unitOfTime.DurationConstructor, amount = 1) => {
                 const amountOrArticle = amount > 1 ? amount : 'a';
                 item.setTitle(`${commonTitle} ${amountOrArticle} ${timeUnit}`).onClick(() =>
                     this.postponeOnClickCallback(task, button, timeUnit, amount),
                 );
             };
 
-            menu.addItem((item) => getMenuItemCallback(item, 'days', 2));
-            menu.addItem((item) => getMenuItemCallback(item, 'days', 3));
-            menu.addItem((item) => getMenuItemCallback(item, 'week'));
-            menu.addItem((item) => getMenuItemCallback(item, 'weeks', 2));
-            menu.addItem((item) => getMenuItemCallback(item, 'month'));
+            menu.addItem((item) => postponeMenuItemCallback(item, 'days', 2));
+            menu.addItem((item) => postponeMenuItemCallback(item, 'days', 3));
+            menu.addItem((item) => postponeMenuItemCallback(item, 'week'));
+            menu.addItem((item) => postponeMenuItemCallback(item, 'weeks', 2));
+            menu.addItem((item) => postponeMenuItemCallback(item, 'month'));
 
             menu.showAtPosition({ x: ev.clientX, y: ev.clientY });
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Some minor refactoring of some symbols and parameter orders in `QueryRenderer.ts`.

## Motivation and Context

Just  to try to make it easier to hold the code in memory, before further work.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

- Running existing tests
- Running the smoke tests in a local build

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
