### PR TITLE
fix: Prevent default action when clicking the postpone button

### DIFF
--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -420,7 +420,10 @@ class QueryRenderChild extends MarkdownRenderChild {
         button.addClasses(classNames);
         button.setText(' ⏩');
 
-        button.addEventListener('click', () => this.postponeOnClickCallback(button, task, amount, timeUnit));
+        button.addEventListener('click', (ev: MouseEvent) => {
+            ev.preventDefault();
+            this.postponeOnClickCallback(button, task, amount, timeUnit);
+        });
 
         /** Open a context menu on right-click.
          * Give a choice of postponing for a week, month, or quarter.

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -421,7 +421,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         button.setText(' ⏩');
 
         button.addEventListener('click', (ev: MouseEvent) => {
-            ev.preventDefault();
+            ev.preventDefault(); // suppress the default click behavior
             this.postponeOnClickCallback(button, task, amount, timeUnit);
         });
 
@@ -429,6 +429,8 @@ class QueryRenderChild extends MarkdownRenderChild {
          * Give a choice of postponing for a week, month, or quarter.
          */
         button.addEventListener('contextmenu', async (ev: MouseEvent) => {
+            ev.stopPropagation(); // suppress the default context menu
+
             const menu = new Menu();
 
             const postponeMenuItemCallback = (item: MenuItem, timeUnit: unitOfTime.DurationConstructor, amount = 1) => {


### PR DESCRIPTION
# Description

When clicking the "postpone" button (a feature introduced in version 5.3.0), then the default behavior of the associated click event should be suppressed.

## Motivation and Context

If the task query appears in a callout, then clicking the postpone button will also trigger opening the callout for editing. This default behavior appears in addition to the desired behavior of postponing the task and is not expected to happen.

Moreover, when right-clicking the button, in addition to the postpone-context-menu, the default context menu for editing the callout will also appear on top of it. This PR fixes this problem as well. The default menu now only appears when right-clicking the callout outside of the postpone button.

Fixes #2512

## How has this been tested?

- Manual testing
- Obsidian 1.5.0 and Tasks 5.3.0
- using the markdown shown in the issue

## Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
