### PR TITLE
test: improve rendering tests with matchers

### DIFF
--- a/tests/CustomMatchers/CustomMatchersForRendering.ts
+++ b/tests/CustomMatchers/CustomMatchersForRendering.ts
@@ -3,18 +3,21 @@ import { diff } from 'jest-diff';
 declare global {
     namespace jest {
         interface Matchers<R> {
+            toHaveAmongDataAttributes(expectedDataAttributes: string): R;
             toHaveDataAttributes(expectedDataAttributes: string): R;
             toHaveAChildSpanWithClass(expectedClass: string): R;
             toHaveAChildSpanWithClassAndDataAttributes(expectedClass: string, expectedDataAttributes: string): R;
         }
 
         interface Expect {
+            toHaveAmongDataAttributes(expectedDataAttributes: string): any;
             toHaveDataAttributes(expectedDataAttributes: string): any;
             toHaveAChildSpanWithClass(expectedClass: string): any;
             toHaveAChildSpanWithClassAndDataAttributes(expectedClass: string, expectedDataAttributes: string): any;
         }
 
         interface InverseAsymmetricMatchers {
+            toHaveAmongDataAttributes(expectedDataAttributes: string): any;
             toHaveDataAttributes(expectedDataAttributes: string): any;
             toHaveAChildSpanWithClass(expectedClass: string): any;
             toHaveAChildSpanWithClassAndDataAttributes(expectedClass: string, expectedDataAttributes: string): any;
@@ -31,6 +34,20 @@ function getDataAttributesAsString(element: HTMLElement): string {
     const keys = Object.keys(dataAttributes);
 
     return keys.map((key) => `${key}: ${dataAttributes[key]}`).join('\n');
+}
+
+export function toHaveAmongDataAttributes(htmlElement: HTMLElement, expectedDataAttributes: string) {
+    const renderedDataAttributes = getDataAttributesAsString(htmlElement);
+
+    const pass: boolean = renderedDataAttributes.includes(expectedDataAttributes);
+    const message: () => string = () =>
+        pass
+            ? `Data attributes should not include '${expectedDataAttributes}'.\nRendered data attributes:\n${renderedDataAttributes}`
+            : `Data attributes should include '${expectedDataAttributes}'.\nRendered data attributes:\n${renderedDataAttributes}`;
+    return {
+        message,
+        pass,
+    };
 }
 
 export function toHaveDataAttributes(htmlElement: HTMLElement, expectedDataAttributes: string) {

--- a/tests/CustomMatchers/CustomMatchersForRendering.ts
+++ b/tests/CustomMatchers/CustomMatchersForRendering.ts
@@ -4,16 +4,19 @@ declare global {
     namespace jest {
         interface Matchers<R> {
             toHaveDataAttributes(expectedDataAttributes: string): R;
+            toHaveAChildSpanWithClass(expectedClass: string): R;
             toHaveAChildSpanWithClassAndDataAttributes(expectedClass: string, expectedDataAttributes: string): R;
         }
 
         interface Expect {
             toHaveDataAttributes(expectedDataAttributes: string): any;
+            toHaveAChildSpanWithClass(expectedClass: string): any;
             toHaveAChildSpanWithClassAndDataAttributes(expectedClass: string, expectedDataAttributes: string): any;
         }
 
         interface InverseAsymmetricMatchers {
             toHaveDataAttributes(expectedDataAttributes: string): any;
+            toHaveAChildSpanWithClass(expectedClass: string): any;
             toHaveAChildSpanWithClassAndDataAttributes(expectedClass: string, expectedDataAttributes: string): any;
         }
     }
@@ -38,6 +41,25 @@ export function toHaveDataAttributes(htmlElement: HTMLElement, expectedDataAttri
         pass
             ? `Data attributes should not be\n${renderedDataAttributes}`
             : `Data attributes are not the same as expected:\n${diff(expectedDataAttributes, renderedDataAttributes)}`;
+    return {
+        message,
+        pass,
+    };
+}
+
+export function toHaveAChildSpanWithClass(listItem: HTMLLIElement, expectedClass: string) {
+    const textSpan = getTextSpan(listItem);
+    const childSpans = Array.from(textSpan.children) as HTMLSpanElement[];
+
+    const pass = childSpans.some((childSpan) => {
+        return childSpan.className === expectedClass;
+    });
+
+    const foundChildSpans = childSpans.map((childSpan) => childSpan.className).join('\n');
+    const message: () => string = () =>
+        pass
+            ? `Span with class ${expectedClass} found.`
+            : `Span with class ${expectedClass} not found. Found spans with classes:\n${foundChildSpans}`;
     return {
         message,
         pass,

--- a/tests/CustomMatchers/CustomMatchersForRendering.ts
+++ b/tests/CustomMatchers/CustomMatchersForRendering.ts
@@ -4,16 +4,23 @@ declare global {
     namespace jest {
         interface Matchers<R> {
             toHaveDataAttributes(expectedDataAttributes: string): R;
+            toHaveAChildSpanWithClassAndDataAttributes(expectedClass: string, expectedDataAttributes: string): R;
         }
 
         interface Expect {
             toHaveDataAttributes(expectedDataAttributes: string): any;
+            toHaveAChildSpanWithClassAndDataAttributes(expectedClass: string, expectedDataAttributes: string): any;
         }
 
         interface InverseAsymmetricMatchers {
             toHaveDataAttributes(expectedDataAttributes: string): any;
+            toHaveAChildSpanWithClassAndDataAttributes(expectedClass: string, expectedDataAttributes: string): any;
         }
     }
+}
+
+function getTextSpan(listItem: HTMLLIElement) {
+    return listItem.children[1] as HTMLSpanElement;
 }
 
 function getDataAttributesAsString(element: HTMLElement): string {
@@ -34,5 +41,39 @@ export function toHaveDataAttributes(htmlElement: HTMLElement, expectedDataAttri
     return {
         message,
         pass,
+    };
+}
+
+export function toHaveAChildSpanWithClassAndDataAttributes(
+    listItem: HTMLLIElement,
+    expectedClass: string,
+    expectedDataAttributes: string,
+) {
+    const textSpan = getTextSpan(listItem);
+    const childSpans = Array.from(textSpan.children) as HTMLSpanElement[];
+
+    for (const childSpan of childSpans) {
+        if (childSpan.className === expectedClass) {
+            const renderedDataAttributes = getDataAttributesAsString(childSpan);
+            const pass: boolean = renderedDataAttributes === expectedDataAttributes;
+            const message: () => string = () =>
+                pass
+                    ? `Data attributes for the span with '${expectedClass}' class should not be\n${renderedDataAttributes}`
+                    : `Data attributes for the span with '${expectedClass}' class are not the same as expected:\n${diff(
+                          expectedDataAttributes,
+                          renderedDataAttributes,
+                      )}`;
+            return {
+                message,
+                pass,
+            };
+        }
+    }
+
+    const foundChildSpans = childSpans.map((childSpan) => childSpan.className).join('\n');
+    return {
+        message: () =>
+            `The rendered list item does not contain a span with class '${expectedClass}'. Found spans with classes:\n${foundChildSpans}`,
+        pass: false,
     };
 }

--- a/tests/CustomMatchers/jest.custom_matchers.setup.ts
+++ b/tests/CustomMatchers/jest.custom_matchers.setup.ts
@@ -52,8 +52,13 @@ expect.extend({
 // ---------------------------------------------------------------------
 // CustomMatchersForRendering
 // ---------------------------------------------------------------------
-import { toHaveAChildSpanWithClassAndDataAttributes, toHaveDataAttributes } from './CustomMatchersForRendering';
+import {
+    toHaveAChildSpanWithClass,
+    toHaveAChildSpanWithClassAndDataAttributes,
+    toHaveDataAttributes,
+} from './CustomMatchersForRendering';
 expect.extend({
+    toHaveAChildSpanWithClass,
     toHaveAChildSpanWithClassAndDataAttributes,
     toHaveDataAttributes,
 });

--- a/tests/CustomMatchers/jest.custom_matchers.setup.ts
+++ b/tests/CustomMatchers/jest.custom_matchers.setup.ts
@@ -52,8 +52,9 @@ expect.extend({
 // ---------------------------------------------------------------------
 // CustomMatchersForRendering
 // ---------------------------------------------------------------------
-import { toHaveDataAttributes } from './CustomMatchersForRendering';
+import { toHaveAChildSpanWithClassAndDataAttributes, toHaveDataAttributes } from './CustomMatchersForRendering';
 expect.extend({
+    toHaveAChildSpanWithClassAndDataAttributes,
     toHaveDataAttributes,
 });
 

--- a/tests/CustomMatchers/jest.custom_matchers.setup.ts
+++ b/tests/CustomMatchers/jest.custom_matchers.setup.ts
@@ -55,11 +55,13 @@ expect.extend({
 import {
     toHaveAChildSpanWithClass,
     toHaveAChildSpanWithClassAndDataAttributes,
+    toHaveAmongDataAttributes,
     toHaveDataAttributes,
 } from './CustomMatchersForRendering';
 expect.extend({
     toHaveAChildSpanWithClass,
     toHaveAChildSpanWithClassAndDataAttributes,
+    toHaveAmongDataAttributes,
     toHaveDataAttributes,
 });
 

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -624,7 +624,7 @@ describe('task line rendering - classes and data attributes', () => {
         expect(listItem).toHaveAmongDataAttributes(attributes);
     };
 
-    it('does not render hidden components but sets their specific classes to the upper li element', async () => {
+    it('should not render hidden components but should set their data attributes to the list item', async () => {
         await testHiddenComponentClasses(
             '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hidePriority: true },

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -77,9 +77,9 @@ function getListItemComponents(listItem: HTMLElement): string[] {
     const components: string[] = [getDescriptionText(listItem)];
 
     const textSpan = getTextSpan(listItem);
-    for (const childSpan of Array.from(textSpan.children)) {
-        if (childSpan.textContent) {
-            components.push(childSpan.textContent);
+    for (const innerSpan of Array.from(textSpan.children)) {
+        if (innerSpan.textContent) {
+            components.push(innerSpan.textContent);
         }
     }
     return components;

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -610,7 +610,6 @@ describe('task line rendering - classes and data attributes', () => {
 
     const taskLine = '- [ ] Full task ⏫ ➕ 2022-07-04 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day';
     const testHiddenComponentClasses = async (
-        taskLine: string,
         layoutOptions: Partial<LayoutOptions>,
         hiddenGenericClass: string,
         attributes: string,
@@ -627,31 +626,26 @@ describe('task line rendering - classes and data attributes', () => {
 
     it('should not render hidden components but should set their data attributes to the list item', async () => {
         await testHiddenComponentClasses(
-            taskLine,
             { hidePriority: true },
             fieldRenderer.className('priority'),
             'taskPriority: high',
         );
         await testHiddenComponentClasses(
-            taskLine,
             { hideCreatedDate: true },
             fieldRenderer.className('createdDate'),
             'taskCreated: past-far',
         );
         await testHiddenComponentClasses(
-            taskLine,
             { hideDueDate: true },
             fieldRenderer.className('dueDate'),
             'taskDue: past-far',
         );
         await testHiddenComponentClasses(
-            taskLine,
             { hideScheduledDate: true },
             fieldRenderer.className('scheduledDate'),
             'taskScheduled: past-far',
         );
         await testHiddenComponentClasses(
-            taskLine,
             { hideStartDate: true },
             fieldRenderer.className('startDate'),
             'taskStart: past-far',

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -599,12 +599,12 @@ describe('task line rendering - classes and data attributes', () => {
         );
     });
 
-    it('does not add specific classes to invalid dates', async () => {
+    it.failing('should not add data attributes for invalid dates', async () => {
         await testComponentClasses(
-            '- [ ] Full task ⏫ 📅 2023-02-29',
+            '- [ ] task with invalid due date 📅 2023-02-29',
             {},
             fieldRenderer.className('dueDate'),
-            'taskDue: ',
+            '',
         );
     });
 

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -608,14 +608,13 @@ describe('task line rendering - classes and data attributes', () => {
         );
     });
 
-    const taskLine = '- [ ] Full task ⏫ ➕ 2022-07-04 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day';
     const testHiddenComponentClasses = async (
         layoutOptions: Partial<LayoutOptions>,
         hiddenGenericClass: string,
         attributes: string,
     ) => {
         const task = fromLine({
-            line: taskLine,
+            line: '- [ ] Full task ⏫ ➕ 2022-07-04 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
         });
         const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
         const listItem = await renderListItem(task, fullLayoutOptions);

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -620,10 +620,7 @@ describe('task line rendering - classes and data attributes', () => {
         const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
         const listItem = await renderListItem(task, fullLayoutOptions);
 
-        const textSpan = getTextSpan(listItem);
-        for (const childSpan of Array.from(textSpan.children)) {
-            expect(childSpan.classList.contains(hiddenGenericClass)).toBeFalsy();
-        }
+        expect(listItem).not.toHaveAChildSpanWithClass(hiddenGenericClass);
 
         // Now verify the attributes
         for (const key in attributes) {

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -20,8 +20,6 @@ import { TaskBuilder } from './TestingTools/TaskBuilder';
 jest.mock('obsidian');
 window.moment = moment;
 
-type AttributesDictionary = { [key: string]: string };
-
 const fieldRenderer = new TaskFieldRenderer();
 
 /**
@@ -690,50 +688,44 @@ describe('task line rendering - classes and data attributes', () => {
         expect(tagSpan.dataset.tagName).toEqual('#illegal-data-attribute');
     });
 
-    const testLiAttributes = async (
-        taskLine: string,
-        layoutOptions: Partial<LayoutOptions>,
-        attributes: AttributesDictionary,
-    ) => {
+    const testLiAttributes = async (taskLine: string, layoutOptions: Partial<LayoutOptions>, attributes: string[]) => {
         const task = fromLine({
             line: taskLine,
         });
         const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
         const listItem = await renderListItem(task, fullLayoutOptions);
-        for (const key in attributes) {
-            expect(listItem.dataset[key]).toEqual(attributes[key]);
+        for (const attribute of attributes) {
+            expect(listItem).toHaveAmongDataAttributes(attribute);
         }
     };
 
     it('creates data attributes for custom statuses', async () => {
-        await testLiAttributes(
-            '- [ ] An incomplete task',
-            {},
-            { task: '', taskStatusName: 'Todo', taskStatusType: 'TODO' },
-        );
-        await testLiAttributes(
-            '- [x] A complete task',
-            {},
-            { task: 'x', taskStatusName: 'Done', taskStatusType: 'DONE' },
-        );
-        await testLiAttributes(
-            '- [/] In-progress task',
-            {},
-            { task: '/', taskStatusName: 'In Progress', taskStatusType: 'IN_PROGRESS' },
-        );
-        await testLiAttributes(
-            '- [-] In-progress task',
-            {},
-            { task: '-', taskStatusName: 'Cancelled', taskStatusType: 'CANCELLED' },
-        );
+        await testLiAttributes('- [ ] An incomplete task', {}, [
+            'task: ',
+            'taskStatusName: Todo',
+            'taskStatusType: TODO',
+        ]);
+        await testLiAttributes('- [x] A complete task', {}, [
+            'task: x',
+            'taskStatusName: Done',
+            'taskStatusType: DONE',
+        ]);
+        await testLiAttributes('- [/] In-progress task', {}, [
+            'task: /',
+            'taskStatusName: In Progress',
+            'taskStatusType: IN_PROGRESS',
+        ]);
+        await testLiAttributes('- [-] In-progress task', {}, [
+            'task: -',
+            'taskStatusName: Cancelled',
+            'taskStatusType: CANCELLED',
+        ]);
     });
 
     it('marks nonexistent task priority as "normal" priority', async () => {
-        await testLiAttributes(
-            '- [ ] Full task 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
-            {},
-            { taskPriority: 'normal' },
-        );
+        await testLiAttributes('- [ ] Full task 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day', {}, [
+            'taskPriority: normal',
+        ]);
     });
 });
 

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -323,7 +323,7 @@ describe('task line rendering - classes and data attributes', () => {
         taskLine: string,
         layoutOptions: Partial<LayoutOptions>,
         mainClass: string,
-        attributes: AttributesDictionary,
+        attributes: string,
     ) => {
         const task = fromLine({
             line: taskLine,
@@ -331,39 +331,27 @@ describe('task line rendering - classes and data attributes', () => {
         const fullLayoutOptions = { ...new LayoutOptions(), ...layoutOptions };
         const listItem = await renderListItem(task, fullLayoutOptions);
 
-        const textSpan = getTextSpan(listItem);
-        let found = false;
-        for (const childSpan of Array.from(textSpan.children)) {
-            if (childSpan.classList.contains(mainClass)) {
-                found = true;
-                const spanElement = childSpan as HTMLSpanElement;
-                // Now verify the attributes
-                for (const key in attributes) {
-                    expect(spanElement.dataset[key]).toEqual(attributes[key]);
-                }
-            }
-        }
-        expect(found).toBeTruthy();
+        expect(listItem).toHaveAChildSpanWithClassAndDataAttributes(mainClass, attributes);
     };
 
     it('renders priority with its correct classes', async () => {
         await testComponentClasses(
-            '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            '- [ ] Full task ⏫ ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             {},
             fieldRenderer.className('priority'),
-            { taskPriority: 'high' },
+            'taskPriority: high',
         );
         await testComponentClasses(
             '- [ ] Full task 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             {},
             fieldRenderer.className('priority'),
-            { taskPriority: 'medium' },
+            'taskPriority: medium',
         );
         await testComponentClasses(
             '- [ ] Full task 🔽 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             {},
             fieldRenderer.className('priority'),
-            { taskPriority: 'low' },
+            'taskPriority: low',
         );
     });
 
@@ -372,142 +360,252 @@ describe('task line rendering - classes and data attributes', () => {
             '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             {},
             fieldRenderer.className('recurrenceRule'),
-            {},
+            '',
         );
     });
 
     it('adds a correct "today" CSS class to dates', async () => {
         const today = DateParser.parseDate('today').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${today}`, {}, fieldRenderer.className('createdDate'), {
-            taskCreated: 'today',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${today}`, {}, fieldRenderer.className('dueDate'), {
-            taskDue: 'today',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${today}`, {}, fieldRenderer.className('scheduledDate'), {
-            taskScheduled: 'today',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${today}`, {}, fieldRenderer.className('startDate'), {
-            taskStart: 'today',
-        });
-        await testComponentClasses(`- [x] Done task ✅ ${today}`, {}, fieldRenderer.className('doneDate'), {
-            taskDone: 'today',
-        });
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ➕ ${today}`,
+            {},
+            fieldRenderer.className('createdDate'),
+            'taskCreated: today',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 📅 ${today}`,
+            {},
+            fieldRenderer.className('dueDate'),
+            'taskDue: today',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ⏳ ${today}`,
+            {},
+            fieldRenderer.className('scheduledDate'),
+            'taskScheduled: today',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 🛫 ${today}`,
+            {},
+            fieldRenderer.className('startDate'),
+            'taskStart: today',
+        );
+        await testComponentClasses(
+            `- [x] Done task ✅ ${today}`,
+            {},
+            fieldRenderer.className('doneDate'),
+            'taskDone: today',
+        );
     });
 
     it('adds a correct "future-1d" CSS class to dates', async () => {
         const future = DateParser.parseDate('tomorrow').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${future}`, {}, fieldRenderer.className('createdDate'), {
-            taskCreated: 'future-1d',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${future}`, {}, fieldRenderer.className('dueDate'), {
-            taskDue: 'future-1d',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${future}`, {}, fieldRenderer.className('scheduledDate'), {
-            taskScheduled: 'future-1d',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${future}`, {}, fieldRenderer.className('startDate'), {
-            taskStart: 'future-1d',
-        });
-        await testComponentClasses(`- [x] Done task ✅ ${future}`, {}, fieldRenderer.className('doneDate'), {
-            taskDone: 'future-1d',
-        });
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ➕ ${future}`,
+            {},
+            fieldRenderer.className('createdDate'),
+            'taskCreated: future-1d',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 📅 ${future}`,
+            {},
+            fieldRenderer.className('dueDate'),
+            'taskDue: future-1d',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ⏳ ${future}`,
+            {},
+            fieldRenderer.className('scheduledDate'),
+            'taskScheduled: future-1d',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 🛫 ${future}`,
+            {},
+            fieldRenderer.className('startDate'),
+            'taskStart: future-1d',
+        );
+        await testComponentClasses(
+            `- [x] Done task ✅ ${future}`,
+            {},
+            fieldRenderer.className('doneDate'),
+            'taskDone: future-1d',
+        );
     });
 
     it('adds a correct "future-7d" CSS class to dates', async () => {
         const future = DateParser.parseDate('in 7 days').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${future}`, {}, fieldRenderer.className('createdDate'), {
-            taskCreated: 'future-7d',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${future}`, {}, fieldRenderer.className('dueDate'), {
-            taskDue: 'future-7d',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${future}`, {}, fieldRenderer.className('scheduledDate'), {
-            taskScheduled: 'future-7d',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${future}`, {}, fieldRenderer.className('startDate'), {
-            taskStart: 'future-7d',
-        });
-        await testComponentClasses(`- [x] Done task ✅ ${future}`, {}, fieldRenderer.className('doneDate'), {
-            taskDone: 'future-7d',
-        });
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ➕ ${future}`,
+            {},
+            fieldRenderer.className('createdDate'),
+            'taskCreated: future-7d',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 📅 ${future}`,
+            {},
+            fieldRenderer.className('dueDate'),
+            'taskDue: future-7d',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ⏳ ${future}`,
+            {},
+            fieldRenderer.className('scheduledDate'),
+            'taskScheduled: future-7d',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 🛫 ${future}`,
+            {},
+            fieldRenderer.className('startDate'),
+            'taskStart: future-7d',
+        );
+        await testComponentClasses(
+            `- [x] Done task ✅ ${future}`,
+            {},
+            fieldRenderer.className('doneDate'),
+            'taskDone: future-7d',
+        );
     });
 
     it('adds a correct "past-1d" CSS class to dates', async () => {
         const past = DateParser.parseDate('yesterday').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${past}`, {}, fieldRenderer.className('createdDate'), {
-            taskCreated: 'past-1d',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${past}`, {}, fieldRenderer.className('dueDate'), {
-            taskDue: 'past-1d',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${past}`, {}, fieldRenderer.className('scheduledDate'), {
-            taskScheduled: 'past-1d',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${past}`, {}, fieldRenderer.className('startDate'), {
-            taskStart: 'past-1d',
-        });
-        await testComponentClasses(`- [x] Done task ✅ ${past}`, {}, fieldRenderer.className('doneDate'), {
-            taskDone: 'past-1d',
-        });
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ➕ ${past}`,
+            {},
+            fieldRenderer.className('createdDate'),
+            'taskCreated: past-1d',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 📅 ${past}`,
+            {},
+            fieldRenderer.className('dueDate'),
+            'taskDue: past-1d',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ⏳ ${past}`,
+            {},
+            fieldRenderer.className('scheduledDate'),
+            'taskScheduled: past-1d',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 🛫 ${past}`,
+            {},
+            fieldRenderer.className('startDate'),
+            'taskStart: past-1d',
+        );
+        await testComponentClasses(
+            `- [x] Done task ✅ ${past}`,
+            {},
+            fieldRenderer.className('doneDate'),
+            'taskDone: past-1d',
+        );
     });
 
     it('adds a correct "past-7d" CSS class to dates', async () => {
         const past = DateParser.parseDate('7 days ago').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${past}`, {}, fieldRenderer.className('createdDate'), {
-            taskCreated: 'past-7d',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${past}`, {}, fieldRenderer.className('dueDate'), {
-            taskDue: 'past-7d',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${past}`, {}, fieldRenderer.className('scheduledDate'), {
-            taskScheduled: 'past-7d',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${past}`, {}, fieldRenderer.className('startDate'), {
-            taskStart: 'past-7d',
-        });
-        await testComponentClasses(`- [x] Done task ✅ ${past}`, {}, fieldRenderer.className('doneDate'), {
-            taskDone: 'past-7d',
-        });
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ➕ ${past}`,
+            {},
+            fieldRenderer.className('createdDate'),
+            'taskCreated: past-7d',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 📅 ${past}`,
+            {},
+            fieldRenderer.className('dueDate'),
+            'taskDue: past-7d',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ⏳ ${past}`,
+            {},
+            fieldRenderer.className('scheduledDate'),
+            'taskScheduled: past-7d',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 🛫 ${past}`,
+            {},
+            fieldRenderer.className('startDate'),
+            'taskStart: past-7d',
+        );
+        await testComponentClasses(
+            `- [x] Done task ✅ ${past}`,
+            {},
+            fieldRenderer.className('doneDate'),
+            'taskDone: past-7d',
+        );
     });
 
     it('adds the classes "...future-far" and "...past-far" to dates that are further than 7 days', async () => {
         const future = DateParser.parseDate('in 8 days').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${future}`, {}, fieldRenderer.className('createdDate'), {
-            taskCreated: 'future-far',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${future}`, {}, fieldRenderer.className('dueDate'), {
-            taskDue: 'future-far',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${future}`, {}, fieldRenderer.className('scheduledDate'), {
-            taskScheduled: 'future-far',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${future}`, {}, fieldRenderer.className('startDate'), {
-            taskStart: 'future-far',
-        });
-        await testComponentClasses(`- [x] Done task ✅ ${future}`, {}, fieldRenderer.className('doneDate'), {
-            taskDone: 'future-far',
-        });
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ➕ ${future}`,
+            {},
+            fieldRenderer.className('createdDate'),
+            'taskCreated: future-far',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 📅 ${future}`,
+            {},
+            fieldRenderer.className('dueDate'),
+            'taskDue: future-far',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ⏳ ${future}`,
+            {},
+            fieldRenderer.className('scheduledDate'),
+            'taskScheduled: future-far',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 🛫 ${future}`,
+            {},
+            fieldRenderer.className('startDate'),
+            'taskStart: future-far',
+        );
+        await testComponentClasses(
+            `- [x] Done task ✅ ${future}`,
+            {},
+            fieldRenderer.className('doneDate'),
+            'taskDone: future-far',
+        );
         const past = DateParser.parseDate('8 days ago').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${past}`, {}, fieldRenderer.className('createdDate'), {
-            taskCreated: 'past-far',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${past}`, {}, fieldRenderer.className('dueDate'), {
-            taskDue: 'past-far',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${past}`, {}, fieldRenderer.className('scheduledDate'), {
-            taskScheduled: 'past-far',
-        });
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${past}`, {}, fieldRenderer.className('startDate'), {
-            taskStart: 'past-far',
-        });
-        await testComponentClasses(`- [x] Done task ✅ ${past}`, {}, fieldRenderer.className('doneDate'), {
-            taskDone: 'past-far',
-        });
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ➕ ${past}`,
+            {},
+            fieldRenderer.className('createdDate'),
+            'taskCreated: past-far',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 📅 ${past}`,
+            {},
+            fieldRenderer.className('dueDate'),
+            'taskDue: past-far',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ ⏳ ${past}`,
+            {},
+            fieldRenderer.className('scheduledDate'),
+            'taskScheduled: past-far',
+        );
+        await testComponentClasses(
+            `- [ ] Full task ⏫ 🛫 ${past}`,
+            {},
+            fieldRenderer.className('startDate'),
+            'taskStart: past-far',
+        );
+        await testComponentClasses(
+            `- [x] Done task ✅ ${past}`,
+            {},
+            fieldRenderer.className('doneDate'),
+            'taskDone: past-far',
+        );
     });
 
     it('does not add specific classes to invalid dates', async () => {
-        await testComponentClasses('- [ ] Full task ⏫ 📅 2023-02-29', {}, fieldRenderer.className('dueDate'), {});
+        await testComponentClasses(
+            '- [ ] Full task ⏫ 📅 2023-02-29',
+            {},
+            fieldRenderer.className('dueDate'),
+            'taskDue: ',
+        );
     });
 
     const testHiddenComponentClasses = async (

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -608,7 +608,7 @@ describe('task line rendering - classes and data attributes', () => {
         );
     });
 
-    const taskLine = '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day';
+    const taskLine = '- [ ] Full task ⏫ ➕ 2022-07-04 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day';
     const testHiddenComponentClasses = async (
         taskLine: string,
         layoutOptions: Partial<LayoutOptions>,
@@ -633,7 +633,7 @@ describe('task line rendering - classes and data attributes', () => {
             'taskPriority: high',
         );
         await testHiddenComponentClasses(
-            '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 ➕ 2022-07-04 🔁 every day',
+            taskLine,
             { hideCreatedDate: true },
             fieldRenderer.className('createdDate'),
             'taskCreated: past-far',

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -608,6 +608,7 @@ describe('task line rendering - classes and data attributes', () => {
         );
     });
 
+    const taskLine = '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day';
     const testHiddenComponentClasses = async (
         taskLine: string,
         layoutOptions: Partial<LayoutOptions>,
@@ -626,7 +627,7 @@ describe('task line rendering - classes and data attributes', () => {
 
     it('should not render hidden components but should set their data attributes to the list item', async () => {
         await testHiddenComponentClasses(
-            '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            taskLine,
             { hidePriority: true },
             fieldRenderer.className('priority'),
             'taskPriority: high',
@@ -638,19 +639,19 @@ describe('task line rendering - classes and data attributes', () => {
             'taskCreated: past-far',
         );
         await testHiddenComponentClasses(
-            '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            taskLine,
             { hideDueDate: true },
             fieldRenderer.className('dueDate'),
             'taskDue: past-far',
         );
         await testHiddenComponentClasses(
-            '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            taskLine,
             { hideScheduledDate: true },
             fieldRenderer.className('scheduledDate'),
             'taskScheduled: past-far',
         );
         await testHiddenComponentClasses(
-            '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
+            taskLine,
             { hideStartDate: true },
             fieldRenderer.className('startDate'),
             'taskStart: past-far',

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -334,7 +334,7 @@ describe('task line rendering - classes and data attributes', () => {
         expect(listItem).toHaveAChildSpanWithClassAndDataAttributes(mainClass, attributes);
     };
 
-    it('renders priority with its correct classes', async () => {
+    it('should render priority component with its class and data attribute', async () => {
         await testComponentClasses(
             '- [ ] Full task ⏫ ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             {},
@@ -355,7 +355,7 @@ describe('task line rendering - classes and data attributes', () => {
         );
     });
 
-    it('renders recurrence with its correct classes', async () => {
+    it('should render recurrence component with its class and data attribute', async () => {
         await testComponentClasses(
             '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             {},
@@ -364,7 +364,7 @@ describe('task line rendering - classes and data attributes', () => {
         );
     });
 
-    it('adds a correct "today" CSS class to dates', async () => {
+    it('should render date component with its class and data attribute with "today" value', async () => {
         const today = DateParser.parseDate('today').format(TaskRegularExpressions.dateFormat);
         await testComponentClasses(
             `- [ ] Full task ⏫ ➕ ${today}`,
@@ -398,7 +398,7 @@ describe('task line rendering - classes and data attributes', () => {
         );
     });
 
-    it('adds a correct "future-1d" CSS class to dates', async () => {
+    it('should render date component with its class and data attribute with "future-1d" value', async () => {
         const future = DateParser.parseDate('tomorrow').format(TaskRegularExpressions.dateFormat);
         await testComponentClasses(
             `- [ ] Full task ⏫ ➕ ${future}`,
@@ -432,7 +432,7 @@ describe('task line rendering - classes and data attributes', () => {
         );
     });
 
-    it('adds a correct "future-7d" CSS class to dates', async () => {
+    it('should render date component with its class and data attribute with "future-7d" value', async () => {
         const future = DateParser.parseDate('in 7 days').format(TaskRegularExpressions.dateFormat);
         await testComponentClasses(
             `- [ ] Full task ⏫ ➕ ${future}`,
@@ -466,7 +466,7 @@ describe('task line rendering - classes and data attributes', () => {
         );
     });
 
-    it('adds a correct "past-1d" CSS class to dates', async () => {
+    it('should render date component with its class and data attribute with "past-1d" value', async () => {
         const past = DateParser.parseDate('yesterday').format(TaskRegularExpressions.dateFormat);
         await testComponentClasses(
             `- [ ] Full task ⏫ ➕ ${past}`,
@@ -500,7 +500,7 @@ describe('task line rendering - classes and data attributes', () => {
         );
     });
 
-    it('adds a correct "past-7d" CSS class to dates', async () => {
+    it('should render date component with its class and data attribute with "past-7d" value', async () => {
         const past = DateParser.parseDate('7 days ago').format(TaskRegularExpressions.dateFormat);
         await testComponentClasses(
             `- [ ] Full task ⏫ ➕ ${past}`,
@@ -534,7 +534,7 @@ describe('task line rendering - classes and data attributes', () => {
         );
     });
 
-    it('adds the classes "...future-far" and "...past-far" to dates that are further than 7 days', async () => {
+    it('should render date component with its class and data attribute with "future-far" & "past-far" values', async () => {
         const future = DateParser.parseDate('in 8 days').format(TaskRegularExpressions.dateFormat);
         await testComponentClasses(
             `- [ ] Full task ⏫ ➕ ${future}`,

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -612,7 +612,7 @@ describe('task line rendering - classes and data attributes', () => {
         taskLine: string,
         layoutOptions: Partial<LayoutOptions>,
         hiddenGenericClass: string,
-        attributes: AttributesDictionary,
+        attributes: string,
     ) => {
         const task = fromLine({
             line: taskLine,
@@ -621,11 +621,7 @@ describe('task line rendering - classes and data attributes', () => {
         const listItem = await renderListItem(task, fullLayoutOptions);
 
         expect(listItem).not.toHaveAChildSpanWithClass(hiddenGenericClass);
-
-        // Now verify the attributes
-        for (const key in attributes) {
-            expect(listItem.dataset[key]).toEqual(attributes[key]);
-        }
+        expect(listItem).toHaveAmongDataAttributes(attributes);
     };
 
     it('does not render hidden components but sets their specific classes to the upper li element', async () => {
@@ -633,31 +629,31 @@ describe('task line rendering - classes and data attributes', () => {
             '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hidePriority: true },
             fieldRenderer.className('priority'),
-            { taskPriority: 'high' },
+            'taskPriority: high',
         );
         await testHiddenComponentClasses(
             '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 ➕ 2022-07-04 🔁 every day',
             { hideCreatedDate: true },
             fieldRenderer.className('createdDate'),
-            { taskCreated: 'past-far' },
+            'taskCreated: past-far',
         );
         await testHiddenComponentClasses(
             '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hideDueDate: true },
             fieldRenderer.className('dueDate'),
-            { taskDue: 'past-far' },
+            'taskDue: past-far',
         );
         await testHiddenComponentClasses(
             '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hideScheduledDate: true },
             fieldRenderer.className('scheduledDate'),
-            { taskScheduled: 'past-far' },
+            'taskScheduled: past-far',
         );
         await testHiddenComponentClasses(
             '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             { hideStartDate: true },
             fieldRenderer.className('startDate'),
-            { taskStart: 'past-far' },
+            'taskStart: past-far',
         );
     });
 


### PR DESCRIPTION
# Description

- add custom matchers for rendering tests
- reformulate test descriptions
- one test is now marked as failing. Now that data attributes are checked as a string, a bug is shown:
  - actual: data attribute with an empty value is added
  - expected: absence of the data attribute

## Motivation and Context

- make the test functions obvious for understanding
- return meaningful messages in case of errors

Please mind the increased number of lines, the tests will be refactored further, this is a (small-er) step towards that and the volume will decrease.

## How has this been tested?

Unit test, breaking code.

## Screenshots

Without matchers:

![Снимок экрана 2023-12-22 в 17 14 13](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/34da823b-b970-4094-ad55-f4b9333233e8)

![Снимок экрана 2023-12-22 в 17 14 50](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/a8ca6c1f-7447-4f09-985f-b263cef332e4)

Matchers now return informative message:

![Снимок экрана 2023-12-22 в 15 28 46](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/636d2e5f-ee44-4c30-a0d2-e6ac55eaa9f9)

![Снимок экрана 2023-12-22 в 15 33 23](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/71870b57-0f63-4503-a4c8-069a4380af61)

## Types of changes

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
