### PR TITLE
test: test `LayoutOptions` with the full task from `TaskBuilder`

### DIFF
--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -196,12 +196,12 @@ describe('task line rendering - layout options', () => {
 
     it('renders correctly with the default layout options', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
             {},
             [
                 'Do exercises #todo #health',
                 ' 🔼',
-                ' 🔁 every day',
+                ' 🔁 every day when done',
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
@@ -211,20 +211,26 @@ describe('task line rendering - layout options', () => {
 
     it('renders without priority', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
             { hidePriority: true },
-            ['Do exercises #todo #health', ' 🔁 every day', ' 🛫 2023-07-02', ' ⏳ 2023-07-03', ' 📅 2023-07-04'],
+            [
+                'Do exercises #todo #health',
+                ' 🔁 every day when done',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
+            ],
         );
     });
 
     it('renders without created date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
             { hideCreatedDate: true },
             [
                 'Do exercises #todo #health',
                 ' 🔼',
-                ' 🔁 every day',
+                ' 🔁 every day when done',
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
@@ -234,31 +240,31 @@ describe('task line rendering - layout options', () => {
 
     it('renders without start date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
             { hideStartDate: true },
-            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day', ' ⏳ 2023-07-03', ' 📅 2023-07-04'],
+            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day when done', ' ⏳ 2023-07-03', ' 📅 2023-07-04'],
         );
     });
 
     it('renders without scheduled date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
             { hideScheduledDate: true },
-            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day', ' 🛫 2023-07-02', ' 📅 2023-07-04'],
+            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day when done', ' 🛫 2023-07-02', ' 📅 2023-07-04'],
         );
     });
 
     it('renders without due date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
             { hideDueDate: true },
-            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day', ' 🛫 2023-07-02', ' ⏳ 2023-07-03'],
+            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day when done', ' 🛫 2023-07-02', ' ⏳ 2023-07-03'],
         );
     });
 
     it('renders without recurrence rule', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
             { hideRecurrenceRule: true },
             ['Do exercises #todo #health', ' 🔼', ' 🛫 2023-07-02', ' ⏳ 2023-07-03', ' 📅 2023-07-04'],
         );
@@ -266,12 +272,12 @@ describe('task line rendering - layout options', () => {
 
     it('renders a done task correctly with the default layout', async () => {
         await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day',
+            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
             {},
             [
                 'Do exercises #todo #health',
                 ' 🔼',
-                ' 🔁 every day',
+                ' 🔁 every day when done',
                 ' ➕ 2022-07-05',
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
@@ -283,12 +289,12 @@ describe('task line rendering - layout options', () => {
 
     it('renders a done task without the done date', async () => {
         await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day',
+            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
             { hideDoneDate: true },
             [
                 'Do exercises #todo #health',
                 ' 🔼',
-                ' 🔁 every day',
+                ' 🔁 every day when done',
                 ' ➕ 2022-07-05',
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -318,7 +318,7 @@ describe('task line rendering - layout options', () => {
         );
     });
 
-    it('renders a done task without the done date', async () => {
+    it('renders without done date', async () => {
         await testLayoutOptions(
             [
                 'Do exercises #todo #health',

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -349,15 +349,29 @@ describe('task line rendering - layout options', () => {
         );
     });
 
+    const testLayoutOptionsFromLine = async (
+        taskLine: string,
+        layoutOptions: Partial<LayoutOptions>,
+        expectedComponents: string[],
+    ) => {
+        const task = fromLine({
+            line: taskLine,
+        });
+        const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
+        const listItem = await renderListItem(task, fullLayoutOptions);
+        const renderedComponents = getListItemComponents(listItem);
+        expect(renderedComponents).toEqual(expectedComponents);
+    };
+
     it('writes a placeholder message if a date is invalid', async () => {
-        await testLayoutOptions('- [ ] Task with invalid due date 📅 2023-13-02', {}, [
+        await testLayoutOptionsFromLine('- [ ] Task with invalid due date 📅 2023-13-02', {}, [
             'Task with invalid due date',
             ' 📅 Invalid date',
         ]);
     });
 
     it('standardise the recurrence rule, even if the rule is invalid', async () => {
-        await testLayoutOptions('- [ ] Task with invalid recurrence rule 🔁 every month on the 32nd', {}, [
+        await testLayoutOptionsFromLine('- [ ] Task with invalid recurrence rule 🔁 every month on the 32nd', {}, [
             'Task with invalid recurrence rule',
             ' 🔁 every month on the 32th',
         ]);

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -196,7 +196,7 @@ describe('task line rendering - layout options', () => {
 
     it('renders correctly with the default layout options', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done ^dcf64c',
             {},
             [
                 'Do exercises #todo #health',
@@ -206,13 +206,14 @@ describe('task line rendering - layout options', () => {
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
+                ' ^dcf64c',
             ],
         );
     });
 
     it('renders without priority', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done ^dcf64c',
             { hidePriority: true },
             [
                 'Do exercises #todo #health',
@@ -221,13 +222,14 @@ describe('task line rendering - layout options', () => {
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
+                ' ^dcf64c',
             ],
         );
     });
 
     it('renders without created date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done ^dcf64c',
             { hideCreatedDate: true },
             [
                 'Do exercises #todo #health',
@@ -236,13 +238,14 @@ describe('task line rendering - layout options', () => {
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
+                ' ^dcf64c',
             ],
         );
     });
 
     it('renders without start date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done ^dcf64c',
             { hideStartDate: true },
             [
                 'Do exercises #todo #health',
@@ -251,13 +254,14 @@ describe('task line rendering - layout options', () => {
                 ' ➕ 2023-07-01',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
+                ' ^dcf64c',
             ],
         );
     });
 
     it('renders without scheduled date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done ^dcf64c',
             { hideScheduledDate: true },
             [
                 'Do exercises #todo #health',
@@ -266,13 +270,14 @@ describe('task line rendering - layout options', () => {
                 ' ➕ 2023-07-01',
                 ' 🛫 2023-07-02',
                 ' 📅 2023-07-04',
+                ' ^dcf64c',
             ],
         );
     });
 
     it('renders without due date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done ^dcf64c',
             { hideDueDate: true },
             [
                 'Do exercises #todo #health',
@@ -281,13 +286,14 @@ describe('task line rendering - layout options', () => {
                 ' ➕ 2023-07-01',
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
+                ' ^dcf64c',
             ],
         );
     });
 
     it('renders without recurrence rule', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done ^dcf64c',
             { hideRecurrenceRule: true },
             [
                 'Do exercises #todo #health',
@@ -296,13 +302,14 @@ describe('task line rendering - layout options', () => {
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
+                ' ^dcf64c',
             ],
         );
     });
 
     it('renders a done task correctly with the default layout', async () => {
         await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2023-07-05 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
+            '- [x] Do exercises #todo #health ✅ 2023-07-05 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done ^dcf64c',
             {},
             [
                 'Do exercises #todo #health',
@@ -313,13 +320,14 @@ describe('task line rendering - layout options', () => {
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
                 ' ✅ 2023-07-05',
+                ' ^dcf64c',
             ],
         );
     });
 
     it('renders a done task without the done date', async () => {
         await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2023-07-05 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
+            '- [x] Do exercises #todo #health ✅ 2023-07-05 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done ^dcf64c',
             { hideDoneDate: true },
             [
                 'Do exercises #todo #health',
@@ -329,6 +337,7 @@ describe('task line rendering - layout options', () => {
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
+                ' ^dcf64c',
             ],
         );
     });

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -180,11 +180,7 @@ describe('task line rendering - global filter', () => {
 });
 
 describe('task line rendering - layout options', () => {
-    const testLayoutOptions = async (
-        _taskLine: string,
-        layoutOptions: Partial<LayoutOptions>,
-        expectedComponents: string[],
-    ) => {
+    const testLayoutOptions = async (layoutOptions: Partial<LayoutOptions>, expectedComponents: string[]) => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
         const listItem = await renderListItem(task, fullLayoutOptions);
@@ -193,158 +189,122 @@ describe('task line rendering - layout options', () => {
     };
 
     it('renders correctly with the default layout options', async () => {
-        await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03  🛫 2023-07-02 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
-            {},
-            [
-                'Do exercises #todo #health',
-                ' 🔼',
-                ' 🔁 every day when done',
-                ' ➕ 2023-07-01',
-                ' 🛫 2023-07-02',
-                ' ⏳ 2023-07-03',
-                ' 📅 2023-07-04',
-                ' ✅ 2023-07-05',
-                ' ^dcf64c',
-            ],
-        );
+        await testLayoutOptions({}, [
+            'Do exercises #todo #health',
+            ' 🔼',
+            ' 🔁 every day when done',
+            ' ➕ 2023-07-01',
+            ' 🛫 2023-07-02',
+            ' ⏳ 2023-07-03',
+            ' 📅 2023-07-04',
+            ' ✅ 2023-07-05',
+            ' ^dcf64c',
+        ]);
     });
 
     it('renders without priority', async () => {
-        await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03  🛫 2023-07-02 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
-            { hidePriority: true },
-            [
-                'Do exercises #todo #health',
-                ' 🔁 every day when done',
-                ' ➕ 2023-07-01',
-                ' 🛫 2023-07-02',
-                ' ⏳ 2023-07-03',
-                ' 📅 2023-07-04',
-                ' ✅ 2023-07-05',
-                ' ^dcf64c',
-            ],
-        );
+        await testLayoutOptions({ hidePriority: true }, [
+            'Do exercises #todo #health',
+            ' 🔁 every day when done',
+            ' ➕ 2023-07-01',
+            ' 🛫 2023-07-02',
+            ' ⏳ 2023-07-03',
+            ' 📅 2023-07-04',
+            ' ✅ 2023-07-05',
+            ' ^dcf64c',
+        ]);
     });
 
     it('renders without created date', async () => {
-        await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
-            { hideCreatedDate: true },
-            [
-                'Do exercises #todo #health',
-                ' 🔼',
-                ' 🔁 every day when done',
-                ' 🛫 2023-07-02',
-                ' ⏳ 2023-07-03',
-                ' 📅 2023-07-04',
-                ' ✅ 2023-07-05',
-                ' ^dcf64c',
-            ],
-        );
+        await testLayoutOptions({ hideCreatedDate: true }, [
+            'Do exercises #todo #health',
+            ' 🔼',
+            ' 🔁 every day when done',
+            ' 🛫 2023-07-02',
+            ' ⏳ 2023-07-03',
+            ' 📅 2023-07-04',
+            ' ✅ 2023-07-05',
+            ' ^dcf64c',
+        ]);
     });
 
     it('renders without start date', async () => {
-        await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03  🛫 2023-07-02 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
-            { hideStartDate: true },
-            [
-                'Do exercises #todo #health',
-                ' 🔼',
-                ' 🔁 every day when done',
-                ' ➕ 2023-07-01',
-                ' ⏳ 2023-07-03',
-                ' 📅 2023-07-04',
-                ' ✅ 2023-07-05',
-                ' ^dcf64c',
-            ],
-        );
+        await testLayoutOptions({ hideStartDate: true }, [
+            'Do exercises #todo #health',
+            ' 🔼',
+            ' 🔁 every day when done',
+            ' ➕ 2023-07-01',
+            ' ⏳ 2023-07-03',
+            ' 📅 2023-07-04',
+            ' ✅ 2023-07-05',
+            ' ^dcf64c',
+        ]);
     });
 
     it('renders without scheduled date', async () => {
-        await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03  🛫 2023-07-02 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
-            { hideScheduledDate: true },
-            [
-                'Do exercises #todo #health',
-                ' 🔼',
-                ' 🔁 every day when done',
-                ' ➕ 2023-07-01',
-                ' 🛫 2023-07-02',
-                ' 📅 2023-07-04',
-                ' ✅ 2023-07-05',
-                ' ^dcf64c',
-            ],
-        );
+        await testLayoutOptions({ hideScheduledDate: true }, [
+            'Do exercises #todo #health',
+            ' 🔼',
+            ' 🔁 every day when done',
+            ' ➕ 2023-07-01',
+            ' 🛫 2023-07-02',
+            ' 📅 2023-07-04',
+            ' ✅ 2023-07-05',
+            ' ^dcf64c',
+        ]);
     });
 
     it('renders without due date', async () => {
-        await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03  🛫 2023-07-02 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
-            { hideDueDate: true },
-            [
-                'Do exercises #todo #health',
-                ' 🔼',
-                ' 🔁 every day when done',
-                ' ➕ 2023-07-01',
-                ' 🛫 2023-07-02',
-                ' ⏳ 2023-07-03',
-                ' ✅ 2023-07-05',
-                ' ^dcf64c',
-            ],
-        );
+        await testLayoutOptions({ hideDueDate: true }, [
+            'Do exercises #todo #health',
+            ' 🔼',
+            ' 🔁 every day when done',
+            ' ➕ 2023-07-01',
+            ' 🛫 2023-07-02',
+            ' ⏳ 2023-07-03',
+            ' ✅ 2023-07-05',
+            ' ^dcf64c',
+        ]);
     });
 
     it('renders without recurrence rule', async () => {
-        await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03  🛫 2023-07-02 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
-            { hideRecurrenceRule: true },
-            [
-                'Do exercises #todo #health',
-                ' 🔼',
-                ' ➕ 2023-07-01',
-                ' 🛫 2023-07-02',
-                ' ⏳ 2023-07-03',
-                ' 📅 2023-07-04',
-                ' ✅ 2023-07-05',
-                ' ^dcf64c',
-            ],
-        );
+        await testLayoutOptions({ hideRecurrenceRule: true }, [
+            'Do exercises #todo #health',
+            ' 🔼',
+            ' ➕ 2023-07-01',
+            ' 🛫 2023-07-02',
+            ' ⏳ 2023-07-03',
+            ' 📅 2023-07-04',
+            ' ✅ 2023-07-05',
+            ' ^dcf64c',
+        ]);
     });
 
     it('renders a done task correctly with the default layout', async () => {
-        await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2023-07-05 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done ^dcf64c',
-            {},
-            [
-                'Do exercises #todo #health',
-                ' 🔼',
-                ' 🔁 every day when done',
-                ' ➕ 2023-07-01',
-                ' 🛫 2023-07-02',
-                ' ⏳ 2023-07-03',
-                ' 📅 2023-07-04',
-                ' ✅ 2023-07-05',
-                ' ^dcf64c',
-            ],
-        );
+        await testLayoutOptions({}, [
+            'Do exercises #todo #health',
+            ' 🔼',
+            ' 🔁 every day when done',
+            ' ➕ 2023-07-01',
+            ' 🛫 2023-07-02',
+            ' ⏳ 2023-07-03',
+            ' 📅 2023-07-04',
+            ' ✅ 2023-07-05',
+            ' ^dcf64c',
+        ]);
     });
 
     it('renders a done task without the done date', async () => {
-        await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2023-07-05 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done ^dcf64c',
-            { hideDoneDate: true },
-            [
-                'Do exercises #todo #health',
-                ' 🔼',
-                ' 🔁 every day when done',
-                ' ➕ 2023-07-01',
-                ' 🛫 2023-07-02',
-                ' ⏳ 2023-07-03',
-                ' 📅 2023-07-04',
-                ' ^dcf64c',
-            ],
-        );
+        await testLayoutOptions({ hideDoneDate: true }, [
+            'Do exercises #todo #health',
+            ' 🔼',
+            ' 🔁 every day when done',
+            ' ➕ 2023-07-01',
+            ' 🛫 2023-07-02',
+            ' ⏳ 2023-07-03',
+            ' 📅 2023-07-04',
+            ' ^dcf64c',
+        ]);
     });
 
     const testLayoutOptionsFromLine = async (taskLine: string, expectedComponents: string[]) => {

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -353,8 +353,7 @@ describe('task line rendering - layout options', () => {
         const task = fromLine({
             line: taskLine,
         });
-        const fullLayoutOptions = { ...new LayoutOptions() };
-        const listItem = await renderListItem(task, fullLayoutOptions);
+        const listItem = await renderListItem(task);
         const renderedComponents = getListItemComponents(listItem);
         expect(renderedComponents).toEqual(expectedComponents);
     };

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -195,70 +195,81 @@ describe('task line rendering - layout options', () => {
     };
 
     it('renders correctly with the default layout options', async () => {
-        await testLayoutOptions('- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day', {}, [
-            'Full task',
-            ' ⏫',
-            ' 🔁 every day',
-            ' 🛫 2022-07-04',
-            ' ⏳ 2022-07-03',
-            ' 📅 2022-07-02',
-        ]);
+        await testLayoutOptions(
+            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            {},
+            [
+                'Do exercises #todo #health',
+                ' ⏫',
+                ' 🔁 every day',
+                ' 🛫 2022-07-04',
+                ' ⏳ 2022-07-03',
+                ' 📅 2022-07-02',
+            ],
+        );
     });
 
     it('renders without priority', async () => {
         await testLayoutOptions(
-            '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hidePriority: true },
-            ['Full task', ' 🔁 every day', ' 🛫 2022-07-04', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
+            ['Do exercises #todo #health', ' 🔁 every day', ' 🛫 2022-07-04', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
         );
     });
 
     it('renders without created date', async () => {
         await testLayoutOptions(
-            '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
+            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
             { hideCreatedDate: true },
-            ['Full task', ' ⏫', ' 🔁 every day', ' 🛫 2022-07-04', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
+            [
+                'Do exercises #todo #health',
+                ' ⏫',
+                ' 🔁 every day',
+                ' 🛫 2022-07-04',
+                ' ⏳ 2022-07-03',
+                ' 📅 2022-07-02',
+            ],
         );
     });
 
     it('renders without start date', async () => {
         await testLayoutOptions(
-            '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hideStartDate: true },
-            ['Full task', ' ⏫', ' 🔁 every day', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
+            ['Do exercises #todo #health', ' ⏫', ' 🔁 every day', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
         );
     });
 
     it('renders without scheduled date', async () => {
         await testLayoutOptions(
-            '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hideScheduledDate: true },
-            ['Full task', ' ⏫', ' 🔁 every day', ' 🛫 2022-07-04', ' 📅 2022-07-02'],
+            ['Do exercises #todo #health', ' ⏫', ' 🔁 every day', ' 🛫 2022-07-04', ' 📅 2022-07-02'],
         );
     });
 
     it('renders without due date', async () => {
         await testLayoutOptions(
-            '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hideDueDate: true },
-            ['Full task', ' ⏫', ' 🔁 every day', ' 🛫 2022-07-04', ' ⏳ 2022-07-03'],
+            ['Do exercises #todo #health', ' ⏫', ' 🔁 every day', ' 🛫 2022-07-04', ' ⏳ 2022-07-03'],
         );
     });
 
     it('renders without recurrence rule', async () => {
         await testLayoutOptions(
-            '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hideRecurrenceRule: true },
-            ['Full task', ' ⏫', ' 🛫 2022-07-04', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
+            ['Do exercises #todo #health', ' ⏫', ' 🛫 2022-07-04', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
         );
     });
 
     it('renders a done task correctly with the default layout', async () => {
         await testLayoutOptions(
-            '- [x] Full task ✅ 2022-07-05 ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
+            '- [x] Do exercises #todo #health ✅ 2022-07-05 ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
             {},
             [
-                'Full task',
+                'Do exercises #todo #health',
                 ' ⏫',
                 ' 🔁 every day',
                 ' ➕ 2022-07-05',
@@ -272,10 +283,10 @@ describe('task line rendering - layout options', () => {
 
     it('renders a done task without the done date', async () => {
         await testLayoutOptions(
-            '- [x] Full task ✅ 2022-07-05 ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
+            '- [x] Do exercises #todo #health ✅ 2022-07-05 ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
             { hideDoneDate: true },
             [
-                'Full task',
+                'Do exercises #todo #health',
                 ' ⏫',
                 ' 🔁 every day',
                 ' ➕ 2022-07-05',

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -196,86 +196,86 @@ describe('task line rendering - layout options', () => {
 
     it('renders correctly with the default layout options', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day',
             {},
             [
                 'Do exercises #todo #health',
                 ' 🔼',
                 ' 🔁 every day',
-                ' 🛫 2022-07-04',
-                ' ⏳ 2022-07-03',
-                ' 📅 2022-07-02',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
             ],
         );
     });
 
     it('renders without priority', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day',
             { hidePriority: true },
-            ['Do exercises #todo #health', ' 🔁 every day', ' 🛫 2022-07-04', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
+            ['Do exercises #todo #health', ' 🔁 every day', ' 🛫 2023-07-02', ' ⏳ 2023-07-03', ' 📅 2023-07-04'],
         );
     });
 
     it('renders without created date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day',
             { hideCreatedDate: true },
             [
                 'Do exercises #todo #health',
                 ' 🔼',
                 ' 🔁 every day',
-                ' 🛫 2022-07-04',
-                ' ⏳ 2022-07-03',
-                ' 📅 2022-07-02',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
             ],
         );
     });
 
     it('renders without start date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day',
             { hideStartDate: true },
-            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
+            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day', ' ⏳ 2023-07-03', ' 📅 2023-07-04'],
         );
     });
 
     it('renders without scheduled date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day',
             { hideScheduledDate: true },
-            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day', ' 🛫 2022-07-04', ' 📅 2022-07-02'],
+            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day', ' 🛫 2023-07-02', ' 📅 2023-07-04'],
         );
     });
 
     it('renders without due date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day',
             { hideDueDate: true },
-            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day', ' 🛫 2022-07-04', ' ⏳ 2022-07-03'],
+            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day', ' 🛫 2023-07-02', ' ⏳ 2023-07-03'],
         );
     });
 
     it('renders without recurrence rule', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day',
             { hideRecurrenceRule: true },
-            ['Do exercises #todo #health', ' 🔼', ' 🛫 2022-07-04', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
+            ['Do exercises #todo #health', ' 🔼', ' 🛫 2023-07-02', ' ⏳ 2023-07-03', ' 📅 2023-07-04'],
         );
     });
 
     it('renders a done task correctly with the default layout', async () => {
         await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
+            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day',
             {},
             [
                 'Do exercises #todo #health',
                 ' 🔼',
                 ' 🔁 every day',
                 ' ➕ 2022-07-05',
-                ' 🛫 2022-07-04',
-                ' ⏳ 2022-07-03',
-                ' 📅 2022-07-02',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
                 ' ✅ 2022-07-05',
             ],
         );
@@ -283,16 +283,16 @@ describe('task line rendering - layout options', () => {
 
     it('renders a done task without the done date', async () => {
         await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
+            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day',
             { hideDoneDate: true },
             [
                 'Do exercises #todo #health',
                 ' 🔼',
                 ' 🔁 every day',
                 ' ➕ 2022-07-05',
-                ' 🛫 2022-07-04',
-                ' ⏳ 2022-07-03',
-                ' 📅 2022-07-02',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
             ],
         );
     });

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -196,11 +196,11 @@ describe('task line rendering - layout options', () => {
 
     it('renders correctly with the default layout options', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             {},
             [
                 'Do exercises #todo #health',
-                ' ⏫',
+                ' 🔼',
                 ' 🔁 every day',
                 ' 🛫 2022-07-04',
                 ' ⏳ 2022-07-03',
@@ -211,7 +211,7 @@ describe('task line rendering - layout options', () => {
 
     it('renders without priority', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hidePriority: true },
             ['Do exercises #todo #health', ' 🔁 every day', ' 🛫 2022-07-04', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
         );
@@ -219,11 +219,11 @@ describe('task line rendering - layout options', () => {
 
     it('renders without created date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
             { hideCreatedDate: true },
             [
                 'Do exercises #todo #health',
-                ' ⏫',
+                ' 🔼',
                 ' 🔁 every day',
                 ' 🛫 2022-07-04',
                 ' ⏳ 2022-07-03',
@@ -234,43 +234,43 @@ describe('task line rendering - layout options', () => {
 
     it('renders without start date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hideStartDate: true },
-            ['Do exercises #todo #health', ' ⏫', ' 🔁 every day', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
+            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
         );
     });
 
     it('renders without scheduled date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hideScheduledDate: true },
-            ['Do exercises #todo #health', ' ⏫', ' 🔁 every day', ' 🛫 2022-07-04', ' 📅 2022-07-02'],
+            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day', ' 🛫 2022-07-04', ' 📅 2022-07-02'],
         );
     });
 
     it('renders without due date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hideDueDate: true },
-            ['Do exercises #todo #health', ' ⏫', ' 🔁 every day', ' 🛫 2022-07-04', ' ⏳ 2022-07-03'],
+            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day', ' 🛫 2022-07-04', ' ⏳ 2022-07-03'],
         );
     });
 
     it('renders without recurrence rule', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Do exercises #todo #health 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hideRecurrenceRule: true },
-            ['Do exercises #todo #health', ' ⏫', ' 🛫 2022-07-04', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
+            ['Do exercises #todo #health', ' 🔼', ' 🛫 2022-07-04', ' ⏳ 2022-07-03', ' 📅 2022-07-02'],
         );
     });
 
     it('renders a done task correctly with the default layout', async () => {
         await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2022-07-05 ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
+            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
             {},
             [
                 'Do exercises #todo #health',
-                ' ⏫',
+                ' 🔼',
                 ' 🔁 every day',
                 ' ➕ 2022-07-05',
                 ' 🛫 2022-07-04',
@@ -283,11 +283,11 @@ describe('task line rendering - layout options', () => {
 
     it('renders a done task without the done date', async () => {
         await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2022-07-05 ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
+            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 ➕ 2022-07-05 🔁 every day',
             { hideDoneDate: true },
             [
                 'Do exercises #todo #health',
-                ' ⏫',
+                ' 🔼',
                 ' 🔁 every day',
                 ' ➕ 2022-07-05',
                 ' 🛫 2022-07-04',

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -180,7 +180,7 @@ describe('task line rendering - global filter', () => {
 });
 
 describe('task line rendering - layout options', () => {
-    const testLayoutOptions = async (layoutOptions: Partial<LayoutOptions>, expectedComponents: string[]) => {
+    const testLayoutOptions = async (expectedComponents: string[], layoutOptions: Partial<LayoutOptions>) => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
         const listItem = await renderListItem(task, fullLayoutOptions);
@@ -189,122 +189,149 @@ describe('task line rendering - layout options', () => {
     };
 
     it('renders correctly with the default layout options', async () => {
-        await testLayoutOptions({}, [
-            'Do exercises #todo #health',
-            ' 🔼',
-            ' 🔁 every day when done',
-            ' ➕ 2023-07-01',
-            ' 🛫 2023-07-02',
-            ' ⏳ 2023-07-03',
-            ' 📅 2023-07-04',
-            ' ✅ 2023-07-05',
-            ' ^dcf64c',
-        ]);
+        await testLayoutOptions(
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' 🔁 every day when done',
+                ' ➕ 2023-07-01',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
+                ' ^dcf64c',
+            ],
+            {},
+        );
     });
 
     it('renders without priority', async () => {
-        await testLayoutOptions({ hidePriority: true }, [
-            'Do exercises #todo #health',
-            ' 🔁 every day when done',
-            ' ➕ 2023-07-01',
-            ' 🛫 2023-07-02',
-            ' ⏳ 2023-07-03',
-            ' 📅 2023-07-04',
-            ' ✅ 2023-07-05',
-            ' ^dcf64c',
-        ]);
+        await testLayoutOptions(
+            [
+                'Do exercises #todo #health',
+                ' 🔁 every day when done',
+                ' ➕ 2023-07-01',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
+                ' ^dcf64c',
+            ],
+            { hidePriority: true },
+        );
     });
 
     it('renders without created date', async () => {
-        await testLayoutOptions({ hideCreatedDate: true }, [
-            'Do exercises #todo #health',
-            ' 🔼',
-            ' 🔁 every day when done',
-            ' 🛫 2023-07-02',
-            ' ⏳ 2023-07-03',
-            ' 📅 2023-07-04',
-            ' ✅ 2023-07-05',
-            ' ^dcf64c',
-        ]);
+        await testLayoutOptions(
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' 🔁 every day when done',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
+                ' ^dcf64c',
+            ],
+            { hideCreatedDate: true },
+        );
     });
 
     it('renders without start date', async () => {
-        await testLayoutOptions({ hideStartDate: true }, [
-            'Do exercises #todo #health',
-            ' 🔼',
-            ' 🔁 every day when done',
-            ' ➕ 2023-07-01',
-            ' ⏳ 2023-07-03',
-            ' 📅 2023-07-04',
-            ' ✅ 2023-07-05',
-            ' ^dcf64c',
-        ]);
+        await testLayoutOptions(
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' 🔁 every day when done',
+                ' ➕ 2023-07-01',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
+                ' ^dcf64c',
+            ],
+            { hideStartDate: true },
+        );
     });
 
     it('renders without scheduled date', async () => {
-        await testLayoutOptions({ hideScheduledDate: true }, [
-            'Do exercises #todo #health',
-            ' 🔼',
-            ' 🔁 every day when done',
-            ' ➕ 2023-07-01',
-            ' 🛫 2023-07-02',
-            ' 📅 2023-07-04',
-            ' ✅ 2023-07-05',
-            ' ^dcf64c',
-        ]);
+        await testLayoutOptions(
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' 🔁 every day when done',
+                ' ➕ 2023-07-01',
+                ' 🛫 2023-07-02',
+                ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
+                ' ^dcf64c',
+            ],
+            { hideScheduledDate: true },
+        );
     });
 
     it('renders without due date', async () => {
-        await testLayoutOptions({ hideDueDate: true }, [
-            'Do exercises #todo #health',
-            ' 🔼',
-            ' 🔁 every day when done',
-            ' ➕ 2023-07-01',
-            ' 🛫 2023-07-02',
-            ' ⏳ 2023-07-03',
-            ' ✅ 2023-07-05',
-            ' ^dcf64c',
-        ]);
+        await testLayoutOptions(
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' 🔁 every day when done',
+                ' ➕ 2023-07-01',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' ✅ 2023-07-05',
+                ' ^dcf64c',
+            ],
+            { hideDueDate: true },
+        );
     });
 
     it('renders without recurrence rule', async () => {
-        await testLayoutOptions({ hideRecurrenceRule: true }, [
-            'Do exercises #todo #health',
-            ' 🔼',
-            ' ➕ 2023-07-01',
-            ' 🛫 2023-07-02',
-            ' ⏳ 2023-07-03',
-            ' 📅 2023-07-04',
-            ' ✅ 2023-07-05',
-            ' ^dcf64c',
-        ]);
+        await testLayoutOptions(
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' ➕ 2023-07-01',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
+                ' ^dcf64c',
+            ],
+            { hideRecurrenceRule: true },
+        );
     });
 
     it('renders a done task correctly with the default layout', async () => {
-        await testLayoutOptions({}, [
-            'Do exercises #todo #health',
-            ' 🔼',
-            ' 🔁 every day when done',
-            ' ➕ 2023-07-01',
-            ' 🛫 2023-07-02',
-            ' ⏳ 2023-07-03',
-            ' 📅 2023-07-04',
-            ' ✅ 2023-07-05',
-            ' ^dcf64c',
-        ]);
+        await testLayoutOptions(
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' 🔁 every day when done',
+                ' ➕ 2023-07-01',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
+                ' ^dcf64c',
+            ],
+            {},
+        );
     });
 
     it('renders a done task without the done date', async () => {
-        await testLayoutOptions({ hideDoneDate: true }, [
-            'Do exercises #todo #health',
-            ' 🔼',
-            ' 🔁 every day when done',
-            ' ➕ 2023-07-01',
-            ' 🛫 2023-07-02',
-            ' ⏳ 2023-07-03',
-            ' 📅 2023-07-04',
-            ' ^dcf64c',
-        ]);
+        await testLayoutOptions(
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' 🔁 every day when done',
+                ' ➕ 2023-07-01',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
+                ' ^dcf64c',
+            ],
+            { hideDoneDate: true },
+        );
     });
 
     const testLayoutOptionsFromLine = async (taskLine: string, expectedComponents: string[]) => {

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -185,9 +185,7 @@ describe('task line rendering - layout options', () => {
         layoutOptions: Partial<LayoutOptions>,
         expectedComponents: string[],
     ) => {
-        const task = fromLine({
-            line: _taskLine,
-        });
+        const task = TaskBuilder.createFullyPopulatedTask();
         const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
         const listItem = await renderListItem(task, fullLayoutOptions);
         const renderedComponents = getListItemComponents(listItem);

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -302,7 +302,7 @@ describe('task line rendering - layout options', () => {
 
     it('renders a done task correctly with the default layout', async () => {
         await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
+            '- [x] Do exercises #todo #health ✅ 2023-07-05 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
             {},
             [
                 'Do exercises #todo #health',
@@ -312,14 +312,14 @@ describe('task line rendering - layout options', () => {
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
-                ' ✅ 2022-07-05',
+                ' ✅ 2023-07-05',
             ],
         );
     });
 
     it('renders a done task without the done date', async () => {
         await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
+            '- [x] Do exercises #todo #health ✅ 2023-07-05 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
             { hideDoneDate: true },
             [
                 'Do exercises #todo #health',

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -181,12 +181,12 @@ describe('task line rendering - global filter', () => {
 
 describe('task line rendering - layout options', () => {
     const testLayoutOptions = async (
-        taskLine: string,
+        _taskLine: string,
         layoutOptions: Partial<LayoutOptions>,
         expectedComponents: string[],
     ) => {
         const task = fromLine({
-            line: taskLine,
+            line: _taskLine,
         });
         const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
         const listItem = await renderListItem(task, fullLayoutOptions);

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -349,29 +349,25 @@ describe('task line rendering - layout options', () => {
         );
     });
 
-    const testLayoutOptionsFromLine = async (
-        taskLine: string,
-        layoutOptions: Partial<LayoutOptions>,
-        expectedComponents: string[],
-    ) => {
+    const testLayoutOptionsFromLine = async (taskLine: string, expectedComponents: string[]) => {
         const task = fromLine({
             line: taskLine,
         });
-        const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
+        const fullLayoutOptions = { ...new LayoutOptions() };
         const listItem = await renderListItem(task, fullLayoutOptions);
         const renderedComponents = getListItemComponents(listItem);
         expect(renderedComponents).toEqual(expectedComponents);
     };
 
     it('writes a placeholder message if a date is invalid', async () => {
-        await testLayoutOptionsFromLine('- [ ] Task with invalid due date 📅 2023-13-02', {}, [
+        await testLayoutOptionsFromLine('- [ ] Task with invalid due date 📅 2023-13-02', [
             'Task with invalid due date',
             ' 📅 Invalid date',
         ]);
     });
 
     it('standardise the recurrence rule, even if the rule is invalid', async () => {
-        await testLayoutOptionsFromLine('- [ ] Task with invalid recurrence rule 🔁 every month on the 32nd', {}, [
+        await testLayoutOptionsFromLine('- [ ] Task with invalid recurrence rule 🔁 every month on the 32nd', [
             'Task with invalid recurrence rule',
             ' 🔁 every month on the 32th',
         ]);

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -196,7 +196,7 @@ describe('task line rendering - layout options', () => {
 
     it('renders correctly with the default layout options', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done ^dcf64c',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03  🛫 2023-07-02 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
             {},
             [
                 'Do exercises #todo #health',
@@ -206,6 +206,7 @@ describe('task line rendering - layout options', () => {
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
         );
@@ -213,7 +214,7 @@ describe('task line rendering - layout options', () => {
 
     it('renders without priority', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done ^dcf64c',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03  🛫 2023-07-02 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
             { hidePriority: true },
             [
                 'Do exercises #todo #health',
@@ -222,6 +223,7 @@ describe('task line rendering - layout options', () => {
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
         );
@@ -229,7 +231,7 @@ describe('task line rendering - layout options', () => {
 
     it('renders without created date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done ^dcf64c',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
             { hideCreatedDate: true },
             [
                 'Do exercises #todo #health',
@@ -238,6 +240,7 @@ describe('task line rendering - layout options', () => {
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
         );
@@ -245,7 +248,7 @@ describe('task line rendering - layout options', () => {
 
     it('renders without start date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done ^dcf64c',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03  🛫 2023-07-02 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
             { hideStartDate: true },
             [
                 'Do exercises #todo #health',
@@ -254,6 +257,7 @@ describe('task line rendering - layout options', () => {
                 ' ➕ 2023-07-01',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
         );
@@ -261,7 +265,7 @@ describe('task line rendering - layout options', () => {
 
     it('renders without scheduled date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done ^dcf64c',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03  🛫 2023-07-02 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
             { hideScheduledDate: true },
             [
                 'Do exercises #todo #health',
@@ -270,6 +274,7 @@ describe('task line rendering - layout options', () => {
                 ' ➕ 2023-07-01',
                 ' 🛫 2023-07-02',
                 ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
         );
@@ -277,7 +282,7 @@ describe('task line rendering - layout options', () => {
 
     it('renders without due date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done ^dcf64c',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03  🛫 2023-07-02 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
             { hideDueDate: true },
             [
                 'Do exercises #todo #health',
@@ -286,6 +291,7 @@ describe('task line rendering - layout options', () => {
                 ' ➕ 2023-07-01',
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
+                ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
         );
@@ -293,7 +299,7 @@ describe('task line rendering - layout options', () => {
 
     it('renders without recurrence rule', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done ^dcf64c',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03  🛫 2023-07-02 ✅ 2023-07-05 🔁 every day when done ^dcf64c',
             { hideRecurrenceRule: true },
             [
                 'Do exercises #todo #health',
@@ -302,6 +308,7 @@ describe('task line rendering - layout options', () => {
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
         );

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -221,6 +221,22 @@ describe('task line rendering - layout options', () => {
         );
     });
 
+    it('renders without recurrence rule', async () => {
+        await testLayoutOptions(
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' ➕ 2023-07-01',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
+                ' ✅ 2023-07-05',
+                ' ^dcf64c',
+            ],
+            { hideRecurrenceRule: true },
+        );
+    });
+
     it('renders without created date', async () => {
         await testLayoutOptions(
             [
@@ -282,22 +298,6 @@ describe('task line rendering - layout options', () => {
                 ' ^dcf64c',
             ],
             { hideDueDate: true },
-        );
-    });
-
-    it('renders without recurrence rule', async () => {
-        await testLayoutOptions(
-            [
-                'Do exercises #todo #health',
-                ' 🔼',
-                ' ➕ 2023-07-01',
-                ' 🛫 2023-07-02',
-                ' ⏳ 2023-07-03',
-                ' 📅 2023-07-04',
-                ' ✅ 2023-07-05',
-                ' ^dcf64c',
-            ],
-            { hideRecurrenceRule: true },
         );
     });
 

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -196,12 +196,13 @@ describe('task line rendering - layout options', () => {
 
     it('renders correctly with the default layout options', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
             {},
             [
                 'Do exercises #todo #health',
                 ' 🔼',
                 ' 🔁 every day when done',
+                ' ➕ 2023-07-01',
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
@@ -211,11 +212,12 @@ describe('task line rendering - layout options', () => {
 
     it('renders without priority', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
             { hidePriority: true },
             [
                 'Do exercises #todo #health',
                 ' 🔁 every day when done',
+                ' ➕ 2023-07-01',
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
@@ -225,7 +227,7 @@ describe('task line rendering - layout options', () => {
 
     it('renders without created date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
             { hideCreatedDate: true },
             [
                 'Do exercises #todo #health',
@@ -240,45 +242,73 @@ describe('task line rendering - layout options', () => {
 
     it('renders without start date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
             { hideStartDate: true },
-            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day when done', ' ⏳ 2023-07-03', ' 📅 2023-07-04'],
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' 🔁 every day when done',
+                ' ➕ 2023-07-01',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
+            ],
         );
     });
 
     it('renders without scheduled date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
             { hideScheduledDate: true },
-            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day when done', ' 🛫 2023-07-02', ' 📅 2023-07-04'],
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' 🔁 every day when done',
+                ' ➕ 2023-07-01',
+                ' 🛫 2023-07-02',
+                ' 📅 2023-07-04',
+            ],
         );
     });
 
     it('renders without due date', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
             { hideDueDate: true },
-            ['Do exercises #todo #health', ' 🔼', ' 🔁 every day when done', ' 🛫 2023-07-02', ' ⏳ 2023-07-03'],
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' 🔁 every day when done',
+                ' ➕ 2023-07-01',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+            ],
         );
     });
 
     it('renders without recurrence rule', async () => {
         await testLayoutOptions(
-            '- [ ] Do exercises #todo #health 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
+            '- [ ] Do exercises #todo #health 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 🔁 every day when done',
             { hideRecurrenceRule: true },
-            ['Do exercises #todo #health', ' 🔼', ' 🛫 2023-07-02', ' ⏳ 2023-07-03', ' 📅 2023-07-04'],
+            [
+                'Do exercises #todo #health',
+                ' 🔼',
+                ' ➕ 2023-07-01',
+                ' 🛫 2023-07-02',
+                ' ⏳ 2023-07-03',
+                ' 📅 2023-07-04',
+            ],
         );
     });
 
     it('renders a done task correctly with the default layout', async () => {
         await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
+            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
             {},
             [
                 'Do exercises #todo #health',
                 ' 🔼',
                 ' 🔁 every day when done',
-                ' ➕ 2022-07-05',
+                ' ➕ 2023-07-01',
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',
@@ -289,13 +319,13 @@ describe('task line rendering - layout options', () => {
 
     it('renders a done task without the done date', async () => {
         await testLayoutOptions(
-            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
+            '- [x] Do exercises #todo #health ✅ 2022-07-05 🔼 ➕ 2023-07-01 📅 2023-07-04 ⏳ 2023-07-03 🛫 2023-07-02 ➕ 2022-07-05 🔁 every day when done',
             { hideDoneDate: true },
             [
                 'Do exercises #todo #health',
                 ' 🔼',
                 ' 🔁 every day when done',
-                ' ➕ 2022-07-05',
+                ' ➕ 2023-07-01',
                 ' 🛫 2023-07-02',
                 ' ⏳ 2023-07-03',
                 ' 📅 2023-07-04',


### PR DESCRIPTION
# Description

LayoutOptions are now tested with a hardcoded task. With this PR the test task is taken from `TaskBuilder.createFullyPopulatedTask()` and the task line parameter is removed from the test helper.

## Motivation and Context

- If a new task field is added
  - It will be seen in the tests (Task field added in `TaskBuilder.createFullyPopulatedTask()` with `// NEW_TASK_FIELD_EDIT_REQUIRED`), so the tests are stronger
  - Remove the need to update each test
  - For instance, the `CreatedDate` field is missing in some tests...
- Remove redundant data between tests (the task line)

## How has this been tested?

Breaking unit tests.

## Types of changes

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
