### PR TITLE
refactor: extract QueryLayoutOptions from LayoutOptions

### DIFF
--- a/src/IQuery.ts
+++ b/src/IQuery.ts
@@ -1,3 +1,4 @@
+import type { QueryLayoutOptions } from './QueryLayoutOptions';
 import type { LayoutOptions } from './TaskLayout';
 import type { Task } from './Task';
 import type { Grouper } from './Query/Grouper';
@@ -47,6 +48,15 @@ export interface IQuery {
      * @memberof IQuery
      */
     layoutOptions: LayoutOptions;
+
+    /**
+     * Any layout options the query engine should be aware of or
+     * used in the query.
+     *
+     * @type {QueryLayoutOptions}
+     * @memberof IQuery
+     */
+    queryLayoutOptions: QueryLayoutOptions;
 
     /**
      * Main method for executing the query. This will be called by the

--- a/src/InlineRenderer.ts
+++ b/src/InlineRenderer.ts
@@ -1,6 +1,7 @@
 import type { MarkdownPostProcessorContext, Plugin } from 'obsidian';
 import { MarkdownRenderChild } from 'obsidian';
 import { GlobalFilter } from './Config/GlobalFilter';
+import { QueryLayoutOptions } from './QueryLayoutOptions';
 import { Task } from './Task';
 import { LayoutOptions } from './TaskLayout';
 import { TaskLineRenderer } from './TaskLineRenderer';
@@ -91,6 +92,7 @@ export class InlineRenderer {
             obsidianComponent: childComponent,
             parentUlElement: element,
             layoutOptions: new LayoutOptions(),
+            queryLayoutOptions: new QueryLayoutOptions(),
         });
 
         // The section index is the nth task within this section.

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -1,3 +1,4 @@
+import { QueryLayoutOptions } from '../QueryLayoutOptions';
 import { expandPlaceholders } from '../Scripting/ExpandPlaceholders';
 import { makeQueryContext } from '../Scripting/QueryContext';
 import { LayoutOptions } from '../TaskLayout';
@@ -24,6 +25,8 @@ export class Query implements IQuery {
     private _limit: number | undefined = undefined;
     private _taskGroupLimit: number | undefined = undefined;
     private _layoutOptions: LayoutOptions = new LayoutOptions();
+    // @ts-expect-error unused variable
+    private _queryLayoutOptions: QueryLayoutOptions = new QueryLayoutOptions();
     private _filters: Filter[] = [];
     private _error: string | undefined = undefined;
     private _sorting: Sorter[] = [];

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -1,4 +1,4 @@
-import { QueryLayoutOptions } from '../QueryLayoutOptions';
+import type { QueryLayoutOptions } from '../QueryLayoutOptions';
 import { expandPlaceholders } from '../Scripting/ExpandPlaceholders';
 import { makeQueryContext } from '../Scripting/QueryContext';
 import { LayoutOptions } from '../TaskLayout';
@@ -25,7 +25,7 @@ export class Query implements IQuery {
     private _limit: number | undefined = undefined;
     private _taskGroupLimit: number | undefined = undefined;
     private _layoutOptions: LayoutOptions = new LayoutOptions();
-    private _queryLayoutOptions: QueryLayoutOptions = new QueryLayoutOptions();
+    private _queryLayoutOptions: QueryLayoutOptions = this._layoutOptions;
     private _filters: Filter[] = [];
     private _error: string | undefined = undefined;
     private _sorting: Sorter[] = [];
@@ -63,10 +63,10 @@ export class Query implements IQuery {
 
             switch (true) {
                 case this.shortModeRegexp.test(line):
-                    this._layoutOptions.shortMode = true;
+                    this._queryLayoutOptions.shortMode = true;
                     break;
                 case this.explainQueryRegexp.test(line):
-                    this._layoutOptions.explainQuery = true;
+                    this._queryLayoutOptions.explainQuery = true;
                     break;
                 case this.ignoreGlobalQueryRegexp.test(line):
                     this._ignoreGlobalQuery = true;
@@ -296,13 +296,13 @@ Problem line: "${line}"`;
 
             switch (option) {
                 case 'task count':
-                    this._layoutOptions.hideTaskCount = hide;
+                    this._queryLayoutOptions.hideTaskCount = hide;
                     break;
                 case 'backlink':
-                    this._layoutOptions.hideBacklinks = hide;
+                    this._queryLayoutOptions.hideBacklinks = hide;
                     break;
                 case 'postpone button':
-                    this._layoutOptions.hidePostponeButton = hide;
+                    this._queryLayoutOptions.hidePostponeButton = hide;
                     break;
                 case 'priority':
                     this._layoutOptions.hidePriority = hide;
@@ -326,10 +326,10 @@ Problem line: "${line}"`;
                     this._layoutOptions.hideRecurrenceRule = hide;
                     break;
                 case 'edit button':
-                    this._layoutOptions.hideEditButton = hide;
+                    this._queryLayoutOptions.hideEditButton = hide;
                     break;
                 case 'urgency':
-                    this._layoutOptions.hideUrgency = hide;
+                    this._queryLayoutOptions.hideUrgency = hide;
                     break;
                 case 'tags':
                     this._layoutOptions.hideTags = hide;

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -1,4 +1,4 @@
-import type { QueryLayoutOptions } from '../QueryLayoutOptions';
+import { QueryLayoutOptions } from '../QueryLayoutOptions';
 import { expandPlaceholders } from '../Scripting/ExpandPlaceholders';
 import { makeQueryContext } from '../Scripting/QueryContext';
 import { LayoutOptions } from '../TaskLayout';
@@ -25,7 +25,7 @@ export class Query implements IQuery {
     private _limit: number | undefined = undefined;
     private _taskGroupLimit: number | undefined = undefined;
     private _layoutOptions: LayoutOptions = new LayoutOptions();
-    private _queryLayoutOptions: QueryLayoutOptions = this._layoutOptions;
+    private _queryLayoutOptions: QueryLayoutOptions = new QueryLayoutOptions();
     private _filters: Filter[] = [];
     private _error: string | undefined = undefined;
     private _sorting: Sorter[] = [];

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -25,7 +25,6 @@ export class Query implements IQuery {
     private _limit: number | undefined = undefined;
     private _taskGroupLimit: number | undefined = undefined;
     private _layoutOptions: LayoutOptions = new LayoutOptions();
-    // @ts-expect-error unused variable
     private _queryLayoutOptions: QueryLayoutOptions = new QueryLayoutOptions();
     private _filters: Filter[] = [];
     private _error: string | undefined = undefined;
@@ -218,6 +217,10 @@ ${source}`;
 
     public get layoutOptions(): LayoutOptions {
         return this._layoutOptions;
+    }
+
+    public get queryLayoutOptions(): QueryLayoutOptions {
+        return this._queryLayoutOptions;
     }
 
     public get filters(): Filter[] {

--- a/src/QueryLayoutOptions.ts
+++ b/src/QueryLayoutOptions.ts
@@ -1,3 +1,8 @@
+/**
+ * Options to control {@link QueryRenderer} behaviour.
+ *
+ * @see LayoutOptions
+ */
 export class QueryLayoutOptions {
     hidePostponeButton: boolean = false;
     hideTaskCount: boolean = false;

--- a/src/QueryLayoutOptions.ts
+++ b/src/QueryLayoutOptions.ts
@@ -1,0 +1,9 @@
+export class QueryLayoutOptions {
+    hidePostponeButton: boolean = false;
+    hideTaskCount: boolean = false;
+    hideBacklinks: boolean = false;
+    hideEditButton: boolean = false;
+    hideUrgency: boolean = true;
+    shortMode: boolean = false;
+    explainQuery: boolean = false;
+}

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -221,7 +221,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private async createTaskList(tasks: Task[], content: HTMLDivElement): Promise<void> {
-        const layout = new TaskLayout(this.query.layoutOptions);
+        const layout = new TaskLayout(this.query.layoutOptions, this.query.queryLayoutOptions);
         const taskList = content.createEl('ul');
         taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);
         taskList.addClasses(layout.taskListHiddenClasses);

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -232,6 +232,7 @@ class QueryRenderChild extends MarkdownRenderChild {
             obsidianComponent: this,
             parentUlElement: taskList,
             layoutOptions: this.query.layoutOptions,
+            queryLayoutOptions: this.query.queryLayoutOptions,
         });
 
         for (const [taskIndex, task] of tasks.entries()) {

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -178,7 +178,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         // See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2160
         this.query.debug(`[render] Render called: plugin state: ${state}; searching ${tasks.length} tasks`);
 
-        if (this.query.layoutOptions.explainQuery) {
+        if (this.query.queryLayoutOptions.explainQuery) {
             this.createExplanation(content);
         }
 
@@ -244,21 +244,21 @@ class QueryRenderChild extends MarkdownRenderChild {
 
             const extrasSpan = listItem.createSpan('task-extras');
 
-            if (!this.query.layoutOptions.hideUrgency) {
+            if (!this.query.queryLayoutOptions.hideUrgency) {
                 this.addUrgency(extrasSpan, task);
             }
 
-            const shortMode = this.query.layoutOptions.shortMode;
+            const shortMode = this.query.queryLayoutOptions.shortMode;
 
-            if (!this.query.layoutOptions.hideBacklinks) {
+            if (!this.query.queryLayoutOptions.hideBacklinks) {
                 this.addBacklinks(extrasSpan, task, shortMode, isFilenameUnique);
             }
 
-            if (!this.query.layoutOptions.hideEditButton) {
+            if (!this.query.queryLayoutOptions.hideEditButton) {
                 this.addEditButton(extrasSpan, task);
             }
 
-            if (!this.query.layoutOptions.hidePostponeButton && shouldShowPostponeButton(task)) {
+            if (!this.query.queryLayoutOptions.hidePostponeButton && shouldShowPostponeButton(task)) {
                 this.addPostponeButton(extrasSpan, task, shortMode);
             }
 
@@ -454,7 +454,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private addTaskCount(content: HTMLDivElement, queryResult: QueryResult) {
-        if (!this.query.layoutOptions.hideTaskCount) {
+        if (!this.query.queryLayoutOptions.hideTaskCount) {
             content.createDiv({
                 text: queryResult.totalTasksCountDisplayText(),
                 cls: 'tasks-count',

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -1,8 +1,10 @@
 import { QueryLayoutOptions } from './QueryLayoutOptions';
 
 /**
- * Various rendering options for a query.
+ * Various rendering options of tasks in a query.
  * See applyOptions below when adding options here.
+ *
+ * @see QueryLayoutOptions
  */
 export class LayoutOptions {
     hidePriority: boolean = false;

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -89,16 +89,16 @@ export class TaskLayout {
             // (see https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1866).
             // This can benefit from some refactoring, i.e. render these components in a similar flow rather than
             // separately.
-            [this.options.hideUrgency, 'urgency'],
-            [this.options.hideBacklinks, 'backlinks'],
-            [this.options.hideEditButton, 'edit-button'],
-            [this.options.hidePostponeButton, 'postpone-button'],
+            [this.queryLayoutOptions.hideUrgency, 'urgency'],
+            [this.queryLayoutOptions.hideBacklinks, 'backlinks'],
+            [this.queryLayoutOptions.hideEditButton, 'edit-button'],
+            [this.queryLayoutOptions.hidePostponeButton, 'postpone-button'],
         ];
         for (const [hide, component] of componentsToGenerateClassesOnly) {
             this.generateHiddenClassForTaskList(hide, component);
         }
 
-        if (this.options.shortMode) this.taskListHiddenClasses.push('tasks-layout-short-mode');
+        if (this.queryLayoutOptions.shortMode) this.taskListHiddenClasses.push('tasks-layout-short-mode');
     }
 
     private generateHiddenClassForTaskList(hide: boolean, component: string) {

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -1,11 +1,10 @@
+import { QueryLayoutOptions } from './QueryLayoutOptions';
+
 /**
  * Various rendering options for a query.
  * See applyOptions below when adding options here.
  */
-export class LayoutOptions {
-    hidePostponeButton: boolean = false;
-    hideTaskCount: boolean = false;
-    hideBacklinks: boolean = false;
+export class LayoutOptions extends QueryLayoutOptions {
     hidePriority: boolean = false;
     hideCreatedDate: boolean = false;
     hideStartDate: boolean = false;
@@ -13,11 +12,7 @@ export class LayoutOptions {
     hideDoneDate: boolean = false;
     hideDueDate: boolean = false;
     hideRecurrenceRule: boolean = false;
-    hideEditButton: boolean = false;
-    hideUrgency: boolean = true;
     hideTags: boolean = false;
-    shortMode: boolean = false;
-    explainQuery: boolean = false;
 }
 
 export type TaskLayoutComponent =

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -48,6 +48,7 @@ export class TaskLayout {
     public shownTaskLayoutComponents: TaskLayoutComponent[];
     public hiddenTaskLayoutComponents: TaskLayoutComponent[] = [];
     public options: LayoutOptions;
+    public queryLayoutOptions: QueryLayoutOptions;
     public taskListHiddenClasses: string[] = [];
 
     constructor(options?: LayoutOptions) {
@@ -56,6 +57,7 @@ export class TaskLayout {
         } else {
             this.options = new LayoutOptions();
         }
+        this.queryLayoutOptions = this.options;
         this.shownTaskLayoutComponents = this.defaultLayout;
         this.applyOptions();
     }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -4,7 +4,7 @@ import { QueryLayoutOptions } from './QueryLayoutOptions';
  * Various rendering options for a query.
  * See applyOptions below when adding options here.
  */
-export class LayoutOptions extends QueryLayoutOptions {
+export class LayoutOptions {
     hidePriority: boolean = false;
     hideCreatedDate: boolean = false;
     hideStartDate: boolean = false;

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -51,13 +51,18 @@ export class TaskLayout {
     public queryLayoutOptions: QueryLayoutOptions;
     public taskListHiddenClasses: string[] = [];
 
-    constructor(options?: LayoutOptions) {
+    constructor(options?: LayoutOptions, queryLayoutOptions?: QueryLayoutOptions) {
         if (options) {
             this.options = options;
         } else {
             this.options = new LayoutOptions();
         }
-        this.queryLayoutOptions = this.options;
+        if (queryLayoutOptions) {
+            this.queryLayoutOptions = queryLayoutOptions;
+        } else {
+            this.queryLayoutOptions = new QueryLayoutOptions();
+        }
+
         this.shownTaskLayoutComponents = this.defaultLayout;
         this.applyOptions();
     }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -3,7 +3,7 @@ import { Component, MarkdownRenderer } from 'obsidian';
 import { GlobalFilter } from './Config/GlobalFilter';
 import { TASK_FORMATS, getSettings } from './Config/Settings';
 import { replaceTaskWithTasks } from './File';
-import { QueryLayoutOptions } from './QueryLayoutOptions';
+import type { QueryLayoutOptions } from './QueryLayoutOptions';
 import type { Task } from './Task';
 import * as taskModule from './Task';
 import { TaskFieldRenderer } from './TaskFieldRenderer';
@@ -30,7 +30,7 @@ export class TaskLineRenderer {
     private readonly parentUlElement: HTMLElement;
     private readonly layoutOptions: LayoutOptions;
     // @ts-expect-error
-    private readonly queryLayoutOptions: QueryLayoutOptions = new QueryLayoutOptions();
+    private readonly queryLayoutOptions: QueryLayoutOptions;
 
     private static async obsidianMarkdownRenderer(
         text: string,
@@ -70,6 +70,7 @@ export class TaskLineRenderer {
         this.obsidianComponent = obsidianComponent;
         this.parentUlElement = parentUlElement;
         this.layoutOptions = layoutOptions;
+        this.queryLayoutOptions = layoutOptions;
     }
 
     /**

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -155,7 +155,12 @@ export class TaskLineRenderer {
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
         // Render and build classes for all the task's visible components
         for (const component of taskLayout.shownTaskLayoutComponents) {
-            const componentString = emojiSerializer.componentToString(task, taskLayout, component);
+            const componentString = emojiSerializer.componentToString(
+                task,
+                taskLayout,
+                component,
+                taskLayout.options.shortMode,
+            );
             if (componentString) {
                 // Create the text span that will hold the rendered component
                 const span = document.createElement('span');

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -53,23 +53,27 @@ export class TaskLineRenderer {
      * @param parentUlElement HTML element where the task shall be rendered.
      *
      * @param layoutOptions See {@link LayoutOptions}.
+     *
+     * @param queryLayoutOptions See {@link QueryLayoutOptions}.
      */
     constructor({
         textRenderer = TaskLineRenderer.obsidianMarkdownRenderer,
         obsidianComponent,
         parentUlElement,
         layoutOptions,
+        queryLayoutOptions,
     }: {
         textRenderer?: TextRenderer;
         obsidianComponent: Component | null;
         parentUlElement: HTMLElement;
         layoutOptions: LayoutOptions;
+        queryLayoutOptions: QueryLayoutOptions;
     }) {
         this.textRenderer = textRenderer;
         this.obsidianComponent = obsidianComponent;
         this.parentUlElement = parentUlElement;
         this.layoutOptions = layoutOptions;
-        this.queryLayoutOptions = layoutOptions;
+        this.queryLayoutOptions = queryLayoutOptions;
     }
 
     /**

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -3,6 +3,7 @@ import { Component, MarkdownRenderer } from 'obsidian';
 import { GlobalFilter } from './Config/GlobalFilter';
 import { TASK_FORMATS, getSettings } from './Config/Settings';
 import { replaceTaskWithTasks } from './File';
+import { QueryLayoutOptions } from './QueryLayoutOptions';
 import type { Task } from './Task';
 import * as taskModule from './Task';
 import { TaskFieldRenderer } from './TaskFieldRenderer';
@@ -28,6 +29,8 @@ export class TaskLineRenderer {
     private readonly obsidianComponent: Component | null;
     private readonly parentUlElement: HTMLElement;
     private readonly layoutOptions: LayoutOptions;
+    // @ts-expect-error
+    private readonly queryLayoutOptions: QueryLayoutOptions = new QueryLayoutOptions();
 
     private static async obsidianMarkdownRenderer(
         text: string,

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -155,7 +155,7 @@ export class TaskLineRenderer {
     }
 
     private async taskToHtml(task: Task, parentElement: HTMLElement, li: HTMLLIElement): Promise<void> {
-        const taskLayout = new TaskLayout(this.layoutOptions);
+        const taskLayout = new TaskLayout(this.layoutOptions, this.queryLayoutOptions);
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
         // Render and build classes for all the task's visible components
         for (const component of taskLayout.shownTaskLayoutComponents) {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -29,7 +29,6 @@ export class TaskLineRenderer {
     private readonly obsidianComponent: Component | null;
     private readonly parentUlElement: HTMLElement;
     private readonly layoutOptions: LayoutOptions;
-    // @ts-expect-error
     private readonly queryLayoutOptions: QueryLayoutOptions;
 
     private static async obsidianMarkdownRenderer(
@@ -144,7 +143,7 @@ export class TaskLineRenderer {
         li.setAttribute('data-task-status-type', task.status.type);
         checkbox.setAttribute('data-line', taskIndex.toString());
 
-        if (this.layoutOptions.shortMode) {
+        if (this.queryLayoutOptions.shortMode) {
             this.addTooltip(task, textSpan, isFilenameUnique);
         }
 

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -155,12 +155,7 @@ export class TaskLineRenderer {
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
         // Render and build classes for all the task's visible components
         for (const component of taskLayout.shownTaskLayoutComponents) {
-            const componentString = emojiSerializer.componentToString(
-                task,
-                taskLayout,
-                component,
-                taskLayout.options.shortMode,
-            );
+            const componentString = emojiSerializer.componentToString(task, taskLayout.options.shortMode, component);
             if (componentString) {
                 // Create the text span that will hold the rendered component
                 const span = document.createElement('span');

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -155,7 +155,11 @@ export class TaskLineRenderer {
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
         // Render and build classes for all the task's visible components
         for (const component of taskLayout.shownTaskLayoutComponents) {
-            const componentString = emojiSerializer.componentToString(task, taskLayout.options.shortMode, component);
+            const componentString = emojiSerializer.componentToString(
+                task,
+                taskLayout.queryLayoutOptions.shortMode,
+                component,
+            );
             if (componentString) {
                 // Create the text span that will hold the rendered component
                 const span = document.createElement('span');

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -111,8 +111,8 @@ export class DataviewTaskSerializer extends DefaultTaskSerializer {
         }
     }
 
-    public componentToString(task: Task, layout: TaskLayout, component: TaskLayoutComponent) {
-        const stringComponent = super.componentToString(task, layout, component, layout.options.shortMode);
+    public componentToString(task: Task, layout: TaskLayout, component: TaskLayoutComponent, shortMode1: boolean) {
+        const stringComponent = super.componentToString(task, layout, component, shortMode1);
         const notInlineFieldComponents: TaskLayoutComponent[] = ['blockLink', 'description'];
         const shouldMakeInlineField = stringComponent !== '' && !notInlineFieldComponents.includes(component);
         return shouldMakeInlineField

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -112,7 +112,7 @@ export class DataviewTaskSerializer extends DefaultTaskSerializer {
     }
 
     public componentToString(task: Task, layout: TaskLayout, component: TaskLayoutComponent) {
-        const stringComponent = super.componentToString(task, layout, component);
+        const stringComponent = super.componentToString(task, layout, component, layout.options.shortMode);
         const notInlineFieldComponents: TaskLayoutComponent[] = ['blockLink', 'description'];
         const shouldMakeInlineField = stringComponent !== '' && !notInlineFieldComponents.includes(component);
         return shouldMakeInlineField

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -1,4 +1,4 @@
-import type { TaskLayout, TaskLayoutComponent } from '../TaskLayout';
+import type { TaskLayoutComponent } from '../TaskLayout';
 import type { Task } from '../Task';
 import { Priority } from '../Task';
 import { DefaultTaskSerializer } from './DefaultTaskSerializer';
@@ -111,8 +111,8 @@ export class DataviewTaskSerializer extends DefaultTaskSerializer {
         }
     }
 
-    public componentToString(task: Task, layout: TaskLayout, component: TaskLayoutComponent, shortMode1: boolean) {
-        const stringComponent = super.componentToString(task, layout, component, shortMode1);
+    public componentToString(task: Task, shortMode: boolean, component: TaskLayoutComponent) {
+        const stringComponent = super.componentToString(task, shortMode, component);
         const notInlineFieldComponents: TaskLayoutComponent[] = ['blockLink', 'description'];
         const shouldMakeInlineField = stringComponent !== '' && !notInlineFieldComponents.includes(component);
         return shouldMakeInlineField

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -84,7 +84,7 @@ export class DefaultTaskSerializer implements TaskSerializer {
         const taskLayout = new TaskLayout();
         let taskString = '';
         for (const component of taskLayout.shownTaskLayoutComponents) {
-            taskString += this.componentToString(task, taskLayout, component, taskLayout.options.shortMode);
+            taskString += this.componentToString(task, taskLayout.options.shortMode, component);
         }
         return taskString;
     }
@@ -92,7 +92,7 @@ export class DefaultTaskSerializer implements TaskSerializer {
     /**
      * Renders a specific TaskLayoutComponent of the task (its description, priority, etc) as a string.
      */
-    public componentToString(task: Task, _layout: TaskLayout, component: TaskLayoutComponent, shortMode1: boolean) {
+    public componentToString(task: Task, shortMode: boolean, component: TaskLayoutComponent) {
         const {
             // NEW_TASK_FIELD_EDIT_REQUIRED
             prioritySymbols,
@@ -104,7 +104,6 @@ export class DefaultTaskSerializer implements TaskSerializer {
             dueDateSymbol,
         } = this.symbols;
 
-        const shortMode = shortMode1;
         switch (component) {
             // NEW_TASK_FIELD_EDIT_REQUIRED
             case 'description':

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -84,7 +84,7 @@ export class DefaultTaskSerializer implements TaskSerializer {
         const taskLayout = new TaskLayout();
         let taskString = '';
         for (const component of taskLayout.shownTaskLayoutComponents) {
-            taskString += this.componentToString(task, taskLayout.options.shortMode, component);
+            taskString += this.componentToString(task, taskLayout.queryLayoutOptions.shortMode, component);
         }
         return taskString;
     }

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -84,7 +84,7 @@ export class DefaultTaskSerializer implements TaskSerializer {
         const taskLayout = new TaskLayout();
         let taskString = '';
         for (const component of taskLayout.shownTaskLayoutComponents) {
-            taskString += this.componentToString(task, taskLayout, component);
+            taskString += this.componentToString(task, taskLayout, component, taskLayout.options.shortMode);
         }
         return taskString;
     }
@@ -92,7 +92,7 @@ export class DefaultTaskSerializer implements TaskSerializer {
     /**
      * Renders a specific TaskLayoutComponent of the task (its description, priority, etc) as a string.
      */
-    public componentToString(task: Task, layout: TaskLayout, component: TaskLayoutComponent) {
+    public componentToString(task: Task, _layout: TaskLayout, component: TaskLayoutComponent, shortMode1: boolean) {
         const {
             // NEW_TASK_FIELD_EDIT_REQUIRED
             prioritySymbols,
@@ -104,6 +104,7 @@ export class DefaultTaskSerializer implements TaskSerializer {
             dueDateSymbol,
         } = this.symbols;
 
+        const shortMode = shortMode1;
         switch (component) {
             // NEW_TASK_FIELD_EDIT_REQUIRED
             case 'description':
@@ -126,34 +127,32 @@ export class DefaultTaskSerializer implements TaskSerializer {
             }
             case 'startDate':
                 if (!task.startDate) return '';
-                return layout.options.shortMode
+                return shortMode
                     ? ' ' + startDateSymbol
                     : ` ${startDateSymbol} ${task.startDate.format(TaskRegularExpressions.dateFormat)}`;
             case 'createdDate':
                 if (!task.createdDate) return '';
-                return layout.options.shortMode
+                return shortMode
                     ? ' ' + createdDateSymbol
                     : ` ${createdDateSymbol} ${task.createdDate.format(TaskRegularExpressions.dateFormat)}`;
             case 'scheduledDate':
                 if (!task.scheduledDate || task.scheduledDateIsInferred) return '';
-                return layout.options.shortMode
+                return shortMode
                     ? ' ' + scheduledDateSymbol
                     : ` ${scheduledDateSymbol} ${task.scheduledDate.format(TaskRegularExpressions.dateFormat)}`;
             case 'doneDate':
                 if (!task.doneDate) return '';
-                return layout.options.shortMode
+                return shortMode
                     ? ' ' + doneDateSymbol
                     : ` ${doneDateSymbol} ${task.doneDate.format(TaskRegularExpressions.dateFormat)}`;
             case 'dueDate':
                 if (!task.dueDate) return '';
-                return layout.options.shortMode
+                return shortMode
                     ? ' ' + dueDateSymbol
                     : ` ${dueDateSymbol} ${task.dueDate.format(TaskRegularExpressions.dateFormat)}`;
             case 'recurrenceRule':
                 if (!task.recurrence) return '';
-                return layout.options.shortMode
-                    ? ' ' + recurrenceSymbol
-                    : ` ${recurrenceSymbol} ${task.recurrence.toText()}`;
+                return shortMode ? ' ' + recurrenceSymbol : ` ${recurrenceSymbol} ${task.recurrence.toText()}`;
             case 'blockLink':
                 return task.blockLink ?? '';
             default:

--- a/tests/TaskLayout.test.ts
+++ b/tests/TaskLayout.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
 import { LayoutOptions, TaskLayout } from '../src/TaskLayout';
 
 describe('TaskLayout tests', () => {
@@ -24,14 +25,20 @@ describe('TaskLayout tests', () => {
 
     it('should generate expected CSS components with all default option reversed', () => {
         const layoutOptions = new LayoutOptions();
-
-        // Negate all the boolean values:
+        // Negate all the task layout boolean values:
         Object.keys(layoutOptions).forEach((key) => {
             const key2 = key as keyof LayoutOptions;
             layoutOptions[key2] = !layoutOptions[key2];
         });
 
-        const taskLayout = new TaskLayout(layoutOptions);
+        const queryLayoutOptions = new QueryLayoutOptions();
+        // Negate all the query layout boolean values:
+        Object.keys(queryLayoutOptions).forEach((key) => {
+            const key2 = key as keyof QueryLayoutOptions;
+            queryLayoutOptions[key2] = !queryLayoutOptions[key2];
+        });
+
+        const taskLayout = new TaskLayout(layoutOptions, queryLayoutOptions);
 
         expect(taskLayout.shownTaskLayoutComponents.join('\n')).toMatchInlineSnapshot(`
             "description

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -687,13 +687,9 @@ ${task.toFileLineString()}
 
     function layoutOptionsShortMode() {
         const queryLayoutOptions = new QueryLayoutOptions();
-
         queryLayoutOptions.shortMode = true;
 
-        const layoutOptions = new LayoutOptions();
-        layoutOptions.shortMode = true;
-
-        return { layoutOptions: layoutOptions, queryLayoutOptions };
+        return { layoutOptions: new LayoutOptions(), queryLayoutOptions };
     }
 
     it('Full task - full mode', async () => {

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -39,13 +39,14 @@ async function renderListItem(
     task: Task,
     layoutOptions?: LayoutOptions,
     testRenderer?: TextRenderer,
-    _queryLayoutOptions?: QueryLayoutOptions,
+    queryLayoutOptions?: QueryLayoutOptions,
 ) {
     const taskLineRenderer = new TaskLineRenderer({
         textRenderer: testRenderer ?? mockTextRenderer,
         obsidianComponent: null,
         parentUlElement: document.createElement('div'),
         layoutOptions: layoutOptions ?? new LayoutOptions(),
+        queryLayoutOptions: queryLayoutOptions ?? new QueryLayoutOptions(),
     });
     return await taskLineRenderer.renderTaskLine(task, 0);
 }
@@ -100,6 +101,7 @@ describe('task line rendering - HTML', () => {
             obsidianComponent: null,
             parentUlElement: ulElement,
             layoutOptions: new LayoutOptions(),
+            queryLayoutOptions: new QueryLayoutOptions(),
         });
         const listItem = await taskLineRenderer.renderTaskLine(new TaskBuilder().build(), 0);
 

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -6,6 +6,7 @@ import { DebugSettings } from '../src/Config/DebugSettings';
 import { GlobalFilter } from '../src/Config/GlobalFilter';
 import { resetSettings, updateSettings } from '../src/Config/Settings';
 import { DateParser } from '../src/Query/DateParser';
+import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
 import type { Task } from '../src/Task';
 import { TaskRegularExpressions } from '../src/Task';
 import { TaskFieldRenderer } from '../src/TaskFieldRenderer';
@@ -31,8 +32,15 @@ const fieldRenderer = new TaskFieldRenderer();
  * @param layoutOptions for the task rendering. Skip for default options. See {@link LayoutOptions}.
  *
  * @param testRenderer imitates Obsidian rendering. Skip for the default {@link mockTextRenderer}.
+ *
+ * @param queryLayoutOptions for the task rendering. Skip for default options. See {@link QueryLayoutOptions}.
  */
-async function renderListItem(task: Task, layoutOptions?: LayoutOptions, testRenderer?: TextRenderer) {
+async function renderListItem(
+    task: Task,
+    layoutOptions?: LayoutOptions,
+    testRenderer?: TextRenderer,
+    _queryLayoutOptions?: QueryLayoutOptions,
+) {
     const taskLineRenderer = new TaskLineRenderer({
         textRenderer: testRenderer ?? mockTextRenderer,
         obsidianComponent: null,
@@ -643,8 +651,11 @@ describe('task line rendering - classes and data attributes', () => {
 });
 
 describe('Visualise HTML', () => {
-    async function renderAndVerifyHTML(task: Task, layoutOptions: LayoutOptions) {
-        const listItem = await renderListItem(task, layoutOptions, mockHTMLRenderer);
+    async function renderAndVerifyHTML(
+        task: Task,
+        { layoutOptions, queryLayoutOptions }: { layoutOptions: LayoutOptions; queryLayoutOptions: QueryLayoutOptions },
+    ) {
+        const listItem = await renderListItem(task, layoutOptions, mockHTMLRenderer, queryLayoutOptions);
 
         const taskAsMarkdown = `<!--
 ${task.toFileLineString()}
@@ -657,7 +668,7 @@ ${task.toFileLineString()}
     const fullTask = TaskBuilder.createFullyPopulatedTask();
     const minimalTask = fromLine({ line: '- [-] empty' });
 
-    function layoutOptionsFullMode(): LayoutOptions {
+    function layoutOptionsFullMode() {
         const layoutOptions = new LayoutOptions();
 
         // Show every Task field, disable short mode, do not explain the query
@@ -669,15 +680,18 @@ ${task.toFileLineString()}
             layoutOptions[key2] = false;
         });
 
-        return layoutOptions;
+        return { layoutOptions, queryLayoutOptions: new QueryLayoutOptions() };
     }
 
-    function layoutOptionsShortMode(): LayoutOptions {
-        const layoutOptions = layoutOptionsFullMode();
+    function layoutOptionsShortMode() {
+        const queryLayoutOptions = new QueryLayoutOptions();
 
+        queryLayoutOptions.shortMode = true;
+
+        const layoutOptions = new LayoutOptions();
         layoutOptions.shortMode = true;
 
-        return layoutOptions;
+        return { layoutOptions: layoutOptions, queryLayoutOptions };
     }
 
     it('Full task - full mode', async () => {

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -38,8 +38,8 @@ const fieldRenderer = new TaskFieldRenderer();
 async function renderListItem(
     task: Task,
     layoutOptions?: LayoutOptions,
-    testRenderer?: TextRenderer,
     queryLayoutOptions?: QueryLayoutOptions,
+    testRenderer?: TextRenderer,
 ) {
     const taskLineRenderer = new TaskLineRenderer({
         textRenderer: testRenderer ?? mockTextRenderer,
@@ -578,7 +578,7 @@ describe('task line rendering - classes and data attributes', () => {
         const task = fromLine({
             line: taskLine,
         });
-        const listItem = await renderListItem(task, new LayoutOptions(), mockHTMLRenderer);
+        const listItem = await renderListItem(task, new LayoutOptions(), new QueryLayoutOptions(), mockHTMLRenderer);
 
         const textSpan = getTextSpan(listItem);
         const descriptionSpan = textSpan.children[0].children[0] as HTMLElement;
@@ -594,7 +594,7 @@ describe('task line rendering - classes and data attributes', () => {
         const task = fromLine({
             line: taskLine,
         });
-        const listItem = await renderListItem(task, new LayoutOptions(), mockHTMLRenderer);
+        const listItem = await renderListItem(task, new LayoutOptions(), new QueryLayoutOptions(), mockHTMLRenderer);
 
         const textSpan = getTextSpan(listItem);
         const descriptionSpan = textSpan.children[0].children[0] as HTMLElement;
@@ -657,7 +657,7 @@ describe('Visualise HTML', () => {
         task: Task,
         { layoutOptions, queryLayoutOptions }: { layoutOptions: LayoutOptions; queryLayoutOptions: QueryLayoutOptions },
     ) {
-        const listItem = await renderListItem(task, layoutOptions, mockHTMLRenderer, queryLayoutOptions);
+        const listItem = await renderListItem(task, layoutOptions, queryLayoutOptions, mockHTMLRenderer);
 
         const taskAsMarkdown = `<!--
 ${task.toFileLineString()}


### PR DESCRIPTION
# Description

Extract QueryLayoutOptions from LayoutOptions.

## Motivation and Context

Starting to think about implementing issues such as #848 #2380 #2198 

Separate concerns between options for task & query rendering.

## How has this been tested?

Unit tests + smoke tests (https://github.com/obsidian-tasks-group/obsidian-tasks/actions/runs/7263529954)

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
