### PR TITLE
fix: Correctly indent Tasks search results in Live Preview

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,11 @@
 
 }
 
+/* Fix indentation of wrapped task lines in Tasks search results, when in Live Preview. */
+ul.contains-task-list .task-list-item-checkbox {
+    margin-inline-start: calc(var(--checkbox-size) * -1.5) !important;
+}
+
 .plugin-tasks-query-explanation{
     /* Prevent long explanation lines wrapping, so they are more readable,
        especially on small screens.


### PR DESCRIPTION
# Description

In Tasks search results viewed in Live Preview, lines long enough to wrap  were not aligned correctly
down the left hand side.

The fix was kindly supplied by @mackaaij in #2361.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

Fixes #2361.

## How has this been tested?

In the Tasks demo vault.

In the following screenshots, look at the bottom half of the middle column:

### Original appearance, with default theme, no snippets, only Tasks installed:

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/fbb34c7c-c185-41cc-8ec0-a6365c1e1073)


### With this fix:

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/f6f5d594-f9df-4fae-a418-9239ff8bbc6b)


### With the alternative fix, taken from https://github.com/kepano/obsidian-minimal/issues/410#issuecomment-1733493410

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/44884d0a-18b6-465b-8335-1ff19b65105a)

## Screenshots (if appropriate)

See above

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
