### PR TITLE
fix: Next recurrent of recurring tasks is now always TODO, IN_PROGRESS or space

### DIFF
--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -219,7 +219,13 @@ export class StatusRegistry {
                     return searchStatus;
                 }
             }
-            // If it fails to find any TODO status, it will use the next symbol after DONE.
+            for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
+                searchStatus = this.getNextStatusOrCreate(searchStatus);
+                if (searchStatus.type === StatusType.IN_PROGRESS) {
+                    return searchStatus;
+                }
+            }
+            // If it fails to find any TODO or IN_PROGRESS status, it will use the next symbol after DONE.
         }
         return nextStatus;
     }

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -214,13 +214,14 @@ export class StatusRegistry {
         const nextStatus = this.getNextStatusOrCreate(newStatus);
 
         {
-            if (nextStatus.type === StatusType.TODO) {
+            const wanted = StatusType.TODO;
+            if (nextStatus.type === wanted) {
                 return nextStatus;
             }
             let searchStatus = nextStatus;
             for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
                 searchStatus = this.getNextStatusOrCreate(searchStatus);
-                if (searchStatus.type === StatusType.TODO) {
+                if (searchStatus.type === wanted) {
                     return searchStatus;
                 }
             }

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -221,15 +221,9 @@ export class StatusRegistry {
         }
 
         {
-            if (nextStatus.type === StatusType.IN_PROGRESS) {
-                return nextStatus;
-            }
-            let searchStatus = nextStatus;
-            for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
-                searchStatus = this.getNextStatusOrCreate(searchStatus);
-                if (searchStatus.type === StatusType.IN_PROGRESS) {
-                    return searchStatus;
-                }
+            const result = this.findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus, StatusType.IN_PROGRESS);
+            if (result) {
+                return result;
             }
         }
 
@@ -242,7 +236,7 @@ export class StatusRegistry {
         return this.bySymbolOrCreate(' ');
     }
 
-    private findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus: Status, wanted: StatusType.TODO) {
+    private findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus: Status, wanted: StatusType) {
         if (nextStatus.type === wanted) {
             return nextStatus;
         }

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -205,7 +205,7 @@ export class StatusRegistry {
      * If the next status is not TODO:
      *   - it first advances through the next statuses until it finds a {@link StatusType.TODO} status - which it returns
      *   - or it then advances through the next statuses until it finds an {@link StatusType.IN_PROGRESS} status - which it returns
-     *   - otherwise, it uses the status for the status `[ ]`, as the default 'TODO' status.
+     *   - otherwise, it uses the status with symbol 'space', which is the default 'TODO' status.
      *
      * @param newStatus - the new status of the task that has just been toggled, which
      *                    is expected to be of type {@link StatusType.DONE}, but this is not checked.

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -213,25 +213,29 @@ export class StatusRegistry {
     public getNextRecurrenceStatusOrCreate(newStatus: Status) {
         const nextStatus = this.getNextStatusOrCreate(newStatus);
 
-        if (nextStatus.type === StatusType.TODO) {
-            return nextStatus;
-        }
-        let searchStatus = nextStatus;
-        for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
-            searchStatus = this.getNextStatusOrCreate(searchStatus);
-            if (searchStatus.type === StatusType.TODO) {
-                return searchStatus;
+        {
+            if (nextStatus.type === StatusType.TODO) {
+                return nextStatus;
+            }
+            let searchStatus = nextStatus;
+            for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
+                searchStatus = this.getNextStatusOrCreate(searchStatus);
+                if (searchStatus.type === StatusType.TODO) {
+                    return searchStatus;
+                }
             }
         }
 
-        if (nextStatus.type === StatusType.IN_PROGRESS) {
-            return nextStatus;
-        }
-        searchStatus = nextStatus;
-        for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
-            searchStatus = this.getNextStatusOrCreate(searchStatus);
-            if (searchStatus.type === StatusType.IN_PROGRESS) {
-                return searchStatus;
+        {
+            if (nextStatus.type === StatusType.IN_PROGRESS) {
+                return nextStatus;
+            }
+            let searchStatus = nextStatus;
+            for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
+                searchStatus = this.getNextStatusOrCreate(searchStatus);
+                if (searchStatus.type === StatusType.IN_PROGRESS) {
+                    return searchStatus;
+                }
             }
         }
 

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -212,25 +212,24 @@ export class StatusRegistry {
      */
     public getNextRecurrenceStatusOrCreate(newStatus: Status) {
         const nextStatus = this.getNextStatusOrCreate(newStatus);
-        if (nextStatus.type !== StatusType.TODO) {
-            let searchStatus = nextStatus;
-            // The goal here is to avoid an infinite loop. By limiting the search to the number of
-            // configured statuses, we ensure it doesn't continue indefinitely.
-            for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
-                searchStatus = this.getNextStatusOrCreate(searchStatus);
-                if (searchStatus.type === StatusType.TODO) {
-                    return searchStatus;
-                }
-            }
 
-            searchStatus = nextStatus;
-            for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
-                searchStatus = this.getNextStatusOrCreate(searchStatus);
-                if (searchStatus.type === StatusType.IN_PROGRESS) {
-                    return searchStatus;
-                }
+        if (nextStatus.type === StatusType.TODO) {
+            return nextStatus;
+        }
+
+        let searchStatus = nextStatus;
+        for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
+            searchStatus = this.getNextStatusOrCreate(searchStatus);
+            if (searchStatus.type === StatusType.TODO) {
+                return searchStatus;
             }
-            // If it fails to find any TODO or IN_PROGRESS status, it will use the next symbol after DONE.
+        }
+        searchStatus = nextStatus;
+        for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
+            searchStatus = this.getNextStatusOrCreate(searchStatus);
+            if (searchStatus.type === StatusType.IN_PROGRESS) {
+                return searchStatus;
+            }
         }
         return nextStatus;
     }

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -237,6 +237,8 @@ export class StatusRegistry {
             return nextStatus;
         }
         let searchStatus = nextStatus;
+        // The goal here is to avoid an infinite loop. By limiting the search to the number of
+        // configured statuses, we ensure it doesn't continue indefinitely.
         for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
             searchStatus = this.getNextStatusOrCreate(searchStatus);
             if (searchStatus.type === wanted) {

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -201,8 +201,11 @@ export class StatusRegistry {
 
     /**
      * Return the status to use for a recurring task that has just been completed.
-     * If the next status is not TODO, it advances through the next statuses until it either
-     * finds a {@link StatusType.TODO} status, or goes ahead and returns the next status after {@link newStatus}.
+     *
+     * If the next status is not TODO:
+     *   - it first advances through the next statuses until it finds a {@link StatusType.TODO} status - which it returns
+     *   - or it then advances through the next statuses until it finds an {@link StatusType.IN_PROGRESS} status - which it returns
+     *   - otherwise, it goes ahead and returns the next status after {@link newStatus}.
      *
      * @param newStatus - the new status of the task that has just been toggled, which
      *                    is expected to be of type {@link StatusType.DONE}, but this is not checked.

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -215,15 +215,9 @@ export class StatusRegistry {
 
         {
             const wanted = StatusType.TODO;
-            if (nextStatus.type === wanted) {
-                return nextStatus;
-            }
-            let searchStatus = nextStatus;
-            for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
-                searchStatus = this.getNextStatusOrCreate(searchStatus);
-                if (searchStatus.type === wanted) {
-                    return searchStatus;
-                }
+            const result = this.findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus, wanted);
+            if (result) {
+                return result;
             }
         }
 
@@ -247,6 +241,20 @@ export class StatusRegistry {
         // status type of space to anything other than TODO - but if they do, it's not
         // our problem.
         return this.bySymbolOrCreate(' ');
+    }
+
+    private findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus: Status, wanted: StatusType.TODO) {
+        if (nextStatus.type === wanted) {
+            return nextStatus;
+        }
+        let searchStatus = nextStatus;
+        for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
+            searchStatus = this.getNextStatusOrCreate(searchStatus);
+            if (searchStatus.type === wanted) {
+                return searchStatus;
+            }
+        }
+        return undefined;
     }
 
     /**

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -213,18 +213,14 @@ export class StatusRegistry {
     public getNextRecurrenceStatusOrCreate(newStatus: Status) {
         const nextStatus = this.getNextStatusOrCreate(newStatus);
 
-        {
-            const result = this.findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus, StatusType.TODO);
-            if (result) {
-                return result;
-            }
+        const result1 = this.findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus, StatusType.TODO);
+        if (result1) {
+            return result1;
         }
 
-        {
-            const result = this.findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus, StatusType.IN_PROGRESS);
-            if (result) {
-                return result;
-            }
+        const result2 = this.findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus, StatusType.IN_PROGRESS);
+        if (result2) {
+            return result2;
         }
 
         // There is no TODO or IN_PROGRESS status in the chain, so we will use a space.

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -222,6 +222,8 @@ export class StatusRegistry {
                     return searchStatus;
                 }
             }
+
+            searchStatus = nextStatus;
             for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
                 searchStatus = this.getNextStatusOrCreate(searchStatus);
                 if (searchStatus.type === StatusType.IN_PROGRESS) {

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -208,7 +208,7 @@ export class StatusRegistry {
      *                    is expected to be of type {@link StatusType.DONE}, but this is not checked.
      */
     public getNextRecurrenceStatusOrCreate(newStatus: Status) {
-        let nextStatus = this.getNextStatusOrCreate(newStatus);
+        const nextStatus = this.getNextStatusOrCreate(newStatus);
         if (nextStatus.type !== StatusType.TODO) {
             let searchStatus = nextStatus;
             // The goal here is to avoid an infinite loop. By limiting the search to the number of
@@ -216,8 +216,7 @@ export class StatusRegistry {
             for (let i = 0; i < this.registeredStatuses.length - 1; i++) {
                 searchStatus = this.getNextStatusOrCreate(searchStatus);
                 if (searchStatus.type === StatusType.TODO) {
-                    nextStatus = searchStatus;
-                    break;
+                    return searchStatus;
                 }
             }
             // If it fails to find any TODO status, it will use the next symbol after DONE.

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -213,12 +213,12 @@ export class StatusRegistry {
     public getNextRecurrenceStatusOrCreate(newStatus: Status) {
         const nextStatus = this.getNextStatusOrCreate(newStatus);
 
-        const result1 = this.findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus, StatusType.TODO);
+        const result1 = this.getNextRecurrenceStatusOfType(nextStatus, StatusType.TODO);
         if (result1) {
             return result1;
         }
 
-        const result2 = this.findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus, StatusType.IN_PROGRESS);
+        const result2 = this.getNextRecurrenceStatusOfType(nextStatus, StatusType.IN_PROGRESS);
         if (result2) {
             return result2;
         }
@@ -232,7 +232,7 @@ export class StatusRegistry {
         return this.bySymbolOrCreate(' ');
     }
 
-    private findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus: Status, wanted: StatusType) {
+    private getNextRecurrenceStatusOfType(nextStatus: Status, wanted: StatusType) {
         if (nextStatus.type === wanted) {
             return nextStatus;
         }

--- a/src/StatusRegistry.ts
+++ b/src/StatusRegistry.ts
@@ -214,8 +214,7 @@ export class StatusRegistry {
         const nextStatus = this.getNextStatusOrCreate(newStatus);
 
         {
-            const wanted = StatusType.TODO;
-            const result = this.findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus, wanted);
+            const result = this.findStatusOfRequiredTypeByFollowingNextStatusChain(nextStatus, StatusType.TODO);
             if (result) {
                 return result;
             }

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -582,5 +582,23 @@ describe('StatusRegistry', () => {
             ];
             checkToggleAndRecurrenceStatuses(statuses, 'a', 'b', 'c');
         });
+
+        it('should return space for symbol if there are no TODO or IN_PROGRESS in sequence', () => {
+            const statuses: StatusCollection = [
+                [' ', 'Todo', 'x', 'TODO'],
+                ['x', 'Done', ' ', 'DONE'],
+                ['C', 'C to D', 'D', 'CANCELLED'],
+                ['D', 'D to C', 'C', 'DONE'],
+            ];
+            checkToggleAndRecurrenceStatuses(statuses, 'C', 'D', ' ');
+        });
+
+        it('should return space for symbol if it is not a known status', () => {
+            const statuses: StatusCollection = [
+                ['C', 'C to D', 'D', 'CANCELLED'],
+                ['D', 'D to C', 'C', 'DONE'],
+            ];
+            checkToggleAndRecurrenceStatuses(statuses, 'C', 'D', ' ');
+        });
     });
 });

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -499,7 +499,7 @@ describe('StatusRegistry', () => {
             expect(nextStatus).toEqual(statusRegistry.bySymbol(' '));
         });
 
-        it.failing('should make CANCELLED next task IN_PROGRESS, if TODO not found', () => {
+        it('should make CANCELLED next task IN_PROGRESS, if TODO not found', () => {
             // Arrange
             const statusRegistry = new StatusRegistry();
             const statuses: StatusCollection = [

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -514,6 +514,22 @@ describe('StatusRegistry', () => {
             checkToggleAndRecurrenceStatuses(statuses, '/', 'x', ' ');
         });
 
+        it('should find IN_PROGRESS for next recurrence, when statuses are IN_PROGRESS then DONE', () => {
+            const statuses: StatusCollection = [
+                ['1', '1 to 2', '2', 'IN_PROGRESS'],
+                ['2', '2 to 1', '1', 'DONE'],
+            ];
+            checkToggleAndRecurrenceStatuses(statuses, '1', '2', '1');
+        });
+
+        it('should find IN_PROGRESS for next recurrence, when statuses are DONE then IN_PROGRESS', () => {
+            const statuses: StatusCollection = [
+                ['1', '1 to 2', '2', 'DONE'],
+                ['2', '2 to 1', '1', 'IN_PROGRESS'],
+            ];
+            checkToggleAndRecurrenceStatuses(statuses, '2', '1', '2');
+        });
+
         it('should make CANCELLED next task IN_PROGRESS, if TODO not found', () => {
             const statuses: StatusCollection = [
                 ['/', '/ to x', 'x', 'IN_PROGRESS'],

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -544,7 +544,7 @@ describe('StatusRegistry', () => {
             expect(nextStatus).toEqual(statusRegistry.bySymbol('T'));
         });
 
-        it.failing('should select the correct next status, when there is ambiguity', () => {
+        it('should select the correct next status, when there is ambiguity', () => {
             // Arrange
             const statusRegistry = new StatusRegistry();
             const statuses: StatusCollection = [

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -7,6 +7,7 @@ import { Status } from '../src/Status';
 import { StatusConfiguration, StatusType } from '../src/StatusConfiguration';
 import { Task } from '../src/Task';
 import { TaskLocation } from '../src/TaskLocation';
+import type { StatusCollection } from '../src/StatusCollection';
 import * as TestHelpers from './TestHelpers';
 import * as StatusExamples from './TestingTools/StatusExamples';
 import { constructStatuses } from './TestingTools/StatusesTestHelpers';
@@ -496,6 +497,27 @@ describe('StatusRegistry', () => {
             // Ensure that the next status skips through to TODO for a recurring task
             const nextStatus = statusRegistry.getNextRecurrenceStatusOrCreate(toggledStatus);
             expect(nextStatus).toEqual(statusRegistry.bySymbol(' '));
+        });
+
+        it.failing('should make CANCELLED next task IN_PROGRESS, if TODO not found', () => {
+            // Arrange
+            const statusRegistry = new StatusRegistry();
+            const statuses: StatusCollection = [
+                ['/', '/ to x', 'x', 'IN_PROGRESS'],
+                ['x', 'x to -', '-', 'DONE'],
+                ['-', '- to /', '/', 'CANCELLED'],
+            ];
+            statusRegistry.set(constructStatuses(statuses));
+
+            const initialStatusForRecurringTask = statusRegistry.bySymbol('/');
+
+            // Act, Assert
+            const toggledStatus = statusRegistry.getNextStatusOrCreate(initialStatusForRecurringTask);
+            expect(toggledStatus).toEqual(statusRegistry.bySymbol('x'));
+
+            // Ensure that the next status skips through to IN_PROGRESS for a recurring task, if TODO not found
+            const nextStatus = statusRegistry.getNextRecurrenceStatusOrCreate(toggledStatus);
+            expect(nextStatus).toEqual(statusRegistry.bySymbol('/'));
         });
     });
 });

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -509,18 +509,9 @@ describe('StatusRegistry', () => {
         it('should make CANCELLED next task TODO', () => {
             // See #2304:
             // Completing a recurring task setting wrong status for new task [if the next custom status is not TODO]
-
+            // Ensure that the next status skips through to TODO for a recurring task:
             const statuses = StatusExamples.doneTogglesToCancelled();
-            const initialStatusSymbol = '/';
-            const expectedToggledStatus = 'x';
-            // Ensure that the next status skips through to TODO for a recurring task
-            const expectedNextTaskStatus = ' ';
-            checkToggleAndRecurrenceStatuses(
-                statuses,
-                initialStatusSymbol,
-                expectedToggledStatus,
-                expectedNextTaskStatus,
-            );
+            checkToggleAndRecurrenceStatuses(statuses, '/', 'x', ' ');
         });
 
         it('should make CANCELLED next task IN_PROGRESS, if TODO not found', () => {

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -503,7 +503,7 @@ describe('StatusRegistry', () => {
             expect(toggledStatus).toEqual(statusRegistry.bySymbol(expectedToggledStatus));
 
             const nextStatus = statusRegistry.getNextRecurrenceStatusOrCreate(toggledStatus);
-            expect(nextStatus).toEqual(statusRegistry.bySymbol(expectedNextTaskStatus));
+            expect(nextStatus).toEqual(statusRegistry.bySymbolOrCreate(expectedNextTaskStatus));
         }
 
         it('should make CANCELLED next task TODO', () => {
@@ -572,6 +572,15 @@ describe('StatusRegistry', () => {
             ];
             // Ensure that the IN_PROGRESS soonest after 2 is chosen:
             checkToggleAndRecurrenceStatuses(statuses, '1', '2', '4');
+        });
+
+        it('should select the correct next status, even when it is unknown', () => {
+            const statuses: StatusCollection = [
+                // A set where the DONE task goes to an unknown symbol
+                ['a', 'Status a', 'b', 'TODO'],
+                ['b', 'Status b', 'c', 'DONE'], // c is not known
+            ];
+            checkToggleAndRecurrenceStatuses(statuses, 'a', 'b', 'c');
         });
     });
 });

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -519,5 +519,29 @@ describe('StatusRegistry', () => {
             const nextStatus = statusRegistry.getNextRecurrenceStatusOrCreate(toggledStatus);
             expect(nextStatus).toEqual(statusRegistry.bySymbol('/'));
         });
+
+        it('should select TODO even if DONE is followed by IN_PROGRESS', () => {
+            // Arrange
+            const statusRegistry = new StatusRegistry();
+            // This is not intended to be realistic: its sole purpose is to have DONE followed by IN_PROGRESS,
+            // and ensure that this is chosen in preference to the TODO that is further ahead in the sequences
+            // of statuses.
+            const statuses: StatusCollection = [
+                ['T', 'T to D', 'D', 'TODO'],
+                ['D', 'D to I', 'I', 'DONE'],
+                ['I', 'I to T', 'T', 'IN_PROGRESS'],
+            ];
+            statusRegistry.set(constructStatuses(statuses));
+
+            const initialStatusForRecurringTask = statusRegistry.bySymbol('T');
+
+            // Act, Assert
+            const toggledStatus = statusRegistry.getNextStatusOrCreate(initialStatusForRecurringTask);
+            expect(toggledStatus).toEqual(statusRegistry.bySymbol('D'));
+
+            // Ensure that TODO is chosen, ignoring the IN_PROGRESS task immediately after DONE:
+            const nextStatus = statusRegistry.getNextRecurrenceStatusOrCreate(toggledStatus);
+            expect(nextStatus).toEqual(statusRegistry.bySymbol('T'));
+        });
     });
 });

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -515,29 +515,16 @@ describe('StatusRegistry', () => {
         });
 
         it('should make CANCELLED next task IN_PROGRESS, if TODO not found', () => {
-            // Arrange
-            const statusRegistry = new StatusRegistry();
             const statuses: StatusCollection = [
                 ['/', '/ to x', 'x', 'IN_PROGRESS'],
                 ['x', 'x to -', '-', 'DONE'],
                 ['-', '- to /', '/', 'CANCELLED'],
             ];
-            statusRegistry.set(constructStatuses(statuses));
-
-            const initialStatusForRecurringTask = statusRegistry.bySymbol('/');
-
-            // Act, Assert
-            const toggledStatus = statusRegistry.getNextStatusOrCreate(initialStatusForRecurringTask);
-            expect(toggledStatus).toEqual(statusRegistry.bySymbol('x'));
-
             // Ensure that the next status skips through to IN_PROGRESS for a recurring task, if TODO not found
-            const nextStatus = statusRegistry.getNextRecurrenceStatusOrCreate(toggledStatus);
-            expect(nextStatus).toEqual(statusRegistry.bySymbol('/'));
+            checkToggleAndRecurrenceStatuses(statuses, '/', 'x', '/');
         });
 
         it('should select TODO even if DONE is followed by IN_PROGRESS', () => {
-            // Arrange
-            const statusRegistry = new StatusRegistry();
             // This is not intended to be realistic: its sole purpose is to have DONE followed by IN_PROGRESS,
             // and ensure that this is chosen in preference to the TODO that is further ahead in the sequences
             // of statuses.
@@ -546,22 +533,11 @@ describe('StatusRegistry', () => {
                 ['D', 'D to I', 'I', 'DONE'],
                 ['I', 'I to T', 'T', 'IN_PROGRESS'],
             ];
-            statusRegistry.set(constructStatuses(statuses));
-
-            const initialStatusForRecurringTask = statusRegistry.bySymbol('T');
-
-            // Act, Assert
-            const toggledStatus = statusRegistry.getNextStatusOrCreate(initialStatusForRecurringTask);
-            expect(toggledStatus).toEqual(statusRegistry.bySymbol('D'));
-
             // Ensure that TODO is chosen, ignoring the IN_PROGRESS task immediately after DONE:
-            const nextStatus = statusRegistry.getNextRecurrenceStatusOrCreate(toggledStatus);
-            expect(nextStatus).toEqual(statusRegistry.bySymbol('T'));
+            checkToggleAndRecurrenceStatuses(statuses, 'T', 'D', 'T');
         });
 
         it('should select the correct next status, when there is ambiguity', () => {
-            // Arrange
-            const statusRegistry = new StatusRegistry();
             const statuses: StatusCollection = [
                 // A set of 4 statuses, chosen to see whether the loop size in getNextRecurrenceStatusOrCreate()
                 // affects the calculation in any way.
@@ -578,17 +554,8 @@ describe('StatusRegistry', () => {
                 ['5', '5 to 6', '6', 'DONE'],
                 ['6', '6 to 1', '1', 'CANCELLED'],
             ];
-            statusRegistry.set(constructStatuses(statuses));
-
-            const initialStatusForRecurringTask = statusRegistry.bySymbol('1');
-
-            // Act, Assert
-            const toggledStatus = statusRegistry.getNextStatusOrCreate(initialStatusForRecurringTask);
-            expect(toggledStatus).toEqual(statusRegistry.bySymbol('2'));
-
             // Ensure that the IN_PROGRESS soonest after 2 is chosen:
-            const nextStatus = statusRegistry.getNextRecurrenceStatusOrCreate(toggledStatus);
-            expect(nextStatus).toEqual(statusRegistry.bySymbol('4'));
+            checkToggleAndRecurrenceStatuses(statuses, '1', '2', '4');
         });
     });
 });

--- a/tests/StatusRegistry.test.ts
+++ b/tests/StatusRegistry.test.ts
@@ -483,20 +483,24 @@ describe('StatusRegistry', () => {
             // See #2304:
             // Completing a recurring task setting wrong status for new task [if the next custom status is not TODO]
 
+            const statuses = StatusExamples.doneTogglesToCancelled();
+            const initialStatusSymbol = '/';
+            const expectedToggledStatus = 'x';
+            const expectedNextTaskStatus = ' ';
+
             // Arrange
             const statusRegistry = new StatusRegistry();
-            const statuses = StatusExamples.doneTogglesToCancelled();
             statusRegistry.set(constructStatuses(statuses));
 
-            const initialStatusForRecurringTask = statusRegistry.bySymbol('/');
+            const initialStatusForRecurringTask = statusRegistry.bySymbol(initialStatusSymbol);
 
             // Act, Assert
             const toggledStatus = statusRegistry.getNextStatusOrCreate(initialStatusForRecurringTask);
-            expect(toggledStatus).toEqual(statusRegistry.bySymbol('x'));
+            expect(toggledStatus).toEqual(statusRegistry.bySymbol(expectedToggledStatus));
 
             // Ensure that the next status skips through to TODO for a recurring task
             const nextStatus = statusRegistry.getNextRecurrenceStatusOrCreate(toggledStatus);
-            expect(nextStatus).toEqual(statusRegistry.bySymbol(' '));
+            expect(nextStatus).toEqual(statusRegistry.bySymbol(expectedNextTaskStatus));
         });
 
         it('should make CANCELLED next task IN_PROGRESS, if TODO not found', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

More improvements to the selection of status of next task, when a recurring task reaches DONE status:

- fix: If can't find a TODO status for new recurrence, look for IN_PROGRESS
- fix: if no TODO or IN_PROGRESS in chain, return space symbol: '[ ]'

## Motivation and Context

Remove more pitfalls from recurring tasks.

## How has this been tested?

- Existing tests
- New tests
- Smoke tests
- Exploratory testing

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
