### PR TITLE
Removed the warning text on the notification screen as the recurring …

### DIFF
--- a/docs/Advanced/Notifications.md
+++ b/docs/Advanced/Notifications.md
@@ -38,9 +38,3 @@ The reminder date doesn't change when completing the task, the date will change 
 ![image](https://user-images.githubusercontent.com/38974541/143464983-542675ae-a467-41c0-aaca-1075c42f8328.png)
 
 ---
-
-> [!warning]
-> Completing recurring tasks does not work correctly with Reminders as of August 2022.
-See [this issue in Reminders to check the current status](https://github.com/uphy/obsidian-reminder/issues/93).
-
----


### PR DESCRIPTION
…bug has been fixed

Removed a warning on the notification page.

# Description

Removed a warning on the notification page.

## Motivation and Context

[Original Issue](https://github.com/uphy/obsidian-reminder/issues/93) were fixed [here](https://github.com/uphy/obsidian-reminder/pull/122), this pr is to just remove the text.

## How has this been tested?

When you complete the example task in [every month on the last: reliable and safe](https://publish.obsidian.md/tasks/Getting+Started/Recurring+Tasks#every+month+on+the+last+reliable+and+safe) several times, do you get the same lines as Tasks?
![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/18597575/ea37e265-b98a-448a-a891-02812b6e96da)

When you complete the example task in [every month: if next calculated date does not exist, move new due date earlier](https://publish.obsidian.md/tasks/Getting+Started/Recurring+Tasks#every+month+if+next+calculated+date+does+not+exist%2C+move+new+due+date+earlier) several times, do you get the same lines as Tasks?
![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/18597575/50669362-7731-4d86-bacc-6ec5cf80b6e4)

When you complete the example task in [every month on the 31st: skips months with fewer than 31 days](https://publish.obsidian.md/tasks/Getting+Started/Recurring+Tasks#every+month+on+the+31st+skips+months+with+fewer+than+31+days) several times, do you get the same lines as Tasks?
![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/18597575/7129b54f-983c-4ec0-8ffe-7be4a72b097b)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
