### PR TITLE
fix: Postponing now works repeatedly

### DIFF
--- a/src/Scripting/TasksDate.ts
+++ b/src/Scripting/TasksDate.ts
@@ -122,6 +122,6 @@ export class TasksDate {
             return today.add(amount, unitOfTime);
         }
 
-        return this._date.add(amount, unitOfTime);
+        return this._date.clone().add(amount, unitOfTime);
     }
 }

--- a/tests/Scripting/TasksDate.test.ts
+++ b/tests/Scripting/TasksDate.test.ts
@@ -128,7 +128,7 @@ describe('TasksDate - postpone', () => {
         expect(postponedDate.formatAsDate()).toEqual(expectedDate);
     }
 
-    it.failing('should not modify the original date when postponing', () => {
+    it('should not modify the original date when postponing', () => {
         function checkPostponingDoesNotModifyOriginalDate(
             initialDate: string,
             amount: number,
@@ -210,13 +210,8 @@ describe('TasksDate - postpone', () => {
             dates.forEach((date) => {
                 const tasksDate = new TasksDate(moment(date));
                 const format = 'YYYY-MM-DD ddd';
-                // We have to save the date before doing the incrementing,
-                // as this test revealed that currently TasksDate.postpone() mutates the original date,
-                // as well as returning the postponed date!!!
-                const dateFormatted = tasksDate.format(format);
-
                 const postponedDate = new TasksDate(tasksDate.postpone(unitOfTime, amount));
-                output += `${dateFormatted} => ${postponedDate.format(format)}\n`;
+                output += `${tasksDate.format(format)} => ${postponedDate.format(format)}\n`;
             });
             return output;
         }


### PR DESCRIPTION
# Description

Postponing of future tasks no longer modifies the original date, which broke subsequent postponing operations.

The root cause was that the original task date was accidentally being modified.

Note: there is some further tidying up that can be done, like removing the call to `triggerRequestCacheUpdate()`, and removing debug logging. I'll tidy those up in later steps, so that this change is minimal.

## Motivation and Context

Fixes #2471

## How has this been tested?

- Updating tests that were failing
- Manual testing

## Screenshots (if appropriate)


https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/f50dc4d5-7598-4f7c-9db5-4668d610a26d



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
