### PR TITLE
test: test adding data attributes with only name & only value

### DIFF
--- a/tests/CustomMatchers/CustomMatchersForRendering.ts
+++ b/tests/CustomMatchers/CustomMatchersForRendering.ts
@@ -1,0 +1,38 @@
+import { diff } from 'jest-diff';
+
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toHaveDataAttributes(expectedDataAttributes: string): R;
+        }
+
+        interface Expect {
+            toHaveDataAttributes(expectedDataAttributes: string): any;
+        }
+
+        interface InverseAsymmetricMatchers {
+            toHaveDataAttributes(expectedDataAttributes: string): any;
+        }
+    }
+}
+
+function getDataAttributesAsString(element: HTMLElement): string {
+    const dataAttributes = element.dataset;
+    const keys = Object.keys(dataAttributes);
+
+    return keys.map((key) => `${key}: ${dataAttributes[key]}`).join('\n');
+}
+
+export function toHaveDataAttributes(htmlElement: HTMLElement, expectedDataAttributes: string) {
+    const renderedDataAttributes = getDataAttributesAsString(htmlElement);
+
+    const pass: boolean = renderedDataAttributes === expectedDataAttributes;
+    const message: () => string = () =>
+        pass
+            ? `Data attributes should not be\n${renderedDataAttributes}`
+            : `Data attributes are not the same as expected:\n${diff(expectedDataAttributes, renderedDataAttributes)}`;
+    return {
+        message,
+        pass,
+    };
+}

--- a/tests/CustomMatchers/jest.custom_matchers.setup.ts
+++ b/tests/CustomMatchers/jest.custom_matchers.setup.ts
@@ -50,6 +50,14 @@ expect.extend({
 });
 
 // ---------------------------------------------------------------------
+// CustomMatchersForRendering
+// ---------------------------------------------------------------------
+import { toHaveDataAttributes } from './CustomMatchersForRendering';
+expect.extend({
+    toHaveDataAttributes,
+});
+
+// ---------------------------------------------------------------------
 // CustomMatchersForTaskBuilder
 // ---------------------------------------------------------------------
 import { toBeIdenticalTo } from './CustomMatchersForTaskBuilder';

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -56,7 +56,7 @@ describe('Field Layout Detail tests', () => {
         expect(fieldLayoutDetail.className).toEqual('stuff');
     });
 
-    it('should add a data attribute with a value for an HTML element', () => {
+    it('should add a data attribute with a value and a name', () => {
         const fieldLayoutDetail = new TaskFieldHTMLData('nameAndValue', 'aKey', () => {
             return 'aValue';
         });
@@ -68,7 +68,7 @@ describe('Field Layout Detail tests', () => {
         expect(span.dataset['aKey']).toEqual('aValue');
     });
 
-    it('should not add a data attribute without a name for an HTML element', () => {
+    it('should not add a data attribute without a name', () => {
         const fieldLayoutDetail = new TaskFieldHTMLData('valueOnly', '', () => {
             return 'aValue';
         });
@@ -80,7 +80,7 @@ describe('Field Layout Detail tests', () => {
         expect(span.dataset['aKey']).toEqual(undefined);
     });
 
-    it('should add a data attribute with a name but without value for an HTML element', () => {
+    it('should add a data attribute with a name but without value', () => {
         const fieldLayoutDetail = new TaskFieldHTMLData('nameOnly', 'aKey', () => {
             return '';
         });

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -56,8 +56,8 @@ describe('Field Layout Detail tests', () => {
         expect(fieldLayoutDetail.className).toEqual('stuff');
     });
 
-    it('should add a data attribute for an HTML element', () => {
-        const fieldLayoutDetail = new TaskFieldHTMLData('dataAttributeTest', 'aKey', () => {
+    it('should add a data attribute with a value for an HTML element', () => {
+        const fieldLayoutDetail = new TaskFieldHTMLData('nameAndValue', 'aKey', () => {
             return 'aValue';
         });
         const span = document.createElement('span');
@@ -66,5 +66,29 @@ describe('Field Layout Detail tests', () => {
 
         expect(Object.keys(span.dataset).length).toEqual(1);
         expect(span.dataset['aKey']).toEqual('aValue');
+    });
+
+    it('should not add a data attribute without a name for an HTML element', () => {
+        const fieldLayoutDetail = new TaskFieldHTMLData('valueOnly', '', () => {
+            return 'aValue';
+        });
+        const span = document.createElement('span');
+
+        fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'description');
+
+        expect(Object.keys(span.dataset).length).toEqual(0);
+        expect(span.dataset['aKey']).toEqual(undefined);
+    });
+
+    it('should add a data attribute with a name but without value for an HTML element', () => {
+        const fieldLayoutDetail = new TaskFieldHTMLData('nameOnly', 'aKey', () => {
+            return '';
+        });
+        const span = document.createElement('span');
+
+        fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'description');
+
+        expect(Object.keys(span.dataset).length).toEqual(1);
+        expect(span.dataset['aKey']).toEqual('');
     });
 });

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -49,6 +49,13 @@ describe('Field Layouts Container tests', () => {
 });
 
 describe('Field Layout Detail tests', () => {
+    function getDataAttributesAsString(element: HTMLElement): string {
+        const dataAttributes = element.dataset;
+        const keys = Object.keys(dataAttributes);
+
+        return keys.map((key) => `${key}: ${dataAttributes[key]}`).join('\n');
+    }
+
     it('should supply a class name', () => {
         const fieldLayoutDetail = new TaskFieldHTMLData('stuff', 'taskAttribute', () => {
             return '';
@@ -64,8 +71,7 @@ describe('Field Layout Detail tests', () => {
 
         fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'description');
 
-        expect(Object.keys(span.dataset).length).toEqual(1);
-        expect(span.dataset['aKey']).toEqual('aValue');
+        expect(getDataAttributesAsString(span)).toEqual('aKey: aValue');
     });
 
     it('should not add a data attribute without a name', () => {
@@ -76,8 +82,7 @@ describe('Field Layout Detail tests', () => {
 
         fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'description');
 
-        expect(Object.keys(span.dataset).length).toEqual(0);
-        expect(span.dataset['aKey']).toEqual(undefined);
+        expect(getDataAttributesAsString(span)).toEqual('');
     });
 
     it.failing('should not add a data attribute with a name but without value', () => {
@@ -88,7 +93,6 @@ describe('Field Layout Detail tests', () => {
 
         fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'description');
 
-        expect(Object.keys(span.dataset).length).toEqual(0);
-        expect(span.dataset['aKey']).toEqual(undefined);
+        expect(getDataAttributesAsString(span)).toEqual('');
     });
 });

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -80,7 +80,7 @@ describe('Field Layout Detail tests', () => {
         expect(span.dataset['aKey']).toEqual(undefined);
     });
 
-    it('should add a data attribute with a name but without value', () => {
+    it.failing('should not add a data attribute with a name but without value', () => {
         const fieldLayoutDetail = new TaskFieldHTMLData('nameOnly', 'aKey', () => {
             return '';
         });
@@ -88,7 +88,7 @@ describe('Field Layout Detail tests', () => {
 
         fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'description');
 
-        expect(Object.keys(span.dataset).length).toEqual(1);
-        expect(span.dataset['aKey']).toEqual('');
+        expect(Object.keys(span.dataset).length).toEqual(0);
+        expect(span.dataset['aKey']).toEqual(undefined);
     });
 });

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -57,41 +57,41 @@ describe('Field Layout Detail tests', () => {
     }
 
     it('should supply a class name', () => {
-        const fieldLayoutDetail = new TaskFieldHTMLData('stuff', 'taskAttribute', () => {
+        const fieldLayoutDetail = new TaskFieldHTMLData('task-description', '', () => {
             return '';
         });
-        expect(fieldLayoutDetail.className).toEqual('stuff');
+        expect(fieldLayoutDetail.className).toEqual('task-description');
     });
 
     it('should add a data attribute with a value and a name', () => {
-        const fieldLayoutDetail = new TaskFieldHTMLData('nameAndValue', 'aKey', () => {
-            return 'aValue';
+        const fieldLayoutDetail = new TaskFieldHTMLData('task-priority', 'taskPriority', () => {
+            return 'highest';
         });
         const span = document.createElement('span');
 
-        fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'description');
+        fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'priority');
 
-        expect(getDataAttributesAsString(span)).toEqual('aKey: aValue');
+        expect(getDataAttributesAsString(span)).toEqual('taskPriority: highest');
     });
 
     it('should not add a data attribute without a name', () => {
-        const fieldLayoutDetail = new TaskFieldHTMLData('valueOnly', '', () => {
-            return 'aValue';
+        const fieldLayoutDetail = new TaskFieldHTMLData('task-due', '', () => {
+            return 'past-far';
         });
         const span = document.createElement('span');
 
-        fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'description');
+        fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'dueDate');
 
         expect(getDataAttributesAsString(span)).toEqual('');
     });
 
     it.failing('should not add a data attribute with a name but without value', () => {
-        const fieldLayoutDetail = new TaskFieldHTMLData('nameOnly', 'aKey', () => {
+        const fieldLayoutDetail = new TaskFieldHTMLData('task-start', 'taskStart', () => {
             return '';
         });
         const span = document.createElement('span');
 
-        fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'description');
+        fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'startDate');
 
         expect(getDataAttributesAsString(span)).toEqual('');
     });

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -49,13 +49,6 @@ describe('Field Layouts Container tests', () => {
 });
 
 describe('Field Layout Detail tests', () => {
-    function getDataAttributesAsString(element: HTMLElement): string {
-        const dataAttributes = element.dataset;
-        const keys = Object.keys(dataAttributes);
-
-        return keys.map((key) => `${key}: ${dataAttributes[key]}`).join('\n');
-    }
-
     it('should supply a class name', () => {
         const fieldLayoutDetail = new TaskFieldHTMLData('task-description', '', () => {
             return '';
@@ -71,7 +64,7 @@ describe('Field Layout Detail tests', () => {
 
         fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'priority');
 
-        expect(getDataAttributesAsString(span)).toEqual('taskPriority: highest');
+        expect(span).toHaveDataAttributes('taskPriority: highest');
     });
 
     it('should not add a data attribute without a name', () => {
@@ -82,7 +75,7 @@ describe('Field Layout Detail tests', () => {
 
         fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'dueDate');
 
-        expect(getDataAttributesAsString(span)).toEqual('');
+        expect(span).toHaveDataAttributes('');
     });
 
     it.failing('should not add a data attribute with a name but without value', () => {
@@ -93,6 +86,6 @@ describe('Field Layout Detail tests', () => {
 
         fieldLayoutDetail.addDataAttribute(span, new TaskBuilder().build(), 'startDate');
 
-        expect(getDataAttributesAsString(span)).toEqual('');
+        expect(span).toHaveDataAttributes('');
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- test adding data attributes with only name & only value

## Motivation and Context

- Describe the current behaviour before any changes
- Increase coverage

## How has this been tested?

New unit tests, breaking code

## Types of changes

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
