### PR TITLE
refactor: rename variables in postpone code

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -488,11 +488,11 @@ class QueryRenderChild extends MarkdownRenderChild {
             return new Notice(errorMessage, 10000);
         }
 
-        const { postponedDate, newTasks } = createPostponedTask(task, dateFieldToPostpone, timeUnit, amount);
+        const { postponedDate, postponedTask } = createPostponedTask(task, dateFieldToPostpone, timeUnit, amount);
 
         await replaceTaskWithTasks({
             originalTask: task,
-            newTasks,
+            newTasks: postponedTask,
         });
         this.postponeSuccessCallback(button, dateFieldToPostpone, postponedDate);
     }

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -480,7 +480,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         button: HTMLButtonElement,
         task: Task,
         amount: number,
-        timeUnit: moment.unitOfTime.DurationConstructor,
+        timeUnit: unitOfTime.DurationConstructor,
     ) {
         const dateTypeToUpdate = getDateFieldToPostpone(task);
         if (dateTypeToUpdate === null) {

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -482,19 +482,19 @@ class QueryRenderChild extends MarkdownRenderChild {
         amount: number,
         timeUnit: unitOfTime.DurationConstructor,
     ) {
-        const dateTypeToUpdate = getDateFieldToPostpone(task);
-        if (dateTypeToUpdate === null) {
+        const dateFieldToPostpone = getDateFieldToPostpone(task);
+        if (dateFieldToPostpone === null) {
             const errorMessage = '⚠️ Postponement requires a date: due, scheduled or start.';
             return new Notice(errorMessage, 10000);
         }
 
-        const { postponedDate, newTasks } = createPostponedTask(task, dateTypeToUpdate, timeUnit, amount);
+        const { postponedDate, newTasks } = createPostponedTask(task, dateFieldToPostpone, timeUnit, amount);
 
         await replaceTaskWithTasks({
             originalTask: task,
             newTasks,
         });
-        this.postponeSuccessCallback(button, dateTypeToUpdate, postponedDate);
+        this.postponeSuccessCallback(button, dateFieldToPostpone, postponedDate);
     }
 
     private postponeSuccessCallback(button: HTMLButtonElement, updatedDateType: HappensDate, postponedDate: Moment) {

--- a/src/Scripting/Postponer.ts
+++ b/src/Scripting/Postponer.ts
@@ -40,8 +40,8 @@ export function createPostponedTask(
     timeUnit: unitOfTime.DurationConstructor,
     amount: number,
 ) {
-    const dateToUpdate = task[dateTypeToUpdate] as Moment;
-    const postponedDate = new TasksDate(dateToUpdate).postpone(timeUnit, amount);
+    const dateToPostpone = task[dateTypeToUpdate] as Moment;
+    const postponedDate = new TasksDate(dateToPostpone).postpone(timeUnit, amount);
     const postponedTask = new Task({ ...task, [dateTypeToUpdate]: postponedDate });
     return { postponedDate, postponedTask };
 }

--- a/src/Scripting/Postponer.ts
+++ b/src/Scripting/Postponer.ts
@@ -46,8 +46,8 @@ export function createPostponedTask(
     return { postponedDate, postponedTask };
 }
 
-export function postponementSuccessMessage(postponedDate: Moment, updatedDateType: HappensDate) {
+export function postponementSuccessMessage(postponedDate: Moment, dateFieldToPostpone: HappensDate) {
     // TODO all logic for invalid dates
     const postponedDateString = postponedDate?.format('DD MMM YYYY');
-    return `Task's ${updatedDateType} postponed until ${postponedDateString}`;
+    return `Task's ${dateFieldToPostpone} postponed until ${postponedDateString}`;
 }

--- a/src/Scripting/Postponer.ts
+++ b/src/Scripting/Postponer.ts
@@ -36,13 +36,13 @@ export function getDateFieldToPostpone(task: Task): HappensDate | null {
 
 export function createPostponedTask(
     task: Task,
-    dateTypeToUpdate: HappensDate,
+    dateFieldToPostpone: HappensDate,
     timeUnit: unitOfTime.DurationConstructor,
     amount: number,
 ) {
-    const dateToPostpone = task[dateTypeToUpdate];
+    const dateToPostpone = task[dateFieldToPostpone];
     const postponedDate = new TasksDate(dateToPostpone).postpone(timeUnit, amount);
-    const postponedTask = new Task({ ...task, [dateTypeToUpdate]: postponedDate });
+    const postponedTask = new Task({ ...task, [dateFieldToPostpone]: postponedDate });
     return { postponedDate, postponedTask };
 }
 

--- a/src/Scripting/Postponer.ts
+++ b/src/Scripting/Postponer.ts
@@ -40,7 +40,7 @@ export function createPostponedTask(
     timeUnit: unitOfTime.DurationConstructor,
     amount: number,
 ) {
-    const dateToPostpone = task[dateTypeToUpdate] as Moment;
+    const dateToPostpone = task[dateTypeToUpdate];
     const postponedDate = new TasksDate(dateToPostpone).postpone(timeUnit, amount);
     const postponedTask = new Task({ ...task, [dateTypeToUpdate]: postponedDate });
     return { postponedDate, postponedTask };

--- a/src/Scripting/Postponer.ts
+++ b/src/Scripting/Postponer.ts
@@ -42,8 +42,8 @@ export function createPostponedTask(
 ) {
     const dateToUpdate = task[dateTypeToUpdate] as Moment;
     const postponedDate = new TasksDate(dateToUpdate).postpone(timeUnit, amount);
-    const newTasks = new Task({ ...task, [dateTypeToUpdate]: postponedDate });
-    return { postponedDate, newTasks };
+    const postponedTask = new Task({ ...task, [dateTypeToUpdate]: postponedDate });
+    return { postponedDate, postponedTask };
 }
 
 export function postponementSuccessMessage(postponedDate: Moment, updatedDateType: HappensDate) {

--- a/tests/Scripting/Postponer.test.ts
+++ b/tests/Scripting/Postponer.test.ts
@@ -157,15 +157,15 @@ describe('postpone - new task creation', () => {
     });
 
     function testPostponedTaskAndDate(task: Task, expectedDateField: HappensDate, expectedPostponedDate: string) {
-        const { postponedDate, newTasks } = createPostponedTask(task, expectedDateField, 'day', 1);
+        const { postponedDate, postponedTask } = createPostponedTask(task, expectedDateField, 'day', 1);
         expect(postponedDate.format('YYYY-MM-DD')).toEqual(expectedPostponedDate);
-        expect(newTasks[expectedDateField]?.format('YYYY-MM-DD')).toEqual(expectedPostponedDate);
+        expect(postponedTask[expectedDateField]?.format('YYYY-MM-DD')).toEqual(expectedPostponedDate);
 
         // If the scheduled date was inferred from the filename, and it is the scheduledDate that was postponed,
         // we must ensure that the 'inferred' flag has been reset to false.
         // Otherwise, the new scheduled date will be ignored in some locations, like rendering of dates.
         if (task.scheduledDateIsInferred && expectedDateField === 'scheduledDate') {
-            expect(newTasks.scheduledDateIsInferred).toEqual(false);
+            expect(postponedTask.scheduledDateIsInferred).toEqual(false);
         }
     }
 


### PR DESCRIPTION
# Description

Rename variables with the following logic:
- `update` -> `postpone`
- `dateType` -> `dateField`
- `newTasks` -> `postponedTask`

Plus remove one type assertion since it is not needed by design (`HappensDate` type ensures the type).

## Motivation and Context

Improve code readability.

## How has this been tested?

Unit tests. Only automated refactorings used.

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
