### PR TITLE
refactor: modify componentString variable closer to its usage

### DIFF
--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -144,11 +144,8 @@ export class TaskLineRenderer {
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
         // Render and build classes for all the task's visible components
         for (const component of taskLayout.shownTaskLayoutComponents) {
-            let componentString = emojiSerializer.componentToString(task, taskLayout, component);
+            const componentString = emojiSerializer.componentToString(task, taskLayout, component);
             if (componentString) {
-                if (component === 'description') {
-                    componentString = GlobalFilter.getInstance().removeAsWordFromDependingOnSettings(componentString);
-                }
                 // Create the text span that will hold the rendered component
                 const span = document.createElement('span');
                 parentElement.appendChild(span);
@@ -197,6 +194,8 @@ export class TaskLineRenderer {
         task: Task,
     ) {
         if (component === 'description') {
+            componentString = GlobalFilter.getInstance().removeAsWordFromDependingOnSettings(componentString);
+
             const { debugSettings } = getSettings();
             if (debugSettings.showTaskHiddenData) {
                 // Add some debug output to enable hidden information in the task to be inspected.


### PR DESCRIPTION
# Description

`componentString` is modified in one function, but then used in another one. This PR groups its modification and usage in the latter function.

## Motivation and Context

Readable code, separation of concerns.

## How has this been tested?

Unit tests, breaking the code.

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
