### PR TITLE
test: improve TaskLineRenderer tests

### DIFF
--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -74,7 +74,7 @@ describe('task line rendering', () => {
         GlobalFilter.getInstance().setRemoveGlobalFilter(false);
     });
 
-    it('should render only one child for the UL and return it with renderTaskLine()', async () => {
+    it('should render only one List Item for the UL and return it with renderTaskLine()', async () => {
         const ulElement = document.createElement('ul');
         const taskLineRenderer = new TaskLineRenderer({
             textRenderer: mockTextRenderer,
@@ -84,11 +84,14 @@ describe('task line rendering', () => {
         });
         const listItem = await taskLineRenderer.renderTaskLine(new TaskBuilder().build(), 0);
 
+        // Just one element
         expect(ulElement.children.length).toEqual(1);
+
+        // It is the rendered one
         expect(ulElement.children[0]).toEqual(listItem);
     });
 
-    it('creates the correct span structure for a basic task', async () => {
+    it('creates the correct span structure for a basic task inside a List Item', async () => {
         const taskLine = '- [ ] This is a simple task';
         const task = fromLine({
             line: taskLine,

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -23,9 +23,9 @@ type AttributesDictionary = { [key: string]: string };
 
 const fieldRenderer = new TaskFieldRenderer();
 
-async function renderListItem(task: Task, layoutOptions: LayoutOptions, testRenderer: TextRenderer) {
+async function renderListItem(task: Task, layoutOptions: LayoutOptions, testRenderer?: TextRenderer) {
     const taskLineRenderer = new TaskLineRenderer({
-        textRenderer: testRenderer,
+        textRenderer: testRenderer ?? defaultTextRenderer,
         obsidianComponent: null,
         parentUlElement: document.createElement('div'),
         layoutOptions: layoutOptions ?? new LayoutOptions(),

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -633,14 +633,12 @@ describe('Visualise HTML', () => {
             parentUlElement: parentElement,
             layoutOptions: layoutOptions ?? new LayoutOptions(),
         });
-        await taskLineRenderer.renderTaskLine(task, 0);
+        const li = await taskLineRenderer.renderTaskLine(task, 0);
 
         const taskAsMarkdown = `<!--
 ${task.toFileLineString()}
 -->\n\n`;
-        const taskAsHTML = parentElement.innerHTML
-            .replace(/ data-/g, '\n    data-')
-            .replace(/<span/g, '\n        <span');
+        const taskAsHTML = li.outerHTML.replace(/ data-/g, '\n    data-').replace(/<span/g, '\n        <span');
 
         verifyWithFileExtension(taskAsMarkdown + taskAsHTML, 'html');
     }

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -33,6 +33,10 @@ async function renderListItem(task: Task, layoutOptions: LayoutOptions, testRend
     return await taskLineRenderer.renderTaskLine(task, 0);
 }
 
+const defaultTextRenderer = async (text: string, element: HTMLSpanElement, _path: string) => {
+    element.innerText = text;
+};
+
 /**
  * Creates a dummy 'parent element' to host a task render, renders a task inside it,
  * and returns it for inspection.
@@ -40,10 +44,7 @@ async function renderListItem(task: Task, layoutOptions: LayoutOptions, testRend
 async function createMockParentAndRender(task: Task, layoutOptions?: LayoutOptions, mockTextRenderer?: TextRenderer) {
     const parentElement = document.createElement('div');
     // Our default text renderer for this method is a simplistic flat text
-    if (!mockTextRenderer)
-        mockTextRenderer = async (text: string, element: HTMLSpanElement, _path: string) => {
-            element.innerText = text;
-        };
+    if (!mockTextRenderer) mockTextRenderer = defaultTextRenderer;
     const taskLineRenderer = new TaskLineRenderer({
         textRenderer: mockTextRenderer,
         obsidianComponent: null,

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -23,6 +23,16 @@ type AttributesDictionary = { [key: string]: string };
 
 const fieldRenderer = new TaskFieldRenderer();
 
+async function renderListItem(task: Task, layoutOptions: LayoutOptions, testRenderer: TextRenderer) {
+    const taskLineRenderer = new TaskLineRenderer({
+        textRenderer: testRenderer,
+        obsidianComponent: null,
+        parentUlElement: document.createElement('div'),
+        layoutOptions: layoutOptions ?? new LayoutOptions(),
+    });
+    return await taskLineRenderer.renderTaskLine(task, 0);
+}
+
 /**
  * Creates a dummy 'parent element' to host a task render, renders a task inside it,
  * and returns it for inspection.
@@ -626,13 +636,7 @@ describe('Visualise HTML', () => {
             element.innerHTML = text;
         };
 
-        const taskLineRenderer = new TaskLineRenderer({
-            textRenderer: mockHTMLRenderer,
-            obsidianComponent: null,
-            parentUlElement: document.createElement('div'),
-            layoutOptions: layoutOptions ?? new LayoutOptions(),
-        });
-        const li = await taskLineRenderer.renderTaskLine(task, 0);
+        const li = await renderListItem(task, layoutOptions, mockHTMLRenderer);
 
         const taskAsMarkdown = `<!--
 ${task.toFileLineString()}

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -74,6 +74,20 @@ describe('task line rendering', () => {
         GlobalFilter.getInstance().setRemoveGlobalFilter(false);
     });
 
+    it('should render only one child for the UL and return it with renderTaskLine()', async () => {
+        const ulElement = document.createElement('ul');
+        const taskLineRenderer = new TaskLineRenderer({
+            textRenderer: mockTextRenderer,
+            obsidianComponent: null,
+            parentUlElement: ulElement,
+            layoutOptions: new LayoutOptions(),
+        });
+        const listItem = await taskLineRenderer.renderTaskLine(new TaskBuilder().build(), 0);
+
+        expect(ulElement.children.length).toEqual(1);
+        expect(ulElement.children[0]).toEqual(listItem);
+    });
+
     it('creates the correct span structure for a basic task', async () => {
         const taskLine = '- [ ] This is a simple task';
         const task = fromLine({

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -37,6 +37,14 @@ const defaultTextRenderer = async (text: string, element: HTMLSpanElement, _path
     element.innerText = text;
 };
 
+const mockHTMLRenderer = async (text: string, element: HTMLSpanElement, _path: string) => {
+    // Contrary to the default mockTextRenderer() in createMockParentAndRender(),
+    // instead of the rendered HTMLSpanElement.innerText,
+    // we need the plain HTML here like in TaskLineRenderer.renderComponentText(),
+    // in order to ensure that any description and tags are retained.
+    element.innerHTML = text;
+};
+
 function getTextSpan(listItem: HTMLElement) {
     return listItem.children[1] as HTMLSpanElement;
 }
@@ -605,14 +613,6 @@ describe('task line rendering', () => {
 
 describe('Visualise HTML', () => {
     async function renderAndVerifyHTML(task: Task, layoutOptions: LayoutOptions) {
-        const mockHTMLRenderer = async (text: string, element: HTMLSpanElement, _path: string) => {
-            // Contrary to the default mockTextRenderer() in createMockParentAndRender(),
-            // instead of the rendered HTMLSpanElement.innerText,
-            // we need the plain HTML here like in TaskLineRenderer.renderComponentText(),
-            // in order to ensure that any description and tags are retained.
-            element.innerHTML = text;
-        };
-
         const li = await renderListItem(task, layoutOptions, mockHTMLRenderer);
 
         const taskAsMarkdown = `<!--

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -89,6 +89,9 @@ describe('task line rendering', () => {
 
         // It is the rendered one
         expect(ulElement.children[0]).toEqual(listItem);
+
+        // And it is a ListItem
+        expect(listItem.nodeName).toEqual('LI');
     });
 
     it('creates the correct span structure for a basic task inside a List Item', async () => {
@@ -97,9 +100,6 @@ describe('task line rendering', () => {
             line: taskLine,
         });
         const listItem = await renderListItem(task);
-
-        // Check that it's an element of type listItem
-        expect(listItem.nodeName).toEqual('LI');
 
         // Check that it has two children: a checkbox and a text span
         expect(listItem.children.length).toEqual(2);

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -23,6 +23,15 @@ type AttributesDictionary = { [key: string]: string };
 
 const fieldRenderer = new TaskFieldRenderer();
 
+/**
+ * Renders a task for test purposes and returns the rendered ListItem.
+ *
+ * @param task to be rendered
+ *
+ * @param layoutOptions for the task rendering. Skip for default options. See {@link LayoutOptions}.
+ *
+ * @param testRenderer imitates Obsidian rendering. Skip for the default {@link mockTextRenderer}.
+ */
 async function renderListItem(task: Task, layoutOptions?: LayoutOptions, testRenderer?: TextRenderer) {
     const taskLineRenderer = new TaskLineRenderer({
         textRenderer: testRenderer ?? mockTextRenderer,
@@ -38,10 +47,10 @@ const mockTextRenderer = async (text: string, element: HTMLSpanElement, _path: s
 };
 
 const mockHTMLRenderer = async (text: string, element: HTMLSpanElement, _path: string) => {
-    // Contrary to the default mockTextRenderer() in createMockParentAndRender(),
+    // Contrary to the default mockTextRenderer(),
     // instead of the rendered HTMLSpanElement.innerText,
     // we need the plain HTML here like in TaskLineRenderer.renderComponentText(),
-    // in order to ensure that any description and tags are retained.
+    // to ensure that description and tags are retained.
     element.innerHTML = text;
 };
 

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -23,7 +23,7 @@ type AttributesDictionary = { [key: string]: string };
 
 const fieldRenderer = new TaskFieldRenderer();
 
-async function renderListItem(task: Task, layoutOptions: LayoutOptions, testRenderer?: TextRenderer) {
+async function renderListItem(task: Task, layoutOptions?: LayoutOptions, testRenderer?: TextRenderer) {
     const taskLineRenderer = new TaskLineRenderer({
         textRenderer: testRenderer ?? defaultTextRenderer,
         obsidianComponent: null,

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -626,11 +626,10 @@ describe('Visualise HTML', () => {
             element.innerHTML = text;
         };
 
-        const parentElement = document.createElement('div');
         const taskLineRenderer = new TaskLineRenderer({
             textRenderer: mockHTMLRenderer,
             obsidianComponent: null,
-            parentUlElement: parentElement,
+            parentUlElement: document.createElement('div'),
             layoutOptions: layoutOptions ?? new LayoutOptions(),
         });
         const li = await taskLineRenderer.renderTaskLine(task, 0);

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -626,11 +626,19 @@ describe('Visualise HTML', () => {
             element.innerHTML = text;
         };
 
-        const parentRender = await createMockParentAndRender(task, layoutOptions, mockHTMLRenderer);
+        const parentElement = document.createElement('div');
+        const taskLineRenderer = new TaskLineRenderer({
+            textRenderer: mockHTMLRenderer,
+            obsidianComponent: null,
+            parentUlElement: parentElement,
+            layoutOptions: layoutOptions ?? new LayoutOptions(),
+        });
+        await taskLineRenderer.renderTaskLine(task, 0);
+
         const taskAsMarkdown = `<!--
 ${task.toFileLineString()}
 -->\n\n`;
-        const taskAsHTML = parentRender.innerHTML
+        const taskAsHTML = parentElement.innerHTML
             .replace(/ data-/g, '\n    data-')
             .replace(/<span/g, '\n        <span');
 

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -79,19 +79,19 @@ describe('task line rendering', () => {
         const task = fromLine({
             line: taskLine,
         });
-        const li = await renderListItem(task);
+        const listItem = await renderListItem(task);
 
-        // Check that it's an element of type LI
-        expect(li.nodeName).toEqual('LI');
+        // Check that it's an element of type listItem
+        expect(listItem.nodeName).toEqual('LI');
 
         // Check that it has two children: a checkbox and a text span
-        expect(li.children.length).toEqual(2);
+        expect(listItem.children.length).toEqual(2);
 
-        const checkbox = li.children[0];
+        const checkbox = listItem.children[0];
         expect(checkbox.nodeName).toEqual('INPUT');
         expect(checkbox.classList.contains('task-list-item-checkbox')).toBeTruthy();
 
-        const textSpan = li.children[1];
+        const textSpan = listItem.children[1];
         expect(textSpan.nodeName).toEqual('SPAN');
         expect(textSpan.classList.contains('tasks-list-text')).toBeTruthy();
 
@@ -290,9 +290,9 @@ describe('task line rendering', () => {
             line: taskLine,
         });
         const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
-        const li = await renderListItem(task, fullLayoutOptions);
+        const listItem = await renderListItem(task, fullLayoutOptions);
 
-        const textSpan = getTextSpan(li);
+        const textSpan = getTextSpan(listItem);
         let found = false;
         for (const childSpan of Array.from(textSpan.children)) {
             if (childSpan.classList.contains(mainClass)) {
@@ -316,9 +316,9 @@ describe('task line rendering', () => {
             line: taskLine,
         });
         const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
-        const li = await renderListItem(task, fullLayoutOptions);
+        const listItem = await renderListItem(task, fullLayoutOptions);
         for (const key in attributes) {
-            expect(li.dataset[key]).toEqual(attributes[key]);
+            expect(listItem.dataset[key]).toEqual(attributes[key]);
         }
     };
 
@@ -332,16 +332,16 @@ describe('task line rendering', () => {
             line: taskLine,
         });
         const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
-        const li = await renderListItem(task, fullLayoutOptions);
+        const listItem = await renderListItem(task, fullLayoutOptions);
 
-        const textSpan = getTextSpan(li);
+        const textSpan = getTextSpan(listItem);
         for (const childSpan of Array.from(textSpan.children)) {
             expect(childSpan.classList.contains(hiddenGenericClass)).toBeFalsy();
         }
 
         // Now verify the attributes
         for (const key in attributes) {
-            expect(li.dataset[key]).toEqual(attributes[key]);
+            expect(listItem.dataset[key]).toEqual(attributes[key]);
         }
     };
 
@@ -607,12 +607,12 @@ describe('task line rendering', () => {
 
 describe('Visualise HTML', () => {
     async function renderAndVerifyHTML(task: Task, layoutOptions: LayoutOptions) {
-        const li = await renderListItem(task, layoutOptions, mockHTMLRenderer);
+        const listItem = await renderListItem(task, layoutOptions, mockHTMLRenderer);
 
         const taskAsMarkdown = `<!--
 ${task.toFileLineString()}
 -->\n\n`;
-        const taskAsHTML = li.outerHTML.replace(/ data-/g, '\n    data-').replace(/<span/g, '\n        <span');
+        const taskAsHTML = listItem.outerHTML.replace(/ data-/g, '\n    data-').replace(/<span/g, '\n        <span');
 
         verifyWithFileExtension(taskAsMarkdown + taskAsHTML, 'html');
     }

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -542,12 +542,6 @@ describe('task line rendering', () => {
         );
     });
 
-    // Unlike the default renderer in createMockParentAndRender, this one accepts a raw HTML rather
-    // than a text, used for the following tests
-    const mockInnerHtmlRenderer = async (text: string, element: HTMLSpanElement, _path: string) => {
-        element.innerHTML = text;
-    };
-
     /*
      * In this test we try to imitate Obsidian's Markdown renderer more thoroughly than other tests,
      * so we can verify that the rendering code adds the correct tag classes inside the rendered
@@ -560,7 +554,7 @@ describe('task line rendering', () => {
         const task = fromLine({
             line: taskLine,
         });
-        const listItem = await renderListItem(task, new LayoutOptions(), mockInnerHtmlRenderer);
+        const listItem = await renderListItem(task, new LayoutOptions(), mockHTMLRenderer);
 
         const textSpan = getTextSpan(listItem);
         const descriptionSpan = textSpan.children[0].children[0] as HTMLElement;
@@ -576,7 +570,7 @@ describe('task line rendering', () => {
         const task = fromLine({
             line: taskLine,
         });
-        const listItem = await renderListItem(task, new LayoutOptions(), mockInnerHtmlRenderer);
+        const listItem = await renderListItem(task, new LayoutOptions(), mockHTMLRenderer);
 
         const textSpan = getTextSpan(listItem);
         const descriptionSpan = textSpan.children[0].children[0] as HTMLElement;

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -25,7 +25,7 @@ const fieldRenderer = new TaskFieldRenderer();
 
 async function renderListItem(task: Task, layoutOptions?: LayoutOptions, testRenderer?: TextRenderer) {
     const taskLineRenderer = new TaskLineRenderer({
-        textRenderer: testRenderer ?? defaultTextRenderer,
+        textRenderer: testRenderer ?? mockTextRenderer,
         obsidianComponent: null,
         parentUlElement: document.createElement('div'),
         layoutOptions: layoutOptions ?? new LayoutOptions(),
@@ -33,7 +33,7 @@ async function renderListItem(task: Task, layoutOptions?: LayoutOptions, testRen
     return await taskLineRenderer.renderTaskLine(task, 0);
 }
 
-const defaultTextRenderer = async (text: string, element: HTMLSpanElement, _path: string) => {
+const mockTextRenderer = async (text: string, element: HTMLSpanElement, _path: string) => {
     element.innerText = text;
 };
 


### PR DESCRIPTION
# Description

Rework TaskLineRenderer tests:
- Test the rendered `ListItem` directly instead of calling `parentRender.children`
- Remove redundant `mockInnerHtmlRenderer()`
- Split tests of the rendered `ListItem` inner structure and the `ListItem` appended to the parent `UnorderedList`

## Motivation and Context

Simplify TaskLineRenderer tests to later increase coverage and conduct future TaskLineRenderer & TaskLayout refactorings.

## How has this been tested?

Unit tests, breaking tests.

## Types of changes

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
