### PR TITLE
test: use the toHaveDataAttributes() matcher in TaskFieldRenderer tests

### DIFF
--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -25,8 +25,7 @@ describe('Field Layouts Container tests', () => {
 
         fieldRenderer.addDataAttribute(span, task, 'dueDate');
 
-        expect(Object.keys(span.dataset).length).toEqual(1);
-        expect(span.dataset['taskDue']).toEqual('future-1d');
+        expect(span).toHaveDataAttributes('taskDue: future-1d');
     });
 
     it('should add a data attribute for an existing component (not date)', () => {
@@ -35,8 +34,7 @@ describe('Field Layouts Container tests', () => {
 
         fieldRenderer.addDataAttribute(span, task, 'priority');
 
-        expect(Object.keys(span.dataset).length).toEqual(1);
-        expect(span.dataset['taskPriority']).toEqual('medium');
+        expect(span).toHaveDataAttributes('taskPriority: medium');
     });
     it('should not add any data attributes for a missing component', () => {
         const task = new TaskBuilder().build();
@@ -44,7 +42,7 @@ describe('Field Layouts Container tests', () => {
 
         fieldRenderer.addDataAttribute(span, task, 'recurrenceRule');
 
-        expect(Object.keys(span.dataset).length).toEqual(0);
+        expect(span).toHaveDataAttributes('');
     });
 });
 


### PR DESCRIPTION
# Description

<!--- Describe your changes in detail -->

## Motivation and Context

- use the newly added toHaveDataAttributes() matcher in TaskFieldRenderer tests

## How has this been tested?

Unit tests.

## Types of changes

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
