### PR TITLE
refactor: do not add data attribute when it's value is empty

### DIFF
--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -118,9 +118,11 @@ export class TaskFieldHTMLData {
      * @param component the component of the task for which the data attribute has to be added.
      */
     public addDataAttribute(element: HTMLElement, task: Task, component: TaskLayoutComponent) {
-        if (this.attributeName !== TaskFieldHTMLData.noAttributeName) {
-            element.dataset[this.attributeName] = this.attributeValueCalculator(component, task);
+        if (this.attributeName === TaskFieldHTMLData.noAttributeName) {
+            return;
         }
+
+        element.dataset[this.attributeName] = this.attributeValueCalculator(component, task);
     }
 }
 

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -11,7 +11,7 @@ export class TaskFieldRenderer {
      * a `<span>` describing a task with medium priority and done yesterday will have
      * `data-task-priority="medium" data-task-due="past-1d"` in its data attributes (One data attribute per component).
      *
-     * If no data was found for a component in a task, data attribute won't be added.
+     * If no data attribute was found for a component or data attribute's value is empty, data attribute won't be added.
      *
      * For detailed calculation see {@link TaskFieldHTMLData.addDataAttribute}.
      *
@@ -112,6 +112,8 @@ export class TaskFieldHTMLData {
      * `data-task-priority="medium" data-task-due="past-1d" ` in its data attributes (One data attribute per component).
      *
      * Calculation of the value is done with {@link TaskFieldHTMLData.attributeValueCalculator}.
+     *
+     * If the data attribute's key or its value is an empty string, no data attribute will be added.
      *
      * @param element the HTML element to add the data attribute to.
      * @param task the task from which the data shall be taken.

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -122,7 +122,8 @@ export class TaskFieldHTMLData {
             return;
         }
 
-        element.dataset[this.attributeName] = this.attributeValueCalculator(component, task);
+        const attributeValue = this.attributeValueCalculator(component, task);
+        element.dataset[this.attributeName] = attributeValue;
     }
 }
 

--- a/src/TaskFieldRenderer.ts
+++ b/src/TaskFieldRenderer.ts
@@ -123,6 +123,10 @@ export class TaskFieldHTMLData {
         }
 
         const attributeValue = this.attributeValueCalculator(component, task);
+        if (attributeValue === '') {
+            return;
+        }
+
         element.dataset[this.attributeName] = attributeValue;
     }
 }

--- a/tests/TaskFieldRenderer.test.ts
+++ b/tests/TaskFieldRenderer.test.ts
@@ -76,7 +76,7 @@ describe('Field Layout Detail tests', () => {
         expect(span).toHaveDataAttributes('');
     });
 
-    it.failing('should not add a data attribute with a name but without value', () => {
+    it('should not add a data attribute with a name but without value', () => {
         const fieldLayoutDetail = new TaskFieldHTMLData('task-start', 'taskStart', () => {
             return '';
         });

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -654,7 +654,7 @@ describe('task line rendering - classes and data attributes', () => {
         );
     });
 
-    it.failing('should not add data attributes for invalid dates', async () => {
+    it('should not add data attributes for invalid dates', async () => {
         await testComponentClasses(
             '- [ ] task with invalid due date 📅 2023-02-29',
             {},


### PR DESCRIPTION
# Description

After refactoring tests, a bug has been revealed (it was present before, but unseen due to the way the tests were done).

Current behaviour: data attributes with empty values are added.
Fixed behaviour:  data attributes with empty values are not added.

## Motivation and Context

Fix bugs =)

## How has this been tested?

Unit tests.

## Types of changes


Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
