### PR TITLE
Postpone vs happens

### DIFF
--- a/src/Scripting/Postponer.ts
+++ b/src/Scripting/Postponer.ts
@@ -3,7 +3,11 @@ import { Task } from '../Task';
 import { TasksDate } from './TasksDate';
 
 export function shouldShowPostponeButton(task: Task) {
-    return !task.isDone;
+    const hasHappensDate = task.happensDates.some((date) => {
+        return date !== null;
+    });
+
+    return !task.isDone && hasHappensDate;
 }
 
 export type HappensDate = keyof Pick<Task, 'startDate' | 'scheduledDate' | 'dueDate'>;

--- a/src/Scripting/Postponer.ts
+++ b/src/Scripting/Postponer.ts
@@ -3,11 +3,11 @@ import { Task } from '../Task';
 import { TasksDate } from './TasksDate';
 
 export function shouldShowPostponeButton(task: Task) {
-    const hasHappensDate = task.happensDates.some((date) => {
-        return date !== null;
+    const hasAValidHappensDate = task.happensDates.some((date) => {
+        return !!date?.isValid();
     });
 
-    return !task.isDone && hasHappensDate;
+    return !task.isDone && hasAValidHappensDate;
 }
 
 export type HappensDate = keyof Pick<Task, 'startDate' | 'scheduledDate' | 'dueDate'>;

--- a/tests/Scripting/Postponer.test.ts
+++ b/tests/Scripting/Postponer.test.ts
@@ -73,7 +73,7 @@ describe('postpone - whether to show button', () => {
     it('should account for status type', () => {
         function checkPostponeButtonVisibility(statusType: StatusType, expected: boolean) {
             const status = new Status(new StatusConfiguration('p', 'Test', 'q', true, statusType));
-            const task = new TaskBuilder().status(status).build();
+            const task = new TaskBuilder().dueDate('2023-10-30').status(status).build();
             expect(shouldShowPostponeButton(task)).toEqual(expected);
         }
 
@@ -87,22 +87,22 @@ describe('postpone - whether to show button', () => {
         checkPostponeButtonVisibility(StatusType.DONE, false);
     });
 
-    it('should show button for a task with no dates', () => {
+    it('should not show button for a task with no dates', () => {
         const task = new TaskBuilder().build();
 
-        expect(shouldShowPostponeButton(task)).toEqual(true);
+        expect(shouldShowPostponeButton(task)).toEqual(false);
     });
 
-    it('should show button for a task with a created date only', () => {
+    it('should not show button for a task with a created date only', () => {
         const task = new TaskBuilder().createdDate('2023-11-29').build();
 
-        expect(shouldShowPostponeButton(task)).toEqual(true);
+        expect(shouldShowPostponeButton(task)).toEqual(false);
     });
 
-    it('should show button for a task with a done date only', () => {
+    it('should not show button for a task with a done date only', () => {
         const task = new TaskBuilder().doneDate('2023-11-30').build();
 
-        expect(shouldShowPostponeButton(task)).toEqual(true);
+        expect(shouldShowPostponeButton(task)).toEqual(false);
     });
 
     it('should show button for a task with a start date only', () => {

--- a/tests/Scripting/Postponer.test.ts
+++ b/tests/Scripting/Postponer.test.ts
@@ -111,10 +111,10 @@ describe('postpone - whether to show button', () => {
         expect(shouldShowPostponeButton(task)).toEqual(true);
     });
 
-    it('should show button for a task with an invalid start date', () => {
+    it('should not show button for a task with an invalid start date', () => {
         const task = new TaskBuilder().startDate('2023-13-01').build();
 
-        expect(shouldShowPostponeButton(task)).toEqual(true);
+        expect(shouldShowPostponeButton(task)).toEqual(false);
     });
 
     it('should show button for a task with a scheduled date only', () => {
@@ -123,10 +123,10 @@ describe('postpone - whether to show button', () => {
         expect(shouldShowPostponeButton(task)).toEqual(true);
     });
 
-    it('should show button for a task with an invalid scheduled date', () => {
+    it('should not show button for a task with an invalid scheduled date', () => {
         const task = new TaskBuilder().scheduledDate('2023-12-36').build();
 
-        expect(shouldShowPostponeButton(task)).toEqual(true);
+        expect(shouldShowPostponeButton(task)).toEqual(false);
     });
 
     it('should show button for a task with a due date only', () => {
@@ -135,10 +135,10 @@ describe('postpone - whether to show button', () => {
         expect(shouldShowPostponeButton(task)).toEqual(true);
     });
 
-    it('should show button for a task with an invalid due date', () => {
+    it('should not show button for a task with an invalid due date', () => {
         const task = new TaskBuilder().dueDate('20233-12-03').build();
 
-        expect(shouldShowPostponeButton(task)).toEqual(true);
+        expect(shouldShowPostponeButton(task)).toEqual(false);
     });
 });
 


### PR DESCRIPTION
# Description

Change `shouldShowPostponeButton()` to account for valid happens dates.

## Motivation and Context

Improve postpone usability: do not show postpone button when it is useless. 

## How has this been tested?

Unit tests + exploratory feature tests.

## Screenshots

## Types of changes

Changes visible to users:

- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
  - documentation for postponement is absent for now
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
