### PR TITLE
refactor: cleanup `TaskLayout.ts`

### DIFF
--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -1,4 +1,4 @@
-import { type TaskLayoutComponent, defaultLayout } from '../TaskLayout';
+import { type TaskLayoutComponent, taskLayoutComponents } from '../TaskLayout';
 
 /**
  * Various rendering options of tasks in a query.
@@ -14,7 +14,7 @@ export class TaskLayoutOptions {
     private tagsVisible: boolean = true;
 
     constructor() {
-        defaultLayout.forEach((component) => {
+        taskLayoutComponents.forEach((component) => {
             this.visible[component] = true;
         });
     }
@@ -40,13 +40,13 @@ export class TaskLayoutOptions {
     }
 
     public get shownComponents() {
-        return defaultLayout.filter((component) => {
+        return taskLayoutComponents.filter((component) => {
             return this.visible[component];
         });
     }
 
     public get hiddenComponents() {
-        return defaultLayout.filter((component) => {
+        return taskLayoutComponents.filter((component) => {
             return !this.visible[component];
         });
     }
@@ -56,7 +56,7 @@ export class TaskLayoutOptions {
      * here because there are no layout options to remove them.
      */
     public get toggleableComponents() {
-        return defaultLayout.filter((component) => {
+        return taskLayoutComponents.filter((component) => {
             // Description and blockLink are always shown
             return component !== 'description' && component !== 'blockLink';
         });

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -75,12 +75,6 @@ export const defaultLayout: TaskLayoutComponent[] = [
  * modified by applying {@link TaskLayoutOptions} objects.
  */
 export class TaskLayout extends QueryLayout {
-    public shownTaskLayoutComponents(): TaskLayoutComponent[] {
-        return this.taskLayoutOptions.shownComponents;
-    }
-    public hiddenTaskLayoutComponents(): TaskLayoutComponent[] {
-        return this.taskLayoutOptions.hiddenComponents;
-    }
     public taskListHiddenClasses(): string[] {
         return this._taskListHiddenClasses;
     }

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -55,7 +55,7 @@ function hiddenComponentClassName(component: string) {
     return `tasks-layout-hide-${component}`;
 }
 
-export const defaultLayout: TaskLayoutComponent[] = [
+export const taskLayoutComponents: TaskLayoutComponent[] = [
     // NEW_TASK_FIELD_EDIT_REQUIRED
     'description',
     'priority',

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -78,7 +78,6 @@ export class TaskLayout extends QueryLayout {
     public taskListHiddenClasses(): string[] {
         return this._taskListHiddenClasses;
     }
-    public defaultLayout: TaskLayoutComponent[] = defaultLayout;
     private taskLayoutOptions: TaskLayoutOptions;
     private _taskListHiddenClasses: string[] = [];
 

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -89,14 +89,9 @@ export class TaskLayout extends QueryLayout {
         } else {
             this.taskLayoutOptions = new TaskLayoutOptions();
         }
-        this.applyOptions();
-    }
-
-    private applyOptions() {
         this.applyTaskLayoutOptions();
         this.applyQueryLayoutOptions(this._taskListHiddenClasses);
     }
-
     private applyTaskLayoutOptions() {
         this.taskLayoutOptions.toggleableComponents.forEach((component) => {
             generateHiddenClassForTaskList(

--- a/src/TaskLayout.ts
+++ b/src/TaskLayout.ts
@@ -14,6 +14,20 @@ export type TaskLayoutComponent =
     | 'cancelledDate'
     | 'blockLink';
 
+export const taskLayoutComponents: TaskLayoutComponent[] = [
+    // NEW_TASK_FIELD_EDIT_REQUIRED
+    'description',
+    'priority',
+    'recurrenceRule',
+    'createdDate',
+    'startDate',
+    'scheduledDate',
+    'dueDate',
+    'cancelledDate',
+    'doneDate',
+    'blockLink',
+];
+
 export class QueryLayout {
     protected queryLayoutOptions: QueryLayoutOptions;
 
@@ -54,20 +68,6 @@ function generateHiddenClassForTaskList(taskListHiddenClasses: string[], hide: b
 function hiddenComponentClassName(component: string) {
     return `tasks-layout-hide-${component}`;
 }
-
-export const taskLayoutComponents: TaskLayoutComponent[] = [
-    // NEW_TASK_FIELD_EDIT_REQUIRED
-    'description',
-    'priority',
-    'recurrenceRule',
-    'createdDate',
-    'startDate',
-    'scheduledDate',
-    'dueDate',
-    'cancelledDate',
-    'doneDate',
-    'blockLink',
-];
 
 /**
  * This represents the desired layout of tasks when they are rendered in a given configuration.

--- a/tests/TaskLayout.test.ts
+++ b/tests/TaskLayout.test.ts
@@ -7,25 +7,12 @@ import { QueryLayoutOptions } from '../src/QueryLayoutOptions';
 import { TaskLayout } from '../src/TaskLayout';
 
 describe('TaskLayout tests', () => {
-    it('should generate expected CSS components for default layout', () => {
+    it('should generate expected CSS classes for default layout', () => {
         const taskLayout = new TaskLayout();
-        expect(taskLayout.shownTaskLayoutComponents().join('\n')).toMatchInlineSnapshot(`
-            "description
-            priority
-            recurrenceRule
-            createdDate
-            startDate
-            scheduledDate
-            dueDate
-            cancelledDate
-            doneDate
-            blockLink"
-        `);
-        expect(taskLayout.hiddenTaskLayoutComponents().join('\n')).toMatchInlineSnapshot('""');
         expect(taskLayout.taskListHiddenClasses().join('\n')).toMatchInlineSnapshot('"tasks-layout-hide-urgency"');
     });
 
-    it('should generate expected CSS components with all default option reversed', () => {
+    it('should generate expected CSS classes with all default options reversed', () => {
         const taskLayoutOptions = new TaskLayoutOptions();
         taskLayoutOptions.toggleVisibilityExceptDescriptionAndBlockLink();
 
@@ -38,20 +25,6 @@ describe('TaskLayout tests', () => {
 
         const taskLayout = new TaskLayout(taskLayoutOptions, queryLayoutOptions);
 
-        expect(taskLayout.shownTaskLayoutComponents().join('\n')).toMatchInlineSnapshot(`
-            "description
-            blockLink"
-        `);
-        expect(taskLayout.hiddenTaskLayoutComponents().join('\n')).toMatchInlineSnapshot(`
-            "priority
-            recurrenceRule
-            createdDate
-            startDate
-            scheduledDate
-            dueDate
-            cancelledDate
-            doneDate"
-        `);
         expect(taskLayout.taskListHiddenClasses().join('\n')).toMatchInlineSnapshot(`
             "tasks-layout-hide-priority
             tasks-layout-hide-recurrenceRule


### PR DESCRIPTION
# Description

Following the previous refactoring:
- rename `defaultLayout` to `taskLayoutComponents`
- remove unused methods in `TaskLayout`
- group similar code around

## Motivation and Context

Code readability and clarity.

## How has this been tested?

Unit tests.

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
