### PR TITLE
refactor: rewrite TaskLayoutOptions to key on TaskLayoutComponent

### DIFF
--- a/src/IQuery.ts
+++ b/src/IQuery.ts
@@ -44,7 +44,7 @@ export interface IQuery {
      * Any layout options the query engine should be aware of or
      * used in the query.
      *
-     * @type {TaskLayoutOptions}
+     * @type {TaskLayoutOptions2}
      * @memberof IQuery
      */
     taskLayoutOptions2: TaskLayoutOptions2;

--- a/src/IQuery.ts
+++ b/src/IQuery.ts
@@ -1,4 +1,4 @@
-import type { TaskLayoutOptions2 } from './Layout/TaskLayoutOptions';
+import type { TaskLayoutOptions } from './Layout/TaskLayoutOptions';
 import type { QueryLayoutOptions } from './QueryLayoutOptions';
 import type { Task } from './Task';
 import type { Grouper } from './Query/Grouper';
@@ -44,10 +44,10 @@ export interface IQuery {
      * Any layout options the query engine should be aware of or
      * used in the query.
      *
-     * @type {TaskLayoutOptions2}
+     * @type {TaskLayoutOptions}
      * @memberof IQuery
      */
-    taskLayoutOptions2: TaskLayoutOptions2;
+    taskLayoutOptions: TaskLayoutOptions;
 
     /**
      * Any layout options the query engine should be aware of or

--- a/src/IQuery.ts
+++ b/src/IQuery.ts
@@ -1,6 +1,5 @@
 import type { TaskLayoutOptions2 } from './Layout/TaskLayoutOptions';
 import type { QueryLayoutOptions } from './QueryLayoutOptions';
-import type { TaskLayoutOptions } from './TaskLayout';
 import type { Task } from './Task';
 import type { Grouper } from './Query/Grouper';
 import type { QueryResult } from './Query/QueryResult';
@@ -48,7 +47,6 @@ export interface IQuery {
      * @type {TaskLayoutOptions}
      * @memberof IQuery
      */
-    taskLayoutOptions: TaskLayoutOptions;
     taskLayoutOptions2: TaskLayoutOptions2;
 
     /**

--- a/src/IQuery.ts
+++ b/src/IQuery.ts
@@ -1,3 +1,4 @@
+import type { TaskLayoutOptions2 } from './Layout/TaskLayoutOptions';
 import type { QueryLayoutOptions } from './QueryLayoutOptions';
 import type { TaskLayoutOptions } from './TaskLayout';
 import type { Task } from './Task';
@@ -48,6 +49,7 @@ export interface IQuery {
      * @memberof IQuery
      */
     taskLayoutOptions: TaskLayoutOptions;
+    taskLayoutOptions2: TaskLayoutOptions2;
 
     /**
      * Any layout options the query engine should be aware of or

--- a/src/InlineRenderer.ts
+++ b/src/InlineRenderer.ts
@@ -4,7 +4,6 @@ import { GlobalFilter } from './Config/GlobalFilter';
 import { TaskLayoutOptions2 } from './Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from './QueryLayoutOptions';
 import { Task } from './Task';
-import { TaskLayoutOptions } from './TaskLayout';
 import { TaskLineRenderer } from './TaskLineRenderer';
 import { TaskLocation } from './TaskLocation';
 
@@ -92,7 +91,6 @@ export class InlineRenderer {
         const taskLineRenderer = new TaskLineRenderer({
             obsidianComponent: childComponent,
             parentUlElement: element,
-            taskLayoutOptions: new TaskLayoutOptions(),
             taskLayoutOptions2: new TaskLayoutOptions2(),
             queryLayoutOptions: new QueryLayoutOptions(),
         });

--- a/src/InlineRenderer.ts
+++ b/src/InlineRenderer.ts
@@ -1,7 +1,7 @@
 import type { MarkdownPostProcessorContext, Plugin } from 'obsidian';
 import { MarkdownRenderChild } from 'obsidian';
 import { GlobalFilter } from './Config/GlobalFilter';
-import { TaskLayoutOptions2 } from './Layout/TaskLayoutOptions';
+import { TaskLayoutOptions } from './Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from './QueryLayoutOptions';
 import { Task } from './Task';
 import { TaskLineRenderer } from './TaskLineRenderer';
@@ -91,7 +91,7 @@ export class InlineRenderer {
         const taskLineRenderer = new TaskLineRenderer({
             obsidianComponent: childComponent,
             parentUlElement: element,
-            taskLayoutOptions2: new TaskLayoutOptions2(),
+            taskLayoutOptions: new TaskLayoutOptions(),
             queryLayoutOptions: new QueryLayoutOptions(),
         });
 

--- a/src/InlineRenderer.ts
+++ b/src/InlineRenderer.ts
@@ -1,6 +1,7 @@
 import type { MarkdownPostProcessorContext, Plugin } from 'obsidian';
 import { MarkdownRenderChild } from 'obsidian';
 import { GlobalFilter } from './Config/GlobalFilter';
+import { TaskLayoutOptions2 } from './Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from './QueryLayoutOptions';
 import { Task } from './Task';
 import { TaskLayoutOptions } from './TaskLayout';
@@ -92,6 +93,7 @@ export class InlineRenderer {
             obsidianComponent: childComponent,
             parentUlElement: element,
             taskLayoutOptions: new TaskLayoutOptions(),
+            taskLayoutOptions2: new TaskLayoutOptions2(),
             queryLayoutOptions: new QueryLayoutOptions(),
         });
 

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -1,0 +1,19 @@
+import { type TaskLayoutComponent, defaultLayout } from '../TaskLayout';
+
+export class TaskLayoutOptions2 {
+    private visible: { [component: string]: boolean } = {};
+
+    constructor() {
+        defaultLayout.forEach((component) => {
+            this.visible[component] = true;
+        });
+    }
+
+    public isShown(component: TaskLayoutComponent) {
+        return this.visible[component];
+    }
+
+    public hide(component: TaskLayoutComponent) {
+        this.visible[component] = false;
+    }
+}

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -57,5 +57,7 @@ export class TaskLayoutOptions2 {
         this.toggleableComponents.forEach((component) => {
             this.visible[component] = !this.visible[component];
         });
+
+        this.setTagsVisibility(!this.areTagsShown());
     }
 }

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -20,4 +20,10 @@ export class TaskLayoutOptions2 {
     public setVisibility(component: TaskLayoutComponent, visible: boolean) {
         this.visible[component] = visible;
     }
+
+    public get visibleComponents() {
+        return defaultLayout.filter((component) => {
+            return this.visible[component];
+        });
+    }
 }

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -21,7 +21,7 @@ export class TaskLayoutOptions2 {
         this.visible[component] = visible;
     }
 
-    public get visibleComponents() {
+    public get shownComponents() {
         return defaultLayout.filter((component) => {
             return this.visible[component];
         });

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -16,4 +16,8 @@ export class TaskLayoutOptions2 {
     public hide(component: TaskLayoutComponent) {
         this.visible[component] = false;
     }
+
+    public setVisibility(component: TaskLayoutComponent, visible: boolean) {
+        this.visible[component] = visible;
+    }
 }

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -2,6 +2,7 @@ import { type TaskLayoutComponent, defaultLayout } from '../TaskLayout';
 
 export class TaskLayoutOptions2 {
     private visible: { [component: string]: boolean } = {};
+    private tagsVisible: boolean = true;
 
     constructor() {
         defaultLayout.forEach((component) => {
@@ -13,12 +14,20 @@ export class TaskLayoutOptions2 {
         return this.visible[component];
     }
 
+    public areTagsShown() {
+        return this.tagsVisible;
+    }
+
     public hide(component: TaskLayoutComponent) {
         this.visible[component] = false;
     }
 
     public setVisibility(component: TaskLayoutComponent, visible: boolean) {
         this.visible[component] = visible;
+    }
+
+    public setTagsVisibility(visibility: boolean) {
+        this.tagsVisible = visibility;
     }
 
     public get shownComponents() {

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -33,8 +33,13 @@ export class TaskLayoutOptions2 {
         });
     }
 
-    public toggleVisibility() {
+    public toggleVisibilityExceptDescriptionAndBlockLink() {
         defaultLayout.forEach((component) => {
+            if (component === 'description' || component === 'blockLink') {
+                // Description and blockLink are always shown
+                return;
+            }
+
             this.visible[component] = !this.visible[component];
         });
     }

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -33,13 +33,15 @@ export class TaskLayoutOptions2 {
         });
     }
 
-    public toggleVisibilityExceptDescriptionAndBlockLink() {
-        defaultLayout.forEach((component) => {
-            if (component === 'description' || component === 'blockLink') {
-                // Description and blockLink are always shown
-                return;
-            }
+    public get toggleableComponents() {
+        return defaultLayout.filter((component) => {
+            // Description and blockLink are always shown
+            return component !== 'description' && component !== 'blockLink';
+        });
+    }
 
+    public toggleVisibilityExceptDescriptionAndBlockLink() {
+        this.toggleableComponents.forEach((component) => {
             this.visible[component] = !this.visible[component];
         });
     }

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -33,6 +33,10 @@ export class TaskLayoutOptions2 {
         });
     }
 
+    /**
+     * These represent the existing task options, so some components (description & block link for now) are not
+     * here because there are no layout options to remove them.
+     */
     public get toggleableComponents() {
         return defaultLayout.filter((component) => {
             // Description and blockLink are always shown

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -26,4 +26,10 @@ export class TaskLayoutOptions2 {
             return this.visible[component];
         });
     }
+
+    public get hiddenComponents() {
+        return defaultLayout.filter((component) => {
+            return !this.visible[component];
+        });
+    }
 }

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -32,4 +32,10 @@ export class TaskLayoutOptions2 {
             return !this.visible[component];
         });
     }
+
+    public toggleVisibility() {
+        defaultLayout.forEach((component) => {
+            this.visible[component] = !this.visible[component];
+        });
+    }
 }

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -1,6 +1,6 @@
 import { type TaskLayoutComponent, defaultLayout } from '../TaskLayout';
 
-export class TaskLayoutOptions2 {
+export class TaskLayoutOptions {
     private visible: { [component: string]: boolean } = {};
     private tagsVisible: boolean = true;
 

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -1,5 +1,14 @@
 import { type TaskLayoutComponent, defaultLayout } from '../TaskLayout';
 
+/**
+ * Various rendering options of tasks in a query.
+ *
+ * See {@link TaskLayoutComponent} for the available options.
+ *
+ * Note that there is an additional special case, for whether tags are shown.
+ *
+ * @see QueryLayoutOptions
+ */
 export class TaskLayoutOptions {
     private visible: { [component: string]: boolean } = {};
     private tagsVisible: boolean = true;

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -312,7 +312,7 @@ Problem line: "${line}"`;
                     break;
                 case 'tags':
                     this._taskLayoutOptions.hideTags = hide;
-                    // this._taskLayoutOptions2.setVisibility('tags', !hide);
+                    this._taskLayoutOptions2.setTagsVisibility(!hide);
                     break;
                 default:
                     this.setError('do not understand hide/show option', line);

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -1,3 +1,4 @@
+import { TaskLayoutOptions2 } from '../Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from '../QueryLayoutOptions';
 import { expandPlaceholders } from '../Scripting/ExpandPlaceholders';
 import { makeQueryContext } from '../Scripting/QueryContext';
@@ -26,6 +27,7 @@ export class Query implements IQuery {
     private _limit: number | undefined = undefined;
     private _taskGroupLimit: number | undefined = undefined;
     private _taskLayoutOptions: TaskLayoutOptions = new TaskLayoutOptions();
+    private _taskLayoutOptions2: TaskLayoutOptions2 = new TaskLayoutOptions2();
     private _queryLayoutOptions: QueryLayoutOptions = new QueryLayoutOptions();
     private _filters: Filter[] = [];
     private _error: string | undefined = undefined;
@@ -268,27 +270,35 @@ Problem line: "${line}"`;
                     break;
                 case 'priority':
                     this._taskLayoutOptions.hidePriority = hide;
+                    this._taskLayoutOptions2.setVisibility('priority', !hide);
                     break;
                 case 'cancelled date':
                     this._taskLayoutOptions.hideCancelledDate = hide;
+                    this._taskLayoutOptions2.setVisibility('cancelledDate', !hide);
                     break;
                 case 'created date':
                     this._taskLayoutOptions.hideCreatedDate = hide;
+                    this._taskLayoutOptions2.setVisibility('createdDate', !hide);
                     break;
                 case 'start date':
                     this._taskLayoutOptions.hideStartDate = hide;
+                    this._taskLayoutOptions2.setVisibility('startDate', !hide);
                     break;
                 case 'scheduled date':
                     this._taskLayoutOptions.hideScheduledDate = hide;
+                    this._taskLayoutOptions2.setVisibility('scheduledDate', !hide);
                     break;
                 case 'due date':
                     this._taskLayoutOptions.hideDueDate = hide;
+                    this._taskLayoutOptions2.setVisibility('dueDate', !hide);
                     break;
                 case 'done date':
                     this._taskLayoutOptions.hideDoneDate = hide;
+                    this._taskLayoutOptions2.setVisibility('doneDate', !hide);
                     break;
                 case 'recurrence rule':
                     this._taskLayoutOptions.hideRecurrenceRule = hide;
+                    this._taskLayoutOptions2.setVisibility('recurrenceRule', !hide);
                     break;
                 case 'edit button':
                     this._queryLayoutOptions.hideEditButton = hide;
@@ -298,6 +308,7 @@ Problem line: "${line}"`;
                     break;
                 case 'tags':
                     this._taskLayoutOptions.hideTags = hide;
+                    // this._taskLayoutOptions2.setVisibility('tags', !hide);
                     break;
                 default:
                     this.setError('do not understand hide/show option', line);

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -2,7 +2,6 @@ import { TaskLayoutOptions2 } from '../Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from '../QueryLayoutOptions';
 import { expandPlaceholders } from '../Scripting/ExpandPlaceholders';
 import { makeQueryContext } from '../Scripting/QueryContext';
-import { TaskLayoutOptions } from '../TaskLayout';
 import type { Task } from '../Task';
 import type { IQuery } from '../IQuery';
 import { getSettings } from '../Config/Settings';
@@ -26,7 +25,6 @@ export class Query implements IQuery {
 
     private _limit: number | undefined = undefined;
     private _taskGroupLimit: number | undefined = undefined;
-    private _taskLayoutOptions: TaskLayoutOptions = new TaskLayoutOptions();
     private _taskLayoutOptions2: TaskLayoutOptions2 = new TaskLayoutOptions2();
     private _queryLayoutOptions: QueryLayoutOptions = new QueryLayoutOptions();
     private _filters: Filter[] = [];
@@ -179,10 +177,6 @@ ${source}`;
         return this._taskGroupLimit;
     }
 
-    public get taskLayoutOptions(): TaskLayoutOptions {
-        return this._taskLayoutOptions;
-    }
-
     get taskLayoutOptions2(): TaskLayoutOptions2 {
         return this._taskLayoutOptions2;
     }
@@ -273,35 +267,27 @@ Problem line: "${line}"`;
                     this._queryLayoutOptions.hidePostponeButton = hide;
                     break;
                 case 'priority':
-                    this._taskLayoutOptions.hidePriority = hide;
                     this._taskLayoutOptions2.setVisibility('priority', !hide);
                     break;
                 case 'cancelled date':
-                    this._taskLayoutOptions.hideCancelledDate = hide;
                     this._taskLayoutOptions2.setVisibility('cancelledDate', !hide);
                     break;
                 case 'created date':
-                    this._taskLayoutOptions.hideCreatedDate = hide;
                     this._taskLayoutOptions2.setVisibility('createdDate', !hide);
                     break;
                 case 'start date':
-                    this._taskLayoutOptions.hideStartDate = hide;
                     this._taskLayoutOptions2.setVisibility('startDate', !hide);
                     break;
                 case 'scheduled date':
-                    this._taskLayoutOptions.hideScheduledDate = hide;
                     this._taskLayoutOptions2.setVisibility('scheduledDate', !hide);
                     break;
                 case 'due date':
-                    this._taskLayoutOptions.hideDueDate = hide;
                     this._taskLayoutOptions2.setVisibility('dueDate', !hide);
                     break;
                 case 'done date':
-                    this._taskLayoutOptions.hideDoneDate = hide;
                     this._taskLayoutOptions2.setVisibility('doneDate', !hide);
                     break;
                 case 'recurrence rule':
-                    this._taskLayoutOptions.hideRecurrenceRule = hide;
                     this._taskLayoutOptions2.setVisibility('recurrenceRule', !hide);
                     break;
                 case 'edit button':
@@ -311,7 +297,6 @@ Problem line: "${line}"`;
                     this._queryLayoutOptions.hideUrgency = hide;
                     break;
                 case 'tags':
-                    this._taskLayoutOptions.hideTags = hide;
                     this._taskLayoutOptions2.setTagsVisibility(!hide);
                     break;
                 default:

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -183,6 +183,10 @@ ${source}`;
         return this._taskLayoutOptions;
     }
 
+    get taskLayoutOptions2(): TaskLayoutOptions2 {
+        return this._taskLayoutOptions2;
+    }
+
     public get queryLayoutOptions(): QueryLayoutOptions {
         return this._queryLayoutOptions;
     }

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -1,4 +1,4 @@
-import { TaskLayoutOptions2 } from '../Layout/TaskLayoutOptions';
+import { TaskLayoutOptions } from '../Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from '../QueryLayoutOptions';
 import { expandPlaceholders } from '../Scripting/ExpandPlaceholders';
 import { makeQueryContext } from '../Scripting/QueryContext';
@@ -25,7 +25,7 @@ export class Query implements IQuery {
 
     private _limit: number | undefined = undefined;
     private _taskGroupLimit: number | undefined = undefined;
-    private _taskLayoutOptions2: TaskLayoutOptions2 = new TaskLayoutOptions2();
+    private _taskLayoutOptions: TaskLayoutOptions = new TaskLayoutOptions();
     private _queryLayoutOptions: QueryLayoutOptions = new QueryLayoutOptions();
     private _filters: Filter[] = [];
     private _error: string | undefined = undefined;
@@ -177,8 +177,8 @@ ${source}`;
         return this._taskGroupLimit;
     }
 
-    get taskLayoutOptions2(): TaskLayoutOptions2 {
-        return this._taskLayoutOptions2;
+    get taskLayoutOptions(): TaskLayoutOptions {
+        return this._taskLayoutOptions;
     }
 
     public get queryLayoutOptions(): QueryLayoutOptions {
@@ -267,28 +267,28 @@ Problem line: "${line}"`;
                     this._queryLayoutOptions.hidePostponeButton = hide;
                     break;
                 case 'priority':
-                    this._taskLayoutOptions2.setVisibility('priority', !hide);
+                    this._taskLayoutOptions.setVisibility('priority', !hide);
                     break;
                 case 'cancelled date':
-                    this._taskLayoutOptions2.setVisibility('cancelledDate', !hide);
+                    this._taskLayoutOptions.setVisibility('cancelledDate', !hide);
                     break;
                 case 'created date':
-                    this._taskLayoutOptions2.setVisibility('createdDate', !hide);
+                    this._taskLayoutOptions.setVisibility('createdDate', !hide);
                     break;
                 case 'start date':
-                    this._taskLayoutOptions2.setVisibility('startDate', !hide);
+                    this._taskLayoutOptions.setVisibility('startDate', !hide);
                     break;
                 case 'scheduled date':
-                    this._taskLayoutOptions2.setVisibility('scheduledDate', !hide);
+                    this._taskLayoutOptions.setVisibility('scheduledDate', !hide);
                     break;
                 case 'due date':
-                    this._taskLayoutOptions2.setVisibility('dueDate', !hide);
+                    this._taskLayoutOptions.setVisibility('dueDate', !hide);
                     break;
                 case 'done date':
-                    this._taskLayoutOptions2.setVisibility('doneDate', !hide);
+                    this._taskLayoutOptions.setVisibility('doneDate', !hide);
                     break;
                 case 'recurrence rule':
-                    this._taskLayoutOptions2.setVisibility('recurrenceRule', !hide);
+                    this._taskLayoutOptions.setVisibility('recurrenceRule', !hide);
                     break;
                 case 'edit button':
                     this._queryLayoutOptions.hideEditButton = hide;
@@ -297,7 +297,7 @@ Problem line: "${line}"`;
                     this._queryLayoutOptions.hideUrgency = hide;
                     break;
                 case 'tags':
-                    this._taskLayoutOptions2.setTagsVisibility(!hide);
+                    this._taskLayoutOptions.setTagsVisibility(!hide);
                     break;
                 default:
                     this.setError('do not understand hide/show option', line);

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -224,6 +224,7 @@ class QueryRenderChild extends MarkdownRenderChild {
             obsidianComponent: this,
             parentUlElement: taskList,
             taskLayoutOptions: this.query.taskLayoutOptions,
+            taskLayoutOptions2: this.query.taskLayoutOptions2,
             queryLayoutOptions: this.query.queryLayoutOptions,
         });
 

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -213,7 +213,11 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private async createTaskList(tasks: Task[], content: HTMLDivElement): Promise<void> {
-        const layout = new TaskLayout(this.query.taskLayoutOptions, this.query.queryLayoutOptions);
+        const layout = new TaskLayout(
+            this.query.taskLayoutOptions,
+            this.query.queryLayoutOptions,
+            this.query.taskLayoutOptions2,
+        );
         const taskList = content.createEl('ul');
         taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);
         taskList.addClasses(layout.taskListHiddenClasses());

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -227,7 +227,6 @@ class QueryRenderChild extends MarkdownRenderChild {
         const taskLineRenderer = new TaskLineRenderer({
             obsidianComponent: this,
             parentUlElement: taskList,
-            taskLayoutOptions: this.query.taskLayoutOptions,
             taskLayoutOptions2: this.query.taskLayoutOptions2,
             queryLayoutOptions: this.query.queryLayoutOptions,
         });

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -213,7 +213,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private async createTaskList(tasks: Task[], content: HTMLDivElement): Promise<void> {
-        const layout = new TaskLayout(this.query.taskLayoutOptions2, this.query.queryLayoutOptions);
+        const layout = new TaskLayout(this.query.taskLayoutOptions, this.query.queryLayoutOptions);
         const taskList = content.createEl('ul');
         taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);
         taskList.addClasses(layout.taskListHiddenClasses());
@@ -223,7 +223,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         const taskLineRenderer = new TaskLineRenderer({
             obsidianComponent: this,
             parentUlElement: taskList,
-            taskLayoutOptions2: this.query.taskLayoutOptions2,
+            taskLayoutOptions: this.query.taskLayoutOptions,
             queryLayoutOptions: this.query.queryLayoutOptions,
         });
 

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -213,11 +213,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private async createTaskList(tasks: Task[], content: HTMLDivElement): Promise<void> {
-        const layout = new TaskLayout(
-            this.query.taskLayoutOptions2,
-            this.query.taskLayoutOptions,
-            this.query.queryLayoutOptions,
-        );
+        const layout = new TaskLayout(this.query.taskLayoutOptions2, this.query.queryLayoutOptions);
         const taskList = content.createEl('ul');
         taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);
         taskList.addClasses(layout.taskListHiddenClasses());

--- a/src/QueryRenderer.ts
+++ b/src/QueryRenderer.ts
@@ -214,9 +214,9 @@ class QueryRenderChild extends MarkdownRenderChild {
 
     private async createTaskList(tasks: Task[], content: HTMLDivElement): Promise<void> {
         const layout = new TaskLayout(
+            this.query.taskLayoutOptions2,
             this.query.taskLayoutOptions,
             this.query.queryLayoutOptions,
-            this.query.taskLayoutOptions2,
         );
         const taskList = content.createEl('ul');
         taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -1,4 +1,4 @@
-import { TaskLayoutOptions2 } from './Layout/TaskLayoutOptions';
+import { TaskLayoutOptions } from './Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from './QueryLayoutOptions';
 
 export type TaskLayoutComponent =
@@ -72,29 +72,29 @@ export const defaultLayout: TaskLayoutComponent[] = [
 /**
  * This represents the desired layout of tasks when they are rendered in a given configuration.
  * The layout is used when flattening the task to a string and when rendering queries, and can be
- * modified by applying {@link TaskLayoutOptions2} objects.
+ * modified by applying {@link TaskLayoutOptions} objects.
  */
 export class TaskLayout extends QueryLayout {
     public shownTaskLayoutComponents(): TaskLayoutComponent[] {
-        return this.taskLayoutOptions2.shownComponents;
+        return this.taskLayoutOptions.shownComponents;
     }
     public hiddenTaskLayoutComponents(): TaskLayoutComponent[] {
-        return this.taskLayoutOptions2.hiddenComponents;
+        return this.taskLayoutOptions.hiddenComponents;
     }
     public taskListHiddenClasses(): string[] {
         return this._taskListHiddenClasses;
     }
     public defaultLayout: TaskLayoutComponent[] = defaultLayout;
-    private taskLayoutOptions2: TaskLayoutOptions2;
+    private taskLayoutOptions: TaskLayoutOptions;
     private _taskListHiddenClasses: string[] = [];
 
-    constructor(taskLayoutOptions2?: TaskLayoutOptions2, queryLayoutOptions?: QueryLayoutOptions) {
+    constructor(taskLayoutOptions?: TaskLayoutOptions, queryLayoutOptions?: QueryLayoutOptions) {
         super(queryLayoutOptions);
 
-        if (taskLayoutOptions2) {
-            this.taskLayoutOptions2 = taskLayoutOptions2;
+        if (taskLayoutOptions) {
+            this.taskLayoutOptions = taskLayoutOptions;
         } else {
-            this.taskLayoutOptions2 = new TaskLayoutOptions2();
+            this.taskLayoutOptions = new TaskLayoutOptions();
         }
         this.applyOptions();
     }
@@ -105,15 +105,15 @@ export class TaskLayout extends QueryLayout {
     }
 
     private applyTaskLayoutOptions() {
-        this.taskLayoutOptions2.toggleableComponents.forEach((component) => {
+        this.taskLayoutOptions.toggleableComponents.forEach((component) => {
             generateHiddenClassForTaskList(
                 this._taskListHiddenClasses,
-                !this.taskLayoutOptions2.isShown(component),
+                !this.taskLayoutOptions.isShown(component),
                 component,
             );
         });
 
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
-        generateHiddenClassForTaskList(this._taskListHiddenClasses, !this.taskLayoutOptions2.areTagsShown(), 'tags');
+        generateHiddenClassForTaskList(this._taskListHiddenClasses, !this.taskLayoutOptions.areTagsShown(), 'tags');
     }
 }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -1,25 +1,6 @@
 import { TaskLayoutOptions2 } from './Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from './QueryLayoutOptions';
 
-/**
- * Various rendering options of tasks in a query.
- * See applyOptions below when adding options here.
- *
- * @see QueryLayoutOptions
- */
-export class TaskLayoutOptions {
-    // NEW_TASK_FIELD_EDIT_REQUIRED
-    hidePriority: boolean = false;
-    hideCreatedDate: boolean = false;
-    hideStartDate: boolean = false;
-    hideScheduledDate: boolean = false;
-    hideDoneDate: boolean = false;
-    hideCancelledDate: boolean = false;
-    hideDueDate: boolean = false;
-    hideRecurrenceRule: boolean = false;
-    hideTags: boolean = false;
-}
-
 export type TaskLayoutComponent =
     // NEW_TASK_FIELD_EDIT_REQUIRED
     | 'description'

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -104,23 +104,11 @@ export class TaskLayout extends QueryLayout {
         return this._taskListHiddenClasses;
     }
     public defaultLayout: TaskLayoutComponent[] = defaultLayout;
-    // @ts-expect-error
-    private taskLayoutOptions: TaskLayoutOptions;
     private taskLayoutOptions2: TaskLayoutOptions2;
     private _taskListHiddenClasses: string[] = [];
 
-    constructor(
-        taskLayoutOptions2?: TaskLayoutOptions2,
-        taskLayoutOptions?: TaskLayoutOptions,
-        queryLayoutOptions?: QueryLayoutOptions,
-    ) {
+    constructor(taskLayoutOptions2?: TaskLayoutOptions2, queryLayoutOptions?: QueryLayoutOptions) {
         super(queryLayoutOptions);
-
-        if (taskLayoutOptions) {
-            this.taskLayoutOptions = taskLayoutOptions;
-        } else {
-            this.taskLayoutOptions = new TaskLayoutOptions();
-        }
 
         if (taskLayoutOptions2) {
             this.taskLayoutOptions2 = taskLayoutOptions2;

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -135,22 +135,13 @@ export class TaskLayout extends QueryLayout {
     }
 
     private applyTaskLayoutOptions() {
-        // Remove components from the layout according to the task options. These represent the existing task options,
-        // so some components (e.g. the description) are not here because there are no layout options to remove them.
-        const componentsToHideAndGenerateClasses: [boolean, TaskLayoutComponent][] = [
-            // NEW_TASK_FIELD_EDIT_REQUIRED
-            [this.taskLayoutOptions.hidePriority, 'priority'],
-            [this.taskLayoutOptions.hideRecurrenceRule, 'recurrenceRule'],
-            [this.taskLayoutOptions.hideCreatedDate, 'createdDate'],
-            [this.taskLayoutOptions.hideStartDate, 'startDate'],
-            [this.taskLayoutOptions.hideScheduledDate, 'scheduledDate'],
-            [this.taskLayoutOptions.hideDueDate, 'dueDate'],
-            [this.taskLayoutOptions.hideCancelledDate, 'cancelledDate'],
-            [this.taskLayoutOptions.hideDoneDate, 'doneDate'],
-        ];
-        for (const [hide, component] of componentsToHideAndGenerateClasses) {
-            generateHiddenClassForTaskList(this._taskListHiddenClasses, hide, component);
-        }
+        this.taskLayoutOptions2.toggleableComponents.forEach((component) => {
+            generateHiddenClassForTaskList(
+                this._taskListHiddenClasses,
+                !this.taskLayoutOptions2.isShown(component),
+                component,
+            );
+        });
 
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
         generateHiddenClassForTaskList(this._taskListHiddenClasses, this.taskLayoutOptions.hideTags, 'tags');

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -73,6 +73,20 @@ function hiddenComponentClassName(component: string) {
     return `tasks-layout-hide-${component}`;
 }
 
+export const defaultLayout: TaskLayoutComponent[] = [
+    // NEW_TASK_FIELD_EDIT_REQUIRED
+    'description',
+    'priority',
+    'recurrenceRule',
+    'createdDate',
+    'startDate',
+    'scheduledDate',
+    'dueDate',
+    'cancelledDate',
+    'doneDate',
+    'blockLink',
+];
+
 /**
  * This represents the desired layout of tasks when they are rendered in a given configuration.
  * The layout is used when flattening the task to a string and when rendering queries, and can be
@@ -88,19 +102,7 @@ export class TaskLayout extends QueryLayout {
     public taskListHiddenClasses(): string[] {
         return this._taskListHiddenClasses;
     }
-    public defaultLayout: TaskLayoutComponent[] = [
-        // NEW_TASK_FIELD_EDIT_REQUIRED
-        'description',
-        'priority',
-        'recurrenceRule',
-        'createdDate',
-        'startDate',
-        'scheduledDate',
-        'dueDate',
-        'cancelledDate',
-        'doneDate',
-        'blockLink',
-    ];
+    public defaultLayout: TaskLayoutComponent[] = defaultLayout;
     private _shownTaskLayoutComponents: TaskLayoutComponent[];
     private _hiddenTaskLayoutComponents: TaskLayoutComponent[] = [];
     private taskLayoutOptions: TaskLayoutOptions;

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -95,7 +95,7 @@ export const defaultLayout: TaskLayoutComponent[] = [
  */
 export class TaskLayout extends QueryLayout {
     public shownTaskLayoutComponents(): TaskLayoutComponent[] {
-        return this._shownTaskLayoutComponents;
+        return this.taskLayoutOptions2.shownComponents;
     }
     public hiddenTaskLayoutComponents(): TaskLayoutComponent[] {
         return this._hiddenTaskLayoutComponents;
@@ -104,10 +104,8 @@ export class TaskLayout extends QueryLayout {
         return this._taskListHiddenClasses;
     }
     public defaultLayout: TaskLayoutComponent[] = defaultLayout;
-    private _shownTaskLayoutComponents: TaskLayoutComponent[];
     private _hiddenTaskLayoutComponents: TaskLayoutComponent[] = [];
     private taskLayoutOptions: TaskLayoutOptions;
-    // @ts-expect-error
     private taskLayoutOptions2: TaskLayoutOptions2;
     private _taskListHiddenClasses: string[] = [];
 
@@ -129,8 +127,6 @@ export class TaskLayout extends QueryLayout {
         } else {
             this.taskLayoutOptions2 = new TaskLayoutOptions2();
         }
-
-        this._shownTaskLayoutComponents = this.defaultLayout;
         this.applyOptions();
     }
 
@@ -168,7 +164,6 @@ export class TaskLayout extends QueryLayout {
     private hideComponent(hide: boolean, component: TaskLayoutComponent) {
         if (hide) {
             this._hiddenTaskLayoutComponents.push(component);
-            this._shownTaskLayoutComponents = this._shownTaskLayoutComponents.filter((element) => element != component);
         }
     }
 }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -1,3 +1,4 @@
+import { TaskLayoutOptions2 } from './Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from './QueryLayoutOptions';
 
 /**
@@ -106,15 +107,27 @@ export class TaskLayout extends QueryLayout {
     private _shownTaskLayoutComponents: TaskLayoutComponent[];
     private _hiddenTaskLayoutComponents: TaskLayoutComponent[] = [];
     private taskLayoutOptions: TaskLayoutOptions;
+    // @ts-expect-error
+    private taskLayoutOptions2: TaskLayoutOptions2;
     private _taskListHiddenClasses: string[] = [];
 
-    constructor(taskLayoutOptions?: TaskLayoutOptions, queryLayoutOptions?: QueryLayoutOptions) {
+    constructor(
+        taskLayoutOptions?: TaskLayoutOptions,
+        queryLayoutOptions?: QueryLayoutOptions,
+        taskLayoutOptions2?: TaskLayoutOptions2,
+    ) {
         super(queryLayoutOptions);
 
         if (taskLayoutOptions) {
             this.taskLayoutOptions = taskLayoutOptions;
         } else {
             this.taskLayoutOptions = new TaskLayoutOptions();
+        }
+
+        if (taskLayoutOptions2) {
+            this.taskLayoutOptions2 = taskLayoutOptions2;
+        } else {
+            this.taskLayoutOptions2 = new TaskLayoutOptions2();
         }
 
         this._shownTaskLayoutComponents = this.defaultLayout;

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -91,7 +91,7 @@ export const defaultLayout: TaskLayoutComponent[] = [
 /**
  * This represents the desired layout of tasks when they are rendered in a given configuration.
  * The layout is used when flattening the task to a string and when rendering queries, and can be
- * modified by applying {@link TaskLayoutOptions} objects.
+ * modified by applying {@link TaskLayoutOptions2} objects.
  */
 export class TaskLayout extends QueryLayout {
     public shownTaskLayoutComponents(): TaskLayoutComponent[] {

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -104,6 +104,7 @@ export class TaskLayout extends QueryLayout {
         return this._taskListHiddenClasses;
     }
     public defaultLayout: TaskLayoutComponent[] = defaultLayout;
+    // @ts-expect-error
     private taskLayoutOptions: TaskLayoutOptions;
     private taskLayoutOptions2: TaskLayoutOptions2;
     private _taskListHiddenClasses: string[] = [];
@@ -144,6 +145,6 @@ export class TaskLayout extends QueryLayout {
         });
 
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
-        generateHiddenClassForTaskList(this._taskListHiddenClasses, this.taskLayoutOptions.hideTags, 'tags');
+        generateHiddenClassForTaskList(this._taskListHiddenClasses, !this.taskLayoutOptions2.areTagsShown(), 'tags');
     }
 }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -110,9 +110,9 @@ export class TaskLayout extends QueryLayout {
     private _taskListHiddenClasses: string[] = [];
 
     constructor(
+        taskLayoutOptions2?: TaskLayoutOptions2,
         taskLayoutOptions?: TaskLayoutOptions,
         queryLayoutOptions?: QueryLayoutOptions,
-        taskLayoutOptions2?: TaskLayoutOptions2,
     ) {
         super(queryLayoutOptions);
 

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -98,13 +98,12 @@ export class TaskLayout extends QueryLayout {
         return this.taskLayoutOptions2.shownComponents;
     }
     public hiddenTaskLayoutComponents(): TaskLayoutComponent[] {
-        return this._hiddenTaskLayoutComponents;
+        return this.taskLayoutOptions2.hiddenComponents;
     }
     public taskListHiddenClasses(): string[] {
         return this._taskListHiddenClasses;
     }
     public defaultLayout: TaskLayoutComponent[] = defaultLayout;
-    private _hiddenTaskLayoutComponents: TaskLayoutComponent[] = [];
     private taskLayoutOptions: TaskLayoutOptions;
     private taskLayoutOptions2: TaskLayoutOptions2;
     private _taskListHiddenClasses: string[] = [];
@@ -150,20 +149,10 @@ export class TaskLayout extends QueryLayout {
             [this.taskLayoutOptions.hideDoneDate, 'doneDate'],
         ];
         for (const [hide, component] of componentsToHideAndGenerateClasses) {
-            this.hideComponent(hide, component);
             generateHiddenClassForTaskList(this._taskListHiddenClasses, hide, component);
         }
 
         // Tags are hidden, rather than removed. See tasks-layout-hide-tags in styles.css.
         generateHiddenClassForTaskList(this._taskListHiddenClasses, this.taskLayoutOptions.hideTags, 'tags');
-    }
-
-    /**
-     * Move a component from the shown to hidden if the given layoutOption criteria is met.
-     */
-    private hideComponent(hide: boolean, component: TaskLayoutComponent) {
-        if (hide) {
-            this._hiddenTaskLayoutComponents.push(component);
-        }
     }
 }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -9,7 +9,6 @@ import type { Task } from './Task';
 import * as taskModule from './Task';
 import { TaskFieldRenderer } from './TaskFieldRenderer';
 import type { TaskLayoutComponent, TaskLayoutOptions } from './TaskLayout';
-import { TaskLayout } from './TaskLayout';
 import { StatusMenu } from './ui/Menus/StatusMenu';
 import { StatusRegistry } from './StatusRegistry';
 
@@ -27,6 +26,7 @@ export class TaskLineRenderer {
     private readonly textRenderer: TextRenderer;
     private readonly obsidianComponent: Component | null;
     private readonly parentUlElement: HTMLElement;
+    // @ts-expect-error
     private readonly taskLayoutOptions: TaskLayoutOptions;
     private readonly taskLayoutOptions2: TaskLayoutOptions2;
     private readonly queryLayoutOptions: QueryLayoutOptions;
@@ -159,10 +159,9 @@ export class TaskLineRenderer {
 
     private async taskToHtml(task: Task, parentElement: HTMLElement, li: HTMLLIElement): Promise<void> {
         const fieldRenderer = new TaskFieldRenderer();
-        const taskLayout = new TaskLayout(this.taskLayoutOptions2, this.taskLayoutOptions, this.queryLayoutOptions);
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
         // Render and build classes for all the task's visible components
-        for (const component of taskLayout.shownTaskLayoutComponents()) {
+        for (const component of this.taskLayoutOptions2.shownComponents) {
             const componentString = emojiSerializer.componentToString(
                 task,
                 this.queryLayoutOptions.shortMode,
@@ -192,7 +191,7 @@ export class TaskLineRenderer {
         }
 
         // Now build classes for the hidden task components without rendering them
-        for (const component of taskLayout.hiddenTaskLayoutComponents()) {
+        for (const component of this.taskLayoutOptions2.hiddenComponents) {
             fieldRenderer.addDataAttribute(li, task, component);
         }
 

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -8,7 +8,7 @@ import type { QueryLayoutOptions } from './QueryLayoutOptions';
 import type { Task } from './Task';
 import * as taskModule from './Task';
 import { TaskFieldRenderer } from './TaskFieldRenderer';
-import type { TaskLayoutComponent, TaskLayoutOptions } from './TaskLayout';
+import type { TaskLayoutComponent } from './TaskLayout';
 import { StatusMenu } from './ui/Menus/StatusMenu';
 import { StatusRegistry } from './StatusRegistry';
 
@@ -26,8 +26,6 @@ export class TaskLineRenderer {
     private readonly textRenderer: TextRenderer;
     private readonly obsidianComponent: Component | null;
     private readonly parentUlElement: HTMLElement;
-    // @ts-expect-error
-    private readonly taskLayoutOptions: TaskLayoutOptions;
     private readonly taskLayoutOptions2: TaskLayoutOptions2;
     private readonly queryLayoutOptions: QueryLayoutOptions;
 
@@ -52,7 +50,7 @@ export class TaskLineRenderer {
      *
      * @param parentUlElement HTML element where the task shall be rendered.
      *
-     * @param layoutOptions See {@link TaskLayoutOptions}.
+     * @param taskLayoutOptions2 See {@link TaskLayoutOptions2}.
      *
      * @param queryLayoutOptions See {@link QueryLayoutOptions}.
      */

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -60,21 +60,18 @@ export class TaskLineRenderer {
         textRenderer = TaskLineRenderer.obsidianMarkdownRenderer,
         obsidianComponent,
         parentUlElement,
-        taskLayoutOptions,
         taskLayoutOptions2,
         queryLayoutOptions,
     }: {
         textRenderer?: TextRenderer;
         obsidianComponent: Component | null;
         parentUlElement: HTMLElement;
-        taskLayoutOptions: TaskLayoutOptions;
         taskLayoutOptions2: TaskLayoutOptions2;
         queryLayoutOptions: QueryLayoutOptions;
     }) {
         this.textRenderer = textRenderer;
         this.obsidianComponent = obsidianComponent;
         this.parentUlElement = parentUlElement;
-        this.taskLayoutOptions = taskLayoutOptions;
         this.taskLayoutOptions2 = taskLayoutOptions2;
         this.queryLayoutOptions = queryLayoutOptions;
     }

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -3,6 +3,7 @@ import { Component, MarkdownRenderer } from 'obsidian';
 import { GlobalFilter } from './Config/GlobalFilter';
 import { TASK_FORMATS, getSettings } from './Config/Settings';
 import { replaceTaskWithTasks } from './File';
+import type { TaskLayoutOptions2 } from './Layout/TaskLayoutOptions';
 import type { QueryLayoutOptions } from './QueryLayoutOptions';
 import type { Task } from './Task';
 import * as taskModule from './Task';
@@ -27,6 +28,8 @@ export class TaskLineRenderer {
     private readonly obsidianComponent: Component | null;
     private readonly parentUlElement: HTMLElement;
     private readonly taskLayoutOptions: TaskLayoutOptions;
+    // @ts-expect-error unused for now
+    private readonly taskLayoutOptions2: TaskLayoutOptions2;
     private readonly queryLayoutOptions: QueryLayoutOptions;
 
     private static async obsidianMarkdownRenderer(
@@ -59,18 +62,21 @@ export class TaskLineRenderer {
         obsidianComponent,
         parentUlElement,
         taskLayoutOptions,
+        taskLayoutOptions2,
         queryLayoutOptions,
     }: {
         textRenderer?: TextRenderer;
         obsidianComponent: Component | null;
         parentUlElement: HTMLElement;
         taskLayoutOptions: TaskLayoutOptions;
+        taskLayoutOptions2: TaskLayoutOptions2;
         queryLayoutOptions: QueryLayoutOptions;
     }) {
         this.textRenderer = textRenderer;
         this.obsidianComponent = obsidianComponent;
         this.parentUlElement = parentUlElement;
         this.taskLayoutOptions = taskLayoutOptions;
+        this.taskLayoutOptions2 = taskLayoutOptions2;
         this.queryLayoutOptions = queryLayoutOptions;
     }
 

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -159,7 +159,7 @@ export class TaskLineRenderer {
 
     private async taskToHtml(task: Task, parentElement: HTMLElement, li: HTMLLIElement): Promise<void> {
         const fieldRenderer = new TaskFieldRenderer();
-        const taskLayout = new TaskLayout(this.taskLayoutOptions, this.queryLayoutOptions, this.taskLayoutOptions2);
+        const taskLayout = new TaskLayout(this.taskLayoutOptions2, this.taskLayoutOptions, this.queryLayoutOptions);
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
         // Render and build classes for all the task's visible components
         for (const component of taskLayout.shownTaskLayoutComponents()) {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -28,7 +28,6 @@ export class TaskLineRenderer {
     private readonly obsidianComponent: Component | null;
     private readonly parentUlElement: HTMLElement;
     private readonly taskLayoutOptions: TaskLayoutOptions;
-    // @ts-expect-error unused for now
     private readonly taskLayoutOptions2: TaskLayoutOptions2;
     private readonly queryLayoutOptions: QueryLayoutOptions;
 
@@ -160,7 +159,7 @@ export class TaskLineRenderer {
 
     private async taskToHtml(task: Task, parentElement: HTMLElement, li: HTMLLIElement): Promise<void> {
         const fieldRenderer = new TaskFieldRenderer();
-        const taskLayout = new TaskLayout(this.taskLayoutOptions, this.queryLayoutOptions);
+        const taskLayout = new TaskLayout(this.taskLayoutOptions, this.queryLayoutOptions, this.taskLayoutOptions2);
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
         // Render and build classes for all the task's visible components
         for (const component of taskLayout.shownTaskLayoutComponents()) {

--- a/src/TaskLineRenderer.ts
+++ b/src/TaskLineRenderer.ts
@@ -3,7 +3,7 @@ import { Component, MarkdownRenderer } from 'obsidian';
 import { GlobalFilter } from './Config/GlobalFilter';
 import { TASK_FORMATS, getSettings } from './Config/Settings';
 import { replaceTaskWithTasks } from './File';
-import type { TaskLayoutOptions2 } from './Layout/TaskLayoutOptions';
+import type { TaskLayoutOptions } from './Layout/TaskLayoutOptions';
 import type { QueryLayoutOptions } from './QueryLayoutOptions';
 import type { Task } from './Task';
 import * as taskModule from './Task';
@@ -26,7 +26,7 @@ export class TaskLineRenderer {
     private readonly textRenderer: TextRenderer;
     private readonly obsidianComponent: Component | null;
     private readonly parentUlElement: HTMLElement;
-    private readonly taskLayoutOptions2: TaskLayoutOptions2;
+    private readonly taskLayoutOptions: TaskLayoutOptions;
     private readonly queryLayoutOptions: QueryLayoutOptions;
 
     private static async obsidianMarkdownRenderer(
@@ -50,7 +50,7 @@ export class TaskLineRenderer {
      *
      * @param parentUlElement HTML element where the task shall be rendered.
      *
-     * @param taskLayoutOptions2 See {@link TaskLayoutOptions2}.
+     * @param taskLayoutOptions See {@link TaskLayoutOptions}.
      *
      * @param queryLayoutOptions See {@link QueryLayoutOptions}.
      */
@@ -58,19 +58,19 @@ export class TaskLineRenderer {
         textRenderer = TaskLineRenderer.obsidianMarkdownRenderer,
         obsidianComponent,
         parentUlElement,
-        taskLayoutOptions2,
+        taskLayoutOptions,
         queryLayoutOptions,
     }: {
         textRenderer?: TextRenderer;
         obsidianComponent: Component | null;
         parentUlElement: HTMLElement;
-        taskLayoutOptions2: TaskLayoutOptions2;
+        taskLayoutOptions: TaskLayoutOptions;
         queryLayoutOptions: QueryLayoutOptions;
     }) {
         this.textRenderer = textRenderer;
         this.obsidianComponent = obsidianComponent;
         this.parentUlElement = parentUlElement;
-        this.taskLayoutOptions2 = taskLayoutOptions2;
+        this.taskLayoutOptions = taskLayoutOptions;
         this.queryLayoutOptions = queryLayoutOptions;
     }
 
@@ -156,7 +156,7 @@ export class TaskLineRenderer {
         const fieldRenderer = new TaskFieldRenderer();
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
         // Render and build classes for all the task's visible components
-        for (const component of this.taskLayoutOptions2.shownComponents) {
+        for (const component of this.taskLayoutOptions.shownComponents) {
             const componentString = emojiSerializer.componentToString(
                 task,
                 this.queryLayoutOptions.shortMode,
@@ -186,7 +186,7 @@ export class TaskLineRenderer {
         }
 
         // Now build classes for the hidden task components without rendering them
-        for (const component of this.taskLayoutOptions2.hiddenComponents) {
+        for (const component of this.taskLayoutOptions.hiddenComponents) {
             fieldRenderer.addDataAttribute(li, task, component);
         }
 

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -1,5 +1,5 @@
 import type { Moment } from 'moment';
-import { TaskLayoutOptions2 } from '../Layout/TaskLayoutOptions';
+import { TaskLayoutOptions } from '../Layout/TaskLayoutOptions';
 import type { TaskLayoutComponent } from '../TaskLayout';
 import { Recurrence } from '../Recurrence';
 import { Priority, Task, TaskRegularExpressions } from '../Task';
@@ -85,7 +85,7 @@ export class DefaultTaskSerializer implements TaskSerializer {
      * @return The string representation of the task
      */
     public serialize(task: Task): string {
-        const taskLayoutOptions = new TaskLayoutOptions2();
+        const taskLayoutOptions = new TaskLayoutOptions();
         let taskString = '';
         const shortMode = false;
         for (const component of taskLayoutOptions.shownComponents) {

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -1,5 +1,5 @@
 import type { Moment } from 'moment';
-import { TaskLayout } from '../TaskLayout';
+import { TaskLayoutOptions2 } from '../Layout/TaskLayoutOptions';
 import type { TaskLayoutComponent } from '../TaskLayout';
 import { Recurrence } from '../Recurrence';
 import { Priority, Task, TaskRegularExpressions } from '../Task';
@@ -85,10 +85,10 @@ export class DefaultTaskSerializer implements TaskSerializer {
      * @return The string representation of the task
      */
     public serialize(task: Task): string {
-        const taskLayout = new TaskLayout();
+        const taskLayoutOptions = new TaskLayoutOptions2();
         let taskString = '';
         const shortMode = false;
-        for (const component of taskLayout.shownTaskLayoutComponents()) {
+        for (const component of taskLayoutOptions.shownComponents) {
             taskString += this.componentToString(task, shortMode, component);
         }
         return taskString;

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -19,4 +19,14 @@ describe('TaskLayoutOptions2', () => {
 
         expect(options.isShown('createdDate')).toEqual(false);
     });
+
+    it('should be settable via a boolean', () => {
+        const options = new TaskLayoutOptions2();
+
+        options.setVisibility('scheduledDate', false);
+        expect(options.isShown('scheduledDate')).toEqual(false);
+
+        options.setVisibility('scheduledDate', true);
+        expect(options.isShown('scheduledDate')).toEqual(true);
+    });
 });

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -106,12 +106,14 @@ describe('TaskLayoutOptions2', () => {
         options.setVisibility('priority', true);
         options.setVisibility('description', true);
         options.setVisibility('blockLink', true);
+        options.setTagsVisibility(true);
         options.toggleVisibilityExceptDescriptionAndBlockLink();
 
         expect(options.isShown('cancelledDate')).toEqual(true);
         expect(options.isShown('priority')).toEqual(false);
         expect(options.isShown('description')).toEqual(true);
         expect(options.isShown('blockLink')).toEqual(true);
+        expect(options.areTagsShown()).toEqual(false);
     });
 
     it('should provide toggleable components', () => {

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -17,6 +17,8 @@ describe('TaskLayoutOptions2', () => {
             doneDate
             blockLink"
         `);
+
+        expect(options.areTagsShown()).toEqual(true);
     });
 
     it('should show fields by default', () => {
@@ -41,6 +43,17 @@ describe('TaskLayoutOptions2', () => {
 
         options.setVisibility('scheduledDate', true);
         expect(options.isShown('scheduledDate')).toEqual(true);
+    });
+
+    it('should set tag visibility', () => {
+        const options = new TaskLayoutOptions2();
+        expect(options.areTagsShown()).toEqual(true);
+
+        options.setTagsVisibility(false);
+        expect(options.areTagsShown()).toEqual(false);
+
+        options.setTagsVisibility(true);
+        expect(options.areTagsShown()).toEqual(true);
     });
 
     it('should provide a list of shown components', () => {

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -4,6 +4,19 @@ describe('TaskLayoutOptions2', () => {
     it('should be constructable', () => {
         const options = new TaskLayoutOptions2();
         expect(options).not.toBeNull();
+
+        expect(options.shownComponents.join('\n')).toMatchInlineSnapshot(`
+            "description
+            priority
+            recurrenceRule
+            createdDate
+            startDate
+            scheduledDate
+            dueDate
+            cancelledDate
+            doneDate
+            blockLink"
+        `);
     });
 
     it('should show fields by default', () => {
@@ -78,9 +91,13 @@ describe('TaskLayoutOptions2', () => {
 
         options.setVisibility('cancelledDate', false);
         options.setVisibility('priority', true);
-        options.toggleVisibility();
+        options.setVisibility('description', true);
+        options.setVisibility('blockLink', true);
+        options.toggleVisibilityExceptDescriptionAndBlockLink();
 
         expect(options.isShown('cancelledDate')).toEqual(true);
         expect(options.isShown('priority')).toEqual(false);
+        expect(options.isShown('description')).toEqual(true);
+        expect(options.isShown('blockLink')).toEqual(true);
     });
 });

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -105,6 +105,7 @@ describe('TaskLayoutOptions', () => {
         options.setVisibility('cancelledDate', false);
         options.setVisibility('priority', true);
         options.setTagsVisibility(true);
+
         options.toggleVisibilityExceptDescriptionAndBlockLink();
 
         expect(options.isShown('cancelledDate')).toEqual(true);

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -1,8 +1,8 @@
-import { TaskLayoutOptions2 } from '../../src/Layout/TaskLayoutOptions';
+import { TaskLayoutOptions } from '../../src/Layout/TaskLayoutOptions';
 
-describe('TaskLayoutOptions2', () => {
+describe('TaskLayoutOptions', () => {
     it('should be constructable', () => {
-        const options = new TaskLayoutOptions2();
+        const options = new TaskLayoutOptions();
         expect(options).not.toBeNull();
 
         expect(options.shownComponents.join('\n')).toMatchInlineSnapshot(`
@@ -22,21 +22,21 @@ describe('TaskLayoutOptions2', () => {
     });
 
     it('should show fields by default', () => {
-        const options = new TaskLayoutOptions2();
+        const options = new TaskLayoutOptions();
 
         expect(options.isShown('priority')).toEqual(true);
         expect(options.isShown('createdDate')).toEqual(true);
     });
 
     it('should be able to hide a field', () => {
-        const options = new TaskLayoutOptions2();
+        const options = new TaskLayoutOptions();
         options.hide('createdDate');
 
         expect(options.isShown('createdDate')).toEqual(false);
     });
 
     it('should be settable via a boolean', () => {
-        const options = new TaskLayoutOptions2();
+        const options = new TaskLayoutOptions();
 
         options.setVisibility('scheduledDate', false);
         expect(options.isShown('scheduledDate')).toEqual(false);
@@ -46,7 +46,7 @@ describe('TaskLayoutOptions2', () => {
     });
 
     it('should set tag visibility', () => {
-        const options = new TaskLayoutOptions2();
+        const options = new TaskLayoutOptions();
         expect(options.areTagsShown()).toEqual(true);
 
         options.setTagsVisibility(false);
@@ -57,7 +57,7 @@ describe('TaskLayoutOptions2', () => {
     });
 
     it('should provide a list of shown components', () => {
-        const options = new TaskLayoutOptions2();
+        const options = new TaskLayoutOptions();
         expect(options.shownComponents.join('\n')).toMatchInlineSnapshot(`
             "description
             priority
@@ -87,7 +87,7 @@ describe('TaskLayoutOptions2', () => {
     });
 
     it('should provide a list of hidden components', () => {
-        const options = new TaskLayoutOptions2();
+        const options = new TaskLayoutOptions();
         expect(options.hiddenComponents.join('\n')).toMatchInlineSnapshot('""');
 
         options.setVisibility('startDate', false);
@@ -100,7 +100,7 @@ describe('TaskLayoutOptions2', () => {
     });
 
     it('should toggle visibility', () => {
-        const options = new TaskLayoutOptions2();
+        const options = new TaskLayoutOptions();
 
         options.setVisibility('cancelledDate', false);
         options.setVisibility('priority', true);
@@ -117,7 +117,7 @@ describe('TaskLayoutOptions2', () => {
     });
 
     it('should provide toggleable components', () => {
-        const options = new TaskLayoutOptions2();
+        const options = new TaskLayoutOptions();
 
         expect(options.toggleableComponents.join('\n')).toMatchInlineSnapshot(`
             "priority

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -100,4 +100,19 @@ describe('TaskLayoutOptions2', () => {
         expect(options.isShown('description')).toEqual(true);
         expect(options.isShown('blockLink')).toEqual(true);
     });
+
+    it('should provide toggleable components', () => {
+        const options = new TaskLayoutOptions2();
+
+        expect(options.toggleableComponents.join('\n')).toMatchInlineSnapshot(`
+            "priority
+            recurrenceRule
+            createdDate
+            startDate
+            scheduledDate
+            dueDate
+            cancelledDate
+            doneDate"
+        `);
+    });
 });

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -104,16 +104,23 @@ describe('TaskLayoutOptions', () => {
 
         options.setVisibility('cancelledDate', false);
         options.setVisibility('priority', true);
-        options.setVisibility('description', true);
-        options.setVisibility('blockLink', true);
         options.setTagsVisibility(true);
         options.toggleVisibilityExceptDescriptionAndBlockLink();
 
         expect(options.isShown('cancelledDate')).toEqual(true);
         expect(options.isShown('priority')).toEqual(false);
+        expect(options.areTagsShown()).toEqual(false);
+    });
+
+    it('should not toggle visibility of description and blockLink', () => {
+        const options = new TaskLayoutOptions();
+        options.setVisibility('description', true);
+        options.setVisibility('blockLink', true);
+
+        options.toggleVisibilityExceptDescriptionAndBlockLink();
+
         expect(options.isShown('description')).toEqual(true);
         expect(options.isShown('blockLink')).toEqual(true);
-        expect(options.areTagsShown()).toEqual(false);
     });
 
     it('should provide toggleable components', () => {

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -59,4 +59,17 @@ describe('TaskLayoutOptions2', () => {
             doneDate"
         `);
     });
+
+    it('should provide a list of hidden components', () => {
+        const options = new TaskLayoutOptions2();
+        expect(options.hiddenComponents.join('\n')).toMatchInlineSnapshot('""');
+
+        options.setVisibility('startDate', false);
+        options.setVisibility('doneDate', false);
+
+        expect(options.hiddenComponents.join('\n')).toMatchInlineSnapshot(`
+            "startDate
+            doneDate"
+        `);
+    });
 });

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -30,9 +30,9 @@ describe('TaskLayoutOptions2', () => {
         expect(options.isShown('scheduledDate')).toEqual(true);
     });
 
-    it('should provide a list of visible components', () => {
+    it('should provide a list of shown components', () => {
         const options = new TaskLayoutOptions2();
-        expect(options.visibleComponents.join('\n')).toMatchInlineSnapshot(`
+        expect(options.shownComponents.join('\n')).toMatchInlineSnapshot(`
             "description
             priority
             recurrenceRule
@@ -48,7 +48,7 @@ describe('TaskLayoutOptions2', () => {
         options.setVisibility('dueDate', false);
         options.setVisibility('blockLink', false);
 
-        expect(options.visibleComponents.join('\n')).toMatchInlineSnapshot(`
+        expect(options.shownComponents.join('\n')).toMatchInlineSnapshot(`
             "description
             priority
             recurrenceRule

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -1,0 +1,22 @@
+import { TaskLayoutOptions2 } from '../../src/Layout/TaskLayoutOptions';
+
+describe('TaskLayoutOptions2', () => {
+    it('should be constructable', () => {
+        const options = new TaskLayoutOptions2();
+        expect(options).not.toBeNull();
+    });
+
+    it('should show fields by default', () => {
+        const options = new TaskLayoutOptions2();
+
+        expect(options.isShown('priority')).toEqual(true);
+        expect(options.isShown('createdDate')).toEqual(true);
+    });
+
+    it('should be able to hide a field', () => {
+        const options = new TaskLayoutOptions2();
+        options.hide('createdDate');
+
+        expect(options.isShown('createdDate')).toEqual(false);
+    });
+});

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -29,4 +29,34 @@ describe('TaskLayoutOptions2', () => {
         options.setVisibility('scheduledDate', true);
         expect(options.isShown('scheduledDate')).toEqual(true);
     });
+
+    it('should provide a list of visible components', () => {
+        const options = new TaskLayoutOptions2();
+        expect(options.visibleComponents.join('\n')).toMatchInlineSnapshot(`
+            "description
+            priority
+            recurrenceRule
+            createdDate
+            startDate
+            scheduledDate
+            dueDate
+            cancelledDate
+            doneDate
+            blockLink"
+        `);
+
+        options.setVisibility('dueDate', false);
+        options.setVisibility('blockLink', false);
+
+        expect(options.visibleComponents.join('\n')).toMatchInlineSnapshot(`
+            "description
+            priority
+            recurrenceRule
+            createdDate
+            startDate
+            scheduledDate
+            cancelledDate
+            doneDate"
+        `);
+    });
 });

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -72,4 +72,15 @@ describe('TaskLayoutOptions2', () => {
             doneDate"
         `);
     });
+
+    it('should toggle visibility', () => {
+        const options = new TaskLayoutOptions2();
+
+        options.setVisibility('cancelledDate', false);
+        options.setVisibility('priority', true);
+        options.toggleVisibility();
+
+        expect(options.isShown('cancelledDate')).toEqual(true);
+        expect(options.isShown('priority')).toEqual(false);
+    });
 });

--- a/tests/TaskLayout.test.ts
+++ b/tests/TaskLayout.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { TaskLayoutOptions2 } from '../src/Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
 import { TaskLayout, TaskLayoutOptions } from '../src/TaskLayout';
 
@@ -39,7 +40,10 @@ describe('TaskLayout tests', () => {
             queryLayoutOptions[key2] = !queryLayoutOptions[key2];
         });
 
-        const taskLayout = new TaskLayout(layoutOptions, queryLayoutOptions);
+        const taskLayoutOptions2 = new TaskLayoutOptions2();
+        taskLayoutOptions2.toggleVisibilityExceptDescriptionAndBlockLink();
+
+        const taskLayout = new TaskLayout(layoutOptions, queryLayoutOptions, taskLayoutOptions2);
 
         expect(taskLayout.shownTaskLayoutComponents().join('\n')).toMatchInlineSnapshot(`
             "description

--- a/tests/TaskLayout.test.ts
+++ b/tests/TaskLayout.test.ts
@@ -4,7 +4,7 @@
 
 import { TaskLayoutOptions2 } from '../src/Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
-import { TaskLayout, TaskLayoutOptions } from '../src/TaskLayout';
+import { TaskLayout } from '../src/TaskLayout';
 
 describe('TaskLayout tests', () => {
     it('should generate expected CSS components for default layout', () => {
@@ -26,13 +26,6 @@ describe('TaskLayout tests', () => {
     });
 
     it('should generate expected CSS components with all default option reversed', () => {
-        const layoutOptions = new TaskLayoutOptions();
-        // Negate all the task layout boolean values:
-        Object.keys(layoutOptions).forEach((key) => {
-            const key2 = key as keyof TaskLayoutOptions;
-            layoutOptions[key2] = !layoutOptions[key2];
-        });
-
         const queryLayoutOptions = new QueryLayoutOptions();
         // Negate all the query layout boolean values:
         Object.keys(queryLayoutOptions).forEach((key) => {
@@ -43,7 +36,7 @@ describe('TaskLayout tests', () => {
         const taskLayoutOptions2 = new TaskLayoutOptions2();
         taskLayoutOptions2.toggleVisibilityExceptDescriptionAndBlockLink();
 
-        const taskLayout = new TaskLayout(taskLayoutOptions2, layoutOptions, queryLayoutOptions);
+        const taskLayout = new TaskLayout(taskLayoutOptions2, queryLayoutOptions);
 
         expect(taskLayout.shownTaskLayoutComponents().join('\n')).toMatchInlineSnapshot(`
             "description

--- a/tests/TaskLayout.test.ts
+++ b/tests/TaskLayout.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
-import { TaskLayout, type TaskLayoutComponent, TaskLayoutOptions, defaultLayout } from '../src/TaskLayout';
+import { TaskLayout, TaskLayoutOptions } from '../src/TaskLayout';
 
 describe('TaskLayout tests', () => {
     it('should generate expected CSS components for default layout', () => {
@@ -70,44 +70,5 @@ describe('TaskLayout tests', () => {
             tasks-layout-hide-postpone-button
             tasks-layout-short-mode"
         `);
-    });
-});
-
-class TaskLayoutOptions2 {
-    private visible: { [component: string]: boolean } = {};
-
-    constructor() {
-        defaultLayout.forEach((component) => {
-            this.visible[component] = true;
-        });
-    }
-
-    public isShown(component: TaskLayoutComponent) {
-        return this.visible[component];
-    }
-
-    public hide(component: TaskLayoutComponent) {
-        this.visible[component] = false;
-    }
-}
-
-describe('TaskLayoutOptions2', () => {
-    it('should be constructable', () => {
-        const options = new TaskLayoutOptions2();
-        expect(options).not.toBeNull();
-    });
-
-    it('should show fields by default', () => {
-        const options = new TaskLayoutOptions2();
-
-        expect(options.isShown('priority')).toEqual(true);
-        expect(options.isShown('createdDate')).toEqual(true);
-    });
-
-    it('should be able to hide a field', () => {
-        const options = new TaskLayoutOptions2();
-        options.hide('createdDate');
-
-        expect(options.isShown('createdDate')).toEqual(false);
     });
 });

--- a/tests/TaskLayout.test.ts
+++ b/tests/TaskLayout.test.ts
@@ -43,7 +43,7 @@ describe('TaskLayout tests', () => {
         const taskLayoutOptions2 = new TaskLayoutOptions2();
         taskLayoutOptions2.toggleVisibilityExceptDescriptionAndBlockLink();
 
-        const taskLayout = new TaskLayout(layoutOptions, queryLayoutOptions, taskLayoutOptions2);
+        const taskLayout = new TaskLayout(taskLayoutOptions2, layoutOptions, queryLayoutOptions);
 
         expect(taskLayout.shownTaskLayoutComponents().join('\n')).toMatchInlineSnapshot(`
             "description

--- a/tests/TaskLayout.test.ts
+++ b/tests/TaskLayout.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { TaskLayoutOptions2 } from '../src/Layout/TaskLayoutOptions';
+import { TaskLayoutOptions } from '../src/Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
 import { TaskLayout } from '../src/TaskLayout';
 
@@ -33,10 +33,10 @@ describe('TaskLayout tests', () => {
             queryLayoutOptions[key2] = !queryLayoutOptions[key2];
         });
 
-        const taskLayoutOptions2 = new TaskLayoutOptions2();
-        taskLayoutOptions2.toggleVisibilityExceptDescriptionAndBlockLink();
+        const taskLayoutOptions = new TaskLayoutOptions();
+        taskLayoutOptions.toggleVisibilityExceptDescriptionAndBlockLink();
 
-        const taskLayout = new TaskLayout(taskLayoutOptions2, queryLayoutOptions);
+        const taskLayout = new TaskLayout(taskLayoutOptions, queryLayoutOptions);
 
         expect(taskLayout.shownTaskLayoutComponents().join('\n')).toMatchInlineSnapshot(`
             "description

--- a/tests/TaskLayout.test.ts
+++ b/tests/TaskLayout.test.ts
@@ -26,15 +26,15 @@ describe('TaskLayout tests', () => {
     });
 
     it('should generate expected CSS components with all default option reversed', () => {
+        const taskLayoutOptions = new TaskLayoutOptions();
+        taskLayoutOptions.toggleVisibilityExceptDescriptionAndBlockLink();
+
         const queryLayoutOptions = new QueryLayoutOptions();
         // Negate all the query layout boolean values:
         Object.keys(queryLayoutOptions).forEach((key) => {
             const key2 = key as keyof QueryLayoutOptions;
             queryLayoutOptions[key2] = !queryLayoutOptions[key2];
         });
-
-        const taskLayoutOptions = new TaskLayoutOptions();
-        taskLayoutOptions.toggleVisibilityExceptDescriptionAndBlockLink();
 
         const taskLayout = new TaskLayout(taskLayoutOptions, queryLayoutOptions);
 

--- a/tests/TaskLayout.test.ts
+++ b/tests/TaskLayout.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
-import { TaskLayout, TaskLayoutOptions } from '../src/TaskLayout';
+import { TaskLayout, type TaskLayoutComponent, TaskLayoutOptions, defaultLayout } from '../src/TaskLayout';
 
 describe('TaskLayout tests', () => {
     it('should generate expected CSS components for default layout', () => {
@@ -70,5 +70,44 @@ describe('TaskLayout tests', () => {
             tasks-layout-hide-postpone-button
             tasks-layout-short-mode"
         `);
+    });
+});
+
+class TaskLayoutOptions2 {
+    private visible: { [component: string]: boolean } = {};
+
+    constructor() {
+        defaultLayout.forEach((component) => {
+            this.visible[component] = true;
+        });
+    }
+
+    public isShown(component: TaskLayoutComponent) {
+        return this.visible[component];
+    }
+
+    public hide(component: TaskLayoutComponent) {
+        this.visible[component] = false;
+    }
+}
+
+describe('TaskLayoutOptions2', () => {
+    it('should be constructable', () => {
+        const options = new TaskLayoutOptions2();
+        expect(options).not.toBeNull();
+    });
+
+    it('should show fields by default', () => {
+        const options = new TaskLayoutOptions2();
+
+        expect(options.isShown('priority')).toEqual(true);
+        expect(options.isShown('createdDate')).toEqual(true);
+    });
+
+    it('should be able to hide a field', () => {
+        const options = new TaskLayoutOptions2();
+        options.hide('createdDate');
+
+        expect(options.isShown('createdDate')).toEqual(false);
     });
 });

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -10,7 +10,7 @@ import { DateParser } from '../src/Query/DateParser';
 import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
 import type { Task } from '../src/Task';
 import { TaskRegularExpressions } from '../src/Task';
-import { type TaskLayoutComponent, TaskLayoutOptions } from '../src/TaskLayout';
+import type { TaskLayoutComponent, TaskLayoutOptions } from '../src/TaskLayout';
 import type { TextRenderer } from '../src/TaskLineRenderer';
 import { TaskLineRenderer } from '../src/TaskLineRenderer';
 import { fromLine } from './TestHelpers';
@@ -680,19 +680,7 @@ ${task.toFileLineString()}
     const minimalTask = fromLine({ line: '- [-] empty' });
 
     function layoutOptionsFullMode() {
-        const layoutOptions = new TaskLayoutOptions();
-
-        // Show every Task field, disable short mode, do not explain the query
-        // Also note that urgency, backlinks and edit button are rendered in QueryRender.createTaskList(),
-        // so they won't be visible in this test it is using TaskLineRenderer.renderTaskLine().
-        // See also comments in TaskLayout.applyOptions().
-        Object.keys(layoutOptions).forEach((key) => {
-            const key2 = key as keyof TaskLayoutOptions;
-            layoutOptions[key2] = false;
-        });
-
         return {
-            layoutOptions,
             taskLayoutOptions2: new TaskLayoutOptions2(), // makes the assumption that all the field are shown by default
             queryLayoutOptions: new QueryLayoutOptions(),
         };
@@ -703,7 +691,6 @@ ${task.toFileLineString()}
         queryLayoutOptions.shortMode = true;
 
         return {
-            layoutOptions: new TaskLayoutOptions(),
             taskLayoutOptions2: new TaskLayoutOptions2(),
             queryLayoutOptions,
         };

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -25,7 +25,7 @@ window.moment = moment;
  *
  * @param task to be rendered
  *
- * @param layoutOptions for the task rendering. Skip for default options. See {@link TaskLayoutOptions}.
+ * @param _layoutOptions for the task rendering. Skip for default options. See {@link TaskLayoutOptions}.
  *
  * @param taskLayoutOptions2
  * @param testRenderer imitates Obsidian rendering. Skip for the default {@link mockTextRenderer}.
@@ -34,7 +34,7 @@ window.moment = moment;
  */
 async function renderListItem(
     task: Task,
-    layoutOptions?: TaskLayoutOptions,
+    _layoutOptions?: TaskLayoutOptions,
     taskLayoutOptions2?: TaskLayoutOptions2,
     queryLayoutOptions?: QueryLayoutOptions,
     testRenderer?: TextRenderer,
@@ -43,7 +43,6 @@ async function renderListItem(
         textRenderer: testRenderer ?? mockTextRenderer,
         obsidianComponent: null,
         parentUlElement: document.createElement('div'),
-        taskLayoutOptions: layoutOptions ?? new TaskLayoutOptions(),
         taskLayoutOptions2: taskLayoutOptions2 ?? new TaskLayoutOptions2(),
         queryLayoutOptions: queryLayoutOptions ?? new QueryLayoutOptions(),
     });
@@ -99,7 +98,6 @@ describe('task line rendering - HTML', () => {
             textRenderer: mockTextRenderer,
             obsidianComponent: null,
             parentUlElement: ulElement,
-            taskLayoutOptions: new TaskLayoutOptions(),
             taskLayoutOptions2: new TaskLayoutOptions2(),
             queryLayoutOptions: new QueryLayoutOptions(),
         });

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -509,21 +509,16 @@ describe('task line rendering - classes and data attributes', () => {
     });
 
     it.each([
-        ['task-priority', 'taskPriority: medium', { hidePriority: true }, 'priority'],
-        ['task-createdDate', 'taskCreated: past-far', { hideCreatedDate: true }, 'createdDate'],
-        ['task-dueDate', 'taskDue: past-far', { hideDueDate: true }, 'dueDate'],
-        ['task-scheduledDate', 'taskScheduled: past-far', { hideScheduledDate: true }, 'scheduledDate'],
-        ['task-startDate', 'taskStart: past-far', { hideStartDate: true }, 'startDate'],
-        ['task-doneDate', 'taskDone: past-far', { hideDoneDate: true }, 'doneDate'],
-        ['task-cancelledDate', 'taskCancelled: past-far', { hideCancelledDate: true }, 'cancelledDate'],
+        ['task-priority', 'taskPriority: medium', 'priority'],
+        ['task-createdDate', 'taskCreated: past-far', 'createdDate'],
+        ['task-dueDate', 'taskDue: past-far', 'dueDate'],
+        ['task-scheduledDate', 'taskScheduled: past-far', 'scheduledDate'],
+        ['task-startDate', 'taskStart: past-far', 'startDate'],
+        ['task-doneDate', 'taskDone: past-far', 'doneDate'],
+        ['task-cancelledDate', 'taskCancelled: past-far', 'cancelledDate'],
     ])(
         'should not render "%s" class but should set "%s" data attributes to the list item',
-        async (
-            expectedAbsentClass: string,
-            expectedDateAttributes: string,
-            _layoutOptions: Partial<TaskLayoutOptions>,
-            hiddenComponent: string,
-        ) => {
+        async (expectedAbsentClass: string, expectedDateAttributes: string, hiddenComponent: string) => {
             const task = TaskBuilder.createFullyPopulatedTask();
             const options = new TaskLayoutOptions2();
             options.hide(hiddenComponent as TaskLayoutComponent);

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -10,7 +10,7 @@ import { DateParser } from '../src/Query/DateParser';
 import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
 import type { Task } from '../src/Task';
 import { TaskRegularExpressions } from '../src/Task';
-import type { TaskLayoutComponent, TaskLayoutOptions } from '../src/TaskLayout';
+import type { TaskLayoutComponent } from '../src/TaskLayout';
 import type { TextRenderer } from '../src/TaskLineRenderer';
 import { TaskLineRenderer } from '../src/TaskLineRenderer';
 import { fromLine } from './TestHelpers';
@@ -578,11 +578,7 @@ describe('task line rendering - classes and data attributes', () => {
         expect(tagSpan.dataset.tagName).toEqual('#illegal-data-attribute');
     });
 
-    const testLiAttributes = async (
-        taskLine: string,
-        _layoutOptions: Partial<TaskLayoutOptions>,
-        attributes: string[],
-    ) => {
+    const testLiAttributes = async (taskLine: string, attributes: string[]) => {
         const task = fromLine({
             line: taskLine,
         });
@@ -593,22 +589,14 @@ describe('task line rendering - classes and data attributes', () => {
     };
 
     it('creates data attributes for custom statuses', async () => {
-        await testLiAttributes('- [ ] An incomplete task', {}, [
-            'task: ',
-            'taskStatusName: Todo',
-            'taskStatusType: TODO',
-        ]);
-        await testLiAttributes('- [x] A complete task', {}, [
-            'task: x',
-            'taskStatusName: Done',
-            'taskStatusType: DONE',
-        ]);
-        await testLiAttributes('- [/] In-progress task', {}, [
+        await testLiAttributes('- [ ] An incomplete task', ['task: ', 'taskStatusName: Todo', 'taskStatusType: TODO']);
+        await testLiAttributes('- [x] A complete task', ['task: x', 'taskStatusName: Done', 'taskStatusType: DONE']);
+        await testLiAttributes('- [/] In-progress task', [
             'task: /',
             'taskStatusName: In Progress',
             'taskStatusType: IN_PROGRESS',
         ]);
-        await testLiAttributes('- [-] In-progress task', {}, [
+        await testLiAttributes('- [-] In-progress task', [
             'task: -',
             'taskStatusName: Cancelled',
             'taskStatusType: CANCELLED',
@@ -616,7 +604,7 @@ describe('task line rendering - classes and data attributes', () => {
     });
 
     it('marks nonexistent task priority as "normal" priority', async () => {
-        await testLiAttributes('- [ ] Full task 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day', {}, [
+        await testLiAttributes('- [ ] Full task 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day', [
             'taskPriority: normal',
         ]);
     });

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { DebugSettings } from '../src/Config/DebugSettings';
 import { GlobalFilter } from '../src/Config/GlobalFilter';
 import { resetSettings, updateSettings } from '../src/Config/Settings';
-import { TaskLayoutOptions2 } from '../src/Layout/TaskLayoutOptions';
+import { TaskLayoutOptions } from '../src/Layout/TaskLayoutOptions';
 import { DateParser } from '../src/Query/DateParser';
 import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
 import type { Task } from '../src/Task';
@@ -25,7 +25,7 @@ window.moment = moment;
  *
  * @param task to be rendered
  *
- * @param taskLayoutOptions2 for the task rendering. Skip for default options. See {@link TaskLayoutOptions2}.
+ * @param taskLayoutOptions for the task rendering. Skip for default options. See {@link TaskLayoutOptions}.
  *
  * @param testRenderer imitates Obsidian rendering. Skip for the default {@link mockTextRenderer}.
  *
@@ -33,7 +33,7 @@ window.moment = moment;
  */
 async function renderListItem(
     task: Task,
-    taskLayoutOptions2?: TaskLayoutOptions2,
+    taskLayoutOptions?: TaskLayoutOptions,
     queryLayoutOptions?: QueryLayoutOptions,
     testRenderer?: TextRenderer,
 ) {
@@ -41,7 +41,7 @@ async function renderListItem(
         textRenderer: testRenderer ?? mockTextRenderer,
         obsidianComponent: null,
         parentUlElement: document.createElement('div'),
-        taskLayoutOptions2: taskLayoutOptions2 ?? new TaskLayoutOptions2(),
+        taskLayoutOptions: taskLayoutOptions ?? new TaskLayoutOptions(),
         queryLayoutOptions: queryLayoutOptions ?? new QueryLayoutOptions(),
     });
     return await taskLineRenderer.renderTaskLine(task, 0);
@@ -96,7 +96,7 @@ describe('task line rendering - HTML', () => {
             textRenderer: mockTextRenderer,
             obsidianComponent: null,
             parentUlElement: ulElement,
-            taskLayoutOptions2: new TaskLayoutOptions2(),
+            taskLayoutOptions: new TaskLayoutOptions(),
             queryLayoutOptions: new QueryLayoutOptions(),
         });
         const listItem = await taskLineRenderer.renderTaskLine(new TaskBuilder().build(), 0);
@@ -178,11 +178,11 @@ describe('task line rendering - global filter', () => {
 describe('task line rendering - layout options', () => {
     const testLayoutOptions = async (expectedComponents: string[], hiddenComponents: TaskLayoutComponent[]) => {
         const task = TaskBuilder.createFullyPopulatedTask();
-        const taskLayoutOptions2 = new TaskLayoutOptions2();
+        const taskLayoutOptions = new TaskLayoutOptions();
         hiddenComponents.forEach((hiddenComponent) => {
-            taskLayoutOptions2.hide(hiddenComponent);
+            taskLayoutOptions.hide(hiddenComponent);
         });
-        const listItem = await renderListItem(task, taskLayoutOptions2);
+        const listItem = await renderListItem(task, taskLayoutOptions);
         const renderedComponents = getListItemComponents(listItem);
         expect(renderedComponents).toEqual(expectedComponents);
     };
@@ -520,7 +520,7 @@ describe('task line rendering - classes and data attributes', () => {
         'should not render "%s" class but should set "%s" data attributes to the list item',
         async (expectedAbsentClass: string, expectedDateAttributes: string, hiddenComponent: string) => {
             const task = TaskBuilder.createFullyPopulatedTask();
-            const options = new TaskLayoutOptions2();
+            const options = new TaskLayoutOptions();
             options.hide(hiddenComponent as TaskLayoutComponent);
             const listItem = await renderListItem(task, options);
 
@@ -543,7 +543,7 @@ describe('task line rendering - classes and data attributes', () => {
         });
         const listItem = await renderListItem(
             task,
-            new TaskLayoutOptions2(),
+            new TaskLayoutOptions(),
             new QueryLayoutOptions(),
             mockHTMLRenderer,
         );
@@ -564,7 +564,7 @@ describe('task line rendering - classes and data attributes', () => {
         });
         const listItem = await renderListItem(
             task,
-            new TaskLayoutOptions2(),
+            new TaskLayoutOptions(),
             new QueryLayoutOptions(),
             mockHTMLRenderer,
         );
@@ -614,14 +614,14 @@ describe('Visualise HTML', () => {
     async function renderAndVerifyHTML(
         task: Task,
         {
-            taskLayoutOptions2,
+            taskLayoutOptions,
             queryLayoutOptions,
         }: {
-            taskLayoutOptions2: TaskLayoutOptions2;
+            taskLayoutOptions: TaskLayoutOptions;
             queryLayoutOptions: QueryLayoutOptions;
         },
     ) {
-        const listItem = await renderListItem(task, taskLayoutOptions2, queryLayoutOptions, mockHTMLRenderer);
+        const listItem = await renderListItem(task, taskLayoutOptions, queryLayoutOptions, mockHTMLRenderer);
 
         const taskAsMarkdown = `<!--
 ${task.toFileLineString()}
@@ -636,7 +636,7 @@ ${task.toFileLineString()}
 
     function layoutOptionsFullMode() {
         return {
-            taskLayoutOptions2: new TaskLayoutOptions2(), // makes the assumption that all the field are shown by default
+            taskLayoutOptions: new TaskLayoutOptions(), // makes the assumption that all the field are shown by default
             queryLayoutOptions: new QueryLayoutOptions(),
         };
     }
@@ -646,7 +646,7 @@ ${task.toFileLineString()}
         queryLayoutOptions.shortMode = true;
 
         return {
-            taskLayoutOptions2: new TaskLayoutOptions2(),
+            taskLayoutOptions: new TaskLayoutOptions(),
             queryLayoutOptions,
         };
     }

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -5,6 +5,7 @@ import moment from 'moment';
 import { DebugSettings } from '../src/Config/DebugSettings';
 import { GlobalFilter } from '../src/Config/GlobalFilter';
 import { resetSettings, updateSettings } from '../src/Config/Settings';
+import { TaskLayoutOptions2 } from '../src/Layout/TaskLayoutOptions';
 import { DateParser } from '../src/Query/DateParser';
 import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
 import type { Task } from '../src/Task';
@@ -26,6 +27,7 @@ window.moment = moment;
  *
  * @param layoutOptions for the task rendering. Skip for default options. See {@link TaskLayoutOptions}.
  *
+ * @param taskLayoutOptions2
  * @param testRenderer imitates Obsidian rendering. Skip for the default {@link mockTextRenderer}.
  *
  * @param queryLayoutOptions for the task rendering. Skip for default options. See {@link QueryLayoutOptions}.
@@ -33,6 +35,7 @@ window.moment = moment;
 async function renderListItem(
     task: Task,
     layoutOptions?: TaskLayoutOptions,
+    taskLayoutOptions2?: TaskLayoutOptions2,
     queryLayoutOptions?: QueryLayoutOptions,
     testRenderer?: TextRenderer,
 ) {
@@ -41,6 +44,7 @@ async function renderListItem(
         obsidianComponent: null,
         parentUlElement: document.createElement('div'),
         taskLayoutOptions: layoutOptions ?? new TaskLayoutOptions(),
+        taskLayoutOptions2: taskLayoutOptions2 ?? new TaskLayoutOptions2(),
         queryLayoutOptions: queryLayoutOptions ?? new QueryLayoutOptions(),
     });
     return await taskLineRenderer.renderTaskLine(task, 0);
@@ -96,6 +100,7 @@ describe('task line rendering - HTML', () => {
             obsidianComponent: null,
             parentUlElement: ulElement,
             taskLayoutOptions: new TaskLayoutOptions(),
+            taskLayoutOptions2: new TaskLayoutOptions2(),
             queryLayoutOptions: new QueryLayoutOptions(),
         });
         const listItem = await taskLineRenderer.renderTaskLine(new TaskBuilder().build(), 0);
@@ -558,6 +563,7 @@ describe('task line rendering - classes and data attributes', () => {
         const listItem = await renderListItem(
             task,
             new TaskLayoutOptions(),
+            new TaskLayoutOptions2(),
             new QueryLayoutOptions(),
             mockHTMLRenderer,
         );
@@ -579,6 +585,7 @@ describe('task line rendering - classes and data attributes', () => {
         const listItem = await renderListItem(
             task,
             new TaskLayoutOptions(),
+            new TaskLayoutOptions2(),
             new QueryLayoutOptions(),
             mockHTMLRenderer,
         );
@@ -642,10 +649,21 @@ describe('Visualise HTML', () => {
         task: Task,
         {
             layoutOptions,
+            taskLayoutOptions2,
             queryLayoutOptions,
-        }: { layoutOptions: TaskLayoutOptions; queryLayoutOptions: QueryLayoutOptions },
+        }: {
+            layoutOptions: TaskLayoutOptions;
+            taskLayoutOptions2: TaskLayoutOptions2;
+            queryLayoutOptions: QueryLayoutOptions;
+        },
     ) {
-        const listItem = await renderListItem(task, layoutOptions, queryLayoutOptions, mockHTMLRenderer);
+        const listItem = await renderListItem(
+            task,
+            layoutOptions,
+            taskLayoutOptions2,
+            queryLayoutOptions,
+            mockHTMLRenderer,
+        );
 
         const taskAsMarkdown = `<!--
 ${task.toFileLineString()}
@@ -670,14 +688,22 @@ ${task.toFileLineString()}
             layoutOptions[key2] = false;
         });
 
-        return { layoutOptions, queryLayoutOptions: new QueryLayoutOptions() };
+        return {
+            layoutOptions,
+            taskLayoutOptions2: new TaskLayoutOptions2(), // makes the assumption that all the field are shown by default
+            queryLayoutOptions: new QueryLayoutOptions(),
+        };
     }
 
     function layoutOptionsShortMode() {
         const queryLayoutOptions = new QueryLayoutOptions();
         queryLayoutOptions.shortMode = true;
 
-        return { layoutOptions: new TaskLayoutOptions(), queryLayoutOptions };
+        return {
+            layoutOptions: new TaskLayoutOptions(),
+            taskLayoutOptions2: new TaskLayoutOptions2(),
+            queryLayoutOptions,
+        };
     }
 
     it('Full task - full mode', async () => {

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -10,7 +10,7 @@ import { DateParser } from '../src/Query/DateParser';
 import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
 import type { Task } from '../src/Task';
 import { TaskRegularExpressions } from '../src/Task';
-import { TaskLayoutOptions } from '../src/TaskLayout';
+import { type TaskLayoutComponent, TaskLayoutOptions } from '../src/TaskLayout';
 import type { TextRenderer } from '../src/TaskLineRenderer';
 import { TaskLineRenderer } from '../src/TaskLineRenderer';
 import { fromLine } from './TestHelpers';
@@ -180,10 +180,18 @@ describe('task line rendering - global filter', () => {
 });
 
 describe('task line rendering - layout options', () => {
-    const testLayoutOptions = async (expectedComponents: string[], layoutOptions: Partial<TaskLayoutOptions>) => {
+    const testLayoutOptions = async (
+        expectedComponents: string[],
+        layoutOptions: Partial<TaskLayoutOptions>,
+        hiddenComponents: TaskLayoutComponent[],
+    ) => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const fullLayoutOptions = { ...new TaskLayoutOptions(), ...layoutOptions };
-        const listItem = await renderListItem(task, fullLayoutOptions);
+        const taskLayoutOptions2 = new TaskLayoutOptions2();
+        hiddenComponents.forEach((hiddenComponent) => {
+            taskLayoutOptions2.hide(hiddenComponent);
+        });
+        const listItem = await renderListItem(task, fullLayoutOptions, taskLayoutOptions2);
         const renderedComponents = getListItemComponents(listItem);
         expect(renderedComponents).toEqual(expectedComponents);
     };
@@ -203,6 +211,7 @@ describe('task line rendering - layout options', () => {
                 ' ^dcf64c',
             ],
             {},
+            [],
         );
     });
 
@@ -220,6 +229,7 @@ describe('task line rendering - layout options', () => {
                 ' ^dcf64c',
             ],
             { hidePriority: true },
+            ['priority'],
         );
     });
 
@@ -237,6 +247,7 @@ describe('task line rendering - layout options', () => {
                 ' ^dcf64c',
             ],
             { hideRecurrenceRule: true },
+            ['recurrenceRule'],
         );
     });
 
@@ -254,6 +265,7 @@ describe('task line rendering - layout options', () => {
                 ' ^dcf64c',
             ],
             { hideCreatedDate: true },
+            ['createdDate'],
         );
     });
 
@@ -271,6 +283,7 @@ describe('task line rendering - layout options', () => {
                 ' ^dcf64c',
             ],
             { hideStartDate: true },
+            ['startDate'],
         );
     });
 
@@ -288,6 +301,7 @@ describe('task line rendering - layout options', () => {
                 ' ^dcf64c',
             ],
             { hideScheduledDate: true },
+            ['scheduledDate'],
         );
     });
 
@@ -305,6 +319,7 @@ describe('task line rendering - layout options', () => {
                 ' ^dcf64c',
             ],
             { hideDueDate: true },
+            ['dueDate'],
         );
     });
 
@@ -323,6 +338,7 @@ describe('task line rendering - layout options', () => {
                 ' ^dcf64c',
             ],
             {},
+            [],
         );
     });
 
@@ -340,6 +356,7 @@ describe('task line rendering - layout options', () => {
                 ' ^dcf64c',
             ],
             { hideDoneDate: true },
+            ['doneDate'],
         );
     });
 
@@ -357,6 +374,7 @@ describe('task line rendering - layout options', () => {
                 ' ^dcf64c',
             ],
             { hideCancelledDate: true },
+            ['cancelledDate'],
         );
     });
 
@@ -525,23 +543,26 @@ describe('task line rendering - classes and data attributes', () => {
     });
 
     it.each([
-        ['task-priority', 'taskPriority: medium', { hidePriority: true }],
-        ['task-createdDate', 'taskCreated: past-far', { hideCreatedDate: true }],
-        ['task-dueDate', 'taskDue: past-far', { hideDueDate: true }],
-        ['task-scheduledDate', 'taskScheduled: past-far', { hideScheduledDate: true }],
-        ['task-startDate', 'taskStart: past-far', { hideStartDate: true }],
-        ['task-doneDate', 'taskDone: past-far', { hideDoneDate: true }],
-        ['task-cancelledDate', 'taskCancelled: past-far', { hideCancelledDate: true }],
+        ['task-priority', 'taskPriority: medium', { hidePriority: true }, 'priority'],
+        ['task-createdDate', 'taskCreated: past-far', { hideCreatedDate: true }, 'createdDate'],
+        ['task-dueDate', 'taskDue: past-far', { hideDueDate: true }, 'dueDate'],
+        ['task-scheduledDate', 'taskScheduled: past-far', { hideScheduledDate: true }, 'scheduledDate'],
+        ['task-startDate', 'taskStart: past-far', { hideStartDate: true }, 'startDate'],
+        ['task-doneDate', 'taskDone: past-far', { hideDoneDate: true }, 'doneDate'],
+        ['task-cancelledDate', 'taskCancelled: past-far', { hideCancelledDate: true }, 'cancelledDate'],
     ])(
         'should not render "%s" class but should set "%s" data attributes to the list item',
         async (
             expectedAbsentClass: string,
             expectedDateAttributes: string,
             layoutOptions: Partial<TaskLayoutOptions>,
+            hiddenComponent: string,
         ) => {
             const task = TaskBuilder.createFullyPopulatedTask();
             const fullLayoutOptions = { ...new TaskLayoutOptions(), ...layoutOptions };
-            const listItem = await renderListItem(task, fullLayoutOptions);
+            const options = new TaskLayoutOptions2();
+            options.hide(hiddenComponent as TaskLayoutComponent);
+            const listItem = await renderListItem(task, fullLayoutOptions, options);
 
             expect(listItem).not.toHaveAChildSpanWithClass(expectedAbsentClass);
             expect(listItem).toHaveAmongDataAttributes(expectedDateAttributes);

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -176,11 +176,7 @@ describe('task line rendering - global filter', () => {
 });
 
 describe('task line rendering - layout options', () => {
-    const testLayoutOptions = async (
-        expectedComponents: string[],
-        _layoutOptions: Partial<TaskLayoutOptions>,
-        hiddenComponents: TaskLayoutComponent[],
-    ) => {
+    const testLayoutOptions = async (expectedComponents: string[], hiddenComponents: TaskLayoutComponent[]) => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const taskLayoutOptions2 = new TaskLayoutOptions2();
         hiddenComponents.forEach((hiddenComponent) => {
@@ -205,7 +201,6 @@ describe('task line rendering - layout options', () => {
                 ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
-            {},
             [],
         );
     });
@@ -223,7 +218,6 @@ describe('task line rendering - layout options', () => {
                 ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
-            { hidePriority: true },
             ['priority'],
         );
     });
@@ -241,7 +235,6 @@ describe('task line rendering - layout options', () => {
                 ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
-            { hideRecurrenceRule: true },
             ['recurrenceRule'],
         );
     });
@@ -259,7 +252,6 @@ describe('task line rendering - layout options', () => {
                 ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
-            { hideCreatedDate: true },
             ['createdDate'],
         );
     });
@@ -277,7 +269,6 @@ describe('task line rendering - layout options', () => {
                 ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
-            { hideStartDate: true },
             ['startDate'],
         );
     });
@@ -295,7 +286,6 @@ describe('task line rendering - layout options', () => {
                 ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
-            { hideScheduledDate: true },
             ['scheduledDate'],
         );
     });
@@ -313,7 +303,6 @@ describe('task line rendering - layout options', () => {
                 ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
-            { hideDueDate: true },
             ['dueDate'],
         );
     });
@@ -332,7 +321,6 @@ describe('task line rendering - layout options', () => {
                 ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
-            {},
             [],
         );
     });
@@ -350,7 +338,6 @@ describe('task line rendering - layout options', () => {
                 ' ❌ 2023-07-06',
                 ' ^dcf64c',
             ],
-            { hideDoneDate: true },
             ['doneDate'],
         );
     });
@@ -368,7 +355,6 @@ describe('task line rendering - layout options', () => {
                 ' ✅ 2023-07-05',
                 ' ^dcf64c',
             ],
-            { hideCancelledDate: true },
             ['cancelledDate'],
         );
     });

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -25,16 +25,14 @@ window.moment = moment;
  *
  * @param task to be rendered
  *
- * @param _layoutOptions for the task rendering. Skip for default options. See {@link TaskLayoutOptions}.
+ * @param taskLayoutOptions2 for the task rendering. Skip for default options. See {@link TaskLayoutOptions2}.
  *
- * @param taskLayoutOptions2
  * @param testRenderer imitates Obsidian rendering. Skip for the default {@link mockTextRenderer}.
  *
  * @param queryLayoutOptions for the task rendering. Skip for default options. See {@link QueryLayoutOptions}.
  */
 async function renderListItem(
     task: Task,
-    _layoutOptions?: TaskLayoutOptions,
     taskLayoutOptions2?: TaskLayoutOptions2,
     queryLayoutOptions?: QueryLayoutOptions,
     testRenderer?: TextRenderer,
@@ -180,16 +178,15 @@ describe('task line rendering - global filter', () => {
 describe('task line rendering - layout options', () => {
     const testLayoutOptions = async (
         expectedComponents: string[],
-        layoutOptions: Partial<TaskLayoutOptions>,
+        _layoutOptions: Partial<TaskLayoutOptions>,
         hiddenComponents: TaskLayoutComponent[],
     ) => {
         const task = TaskBuilder.createFullyPopulatedTask();
-        const fullLayoutOptions = { ...new TaskLayoutOptions(), ...layoutOptions };
         const taskLayoutOptions2 = new TaskLayoutOptions2();
         hiddenComponents.forEach((hiddenComponent) => {
             taskLayoutOptions2.hide(hiddenComponent);
         });
-        const listItem = await renderListItem(task, fullLayoutOptions, taskLayoutOptions2);
+        const listItem = await renderListItem(task, taskLayoutOptions2);
         const renderedComponents = getListItemComponents(listItem);
         expect(renderedComponents).toEqual(expectedComponents);
     };
@@ -420,15 +417,14 @@ describe('task line rendering - debug info rendering', () => {
 describe('task line rendering - classes and data attributes', () => {
     const testComponentClasses = async (
         taskLine: string,
-        layoutOptions: Partial<TaskLayoutOptions>,
+        _layoutOptions: Partial<TaskLayoutOptions>,
         mainClass: string,
         attributes: string,
     ) => {
         const task = fromLine({
             line: taskLine,
         });
-        const fullLayoutOptions = { ...new TaskLayoutOptions(), ...layoutOptions };
-        const listItem = await renderListItem(task, fullLayoutOptions);
+        const listItem = await renderListItem(task);
 
         expect(listItem).toHaveAChildSpanWithClassAndDataAttributes(mainClass, attributes);
     };
@@ -553,14 +549,13 @@ describe('task line rendering - classes and data attributes', () => {
         async (
             expectedAbsentClass: string,
             expectedDateAttributes: string,
-            layoutOptions: Partial<TaskLayoutOptions>,
+            _layoutOptions: Partial<TaskLayoutOptions>,
             hiddenComponent: string,
         ) => {
             const task = TaskBuilder.createFullyPopulatedTask();
-            const fullLayoutOptions = { ...new TaskLayoutOptions(), ...layoutOptions };
             const options = new TaskLayoutOptions2();
             options.hide(hiddenComponent as TaskLayoutComponent);
-            const listItem = await renderListItem(task, fullLayoutOptions, options);
+            const listItem = await renderListItem(task, options);
 
             expect(listItem).not.toHaveAChildSpanWithClass(expectedAbsentClass);
             expect(listItem).toHaveAmongDataAttributes(expectedDateAttributes);
@@ -581,7 +576,6 @@ describe('task line rendering - classes and data attributes', () => {
         });
         const listItem = await renderListItem(
             task,
-            new TaskLayoutOptions(),
             new TaskLayoutOptions2(),
             new QueryLayoutOptions(),
             mockHTMLRenderer,
@@ -603,7 +597,6 @@ describe('task line rendering - classes and data attributes', () => {
         });
         const listItem = await renderListItem(
             task,
-            new TaskLayoutOptions(),
             new TaskLayoutOptions2(),
             new QueryLayoutOptions(),
             mockHTMLRenderer,
@@ -620,14 +613,13 @@ describe('task line rendering - classes and data attributes', () => {
 
     const testLiAttributes = async (
         taskLine: string,
-        layoutOptions: Partial<TaskLayoutOptions>,
+        _layoutOptions: Partial<TaskLayoutOptions>,
         attributes: string[],
     ) => {
         const task = fromLine({
             line: taskLine,
         });
-        const fullLayoutOptions = { ...new TaskLayoutOptions(), ...layoutOptions };
-        const listItem = await renderListItem(task, fullLayoutOptions);
+        const listItem = await renderListItem(task);
         for (const attribute of attributes) {
             expect(listItem).toHaveAmongDataAttributes(attribute);
         }
@@ -667,22 +659,14 @@ describe('Visualise HTML', () => {
     async function renderAndVerifyHTML(
         task: Task,
         {
-            layoutOptions,
             taskLayoutOptions2,
             queryLayoutOptions,
         }: {
-            layoutOptions: TaskLayoutOptions;
             taskLayoutOptions2: TaskLayoutOptions2;
             queryLayoutOptions: QueryLayoutOptions;
         },
     ) {
-        const listItem = await renderListItem(
-            task,
-            layoutOptions,
-            taskLayoutOptions2,
-            queryLayoutOptions,
-            mockHTMLRenderer,
-        );
+        const listItem = await renderListItem(task, taskLayoutOptions2, queryLayoutOptions, mockHTMLRenderer);
 
         const taskAsMarkdown = `<!--
 ${task.toFileLineString()}

--- a/tests/TaskLineRenderer.test.ts
+++ b/tests/TaskLineRenderer.test.ts
@@ -401,12 +401,7 @@ describe('task line rendering - debug info rendering', () => {
 });
 
 describe('task line rendering - classes and data attributes', () => {
-    const testComponentClasses = async (
-        taskLine: string,
-        _layoutOptions: Partial<TaskLayoutOptions>,
-        mainClass: string,
-        attributes: string,
-    ) => {
+    const testComponentClasses = async (taskLine: string, mainClass: string, attributes: string) => {
         const task = fromLine({
             line: taskLine,
         });
@@ -418,19 +413,16 @@ describe('task line rendering - classes and data attributes', () => {
     it('should render priority component with its class and data attribute', async () => {
         await testComponentClasses(
             '- [ ] Full task ⏫ ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
-            {},
             'task-priority',
             'taskPriority: high',
         );
         await testComponentClasses(
             '- [ ] Full task 🔼 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
-            {},
             'task-priority',
             'taskPriority: medium',
         );
         await testComponentClasses(
             '- [ ] Full task 🔽 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
-            {},
             'task-priority',
             'taskPriority: low',
         );
@@ -439,7 +431,6 @@ describe('task line rendering - classes and data attributes', () => {
     it('should render recurrence component with its class and data attribute', async () => {
         await testComponentClasses(
             '- [ ] Full task ⏫ 📅 2022-07-02 ⏳ 2022-07-03 🛫 2022-07-04 🔁 every day',
-            {},
             'task-recurring',
             '',
         );
@@ -447,79 +438,74 @@ describe('task line rendering - classes and data attributes', () => {
 
     it('should render date component with its class and data attribute with "today" value', async () => {
         const today = DateParser.parseDate('today').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${today}`, {}, 'task-created', 'taskCreated: today');
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${today}`, {}, 'task-due', 'taskDue: today');
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${today}`, {}, 'task-scheduled', 'taskScheduled: today');
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${today}`, {}, 'task-start', 'taskStart: today');
-        await testComponentClasses(`- [x] Done task ✅ ${today}`, {}, 'task-done', 'taskDone: today');
-        await testComponentClasses(`- [-] Canc task ❌ ${today}`, {}, 'task-cancelled', 'taskCancelled: today');
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${today}`, 'task-created', 'taskCreated: today');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${today}`, 'task-due', 'taskDue: today');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${today}`, 'task-scheduled', 'taskScheduled: today');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${today}`, 'task-start', 'taskStart: today');
+        await testComponentClasses(`- [x] Done task ✅ ${today}`, 'task-done', 'taskDone: today');
+        await testComponentClasses(`- [-] Canc task ❌ ${today}`, 'task-cancelled', 'taskCancelled: today');
     });
 
     it('should render date component with its class and data attribute with "future-1d" value', async () => {
         const future = DateParser.parseDate('tomorrow').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${future}`, {}, 'task-created', 'taskCreated: future-1d');
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${future}`, {}, 'task-due', 'taskDue: future-1d');
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${future}`, {}, 'task-scheduled', 'taskScheduled: future-1d');
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${future}`, {}, 'task-start', 'taskStart: future-1d');
-        await testComponentClasses(`- [x] Done task ✅ ${future}`, {}, 'task-done', 'taskDone: future-1d');
-        await testComponentClasses(`- [-] Canc task ❌ ${future}`, {}, 'task-cancelled', 'taskCancelled: future-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${future}`, 'task-created', 'taskCreated: future-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${future}`, 'task-due', 'taskDue: future-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${future}`, 'task-scheduled', 'taskScheduled: future-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${future}`, 'task-start', 'taskStart: future-1d');
+        await testComponentClasses(`- [x] Done task ✅ ${future}`, 'task-done', 'taskDone: future-1d');
+        await testComponentClasses(`- [-] Canc task ❌ ${future}`, 'task-cancelled', 'taskCancelled: future-1d');
     });
 
     it('should render date component with its class and data attribute with "future-7d" value', async () => {
         const future = DateParser.parseDate('in 7 days').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${future}`, {}, 'task-created', 'taskCreated: future-7d');
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${future}`, {}, 'task-due', 'taskDue: future-7d');
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${future}`, {}, 'task-scheduled', 'taskScheduled: future-7d');
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${future}`, {}, 'task-start', 'taskStart: future-7d');
-        await testComponentClasses(`- [x] Done task ✅ ${future}`, {}, 'task-done', 'taskDone: future-7d');
-        await testComponentClasses(`- [-] Canc task ❌ ${future}`, {}, 'task-cancelled', 'taskCancelled: future-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${future}`, 'task-created', 'taskCreated: future-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${future}`, 'task-due', 'taskDue: future-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${future}`, 'task-scheduled', 'taskScheduled: future-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${future}`, 'task-start', 'taskStart: future-7d');
+        await testComponentClasses(`- [x] Done task ✅ ${future}`, 'task-done', 'taskDone: future-7d');
+        await testComponentClasses(`- [-] Canc task ❌ ${future}`, 'task-cancelled', 'taskCancelled: future-7d');
     });
 
     it('should render date component with its class and data attribute with "past-1d" value', async () => {
         const past = DateParser.parseDate('yesterday').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${past}`, {}, 'task-created', 'taskCreated: past-1d');
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${past}`, {}, 'task-due', 'taskDue: past-1d');
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${past}`, {}, 'task-scheduled', 'taskScheduled: past-1d');
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${past}`, {}, 'task-start', 'taskStart: past-1d');
-        await testComponentClasses(`- [x] Done task ✅ ${past}`, {}, 'task-done', 'taskDone: past-1d');
-        await testComponentClasses(`- [-] Canc task ❌ ${past}`, {}, 'task-cancelled', 'taskCancelled: past-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${past}`, 'task-created', 'taskCreated: past-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${past}`, 'task-due', 'taskDue: past-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${past}`, 'task-scheduled', 'taskScheduled: past-1d');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${past}`, 'task-start', 'taskStart: past-1d');
+        await testComponentClasses(`- [x] Done task ✅ ${past}`, 'task-done', 'taskDone: past-1d');
+        await testComponentClasses(`- [-] Canc task ❌ ${past}`, 'task-cancelled', 'taskCancelled: past-1d');
     });
 
     it('should render date component with its class and data attribute with "past-7d" value', async () => {
         const past = DateParser.parseDate('7 days ago').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${past}`, {}, 'task-created', 'taskCreated: past-7d');
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${past}`, {}, 'task-due', 'taskDue: past-7d');
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${past}`, {}, 'task-scheduled', 'taskScheduled: past-7d');
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${past}`, {}, 'task-start', 'taskStart: past-7d');
-        await testComponentClasses(`- [x] Done task ✅ ${past}`, {}, 'task-done', 'taskDone: past-7d');
-        await testComponentClasses(`- [-] Canc task ❌ ${past}`, {}, 'task-cancelled', 'taskCancelled: past-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${past}`, 'task-created', 'taskCreated: past-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${past}`, 'task-due', 'taskDue: past-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${past}`, 'task-scheduled', 'taskScheduled: past-7d');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${past}`, 'task-start', 'taskStart: past-7d');
+        await testComponentClasses(`- [x] Done task ✅ ${past}`, 'task-done', 'taskDone: past-7d');
+        await testComponentClasses(`- [-] Canc task ❌ ${past}`, 'task-cancelled', 'taskCancelled: past-7d');
     });
 
     it('should render date component with its class and data attribute with "future-far" & "past-far" values', async () => {
         const future = DateParser.parseDate('in 8 days').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${future}`, {}, 'task-created', 'taskCreated: future-far');
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${future}`, {}, 'task-due', 'taskDue: future-far');
-        await testComponentClasses(
-            `- [ ] Full task ⏫ ⏳ ${future}`,
-            {},
-            'task-scheduled',
-            'taskScheduled: future-far',
-        );
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${future}`, {}, 'task-start', 'taskStart: future-far');
-        await testComponentClasses(`- [x] Done task ✅ ${future}`, {}, 'task-done', 'taskDone: future-far');
-        await testComponentClasses(`- [-] Canc task ❌ ${future}`, {}, 'task-cancelled', 'taskCancelled: future-far');
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${future}`, 'task-created', 'taskCreated: future-far');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${future}`, 'task-due', 'taskDue: future-far');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${future}`, 'task-scheduled', 'taskScheduled: future-far');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${future}`, 'task-start', 'taskStart: future-far');
+        await testComponentClasses(`- [x] Done task ✅ ${future}`, 'task-done', 'taskDone: future-far');
+        await testComponentClasses(`- [-] Canc task ❌ ${future}`, 'task-cancelled', 'taskCancelled: future-far');
 
         const past = DateParser.parseDate('8 days ago').format(TaskRegularExpressions.dateFormat);
-        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${past}`, {}, 'task-created', 'taskCreated: past-far');
-        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${past}`, {}, 'task-due', 'taskDue: past-far');
-        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${past}`, {}, 'task-scheduled', 'taskScheduled: past-far');
-        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${past}`, {}, 'task-start', 'taskStart: past-far');
-        await testComponentClasses(`- [x] Done task ✅ ${past}`, {}, 'task-done', 'taskDone: past-far');
-        await testComponentClasses(`- [-] Canc task ❌ ${past}`, {}, 'task-cancelled', 'taskCancelled: past-far');
+        await testComponentClasses(`- [ ] Full task ⏫ ➕ ${past}`, 'task-created', 'taskCreated: past-far');
+        await testComponentClasses(`- [ ] Full task ⏫ 📅 ${past}`, 'task-due', 'taskDue: past-far');
+        await testComponentClasses(`- [ ] Full task ⏫ ⏳ ${past}`, 'task-scheduled', 'taskScheduled: past-far');
+        await testComponentClasses(`- [ ] Full task ⏫ 🛫 ${past}`, 'task-start', 'taskStart: past-far');
+        await testComponentClasses(`- [x] Done task ✅ ${past}`, 'task-done', 'taskDone: past-far');
+        await testComponentClasses(`- [-] Canc task ❌ ${past}`, 'task-cancelled', 'taskCancelled: past-far');
     });
 
     it('should not add data attributes for invalid dates', async () => {
-        await testComponentClasses('- [ ] task with invalid due date 📅 2023-02-29', {}, 'task-due', '');
+        await testComponentClasses('- [ ] task with invalid due date 📅 2023-02-29', 'task-due', '');
     });
 
     it.each([


### PR DESCRIPTION
# Description

Rewrite `TaskLayoutOptions` to have a container the data as a dictionary.

Done as a pairing session with @claremacrae.

By the end of this refactoring:

* `TaskLayoutOptions` has moved:
    * from
        * `src/TaskLayout.ts`
    * to:
        * `src/Layout/TaskLayoutOptions.ts`
* It now encapsulates some behaviours associated with showing and hiding components, both in serialising/deserialising task lines, and in rendering tasks:
    * Instead of being a collection of unrelated `boolean` values, it now stores a container of `boolean` values, which are looked up with a `TaskLayoutComponent` value
    * this makes it much more convenient to use in the various bits of code that loop over collections of `TaskLayoutComponent` values
* This new encapsulation has simplified the implementation of `TaskLayout` nicely, removing two sets of duplicated data entirely.

## Motivation and Context

- Make adding new layout options easier.
- Make adding new fields to `Task` easier - remove the number of `NEW_TASK_FIELD_EDIT_REQUIRED` locations.
    - One removed from `TaskLayoutOptions`
    - One removed from `TaskLayout.componentsToHideAndGenerateClasses`

## How has this been tested?

- Unit tests.
- Exploratory testing, to confirm that the following still work, and are cancelled by a subsequent `show` command.
    - `hide due date`
    - `hide tags`
    - `hide recurrence rule`
    - `hide backlinks`
    - `hide edit button` 

## Types of changes

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
