### PR TITLE
fix: better menu items to postpone future dates

### DIFF
--- a/src/Scripting/Postponer.ts
+++ b/src/Scripting/Postponer.ts
@@ -1,4 +1,4 @@
-import type { Moment, unitOfTime } from 'moment';
+import moment, { type Moment, type unitOfTime } from 'moment';
 import { Task } from '../Task';
 import { TasksDate } from './TasksDate';
 
@@ -63,11 +63,21 @@ export function postponeMenuItemTitle(task: Task, amount: number, timeUnit: unit
     }
     const updatedDateType = getDateFieldToPostpone(task)!;
     const dateToUpdate = task[updatedDateType] as Moment;
-    const updatedDateDisplayText = capitalizeFirstLetter(updatedDateType.replace('Date', ''));
+    if (dateToUpdate.isSameOrBefore(moment(), 'day')) {
+        const updatedDateDisplayText = capitalizeFirstLetter(updatedDateType.replace('Date', ''));
 
-    const postponedDate = new TasksDate(dateToUpdate).postpone(timeUnit, amount);
-    const formattedNewDate = postponedDate.format('ddd Do MMM');
+        const postponedDate = new TasksDate(dateToUpdate).postpone(timeUnit, amount);
+        const formattedNewDate = postponedDate.format('ddd Do MMM');
 
-    const amountOrArticle = amount > 1 ? amount : 'a';
-    return `${updatedDateDisplayText} in ${amountOrArticle} ${timeUnit}, on ${formattedNewDate}`;
+        const amountOrArticle = amount > 1 ? amount : 'a';
+        return `${updatedDateDisplayText} in ${amountOrArticle} ${timeUnit}, on ${formattedNewDate}`;
+    } else {
+        const updatedDateDisplayText = updatedDateType.replace('Date', ' date');
+        const amountOrArticle = amount > 1 ? amount : 'a';
+
+        const postponedDate = new TasksDate(dateToUpdate).postpone(timeUnit, amount);
+        const formattedNewDate = postponedDate.format('ddd Do MMM');
+        // 'Postpone due date by a day, to Tue 5th Dec')
+        return `Postpone ${updatedDateDisplayText} by ${amountOrArticle} ${timeUnit}, to ${formattedNewDate}`;
+    }
 }

--- a/src/Scripting/Postponer.ts
+++ b/src/Scripting/Postponer.ts
@@ -1,4 +1,4 @@
-import moment, { type Moment, type unitOfTime } from 'moment';
+import type { Moment, unitOfTime } from 'moment';
 import { Task } from '../Task';
 import { TasksDate } from './TasksDate';
 
@@ -69,7 +69,7 @@ export function postponeMenuItemTitle(task: Task, amount: number, timeUnit: unit
     const formattedNewDate = postponedDate.format('ddd Do MMM');
 
     const amountOrArticle = amount > 1 ? amount : 'a';
-    if (dateToUpdate.isSameOrBefore(moment(), 'day')) {
+    if (dateToUpdate.isSameOrBefore(window.moment(), 'day')) {
         const updatedDateDisplayText = capitalizeFirstLetter(updatedDateType.replace('Date', ''));
         return `${updatedDateDisplayText} in ${amountOrArticle} ${timeUnit}, on ${formattedNewDate}`;
     } else {

--- a/src/Scripting/Postponer.ts
+++ b/src/Scripting/Postponer.ts
@@ -61,23 +61,19 @@ export function postponeMenuItemTitle(task: Task, amount: number, timeUnit: unit
     function capitalizeFirstLetter(word: string) {
         return word.charAt(0).toUpperCase() + word.slice(1);
     }
+
     const updatedDateType = getDateFieldToPostpone(task)!;
     const dateToUpdate = task[updatedDateType] as Moment;
+
+    const postponedDate = new TasksDate(dateToUpdate).postpone(timeUnit, amount);
+    const formattedNewDate = postponedDate.format('ddd Do MMM');
+
+    const amountOrArticle = amount > 1 ? amount : 'a';
     if (dateToUpdate.isSameOrBefore(moment(), 'day')) {
         const updatedDateDisplayText = capitalizeFirstLetter(updatedDateType.replace('Date', ''));
-
-        const postponedDate = new TasksDate(dateToUpdate).postpone(timeUnit, amount);
-        const formattedNewDate = postponedDate.format('ddd Do MMM');
-
-        const amountOrArticle = amount > 1 ? amount : 'a';
         return `${updatedDateDisplayText} in ${amountOrArticle} ${timeUnit}, on ${formattedNewDate}`;
     } else {
         const updatedDateDisplayText = updatedDateType.replace('Date', ' date');
-        const amountOrArticle = amount > 1 ? amount : 'a';
-
-        const postponedDate = new TasksDate(dateToUpdate).postpone(timeUnit, amount);
-        const formattedNewDate = postponedDate.format('ddd Do MMM');
-        // 'Postpone due date by a day, to Tue 5th Dec')
         return `Postpone ${updatedDateDisplayText} by ${amountOrArticle} ${timeUnit}, to ${formattedNewDate}`;
     }
 }

--- a/tests/Scripting/Postponer.test.ts
+++ b/tests/Scripting/Postponer.test.ts
@@ -18,7 +18,10 @@ import { TaskBuilder } from '../TestingTools/TaskBuilder';
 
 window.moment = moment;
 
+const yesterday = '2023-12-02';
 const today = '2023-12-03';
+const tomorrow = '2023-12-04';
+
 beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date(today));
@@ -169,12 +172,26 @@ describe('postpone - UI text', () => {
         );
     });
 
-    it('should include date type and new date in context menu labels', () => {
+    it('should include date type and new date in context menu labels when due today', () => {
         const task = new TaskBuilder().dueDate(today).build();
         // TODO This text is misleading if the date is already in the future.
         //      In that case, it should still be 'Postpone'???
         expect(postponeMenuItemTitle(task, 1, 'day')).toEqual('Due in a day, on Mon 4th Dec');
         expect(postponeMenuItemTitle(task, 2, 'days')).toEqual('Due in 2 days, on Tue 5th Dec');
+    });
+
+    it('should include date type and new date in context menu labels when overdue', () => {
+        const task = new TaskBuilder().dueDate(yesterday).build();
+
+        expect(postponeMenuItemTitle(task, 1, 'day')).toEqual('Due in a day, on Mon 4th Dec');
+        expect(postponeMenuItemTitle(task, 2, 'days')).toEqual('Due in 2 days, on Tue 5th Dec');
+    });
+
+    it('should include date type and new date in context menu labels when due in future', () => {
+        const task = new TaskBuilder().dueDate(tomorrow).build();
+
+        expect(postponeMenuItemTitle(task, 1, 'day')).toEqual('Due in a day, on Tue 5th Dec');
+        expect(postponeMenuItemTitle(task, 2, 'days')).toEqual('Due in 2 days, on Wed 6th Dec');
     });
 });
 

--- a/tests/Scripting/Postponer.test.ts
+++ b/tests/Scripting/Postponer.test.ts
@@ -174,24 +174,23 @@ describe('postpone - UI text', () => {
 
     it('should include date type and new date in context menu labels when due today', () => {
         const task = new TaskBuilder().dueDate(today).build();
-        // TODO This text is misleading if the date is already in the future.
-        //      In that case, it should still be 'Postpone'???
+
         expect(postponeMenuItemTitle(task, 1, 'day')).toEqual('Due in a day, on Mon 4th Dec');
         expect(postponeMenuItemTitle(task, 2, 'days')).toEqual('Due in 2 days, on Tue 5th Dec');
     });
 
     it('should include date type and new date in context menu labels when overdue', () => {
-        const task = new TaskBuilder().dueDate(yesterday).build();
+        const task = new TaskBuilder().scheduledDate(yesterday).build();
 
-        expect(postponeMenuItemTitle(task, 1, 'day')).toEqual('Due in a day, on Mon 4th Dec');
-        expect(postponeMenuItemTitle(task, 2, 'days')).toEqual('Due in 2 days, on Tue 5th Dec');
+        expect(postponeMenuItemTitle(task, 1, 'day')).toEqual('Scheduled in a day, on Mon 4th Dec');
+        expect(postponeMenuItemTitle(task, 2, 'days')).toEqual('Scheduled in 2 days, on Tue 5th Dec');
     });
 
     it('should include date type and new date in context menu labels when due in future', () => {
-        const task = new TaskBuilder().dueDate(tomorrow).build();
+        const task = new TaskBuilder().startDate(tomorrow).build();
 
-        expect(postponeMenuItemTitle(task, 1, 'day')).toEqual('Due in a day, on Tue 5th Dec');
-        expect(postponeMenuItemTitle(task, 2, 'days')).toEqual('Due in 2 days, on Wed 6th Dec');
+        expect(postponeMenuItemTitle(task, 1, 'day')).toEqual('Postpone start date by a day, to Tue 5th Dec');
+        expect(postponeMenuItemTitle(task, 2, 'days')).toEqual('Postpone start date by 2 days, to Wed 6th Dec');
     });
 });
 


### PR DESCRIPTION
# Description

Better menu items to postpone future dates.

## Motivation and Context

Improve usability.

## How has this been tested?

New unit tests + exploratory tests.

## Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
