### PR TITLE
test: remove FieldRenderer from TaskLineRenderer tests

### DIFF
--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -9,7 +9,6 @@ import { DateParser } from '../src/Query/DateParser';
 import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
 import type { Task } from '../src/Task';
 import { TaskRegularExpressions } from '../src/Task';
-import { TaskFieldRenderer } from '../src/TaskFieldRenderer';
 import { LayoutOptions } from '../src/TaskLayout';
 import type { TextRenderer } from '../src/TaskLineRenderer';
 import { TaskLineRenderer } from '../src/TaskLineRenderer';
@@ -19,8 +18,6 @@ import { TaskBuilder } from './TestingTools/TaskBuilder';
 
 jest.mock('obsidian');
 window.moment = moment;
-
-const fieldRenderer = new TaskFieldRenderer();
 
 /**
  * Renders a task for test purposes and returns the rendered ListItem.
@@ -393,19 +390,19 @@ describe('task line rendering - classes and data attributes', () => {
         await testComponentClasses(
             '- [ ] Full task ⏫ ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             {},
-            fieldRenderer.className('priority'),
+            'task-priority',
             'taskPriority: high',
         );
         await testComponentClasses(
             '- [ ] Full task 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             {},
-            fieldRenderer.className('priority'),
+            'task-priority',
             'taskPriority: medium',
         );
         await testComponentClasses(
             '- [ ] Full task 🔽 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             {},
-            fieldRenderer.className('priority'),
+            'task-priority',
             'taskPriority: low',
         );
     });
@@ -414,261 +411,86 @@ describe('task line rendering - classes and data attributes', () => {
         await testComponentClasses(
             '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
             {},
-            fieldRenderer.className('recurrenceRule'),
+            'task-recurring',
             '',
         );
     });
 
     it('should render date component with its class and data attribute with "today" value', async () => {
         const today = DateParser.parseDate('today').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ➕ ${today}`,
-            {},
-            fieldRenderer.className('createdDate'),
-            'taskCreated: today',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 📅 ${today}`,
-            {},
-            fieldRenderer.className('dueDate'),
-            'taskDue: today',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ⏳ ${today}`,
-            {},
-            fieldRenderer.className('scheduledDate'),
-            'taskScheduled: today',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 🛫 ${today}`,
-            {},
-            fieldRenderer.className('startDate'),
-            'taskStart: today',
-        );
-        await testComponentClasses(
-            `- [x] Done task ✅ ${today}`,
-            {},
-            fieldRenderer.className('doneDate'),
-            'taskDone: today',
-        );
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${today}`, {}, 'task-created', 'taskCreated: today');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${today}`, {}, 'task-due', 'taskDue: today');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${today}`, {}, 'task-scheduled', 'taskScheduled: today');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${today}`, {}, 'task-start', 'taskStart: today');
+        await testComponentClasses(`- [x] Done task ✅ ${today}`, {}, 'task-done', 'taskDone: today');
     });
 
     it('should render date component with its class and data attribute with "future-1d" value', async () => {
         const future = DateParser.parseDate('tomorrow').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ➕ ${future}`,
-            {},
-            fieldRenderer.className('createdDate'),
-            'taskCreated: future-1d',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 📅 ${future}`,
-            {},
-            fieldRenderer.className('dueDate'),
-            'taskDue: future-1d',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ⏳ ${future}`,
-            {},
-            fieldRenderer.className('scheduledDate'),
-            'taskScheduled: future-1d',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 🛫 ${future}`,
-            {},
-            fieldRenderer.className('startDate'),
-            'taskStart: future-1d',
-        );
-        await testComponentClasses(
-            `- [x] Done task ✅ ${future}`,
-            {},
-            fieldRenderer.className('doneDate'),
-            'taskDone: future-1d',
-        );
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${future}`, {}, 'task-created', 'taskCreated: future-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${future}`, {}, 'task-due', 'taskDue: future-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${future}`, {}, 'task-scheduled', 'taskScheduled: future-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${future}`, {}, 'task-start', 'taskStart: future-1d');
+        await testComponentClasses(`- [x] Done task ✅ ${future}`, {}, 'task-done', 'taskDone: future-1d');
     });
 
     it('should render date component with its class and data attribute with "future-7d" value', async () => {
         const future = DateParser.parseDate('in 7 days').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ➕ ${future}`,
-            {},
-            fieldRenderer.className('createdDate'),
-            'taskCreated: future-7d',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 📅 ${future}`,
-            {},
-            fieldRenderer.className('dueDate'),
-            'taskDue: future-7d',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ⏳ ${future}`,
-            {},
-            fieldRenderer.className('scheduledDate'),
-            'taskScheduled: future-7d',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 🛫 ${future}`,
-            {},
-            fieldRenderer.className('startDate'),
-            'taskStart: future-7d',
-        );
-        await testComponentClasses(
-            `- [x] Done task ✅ ${future}`,
-            {},
-            fieldRenderer.className('doneDate'),
-            'taskDone: future-7d',
-        );
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${future}`, {}, 'task-created', 'taskCreated: future-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${future}`, {}, 'task-due', 'taskDue: future-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${future}`, {}, 'task-scheduled', 'taskScheduled: future-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${future}`, {}, 'task-start', 'taskStart: future-7d');
+        await testComponentClasses(`- [x] Done task ✅ ${future}`, {}, 'task-done', 'taskDone: future-7d');
     });
 
     it('should render date component with its class and data attribute with "past-1d" value', async () => {
         const past = DateParser.parseDate('yesterday').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ➕ ${past}`,
-            {},
-            fieldRenderer.className('createdDate'),
-            'taskCreated: past-1d',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 📅 ${past}`,
-            {},
-            fieldRenderer.className('dueDate'),
-            'taskDue: past-1d',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ⏳ ${past}`,
-            {},
-            fieldRenderer.className('scheduledDate'),
-            'taskScheduled: past-1d',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 🛫 ${past}`,
-            {},
-            fieldRenderer.className('startDate'),
-            'taskStart: past-1d',
-        );
-        await testComponentClasses(
-            `- [x] Done task ✅ ${past}`,
-            {},
-            fieldRenderer.className('doneDate'),
-            'taskDone: past-1d',
-        );
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${past}`, {}, 'task-created', 'taskCreated: past-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${past}`, {}, 'task-due', 'taskDue: past-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${past}`, {}, 'task-scheduled', 'taskScheduled: past-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${past}`, {}, 'task-start', 'taskStart: past-1d');
+        await testComponentClasses(`- [x] Done task ✅ ${past}`, {}, 'task-done', 'taskDone: past-1d');
     });
 
     it('should render date component with its class and data attribute with "past-7d" value', async () => {
         const past = DateParser.parseDate('7 days ago').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ➕ ${past}`,
-            {},
-            fieldRenderer.className('createdDate'),
-            'taskCreated: past-7d',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 📅 ${past}`,
-            {},
-            fieldRenderer.className('dueDate'),
-            'taskDue: past-7d',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ⏳ ${past}`,
-            {},
-            fieldRenderer.className('scheduledDate'),
-            'taskScheduled: past-7d',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 🛫 ${past}`,
-            {},
-            fieldRenderer.className('startDate'),
-            'taskStart: past-7d',
-        );
-        await testComponentClasses(
-            `- [x] Done task ✅ ${past}`,
-            {},
-            fieldRenderer.className('doneDate'),
-            'taskDone: past-7d',
-        );
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${past}`, {}, 'task-created', 'taskCreated: past-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${past}`, {}, 'task-due', 'taskDue: past-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${past}`, {}, 'task-scheduled', 'taskScheduled: past-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${past}`, {}, 'task-start', 'taskStart: past-7d');
+        await testComponentClasses(`- [x] Done task ✅ ${past}`, {}, 'task-done', 'taskDone: past-7d');
     });
 
     it('should render date component with its class and data attribute with "future-far" & "past-far" values', async () => {
         const future = DateParser.parseDate('in 8 days').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ➕ ${future}`,
-            {},
-            fieldRenderer.className('createdDate'),
-            'taskCreated: future-far',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 📅 ${future}`,
-            {},
-            fieldRenderer.className('dueDate'),
-            'taskDue: future-far',
-        );
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${future}`, {}, 'task-created', 'taskCreated: future-far');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${future}`, {}, 'task-due', 'taskDue: future-far');
         await testComponentClasses(
             `- [ ] Full task ⏫ ⏳ ${future}`,
             {},
-            fieldRenderer.className('scheduledDate'),
+            'task-scheduled',
             'taskScheduled: future-far',
         );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 🛫 ${future}`,
-            {},
-            fieldRenderer.className('startDate'),
-            'taskStart: future-far',
-        );
-        await testComponentClasses(
-            `- [x] Done task ✅ ${future}`,
-            {},
-            fieldRenderer.className('doneDate'),
-            'taskDone: future-far',
-        );
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${future}`, {}, 'task-start', 'taskStart: future-far');
+        await testComponentClasses(`- [x] Done task ✅ ${future}`, {}, 'task-done', 'taskDone: future-far');
         const past = DateParser.parseDate('8 days ago').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ➕ ${past}`,
-            {},
-            fieldRenderer.className('createdDate'),
-            'taskCreated: past-far',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 📅 ${past}`,
-            {},
-            fieldRenderer.className('dueDate'),
-            'taskDue: past-far',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ⏳ ${past}`,
-            {},
-            fieldRenderer.className('scheduledDate'),
-            'taskScheduled: past-far',
-        );
-        await testComponentClasses(
-            `- [ ] Full task ⏫ 🛫 ${past}`,
-            {},
-            fieldRenderer.className('startDate'),
-            'taskStart: past-far',
-        );
-        await testComponentClasses(
-            `- [x] Done task ✅ ${past}`,
-            {},
-            fieldRenderer.className('doneDate'),
-            'taskDone: past-far',
-        );
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${past}`, {}, 'task-created', 'taskCreated: past-far');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${past}`, {}, 'task-due', 'taskDue: past-far');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${past}`, {}, 'task-scheduled', 'taskScheduled: past-far');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${past}`, {}, 'task-start', 'taskStart: past-far');
+        await testComponentClasses(`- [x] Done task ✅ ${past}`, {}, 'task-done', 'taskDone: past-far');
     });
 
     it('should not add data attributes for invalid dates', async () => {
-        await testComponentClasses(
-            '- [ ] task with invalid due date 📅 2023-02-29',
-            {},
-            fieldRenderer.className('dueDate'),
-            '',
-        );
+        await testComponentClasses('- [ ] task with invalid due date 📅 2023-02-29', {}, 'task-due', '');
     });
 
     it.each([
-        [fieldRenderer.className('priority'), 'taskPriority: medium', { hidePriority: true }],
-        [fieldRenderer.className('createdDate'), 'taskCreated: past-far', { hideCreatedDate: true }],
-        [fieldRenderer.className('dueDate'), 'taskDue: past-far', { hideDueDate: true }],
-        [fieldRenderer.className('scheduledDate'), 'taskScheduled: past-far', { hideScheduledDate: true }],
-        [fieldRenderer.className('startDate'), 'taskStart: past-far', { hideStartDate: true }],
+        ['task-priority', 'taskPriority: medium', { hidePriority: true }],
+        ['task-createdDate', 'taskCreated: past-far', { hideCreatedDate: true }],
+        ['task-dueDate', 'taskDue: past-far', { hideDueDate: true }],
+        ['task-scheduledDate', 'taskScheduled: past-far', { hideScheduledDate: true }],
+        ['task-startDate', 'taskStart: past-far', { hideStartDate: true }],
     ])(
         'should not render "%s" class but should set "%s" data attributes to the list item',
         async (expectedAbsentClass: string, expectedDateAttributes: string, layoutOptions: Partial<LayoutOptions>) => {


### PR DESCRIPTION
# Description

Write hardcoded values instead of getting them from the `TaskFieldRenderer` class.

## Motivation and Context

- Make tests
  - Stronger (Test against hardcoded values)
  - Expressive (Show the actual expected value)
- Decrease imports

## How has this been tested?

Breaking unit tests.

## Types of changes

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
