### PR TITLE
feat: Complete implementation of 'sort by function'

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/Functions/Custom Sorting.md
+++ b/resources/sample_vaults/Tasks-Demo/Functions/Custom Sorting.md
@@ -1,0 +1,43 @@
+# Custom Sorting
+
+This file contains samples for experimenting with 'sort by function'.
+
+## Examples
+
+==TODO==
+
+## Error Handling
+
+Demonstrate how errors are handled.
+
+### Parsing Errors
+
+Errors when reading 'sort by function' instructions.
+
+#### SyntaxError
+
+```tasks
+sort by function task.due.formatAsDate(
+```
+
+### Evaluation Errors
+
+Errors when evaluating 'sort by function' instructions during searches.
+
+#### ReferenceError
+
+```tasks
+sort by function hello
+```
+
+#### Non-existent field
+
+```tasks
+sort by function task.nonExistentField
+```
+
+#### task.tags
+
+```tasks
+sort by function task.tags
+```

--- a/resources/sample_vaults/Tasks-Demo/Functions/Custom Sorting.md
+++ b/resources/sample_vaults/Tasks-Demo/Functions/Custom Sorting.md
@@ -30,13 +30,13 @@ Errors when evaluating 'sort by function' instructions during searches.
 sort by function hello
 ```
 
-#### Non-existent field
+#### Non-existent task field
 
 ```tasks
 sort by function task.nonExistentField
 ```
 
-#### task.tags
+#### Unsupported sort key type
 
 ```tasks
 sort by function task.tags

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -113,13 +113,9 @@ export class FunctionField extends Field {
         const valueAType = getValueType(valueA);
         const valueBType = getValueType(valueB);
 
-        const aIsMoment = valueAType === 'Moment';
-        const bIsMoment = valueBType === 'Moment';
-        const bothAreMoment = aIsMoment && bIsMoment;
-        const aIsMomentBIsNull = aIsMoment && valueB === null;
-        const bIsMomentAIsNull = bIsMoment && valueA === null;
-        if (bothAreMoment || aIsMomentBIsNull || bIsMomentAIsNull) {
-            return compareByDate(valueA, valueB);
+        const resultIfMoment = this.compareTaskSortKeysIfOptionalMoment(valueA, valueB, valueAType, valueBType);
+        if (resultIfMoment !== undefined) {
+            return resultIfMoment;
         }
 
         const resultIfNull = this.compareTaskSortKeysIfEitherIsNull(valueA, valueB);
@@ -148,6 +144,21 @@ export class FunctionField extends Field {
             throw new Error(`Unable to determine sort order for expression '${line}'`);
         }
         return result;
+    }
+
+    private compareTaskSortKeysIfOptionalMoment(valueA: any, valueB: any, valueAType: string, valueBType: string) {
+        const aIsMoment = valueAType === 'Moment';
+        const bIsMoment = valueBType === 'Moment';
+
+        const bothAreMoment = aIsMoment && bIsMoment;
+        const aIsMomentBIsNull = aIsMoment && valueB === null;
+        const bIsMomentAIsNull = bIsMoment && valueA === null;
+
+        if (bothAreMoment || aIsMomentBIsNull || bIsMomentAIsNull) {
+            return compareByDate(valueA, valueB);
+        }
+
+        return undefined;
     }
 
     private compareTaskSortKeysIfEitherIsNull(valueA: any, valueB: any) {

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -85,16 +85,13 @@ export class FunctionField extends Field {
         }
 
         if (sortKey === undefined) {
-            const sortKeyType = 'undefined';
-            throwSortKeyTypeError(sortKeyType);
+            throwSortKeyTypeError('undefined');
         }
         if (Number.isNaN(sortKey)) {
-            const sortKeyType = 'NaN (Not a Number)';
-            throwSortKeyTypeError(sortKeyType);
+            throwSortKeyTypeError('NaN (Not a Number)');
         }
         if (Array.isArray(sortKey)) {
-            const sortKeyType = 'array';
-            throwSortKeyTypeError(sortKeyType);
+            throwSortKeyTypeError('array');
         }
         return sortKey;
     }

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -109,13 +109,24 @@ export class FunctionField extends Field {
      */
     public compareTaskSortKeys(valueA: any, valueB: any, line: string) {
         // Precondition: Both parameter values have satisfied constraints in validateTaskSortKey().
+
+        const valueAType = getValueType(valueA);
+        const valueBType = getValueType(valueB);
+
+        const aIsMoment = valueAType === 'Moment';
+        const bIsMoment = valueBType === 'Moment';
+        const bothAreMoment = aIsMoment && bIsMoment;
+        const aIsMomentBIsNull = aIsMoment && valueB === null;
+        const bIsMomentAIsNull = bIsMoment && valueA === null;
+        if (bothAreMoment || aIsMomentBIsNull || bIsMomentAIsNull) {
+            return compareByDate(valueA, valueB);
+        }
+
         const resultIfNull = this.compareTaskSortKeysIfEitherIsNull(valueA, valueB);
         if (resultIfNull !== undefined) {
             return resultIfNull;
         }
 
-        const valueAType = getValueType(valueA);
-        const valueBType = getValueType(valueB);
         if (valueAType !== valueBType) {
             throw new Error(
                 `Unable to compare two different types: '${valueAType}' and '${valueBType}' order for expression '${line}'`,

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -141,7 +141,9 @@ export class FunctionField extends Field {
         // We use Number() to prevent implicit type conversion, by making the conversion explicit:
         const result = Number(valueA) - Number(valueB);
         if (isNaN(result)) {
-            throw new Error(`Unable to determine sort order for expression '${line}'`);
+            throw new Error(
+                `Unable to determine sort order for sort key types '${valueAType}' and '${valueBType}' from expression '${line}'`,
+            );
         }
         return result;
     }

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -72,10 +72,6 @@ export class FunctionField extends Field {
             return null;
         }
         const comparator = (a: Task, b: Task) => {
-            // If the result is negative, a is sorted before b.
-            // If the result is positive, b is sorted before a.
-            // If the result is 0, no changes are done with the sort order of the two values.
-
             const valueA = this.validateTaskSortKey(taskExpression.evaluate(a), line);
             const valueB = this.validateTaskSortKey(taskExpression.evaluate(b), line);
             return this.compareTaskSortKeys(valueA, valueB, line);
@@ -90,11 +86,28 @@ export class FunctionField extends Field {
         if (Number.isNaN(sortKey)) {
             throw new Error(`"NaN (Not a Number)" is not a valid sort key, from expression: "${line}"`);
         }
+        if (Array.isArray(sortKey)) {
+            throw new Error(`"array" is not a valid sort key, from expression: "${line}"`);
+        }
         return sortKey;
     }
 
-    // TODO Write tests of the behaviour of this for wide range of different value types
+    /**
+     * A comparator function for sorting two values
+     *
+     * **IMPORTANT**: Both values must already have been checked by {@link validateTaskSortKey}.
+     *
+     * - If the result is negative, a is sorted before b.
+     * - If the result is positive, b is sorted before a.
+     * - If the result is 0, no changes are done with the sort order of the two values.
+     *
+     * @param valueA - a value that satisfies {@link validateTaskSortKey}.
+     * @param valueB - a value that satisfies {@link validateTaskSortKey}.
+     * @param line - the instruction line: used for error messages.
+     */
     public compareTaskSortKeys(valueA: any, valueB: any, line: string) {
+        // Precondition: Both parameter values have satisfied constraints in validateTaskSortKey().
+
         if (valueA === null && valueB === null) {
             return 0;
         }

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -76,11 +76,15 @@ export class FunctionField extends Field {
             // If the result is positive, b is sorted before a.
             // If the result is 0, no changes are done with the sort order of the two values.
 
-            const valueA = taskExpression.evaluate(a);
-            const valueB = taskExpression.evaluate(b);
+            const valueA = this.validateTaskSortKey(taskExpression.evaluate(a));
+            const valueB = this.validateTaskSortKey(taskExpression.evaluate(b));
             return this.compareTaskSortKeys(valueA, valueB, line);
         };
         return new Sorter(line, this.fieldNameSingular(), comparator, reverse);
+    }
+
+    private validateTaskSortKey(sortKey: any) {
+        return sortKey;
     }
 
     // TODO Write tests of the behaviour of this for wide range of different value types

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -85,7 +85,11 @@ export class FunctionField extends Field {
 
             // Treat as numeric, so it works well with booleans
             // We use Number() to prevent implicit type conversion, by making the conversion explicit:
-            return Number(valueA) - Number(valueB);
+            const result = Number(valueA) - Number(valueB);
+            if (isNaN(result)) {
+                throw new Error(`Unable to determine sort order for expression '${line}'`);
+            }
+            return result;
         };
         return new Sorter(line, this.fieldNameSingular(), comparator, reverse);
     }

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -83,8 +83,9 @@ export class FunctionField extends Field {
                 return valueA.localeCompare(valueB, undefined, { numeric: true });
             }
 
-            // Treat as numeric
-            return valueA - valueB;
+            // Treat as numeric, so it works well with booleans
+            // We use Number() to prevent implicit type conversion, by making the conversion explicit:
+            return Number(valueA) - Number(valueB);
         };
         return new Sorter(line, this.fieldNameSingular(), comparator, reverse);
     }

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -69,7 +69,7 @@ export class FunctionField extends Field {
         const expression = match[2];
         const taskExpression = new TaskExpression(expression);
         if (!taskExpression.isValid()) {
-            throw new Error(`${taskExpression.parseError}, from instruction: "${line}"`);
+            throw new Error(`${taskExpression.parseError}: while parsing instruction: '${line}'`);
         }
         const comparator = (a: Task, b: Task) => {
             try {
@@ -78,7 +78,7 @@ export class FunctionField extends Field {
                 return this.compareTaskSortKeys(valueA, valueB);
             } catch (exception) {
                 if (exception instanceof Error) {
-                    exception.message += ` from instruction "${line}"`;
+                    exception.message += `: while evaluating instruction '${line}'`;
                 }
                 throw exception;
             }

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -78,20 +78,24 @@ export class FunctionField extends Field {
 
             const valueA = taskExpression.evaluate(a);
             const valueB = taskExpression.evaluate(b);
-
-            if (typeof valueA === 'string') {
-                return valueA.localeCompare(valueB, undefined, { numeric: true });
-            }
-
-            // Treat as numeric, so it works well with booleans
-            // We use Number() to prevent implicit type conversion, by making the conversion explicit:
-            const result = Number(valueA) - Number(valueB);
-            if (isNaN(result)) {
-                throw new Error(`Unable to determine sort order for expression '${line}'`);
-            }
-            return result;
+            return this.compareTaskSortKeys(valueA, valueB, line);
         };
         return new Sorter(line, this.fieldNameSingular(), comparator, reverse);
+    }
+
+    // TODO Write tests of the behaviour of this for wide range of different value types
+    private compareTaskSortKeys(valueA: any, valueB: any, line: string) {
+        if (typeof valueA === 'string') {
+            return valueA.localeCompare(valueB, undefined, { numeric: true });
+        }
+
+        // Treat as numeric, so it works well with booleans
+        // We use Number() to prevent implicit type conversion, by making the conversion explicit:
+        const result = Number(valueA) - Number(valueB);
+        if (isNaN(result)) {
+            throw new Error(`Unable to determine sort order for expression '${line}'`);
+        }
+        return result;
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -87,6 +87,9 @@ export class FunctionField extends Field {
         if (sortKey === undefined) {
             throw new Error(`"undefined" is not a valid sort key, from expression: "${line}"`);
         }
+        if (Number.isNaN(sortKey)) {
+            throw new Error(`"NaN (Not a Number)" is not a valid sort key, from expression: "${line}"`);
+        }
         return sortKey;
     }
 

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -107,20 +107,9 @@ export class FunctionField extends Field {
      */
     public compareTaskSortKeys(valueA: any, valueB: any, line: string) {
         // Precondition: Both parameter values have satisfied constraints in validateTaskSortKey().
-
-        if (valueA === null && valueB === null) {
-            return 0;
-        }
-
-        // Null sorts before anything else.
-        // This is consistent with how null headings are handled.
-        // However, it differs from how compareByDate() works, so special-case code will be needed
-        // for that, later.
-        if (valueA === null && valueB !== null) {
-            return -1;
-        }
-        if (valueA !== null && valueB === null) {
-            return 1;
+        const resultIfNull = this.compareTaskSortKeysIfEitherIsNull(valueA, valueB);
+        if (resultIfNull !== undefined) {
+            return resultIfNull;
         }
 
         const valueAType = typeof valueA;
@@ -142,6 +131,25 @@ export class FunctionField extends Field {
             throw new Error(`Unable to determine sort order for expression '${line}'`);
         }
         return result;
+    }
+
+    private compareTaskSortKeysIfEitherIsNull(valueA: any, valueB: any) {
+        if (valueA === null && valueB === null) {
+            return 0;
+        }
+
+        // Null sorts before anything else.
+        // This is consistent with how null headings are handled.
+        // However, it differs from how compareByDate() works, so special-case code will be needed
+        // for that, later.
+        if (valueA === null && valueB !== null) {
+            return -1;
+        }
+        if (valueA !== null && valueB === null) {
+            return 1;
+        }
+
+        return undefined;
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -69,9 +69,7 @@ export class FunctionField extends Field {
         const expression = match[2];
         const taskExpression = new TaskExpression(expression);
         if (!taskExpression.isValid()) {
-            // TODO Figure out error handling
-            // return FilterOrErrorMessage.fromError(line, taskExpression.parseError!);
-            return null;
+            throw new Error(`${taskExpression.parseError}, from instruction: "${line}"`);
         }
         const comparator = (a: Task, b: Task) => {
             const valueA = this.validateTaskSortKey(taskExpression.evaluate(a), line);

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -76,14 +76,17 @@ export class FunctionField extends Field {
             // If the result is positive, b is sorted before a.
             // If the result is 0, no changes are done with the sort order of the two values.
 
-            const valueA = this.validateTaskSortKey(taskExpression.evaluate(a));
-            const valueB = this.validateTaskSortKey(taskExpression.evaluate(b));
+            const valueA = this.validateTaskSortKey(taskExpression.evaluate(a), line);
+            const valueB = this.validateTaskSortKey(taskExpression.evaluate(b), line);
             return this.compareTaskSortKeys(valueA, valueB, line);
         };
         return new Sorter(line, this.fieldNameSingular(), comparator, reverse);
     }
 
-    private validateTaskSortKey(sortKey: any) {
+    public validateTaskSortKey(sortKey: any, line: string) {
+        if (sortKey === undefined) {
+            throw new Error(`"undefined" is not a valid sort key, from expression: "${line}"`);
+        }
         return sortKey;
     }
 

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -113,11 +113,13 @@ export class FunctionField extends Field {
         const valueAType = getValueType(valueA);
         const valueBType = getValueType(valueB);
 
+        // Sort Task.dueDate and similar in same order as 'sort by due' etc: null values come after Moment values:
         const resultIfMoment = this.compareTaskSortKeysIfOptionalMoment(valueA, valueB, valueAType, valueBType);
         if (resultIfMoment !== undefined) {
             return resultIfMoment;
         }
 
+        // Otherwise, any null values come after non-null values
         const resultIfNull = this.compareTaskSortKeysIfEitherIsNull(valueA, valueB);
         if (resultIfNull !== undefined) {
             return resultIfNull;

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -94,7 +94,22 @@ export class FunctionField extends Field {
     }
 
     // TODO Write tests of the behaviour of this for wide range of different value types
-    private compareTaskSortKeys(valueA: any, valueB: any, line: string) {
+    public compareTaskSortKeys(valueA: any, valueB: any, line: string) {
+        if (valueA === null && valueB === null) {
+            return 0;
+        }
+
+        // Null sorts before anything else.
+        // This is consistent with how null headings are handled.
+        // However, it differs from how compareByDate() works, so special-case code will be needed
+        // for that, later.
+        if (valueA === null && valueB !== null) {
+            return -1;
+        }
+        if (valueA !== null && valueB === null) {
+            return 1;
+        }
+
         if (typeof valueA === 'string') {
             return valueA.localeCompare(valueB, undefined, { numeric: true });
         }

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -110,7 +110,15 @@ export class FunctionField extends Field {
             return 1;
         }
 
-        if (typeof valueA === 'string') {
+        const valueAType = typeof valueA;
+        const valueBType = typeof valueB;
+        if (valueAType !== valueBType) {
+            throw new Error(
+                `Unable to compare two different types: '${valueAType}' and '${valueBType}' order for expression '${line}'`,
+            );
+        }
+
+        if (valueAType === 'string') {
             return valueA.localeCompare(valueB, undefined, { numeric: true });
         }
 

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -80,17 +80,21 @@ export class FunctionField extends Field {
     }
 
     public validateTaskSortKey(sortKey: any, line: string) {
+        function throwSortKeyTypeError(sortKeyType: string) {
+            throw new Error(`"${sortKeyType}" is not a valid sort key, from instruction "${line}"`);
+        }
+
         if (sortKey === undefined) {
             const sortKeyType = 'undefined';
-            throw new Error(`"${sortKeyType}" is not a valid sort key, from instruction "${line}"`);
+            throwSortKeyTypeError(sortKeyType);
         }
         if (Number.isNaN(sortKey)) {
             const sortKeyType = 'NaN (Not a Number)';
-            throw new Error(`"${sortKeyType}" is not a valid sort key, from instruction "${line}"`);
+            throwSortKeyTypeError(sortKeyType);
         }
         if (Array.isArray(sortKey)) {
             const sortKeyType = 'array';
-            throw new Error(`"${sortKeyType}" is not a valid sort key, from instruction "${line}"`);
+            throwSortKeyTypeError(sortKeyType);
         }
         return sortKey;
     }

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -81,13 +81,13 @@ export class FunctionField extends Field {
 
     public validateTaskSortKey(sortKey: any, line: string) {
         if (sortKey === undefined) {
-            throw new Error(`"undefined" is not a valid sort key, from expression: "${line}"`);
+            throw new Error(`"undefined" is not a valid sort key, from instruction "${line}"`);
         }
         if (Number.isNaN(sortKey)) {
-            throw new Error(`"NaN (Not a Number)" is not a valid sort key, from expression: "${line}"`);
+            throw new Error(`"NaN (Not a Number)" is not a valid sort key, from instruction "${line}"`);
         }
         if (Array.isArray(sortKey)) {
-            throw new Error(`"array" is not a valid sort key, from expression: "${line}"`);
+            throw new Error(`"array" is not a valid sort key, from instruction "${line}"`);
         }
         return sortKey;
     }
@@ -125,7 +125,7 @@ export class FunctionField extends Field {
 
         if (valueAType !== valueBType) {
             throw new Error(
-                `Unable to compare two different types: '${valueAType}' and '${valueBType}' order for expression '${line}'`,
+                `Unable to compare two different sort key types '${valueAType}' and '${valueBType}' order from instruction '${line}'`,
             );
         }
 
@@ -142,7 +142,7 @@ export class FunctionField extends Field {
         const result = Number(valueA) - Number(valueB);
         if (isNaN(result)) {
             throw new Error(
-                `Unable to determine sort order for sort key types '${valueAType}' and '${valueBType}' from expression '${line}'`,
+                `Unable to determine sort order for sort key types '${valueAType}' and '${valueBType}' from instruction '${line}'`,
             );
         }
         return result;

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -6,6 +6,7 @@ import { TaskExpression, parseAndEvaluateExpression } from '../../Scripting/Task
 import type { QueryContext } from '../../Scripting/QueryContext';
 import type { SearchInfo } from '../SearchInfo';
 import { Sorter } from '../Sorter';
+import { compareByDate } from '../../lib/DateTools';
 import { getValueType } from '../../lib/TypeDetection';
 import { Field } from './Field';
 import { Filter, type FilterFunction } from './Filter';
@@ -123,6 +124,10 @@ export class FunctionField extends Field {
 
         if (valueAType === 'string') {
             return valueA.localeCompare(valueB, undefined, { numeric: true });
+        }
+
+        if (valueAType === 'TasksDate') {
+            return compareByDate(valueA.moment, valueB.moment);
         }
 
         // Treat as numeric, so it works well with booleans

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -81,13 +81,16 @@ export class FunctionField extends Field {
 
     public validateTaskSortKey(sortKey: any, line: string) {
         if (sortKey === undefined) {
-            throw new Error(`"undefined" is not a valid sort key, from instruction "${line}"`);
+            const sortKeyType = 'undefined';
+            throw new Error(`"${sortKeyType}" is not a valid sort key, from instruction "${line}"`);
         }
         if (Number.isNaN(sortKey)) {
-            throw new Error(`"NaN (Not a Number)" is not a valid sort key, from instruction "${line}"`);
+            const sortKeyType = 'NaN (Not a Number)';
+            throw new Error(`"${sortKeyType}" is not a valid sort key, from instruction "${line}"`);
         }
         if (Array.isArray(sortKey)) {
-            throw new Error(`"array" is not a valid sort key, from instruction "${line}"`);
+            const sortKeyType = 'array';
+            throw new Error(`"${sortKeyType}" is not a valid sort key, from instruction "${line}"`);
         }
         return sortKey;
     }

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -6,6 +6,7 @@ import { TaskExpression, parseAndEvaluateExpression } from '../../Scripting/Task
 import type { QueryContext } from '../../Scripting/QueryContext';
 import type { SearchInfo } from '../SearchInfo';
 import { Sorter } from '../Sorter';
+import { getValueType } from '../../lib/TypeDetection';
 import { Field } from './Field';
 import { Filter, type FilterFunction } from './Filter';
 import { FilterOrErrorMessage } from './FilterOrErrorMessage';
@@ -112,8 +113,8 @@ export class FunctionField extends Field {
             return resultIfNull;
         }
 
-        const valueAType = typeof valueA;
-        const valueBType = typeof valueB;
+        const valueAType = getValueType(valueA);
+        const valueBType = getValueType(valueB);
         if (valueAType !== valueBType) {
             throw new Error(
                 `Unable to compare two different types: '${valueAType}' and '${valueBType}' order for expression '${line}'`,

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -73,9 +73,9 @@ export class FunctionField extends Field {
         }
         const comparator = (a: Task, b: Task) => {
             try {
-                const valueA = this.validateTaskSortKey(taskExpression.evaluate(a), line);
-                const valueB = this.validateTaskSortKey(taskExpression.evaluate(b), line);
-                return this.compareTaskSortKeys(valueA, valueB, line);
+                const valueA = this.validateTaskSortKey(taskExpression.evaluate(a));
+                const valueB = this.validateTaskSortKey(taskExpression.evaluate(b));
+                return this.compareTaskSortKeys(valueA, valueB);
             } catch (exception) {
                 if (exception instanceof Error) {
                     exception.message += ` from instruction "${line}"`;
@@ -86,7 +86,7 @@ export class FunctionField extends Field {
         return new Sorter(line, this.fieldNameSingular(), comparator, reverse);
     }
 
-    public validateTaskSortKey(sortKey: any, _line: string) {
+    public validateTaskSortKey(sortKey: any) {
         function throwSortKeyTypeError(sortKeyType: string) {
             throw new Error(`"${sortKeyType}" is not a valid sort key`);
         }
@@ -114,9 +114,8 @@ export class FunctionField extends Field {
      *
      * @param valueA - a value that satisfies {@link validateTaskSortKey}.
      * @param valueB - a value that satisfies {@link validateTaskSortKey}.
-     * @param line - the instruction line: used for error messages.
      */
-    public compareTaskSortKeys(valueA: any, valueB: any, _line: string) {
+    public compareTaskSortKeys(valueA: any, valueB: any) {
         // Precondition: Both parameter values have satisfied constraints in validateTaskSortKey().
 
         const valueAType = getValueType(valueA);

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -69,7 +69,9 @@ export class FunctionField extends Field {
         const expression = match[2];
         const taskExpression = new TaskExpression(expression);
         if (!taskExpression.isValid()) {
-            throw new Error(`${taskExpression.parseError}: while parsing instruction: '${line}'`);
+            // This does not need to report the line, and that it was parsing, as calling code
+            // will add that information.
+            throw new Error(taskExpression.parseError);
         }
         const comparator = (a: Task, b: Task) => {
             try {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -62,39 +62,42 @@ export class Query implements IQuery {
                 // There was an error expanding placeholders.
                 return;
             }
-
-            switch (true) {
-                case this.shortModeRegexp.test(line):
-                    this._queryLayoutOptions.shortMode = true;
-                    break;
-                case this.fullModeRegexp.test(line):
-                    this._queryLayoutOptions.shortMode = false;
-                    break;
-                case this.explainQueryRegexp.test(line):
-                    this._queryLayoutOptions.explainQuery = true;
-                    break;
-                case this.ignoreGlobalQueryRegexp.test(line):
-                    this._ignoreGlobalQuery = true;
-                    break;
-                case this.limitRegexp.test(line):
-                    this.parseLimit(line);
-                    break;
-                case this.parseSortBy(line):
-                    break;
-                case this.parseGroupBy(line):
-                    break;
-                case this.hideOptionsRegexp.test(line):
-                    this.parseHideOptions(line);
-                    break;
-                case this.commentRegexp.test(line):
-                    // Comment lines are ignored
-                    break;
-                case this.parseFilter(line):
-                    break;
-                default:
-                    this.setError('do not understand query', line);
-            }
+            this.parseLine(line);
         });
+    }
+
+    private parseLine(line: string) {
+        switch (true) {
+            case this.shortModeRegexp.test(line):
+                this._queryLayoutOptions.shortMode = true;
+                break;
+            case this.fullModeRegexp.test(line):
+                this._queryLayoutOptions.shortMode = false;
+                break;
+            case this.explainQueryRegexp.test(line):
+                this._queryLayoutOptions.explainQuery = true;
+                break;
+            case this.ignoreGlobalQueryRegexp.test(line):
+                this._ignoreGlobalQuery = true;
+                break;
+            case this.limitRegexp.test(line):
+                this.parseLimit(line);
+                break;
+            case this.parseSortBy(line):
+                break;
+            case this.parseGroupBy(line):
+                break;
+            case this.hideOptionsRegexp.test(line):
+                this.parseHideOptions(line);
+                break;
+            case this.commentRegexp.test(line):
+                // Comment lines are ignored
+                break;
+            case this.parseFilter(line):
+                break;
+            default:
+                this.setError('do not understand query', line);
+        }
     }
 
     private formatQueryForLogging() {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -62,7 +62,20 @@ export class Query implements IQuery {
                 // There was an error expanding placeholders.
                 return;
             }
-            this.parseLine(line);
+
+            try {
+                this.parseLine(line);
+            } catch (e) {
+                let message;
+                if (e instanceof Error) {
+                    message = e.message;
+                } else {
+                    message = 'Unknown error';
+                }
+
+                this.setError(message, line);
+                return;
+            }
         });
     }
 

--- a/src/lib/TypeDetection.ts
+++ b/src/lib/TypeDetection.ts
@@ -7,5 +7,10 @@ export function getValueType(value: any): string {
         return 'null';
     }
 
-    return typeof value;
+    const type = typeof value;
+    if (type === 'object') {
+        return value.constructor.name;
+    }
+
+    return type;
 }

--- a/src/lib/TypeDetection.ts
+++ b/src/lib/TypeDetection.ts
@@ -3,5 +3,9 @@
  * @param value
  */
 export function getValueType(value: any): string {
+    if (value === null) {
+        return 'null';
+    }
+
     return typeof value;
 }

--- a/src/lib/TypeDetection.ts
+++ b/src/lib/TypeDetection.ts
@@ -1,0 +1,7 @@
+/**
+ * Return a string representation of the {@link value}'s type, for showing to users, such as in error messages.
+ * @param value
+ */
+export function getValueType(value: any): string {
+    return typeof value;
+}

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -125,6 +125,11 @@ describe('FunctionField - sorting', () => {
                 expect(Object.is(field.validateTaskSortKey(key, key), key)).toEqual(true);
             });
 
+            it('should accept boolean sort key', () => {
+                expect(field.validateTaskSortKey(true, 'boolean - true')).toEqual(true);
+                expect(field.validateTaskSortKey(false, 'boolean - false')).toEqual(false);
+            });
+
             it('should accept null sort key', () => {
                 expect(Object.is(field.validateTaskSortKey(null, 'null'), null)).toEqual(true);
             });

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -308,7 +308,7 @@ describe('FunctionField - sorting', () => {
             expect(t).toThrowError(
                 `Error: Failed parsing expression "task.due.formatAsDate(".
 The error message was:
-    "SyntaxError: Unexpected token '}'", from instruction: "sort by function task.due.formatAsDate("`,
+    "SyntaxError: Unexpected token '}'": while parsing instruction: 'sort by function task.due.formatAsDate('`,
             );
         });
 
@@ -325,7 +325,7 @@ The error message was:
             expect(result.searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
-                    "ReferenceError: hello is not defined from instruction "sort by function hello"""
+                    "ReferenceError: hello is not defined: while evaluating instruction 'sort by function hello'""
             `);
         });
 
@@ -341,7 +341,7 @@ The error message was:
             expect(result.searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
-                    "Error: "undefined" is not a valid sort key from instruction "sort by function task.nonExistentField"""
+                    "Error: "undefined" is not a valid sort key: while evaluating instruction 'sort by function task.nonExistentField'""
             `);
         });
 
@@ -358,7 +358,7 @@ The error message was:
             expect(result.searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
-                    "Error: "array" is not a valid sort key from instruction "sort by function task.tags"""
+                    "Error: "array" is not a valid sort key: while evaluating instruction 'sort by function task.tags'""
             `);
         });
     });

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -301,6 +301,19 @@ describe('FunctionField - sorting', () => {
             expect(t).toThrow(Error);
         });
 
+        it('should throw if SyntaxError in expression', () => {
+            const line = 'sort by function task.due.formatAsDate(';
+            const t = () => {
+                field.createSorterFromLine(line);
+            };
+            expect(t).toThrow(Error);
+            expect(t).toThrowError(
+                `Error: Failed parsing expression "task.due.formatAsDate(".
+The error message was:
+    "SyntaxError: Unexpected token '}'", from instruction: "sort by function task.due.formatAsDate("`,
+            );
+        });
+
         it('should give a meaningful error for invalid syntax', () => {
             // Arrange
             const line = 'sort by function hello';

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -21,8 +21,23 @@ import {
 } from '../../CustomMatchers/CustomMatchersForSorting';
 import { fromLine } from '../../TestHelpers';
 import { Query } from '../../../src/Query/Query';
+import { TasksDate } from '../../../src/Scripting/TasksDate';
 
 window.moment = moment;
+
+const yesterday = '2023-12-02';
+const today = '2023-12-03';
+const tomorrow = '2023-12-04';
+
+const yesterdayDate = new TasksDate(moment(yesterday));
+const todayDate = new TasksDate(moment(today));
+const tomorrowDate = new TasksDate(moment(tomorrow));
+const undated = new TasksDate(null);
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(today));
+});
 
 // -----------------------------------------------------------------------------------------------------------------
 // Filtering
@@ -217,7 +232,12 @@ describe('FunctionField - sorting', () => {
         });
 
         // Note: Arrays are rejected at the validateTaskSortKey() stage.
-        // TODO TaskDates
+
+        it('should sort TaskDate objects in ascending date order, before any undated objects', () => {
+            expect(field.compareTaskSortKeys(todayDate, yesterdayDate, 'today and yesterday')).toEqual(AFTER);
+            expect(field.compareTaskSortKeys(todayDate, tomorrowDate, 'today and tomorrow')).toEqual(BEFORE);
+            expect(field.compareTaskSortKeys(todayDate, undated, 'today and undated')).toEqual(BEFORE);
+        });
 
         it('should refuse to compare values of different types (other than null)', () => {
             const valueA = 42;

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -319,17 +319,16 @@ describe('FunctionField - sorting', () => {
             expect(t).toThrowError(
                 `Error: Failed parsing expression "task.due.formatAsDate(".
 The error message was:
-    "SyntaxError: Unexpected token '}'": while parsing instruction: 'sort by function task.due.formatAsDate('`,
+    "SyntaxError: Unexpected token '}'"`,
             );
         });
 
         it('should give a meaningful error for syntax error', () => {
             const searchErrorMessage = getQueryErrorMessage('sort by function task.due.formatAsDate(');
-            // TODO This is too verbose - simplify it.
             expect(searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Failed parsing expression "task.due.formatAsDate(".
                 The error message was:
-                    "SyntaxError: Unexpected token '}'": while parsing instruction: 'sort by function task.due.formatAsDate('
+                    "SyntaxError: Unexpected token '}'"
                 Problem line: "sort by function task.due.formatAsDate(""
             `);
         });

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -326,7 +326,6 @@ The error message was:
             const result = query.applyQueryToTasks([task, task]);
 
             // Assert
-            // TODO It would be good to include the instruction line in this error message.
             expect(result.searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -205,7 +205,7 @@ describe('FunctionField - sorting', () => {
         const BEFORE = -1;
         const AFTER = 1;
 
-        function checkAndCompareSortKeys(valueA: null, valueB: null, description: string) {
+        function checkAndCompareSortKeys(valueA: any, valueB: any, description: string) {
             return field.compareTaskSortKeys(valueA, valueB, description);
         }
 
@@ -215,53 +215,53 @@ describe('FunctionField - sorting', () => {
             const valueB = null;
             const description = 'two nulls';
             expect(checkAndCompareSortKeys(valueA, valueB, description)).toEqual(SAME);
-            expect(field.compareTaskSortKeys(null, 'a string', 'null and "a string"')).toEqual(BEFORE);
-            expect(field.compareTaskSortKeys(false, null, 'false and null')).toEqual(AFTER);
+            expect(checkAndCompareSortKeys(null, 'a string', 'null and "a string"')).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys(false, null, 'false and null')).toEqual(AFTER);
         });
 
         it('should sort numbers in ascending order', () => {
-            expect(field.compareTaskSortKeys(1, 1, '1 1')).toEqual(SAME);
+            expect(checkAndCompareSortKeys(1, 1, '1 1')).toEqual(SAME);
             // number comparison is implementing with subtraction of the two values,
             // so we cannot just check for values -1 pr +1.
-            expect(field.compareTaskSortKeys(42, 47, '42 and 47')).toBeLessThan(0);
-            expect(field.compareTaskSortKeys(3.15634, 1.535436, '3.15634 and 1.535436')).toBeGreaterThan(0);
+            expect(checkAndCompareSortKeys(42, 47, '42 and 47')).toBeLessThan(0);
+            expect(checkAndCompareSortKeys(3.15634, 1.535436, '3.15634 and 1.535436')).toBeGreaterThan(0);
         });
 
         it('should sort false boolean before true', () => {
-            expect(field.compareTaskSortKeys(1, 1, '1 1')).toEqual(SAME);
-            expect(field.compareTaskSortKeys(false, true, 'false and true')).toEqual(BEFORE);
-            expect(field.compareTaskSortKeys(true, false, 'true and false')).toEqual(AFTER);
+            expect(checkAndCompareSortKeys(1, 1, '1 1')).toEqual(SAME);
+            expect(checkAndCompareSortKeys(false, true, 'false and true')).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys(true, false, 'true and false')).toEqual(AFTER);
         });
 
         it('should sort strings case-sensitively and be number-aware', () => {
-            expect(field.compareTaskSortKeys('9', '10', 'true and false')).toEqual(BEFORE);
-            expect(field.compareTaskSortKeys('ABCDE', 'abcde', 'ABCDE and abcde')).toEqual(AFTER);
+            expect(checkAndCompareSortKeys('9', '10', 'true and false')).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys('ABCDE', 'abcde', 'ABCDE and abcde')).toEqual(AFTER);
         });
 
         // Note: Arrays are rejected at the validateTaskSortKey() stage.
 
         it('should sort TaskDate objects in ascending date order, before any undated objects', () => {
-            expect(field.compareTaskSortKeys(todayDate, yesterdayDate, 'today and yesterday')).toEqual(AFTER);
-            expect(field.compareTaskSortKeys(todayDate, tomorrowDate, 'today and tomorrow')).toEqual(BEFORE);
-            expect(field.compareTaskSortKeys(todayDate, undated, 'today and undated')).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys(todayDate, yesterdayDate, 'today and yesterday')).toEqual(AFTER);
+            expect(checkAndCompareSortKeys(todayDate, tomorrowDate, 'today and tomorrow')).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys(todayDate, undated, 'today and undated')).toEqual(BEFORE);
         });
 
         it('should sort Moment objects in ascending date order, before any undated objects', () => {
-            expect(field.compareTaskSortKeys(todayDate.moment, yesterdayDate.moment, 'today and yesterday')).toEqual(
+            expect(checkAndCompareSortKeys(todayDate.moment, yesterdayDate.moment, 'today and yesterday')).toEqual(
                 AFTER,
             );
-            expect(field.compareTaskSortKeys(todayDate.moment, tomorrowDate.moment, 'today and tomorrow')).toEqual(
+            expect(checkAndCompareSortKeys(todayDate.moment, tomorrowDate.moment, 'today and tomorrow')).toEqual(
                 BEFORE,
             );
-            expect(field.compareTaskSortKeys(todayDate.moment, undated.moment, 'today and undated')).toEqual(BEFORE);
-            expect(field.compareTaskSortKeys(undated.moment, todayDate.moment, 'undated and today')).toEqual(AFTER);
+            expect(checkAndCompareSortKeys(todayDate.moment, undated.moment, 'today and undated')).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys(undated.moment, todayDate.moment, 'undated and today')).toEqual(AFTER);
         });
 
         it('should refuse to compare values of different types (other than null)', () => {
             const valueA = 42;
             const valueB = '97';
             const t = () => {
-                field.compareTaskSortKeys(valueA, valueB, 'group by function something or other...');
+                checkAndCompareSortKeys(valueA, valueB, 'group by function something or other...');
             };
             expect(t).toThrow(Error);
             expect(t).toThrowError(
@@ -273,7 +273,7 @@ describe('FunctionField - sorting', () => {
             const taskA = new TaskBuilder().description('A').build();
             const taskB = new TaskBuilder().description('B').build();
             const t = () => {
-                field.compareTaskSortKeys(taskA, taskB, 'two Task objects');
+                checkAndCompareSortKeys(taskA, taskB, 'two Task objects');
             };
             expect(t).toThrow(Error);
             expect(t).toThrowError(

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -159,6 +159,18 @@ describe('FunctionField - sorting', () => {
                     "ReferenceError: hello is not defined""
             `);
         });
+
+        it.failing('should give a meaningful error for unknown task field', () => {
+            const line = 'sort by function task.nonExistentField';
+            const query = new Query(line);
+            const task = fromLine({ line: '- [ ] stuff' });
+
+            // Act
+            const result = query.applyQueryToTasks([task, task]);
+
+            // Assert
+            expect(result.searchErrorMessage).not.toBeUndefined();
+        });
     });
 
     describe('example functions', () => {

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -160,7 +160,7 @@ describe('FunctionField - sorting', () => {
             `);
         });
 
-        it.failing('should give a meaningful error for unknown task field', () => {
+        it('should give a meaningful error for unknown task field', () => {
             const line = 'sort by function task.nonExistentField';
             const query = new Query(line);
             const task = fromLine({ line: '- [ ] stuff' });
@@ -169,7 +169,28 @@ describe('FunctionField - sorting', () => {
             const result = query.applyQueryToTasks([task, task]);
 
             // Assert
-            expect(result.searchErrorMessage).not.toBeUndefined();
+            expect(result.searchErrorMessage).toMatchInlineSnapshot(`
+                "Error: Search failed.
+                The error message was:
+                    "Error: Unable to determine sort order for expression 'sort by function task.nonExistentField'""
+            `);
+        });
+
+        it('should give a meaningful error when sorting by arrays', () => {
+            // Arrange
+            const line = 'sort by function task.tags';
+            const query = new Query(line);
+            const task = fromLine({ line: '- [ ] stuff #tag1' });
+
+            // Act
+            const result = query.applyQueryToTasks([task, task]);
+
+            // Assert
+            expect(result.searchErrorMessage).toMatchInlineSnapshot(`
+                "Error: Search failed.
+                The error message was:
+                    "Error: Unable to determine sort order for expression 'sort by function task.tags'""
+            `);
         });
     });
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -165,6 +165,17 @@ describe('FunctionField - sorting', () => {
         });
     });
 
+    describe('comparing', () => {
+        const field = new FunctionField();
+
+        it('should sort null before any other valid values', () => {
+            // Note: once we test sorting by date, we will need extra tests here. See compareByDate()
+            expect(field.compareTaskSortKeys(null, null, 'two nulls')).toEqual(0);
+            expect(field.compareTaskSortKeys(null, 'a string', 'null and "a string"')).toEqual(-1);
+            expect(field.compareTaskSortKeys(false, null, 'false and null')).toEqual(1);
+        });
+    });
+
     describe('error-handling', () => {
         const field = new FunctionField();
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -163,7 +163,7 @@ describe('FunctionField - sorting', () => {
                 };
                 expect(t).toThrow(Error);
                 expect(t).toThrowError(
-                    '"undefined" is not a valid sort key, from expression: "group by function undefined"',
+                    '"undefined" is not a valid sort key, from instruction "group by function undefined"',
                 );
             });
 
@@ -174,7 +174,7 @@ describe('FunctionField - sorting', () => {
                 };
                 expect(t).toThrow(Error);
                 expect(t).toThrowError(
-                    '"NaN (Not a Number)" is not a valid sort key, from expression: "group by function NaN"',
+                    '"NaN (Not a Number)" is not a valid sort key, from instruction "group by function NaN"',
                 );
             });
 
@@ -184,7 +184,7 @@ describe('FunctionField - sorting', () => {
                     field.validateTaskSortKey(key, 'group by function [17]');
                 };
                 expect(t).toThrow(Error);
-                expect(t).toThrowError('"array" is not a valid sort key, from expression: "group by function [17]"');
+                expect(t).toThrowError('"array" is not a valid sort key, from instruction "group by function [17]"');
             });
 
             it('should forbid an empty array sort key', () => {
@@ -193,7 +193,7 @@ describe('FunctionField - sorting', () => {
                     field.validateTaskSortKey(key, 'group by function []');
                 };
                 expect(t).toThrow(Error);
-                expect(t).toThrowError('"array" is not a valid sort key, from expression: "group by function []"');
+                expect(t).toThrowError('"array" is not a valid sort key, from instruction "group by function []"');
             });
         });
     });
@@ -268,7 +268,7 @@ describe('FunctionField - sorting', () => {
             };
             expect(t).toThrow(Error);
             expect(t).toThrowError(
-                "Unable to compare two different types: 'number' and 'string' order for expression 'group by function something or other...'",
+                "Unable to compare two different sort key types 'number' and 'string' order from instruction 'group by function something or other...'",
             );
         });
 
@@ -280,7 +280,7 @@ describe('FunctionField - sorting', () => {
             };
             expect(t).toThrow(Error);
             expect(t).toThrowError(
-                "Unable to determine sort order for sort key types 'Task' and 'Task' from expression 'two Task objects'",
+                "Unable to determine sort order for sort key types 'Task' and 'Task' from instruction 'two Task objects'",
             );
         });
     });
@@ -354,7 +354,7 @@ The error message was:
             expect(result.searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
-                    "Error: "undefined" is not a valid sort key, from expression: "sort by function task.nonExistentField"""
+                    "Error: "undefined" is not a valid sort key, from instruction "sort by function task.nonExistentField"""
             `);
         });
 
@@ -371,7 +371,7 @@ The error message was:
             expect(result.searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
-                    "Error: "array" is not a valid sort key, from expression: "sort by function task.tags"""
+                    "Error: "array" is not a valid sort key, from instruction "sort by function task.tags"""
             `);
         });
     });

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -168,11 +168,15 @@ describe('FunctionField - sorting', () => {
     describe('comparing', () => {
         const field = new FunctionField();
 
+        const SAME = 0;
+        const BEFORE = -1;
+        const AFTER = 1;
+
         it('should sort null before any other valid values', () => {
             // Note: once we test sorting by date, we will need extra tests here. See compareByDate()
-            expect(field.compareTaskSortKeys(null, null, 'two nulls')).toEqual(0);
-            expect(field.compareTaskSortKeys(null, 'a string', 'null and "a string"')).toEqual(-1);
-            expect(field.compareTaskSortKeys(false, null, 'false and null')).toEqual(1);
+            expect(field.compareTaskSortKeys(null, null, 'two nulls')).toEqual(SAME);
+            expect(field.compareTaskSortKeys(null, 'a string', 'null and "a string"')).toEqual(BEFORE);
+            expect(field.compareTaskSortKeys(false, null, 'false and null')).toEqual(AFTER);
         });
     });
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -137,21 +137,21 @@ describe('FunctionField - sorting', () => {
         describe('allowed sort key types', () => {
             it('should accept string sort key', () => {
                 const key = 'anything';
-                expect(Object.is(field.validateTaskSortKey(key, 'group by function "anything"'), key)).toEqual(true);
+                expect(Object.is(field.validateTaskSortKey(key), key)).toEqual(true);
             });
 
             it('should accept number sort key', () => {
-                expect(field.validateTaskSortKey(42, 'group by function 42')).toEqual(42);
-                expect(field.validateTaskSortKey(0.15634, 'group by function 0.15634')).toEqual(0.15634);
+                expect(field.validateTaskSortKey(42)).toEqual(42);
+                expect(field.validateTaskSortKey(0.15634)).toEqual(0.15634);
             });
 
             it('should accept boolean sort key', () => {
-                expect(field.validateTaskSortKey(true, 'group by function true')).toEqual(true);
-                expect(field.validateTaskSortKey(false, 'group by function false')).toEqual(false);
+                expect(field.validateTaskSortKey(true)).toEqual(true);
+                expect(field.validateTaskSortKey(false)).toEqual(false);
             });
 
             it('should accept null sort key', () => {
-                expect(Object.is(field.validateTaskSortKey(null, 'group by function null'), null)).toEqual(true);
+                expect(Object.is(field.validateTaskSortKey(null), null)).toEqual(true);
             });
         });
 
@@ -159,7 +159,7 @@ describe('FunctionField - sorting', () => {
             it('should forbid undefined sort key', () => {
                 const key = undefined;
                 const t = () => {
-                    field.validateTaskSortKey(key, 'group by function undefined');
+                    field.validateTaskSortKey(key);
                 };
                 expect(t).toThrow(Error);
                 expect(t).toThrowError('"undefined" is not a valid sort key');
@@ -168,7 +168,7 @@ describe('FunctionField - sorting', () => {
             it('should forbid NaN sort key', () => {
                 const key = NaN;
                 const t = () => {
-                    field.validateTaskSortKey(key, 'group by function NaN');
+                    field.validateTaskSortKey(key);
                 };
                 expect(t).toThrow(Error);
                 expect(t).toThrowError('"NaN (Not a Number)" is not a valid sort key');
@@ -177,7 +177,7 @@ describe('FunctionField - sorting', () => {
             it('should forbid a non-empty array sort key', () => {
                 const key = [17];
                 const t = () => {
-                    field.validateTaskSortKey(key, 'group by function [17]');
+                    field.validateTaskSortKey(key);
                 };
                 expect(t).toThrow(Error);
                 expect(t).toThrowError('"array" is not a valid sort key');
@@ -186,7 +186,7 @@ describe('FunctionField - sorting', () => {
             it('should forbid an empty array sort key', () => {
                 const key: number[] = [];
                 const t = () => {
-                    field.validateTaskSortKey(key, 'group by function []');
+                    field.validateTaskSortKey(key);
                 };
                 expect(t).toThrow(Error);
                 expect(t).toThrowError('"array" is not a valid sort key');
@@ -201,14 +201,14 @@ describe('FunctionField - sorting', () => {
         const BEFORE = -1;
         const AFTER = 1;
 
-        function checkAndCompareSortKeys(valueA: any, valueB: any, description: string) {
+        function checkAndCompareSortKeys(valueA: any, valueB: any, _description: string) {
             // A pre-condition of compareTaskSortKeys() is that the values satisfy validateTaskSortKey().
             // By calling validateTaskSortKey() here, we ensure that any test failures from
             // compareTaskSortKeys() are failing for the correct reason.
-            field.validateTaskSortKey(valueA, description);
-            field.validateTaskSortKey(valueB, description);
+            field.validateTaskSortKey(valueA);
+            field.validateTaskSortKey(valueB);
 
-            return field.compareTaskSortKeys(valueA, valueB, description);
+            return field.compareTaskSortKeys(valueA, valueB);
         }
 
         it('should sort null before any other valid values - except for Moment and TasksDate', () => {

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -330,15 +330,8 @@ The error message was:
         });
 
         it('should give a meaningful error for unknown task field', () => {
-            const line = 'sort by function task.nonExistentField';
-            const query = new Query(line);
-            const task = fromLine({ line: '- [ ] stuff' });
-
-            // Act
-            const result = query.applyQueryToTasks([task, task]);
-
-            // Assert
-            expect(result.searchErrorMessage).toMatchInlineSnapshot(`
+            const searchErrorMessage = getQueryErrorMessage('sort by function task.nonExistentField');
+            expect(searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
                     "Error: "undefined" is not a valid sort key: while evaluating instruction 'sort by function task.nonExistentField'""
@@ -346,16 +339,8 @@ The error message was:
         });
 
         it('should give a meaningful error when sorting by arrays', () => {
-            // Arrange
-            const line = 'sort by function task.tags';
-            const query = new Query(line);
-            const task = fromLine({ line: '- [ ] stuff #tag1' });
-
-            // Act
-            const result = query.applyQueryToTasks([task, task]);
-
-            // Assert
-            expect(result.searchErrorMessage).toMatchInlineSnapshot(`
+            const searchErrorMessage = getQueryErrorMessage('sort by function task.tags');
+            expect(searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
                     "Error: "array" is not a valid sort key: while evaluating instruction 'sort by function task.tags'""

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -187,7 +187,12 @@ describe('FunctionField - sorting', () => {
             expect(field.compareTaskSortKeys(3.15634, 1.535436, '3.15634 and 1.535436')).toBeGreaterThan(0);
         });
 
-        // TODO boolean
+        it('should sort false boolean before true', () => {
+            expect(field.compareTaskSortKeys(1, 1, '1 1')).toEqual(SAME);
+            expect(field.compareTaskSortKeys(false, true, 'false and true')).toEqual(BEFORE);
+            expect(field.compareTaskSortKeys(true, false, 'true and false')).toEqual(AFTER);
+        });
+
         // TODO string
         // TODO array
         // TODO mixed types

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -217,10 +217,7 @@ describe('FunctionField - sorting', () => {
 
         it('should sort null before any other valid values', () => {
             // Note: once we test sorting by date, we will need extra tests here. See compareByDate()
-            const valueA = null;
-            const valueB = null;
-            const description = 'two nulls';
-            expect(checkAndCompareSortKeys(valueA, valueB, description)).toEqual(SAME);
+            expect(checkAndCompareSortKeys(null, null, 'two nulls')).toEqual(SAME);
             expect(checkAndCompareSortKeys(null, 'a string', 'null and "a string"')).toEqual(BEFORE);
             expect(checkAndCompareSortKeys(false, null, 'false and null')).toEqual(AFTER);
         });

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -215,8 +215,8 @@ describe('FunctionField - sorting', () => {
             return field.compareTaskSortKeys(valueA, valueB, description);
         }
 
-        it('should sort null before any other valid values', () => {
-            // Note: once we test sorting by date, we will need extra tests here. See compareByDate()
+        it('should sort null before any other valid values - except for Moment and TasksDate', () => {
+            // Note: TasksDate and Moment with null sorts the opposite round - see later tests.
             expect(checkAndCompareSortKeys(null, null, 'two nulls')).toEqual(SAME);
             expect(checkAndCompareSortKeys(null, 'a string', 'null and "a string"')).toEqual(BEFORE);
             expect(checkAndCompareSortKeys(false, null, 'false and null')).toEqual(AFTER);
@@ -225,7 +225,7 @@ describe('FunctionField - sorting', () => {
         it('should sort numbers in ascending order', () => {
             expect(checkAndCompareSortKeys(1, 1, '1 1')).toEqual(SAME);
             // number comparison is implementing with subtraction of the two values,
-            // so we cannot just check for values -1 pr +1.
+            // so we cannot just check for values -1 or +1.
             expect(checkAndCompareSortKeys(42, 47, '42 and 47')).toBeLessThan(0);
             expect(checkAndCompareSortKeys(3.15634, 1.535436, '3.15634 and 1.535436')).toBeGreaterThan(0);
         });

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -115,6 +115,33 @@ describe('FunctionField - sorting', () => {
         });
     });
 
+    describe('error-handling', () => {
+        const field = new FunctionField();
+
+        it('should throw in comparator()', () => {
+            // It's not possible to create a Comparator without a line,
+            // so comparator() method needs to throw and report it cannot work.
+            const t = () => {
+                field.comparator();
+            };
+            expect(t).toThrow(Error);
+        });
+
+        it('should throw creating a normal sorter()', () => {
+            const t = () => {
+                field.createNormalSorter();
+            };
+            expect(t).toThrow(Error);
+        });
+
+        it('should throw creating a reverse sorter()', () => {
+            const t = () => {
+                field.createReverseSorter();
+            };
+            expect(t).toThrow(Error);
+        });
+    });
+
     describe('example functions', () => {
         // Helper function to create a task with a given path
         function with_description(description: string) {

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -162,6 +162,24 @@ describe('FunctionField - sorting', () => {
                     '"NaN (Not a Number)" is not a valid sort key, from expression: "group by function NaN"',
                 );
             });
+
+            it('should forbid a non-empty array sort key', () => {
+                const key = [17];
+                const t = () => {
+                    field.validateTaskSortKey(key, 'group by function [17]');
+                };
+                expect(t).toThrow(Error);
+                expect(t).toThrowError('"array" is not a valid sort key, from expression: "group by function [17]"');
+            });
+
+            it('should forbid an empty array sort key', () => {
+                const key: number[] = [];
+                const t = () => {
+                    field.validateTaskSortKey(key, 'group by function []');
+                };
+                expect(t).toThrow(Error);
+                expect(t).toThrowError('"array" is not a valid sort key, from expression: "group by function []"');
+            });
         });
     });
 
@@ -198,7 +216,7 @@ describe('FunctionField - sorting', () => {
             expect(field.compareTaskSortKeys('ABCDE', 'abcde', 'ABCDE and abcde')).toEqual(AFTER);
         });
 
-        // TODO array
+        // Note: Arrays are rejected at the validateTaskSortKey() stage.
         // TODO TaskDates
 
         it('should refuse to compare values of different types (other than null)', () => {
@@ -287,7 +305,7 @@ describe('FunctionField - sorting', () => {
             expect(result.searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
-                    "Error: Unable to determine sort order for expression 'sort by function task.tags'""
+                    "Error: "array" is not a valid sort key, from expression: "sort by function task.tags"""
             `);
         });
     });

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -193,9 +193,14 @@ describe('FunctionField - sorting', () => {
             expect(field.compareTaskSortKeys(true, false, 'true and false')).toEqual(AFTER);
         });
 
-        // TODO string
+        it('should sort strings case-sensitively and be number-aware', () => {
+            expect(field.compareTaskSortKeys('9', '10', 'true and false')).toEqual(BEFORE);
+            expect(field.compareTaskSortKeys('ABCDE', 'abcde', 'ABCDE and abcde')).toEqual(AFTER);
+        });
+
         // TODO array
         // TODO mixed types
+        // TODO TaskDates
     });
 
     describe('error-handling', () => {

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -124,6 +124,10 @@ describe('FunctionField - sorting', () => {
                 const key = 'anything';
                 expect(Object.is(field.validateTaskSortKey(key, key), key)).toEqual(true);
             });
+
+            it('should accept null sort key', () => {
+                expect(Object.is(field.validateTaskSortKey(null, 'null'), null)).toEqual(true);
+            });
         });
 
         describe('forbidden sort key types', () => {

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -125,6 +125,11 @@ describe('FunctionField - sorting', () => {
                 expect(Object.is(field.validateTaskSortKey(key, 'group by function "anything"'), key)).toEqual(true);
             });
 
+            it('should accept number sort key', () => {
+                expect(field.validateTaskSortKey(42, 'group by function 42')).toEqual(42);
+                expect(field.validateTaskSortKey(0.15634, 'group by function 0.15634')).toEqual(0.15634);
+            });
+
             it('should accept boolean sort key', () => {
                 expect(field.validateTaskSortKey(true, 'group by function true')).toEqual(true);
                 expect(field.validateTaskSortKey(false, 'group by function false')).toEqual(false);

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -205,9 +205,16 @@ describe('FunctionField - sorting', () => {
         const BEFORE = -1;
         const AFTER = 1;
 
+        function checkAndCompareSortKeys(valueA: null, valueB: null, description: string) {
+            return field.compareTaskSortKeys(valueA, valueB, description);
+        }
+
         it('should sort null before any other valid values', () => {
             // Note: once we test sorting by date, we will need extra tests here. See compareByDate()
-            expect(field.compareTaskSortKeys(null, null, 'two nulls')).toEqual(SAME);
+            const valueA = null;
+            const valueB = null;
+            const description = 'two nulls';
+            expect(checkAndCompareSortKeys(valueA, valueB, description)).toEqual(SAME);
             expect(field.compareTaskSortKeys(null, 'a string', 'null and "a string"')).toEqual(BEFORE);
             expect(field.compareTaskSortKeys(false, null, 'false and null')).toEqual(AFTER);
         });

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -223,6 +223,17 @@ describe('FunctionField - sorting', () => {
             expectTaskComparesEqual(sorter!, fromLine({ line: '- [ ] Hello' }), fromLine({ line: '- [ ] Hello' }));
             expectTaskComparesAfter(sorter!, fromLine({ line: '* [ ] Hello' }), fromLine({ line: '- [ ] Hello' }));
         });
+
+        it('sort by function - boolean expression - false sorts before true', () => {
+            // Arrange
+            const sorter = new FunctionField().createSorterFromLine('sort by function task.isDone');
+            const todoTask = fromLine({ line: '- [ ] todo' });
+            const doneTask = fromLine({ line: '- [x] done' });
+
+            // Assert
+            expect(sorter).not.toBeNull();
+            expectTaskComparesBefore(sorter!, todoTask, doneTask);
+        });
     });
 });
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -135,6 +135,15 @@ describe('FunctionField - sorting', () => {
                 expect(t).toThrow(Error);
                 expect(t).toThrowError('"undefined" is not a valid sort key, from expression: "undefined"');
             });
+
+            it('should forbid NaN sort key', () => {
+                const key = NaN;
+                const t = () => {
+                    field.validateTaskSortKey(key, 'NaN');
+                };
+                expect(t).toThrow(Error);
+                expect(t).toThrowError('"NaN (Not a Number)" is not a valid sort key, from expression: "NaN"');
+            });
         });
     });
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -162,9 +162,7 @@ describe('FunctionField - sorting', () => {
                     field.validateTaskSortKey(key, 'group by function undefined');
                 };
                 expect(t).toThrow(Error);
-                expect(t).toThrowError(
-                    '"undefined" is not a valid sort key, from instruction "group by function undefined"',
-                );
+                expect(t).toThrowError('"undefined" is not a valid sort key');
             });
 
             it('should forbid NaN sort key', () => {
@@ -173,9 +171,7 @@ describe('FunctionField - sorting', () => {
                     field.validateTaskSortKey(key, 'group by function NaN');
                 };
                 expect(t).toThrow(Error);
-                expect(t).toThrowError(
-                    '"NaN (Not a Number)" is not a valid sort key, from instruction "group by function NaN"',
-                );
+                expect(t).toThrowError('"NaN (Not a Number)" is not a valid sort key');
             });
 
             it('should forbid a non-empty array sort key', () => {
@@ -184,7 +180,7 @@ describe('FunctionField - sorting', () => {
                     field.validateTaskSortKey(key, 'group by function [17]');
                 };
                 expect(t).toThrow(Error);
-                expect(t).toThrowError('"array" is not a valid sort key, from instruction "group by function [17]"');
+                expect(t).toThrowError('"array" is not a valid sort key');
             });
 
             it('should forbid an empty array sort key', () => {
@@ -193,7 +189,7 @@ describe('FunctionField - sorting', () => {
                     field.validateTaskSortKey(key, 'group by function []');
                 };
                 expect(t).toThrow(Error);
-                expect(t).toThrowError('"array" is not a valid sort key, from instruction "group by function []"');
+                expect(t).toThrowError('"array" is not a valid sort key');
             });
         });
     });
@@ -267,9 +263,7 @@ describe('FunctionField - sorting', () => {
                 checkAndCompareSortKeys(valueA, valueB, 'group by function something or other...');
             };
             expect(t).toThrow(Error);
-            expect(t).toThrowError(
-                "Unable to compare two different sort key types 'number' and 'string' order from instruction 'group by function something or other...'",
-            );
+            expect(t).toThrowError("Unable to compare two different sort key types 'number' and 'string' order");
         });
 
         it('should refuse to compare unrecognised type', () => {
@@ -279,9 +273,7 @@ describe('FunctionField - sorting', () => {
                 checkAndCompareSortKeys(taskA, taskB, 'two Task objects');
             };
             expect(t).toThrow(Error);
-            expect(t).toThrowError(
-                "Unable to determine sort order for sort key types 'Task' and 'Task' from instruction 'two Task objects'",
-            );
+            expect(t).toThrowError("Unable to determine sort order for sort key types 'Task' and 'Task'");
         });
     });
 
@@ -338,7 +330,7 @@ The error message was:
             expect(result.searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
-                    "ReferenceError: hello is not defined""
+                    "ReferenceError: hello is not defined from instruction "sort by function hello"""
             `);
         });
 
@@ -354,7 +346,7 @@ The error message was:
             expect(result.searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
-                    "Error: "undefined" is not a valid sort key, from instruction "sort by function task.nonExistentField"""
+                    "Error: "undefined" is not a valid sort key from instruction "sort by function task.nonExistentField"""
             `);
         });
 
@@ -371,7 +363,7 @@ The error message was:
             expect(result.searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
-                    "Error: "array" is not a valid sort key, from instruction "sort by function task.tags"""
+                    "Error: "array" is not a valid sort key from instruction "sort by function task.tags"""
             `);
         });
     });

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -179,7 +179,7 @@ describe('FunctionField - sorting', () => {
             return new TaskBuilder().description(description).build();
         }
 
-        it('sort by function - integer expression', () => {
+        it('sort by function - integer expression - smaller numbers come before larger ones', () => {
             // Arrange
             const sorter = new FunctionField().createSorterFromLine('sort by function task.description.length');
 
@@ -211,7 +211,7 @@ describe('FunctionField - sorting', () => {
             expectTaskComparesBefore(sorter!, with_description('xxxx'), with_description('x'));
         });
 
-        it('sort by function - string expression', () => {
+        it('sort by function - string expression - case-insensitive, number sort', () => {
             // Arrange
             const sorter = new FunctionField().createSorterFromLine('sort by function task.originalMarkdown');
 
@@ -220,7 +220,7 @@ describe('FunctionField - sorting', () => {
             expectTaskComparesBefore(sorter!, fromLine({ line: '- [ ] Hello' }), fromLine({ line: '* [ ] Hello' }));
             expectTaskComparesBefore(sorter!, fromLine({ line: '* [ ] Apple' }), fromLine({ line: '* [ ] Hello' }));
             expectTaskComparesBefore(sorter!, fromLine({ line: '* [ ] Apple' }), fromLine({ line: '* [ ] APPLE' })); // case-insensitive
-            expectTaskComparesEqual(sorter!, fromLine({ line: '- [ ] Hello' }), fromLine({ line: '- [ ] Hello' }));
+            expectTaskComparesAfter(sorter!, fromLine({ line: '- [ ] 10 Hello' }), fromLine({ line: '- [ ] 9 Hello' }));
             expectTaskComparesAfter(sorter!, fromLine({ line: '* [ ] Hello' }), fromLine({ line: '- [ ] Hello' }));
         });
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -278,6 +278,9 @@ describe('FunctionField - sorting', () => {
 
         function getQueryErrorMessage(line: string) {
             const query = new Query(line);
+            if (query.error) {
+                return query.error;
+            }
             const task = fromLine({ line: '- [ ] stuff' });
 
             const result = query.applyQueryToTasks([task, task]);
@@ -318,6 +321,17 @@ describe('FunctionField - sorting', () => {
 The error message was:
     "SyntaxError: Unexpected token '}'": while parsing instruction: 'sort by function task.due.formatAsDate('`,
             );
+        });
+
+        it('should give a meaningful error for syntax error', () => {
+            const searchErrorMessage = getQueryErrorMessage('sort by function task.due.formatAsDate(');
+            // TODO This is too verbose - simplify it.
+            expect(searchErrorMessage).toMatchInlineSnapshot(`
+                "Error: Failed parsing expression "task.due.formatAsDate(".
+                The error message was:
+                    "SyntaxError: Unexpected token '}'": while parsing instruction: 'sort by function task.due.formatAsDate('
+                Problem line: "sort by function task.due.formatAsDate(""
+            `);
         });
 
         it('should give a meaningful error for invalid syntax', () => {

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -201,7 +201,7 @@ describe('FunctionField - sorting', () => {
         const BEFORE = -1;
         const AFTER = 1;
 
-        function checkAndCompareSortKeys(valueA: any, valueB: any, _description: string) {
+        function checkAndCompareSortKeys(valueA: any, valueB: any) {
             // A pre-condition of compareTaskSortKeys() is that the values satisfy validateTaskSortKey().
             // By calling validateTaskSortKey() here, we ensure that any test failures from
             // compareTaskSortKeys() are failing for the correct reason.
@@ -213,54 +213,50 @@ describe('FunctionField - sorting', () => {
 
         it('should sort null before any other valid values - except for Moment and TasksDate', () => {
             // Note: TasksDate and Moment with null sorts the opposite round - see later tests.
-            expect(checkAndCompareSortKeys(null, null, 'two nulls')).toEqual(SAME);
-            expect(checkAndCompareSortKeys(null, 'a string', 'null and "a string"')).toEqual(BEFORE);
-            expect(checkAndCompareSortKeys(false, null, 'false and null')).toEqual(AFTER);
+            expect(checkAndCompareSortKeys(null, null)).toEqual(SAME);
+            expect(checkAndCompareSortKeys(null, 'a string')).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys(false, null)).toEqual(AFTER);
         });
 
         it('should sort numbers in ascending order', () => {
-            expect(checkAndCompareSortKeys(1, 1, '1 1')).toEqual(SAME);
+            expect(checkAndCompareSortKeys(1, 1)).toEqual(SAME);
             // number comparison is implementing with subtraction of the two values,
             // so we cannot just check for values -1 or +1.
-            expect(checkAndCompareSortKeys(42, 47, '42 and 47')).toBeLessThan(0);
-            expect(checkAndCompareSortKeys(3.15634, 1.535436, '3.15634 and 1.535436')).toBeGreaterThan(0);
+            expect(checkAndCompareSortKeys(42, 47)).toBeLessThan(0);
+            expect(checkAndCompareSortKeys(3.15634, 1.535436)).toBeGreaterThan(0);
         });
 
         it('should sort false boolean before true', () => {
-            expect(checkAndCompareSortKeys(1, 1, '1 1')).toEqual(SAME);
-            expect(checkAndCompareSortKeys(false, true, 'false and true')).toEqual(BEFORE);
-            expect(checkAndCompareSortKeys(true, false, 'true and false')).toEqual(AFTER);
+            expect(checkAndCompareSortKeys(1, 1)).toEqual(SAME);
+            expect(checkAndCompareSortKeys(false, true)).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys(true, false)).toEqual(AFTER);
         });
 
         it('should sort strings case-sensitively and be number-aware', () => {
-            expect(checkAndCompareSortKeys('9', '10', 'true and false')).toEqual(BEFORE);
-            expect(checkAndCompareSortKeys('ABCDE', 'abcde', 'ABCDE and abcde')).toEqual(AFTER);
+            expect(checkAndCompareSortKeys('9', '10')).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys('ABCDE', 'abcde')).toEqual(AFTER);
         });
 
         // Note: Arrays are rejected at the validateTaskSortKey() stage.
 
         it('should sort TaskDate objects in ascending date order, before any undated objects', () => {
-            expect(checkAndCompareSortKeys(todayDate, yesterdayDate, 'today and yesterday')).toEqual(AFTER);
-            expect(checkAndCompareSortKeys(todayDate, tomorrowDate, 'today and tomorrow')).toEqual(BEFORE);
-            expect(checkAndCompareSortKeys(todayDate, undated, 'today and undated')).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys(todayDate, yesterdayDate)).toEqual(AFTER);
+            expect(checkAndCompareSortKeys(todayDate, tomorrowDate)).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys(todayDate, undated)).toEqual(BEFORE);
         });
 
         it('should sort Moment objects in ascending date order, before any undated objects', () => {
-            expect(checkAndCompareSortKeys(todayDate.moment, yesterdayDate.moment, 'today and yesterday')).toEqual(
-                AFTER,
-            );
-            expect(checkAndCompareSortKeys(todayDate.moment, tomorrowDate.moment, 'today and tomorrow')).toEqual(
-                BEFORE,
-            );
-            expect(checkAndCompareSortKeys(todayDate.moment, undated.moment, 'today and undated')).toEqual(BEFORE);
-            expect(checkAndCompareSortKeys(undated.moment, todayDate.moment, 'undated and today')).toEqual(AFTER);
+            expect(checkAndCompareSortKeys(todayDate.moment, yesterdayDate.moment)).toEqual(AFTER);
+            expect(checkAndCompareSortKeys(todayDate.moment, tomorrowDate.moment)).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys(todayDate.moment, undated.moment)).toEqual(BEFORE);
+            expect(checkAndCompareSortKeys(undated.moment, todayDate.moment)).toEqual(AFTER);
         });
 
         it('should refuse to compare values of different types (other than null)', () => {
             const valueA = 42;
             const valueB = '97';
             const t = () => {
-                checkAndCompareSortKeys(valueA, valueB, 'group by function something or other...');
+                checkAndCompareSortKeys(valueA, valueB);
             };
             expect(t).toThrow(Error);
             expect(t).toThrowError("Unable to compare two different sort key types 'number' and 'string' order");
@@ -270,7 +266,7 @@ describe('FunctionField - sorting', () => {
             const taskA = new TaskBuilder().description('A').build();
             const taskB = new TaskBuilder().description('B').build();
             const t = () => {
-                checkAndCompareSortKeys(taskA, taskB, 'two Task objects');
+                checkAndCompareSortKeys(taskA, taskB);
             };
             expect(t).toThrow(Error);
             expect(t).toThrowError("Unable to determine sort order for sort key types 'Task' and 'Task'");

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -122,16 +122,16 @@ describe('FunctionField - sorting', () => {
         describe('allowed sort key types', () => {
             it('should accept string sort key', () => {
                 const key = 'anything';
-                expect(Object.is(field.validateTaskSortKey(key, key), key)).toEqual(true);
+                expect(Object.is(field.validateTaskSortKey(key, 'group by function "anything"'), key)).toEqual(true);
             });
 
             it('should accept boolean sort key', () => {
-                expect(field.validateTaskSortKey(true, 'boolean - true')).toEqual(true);
-                expect(field.validateTaskSortKey(false, 'boolean - false')).toEqual(false);
+                expect(field.validateTaskSortKey(true, 'group by function true')).toEqual(true);
+                expect(field.validateTaskSortKey(false, 'group by function false')).toEqual(false);
             });
 
             it('should accept null sort key', () => {
-                expect(Object.is(field.validateTaskSortKey(null, 'null'), null)).toEqual(true);
+                expect(Object.is(field.validateTaskSortKey(null, 'group by function null'), null)).toEqual(true);
             });
         });
 
@@ -139,19 +139,23 @@ describe('FunctionField - sorting', () => {
             it('should forbid undefined sort key', () => {
                 const key = undefined;
                 const t = () => {
-                    field.validateTaskSortKey(key, 'undefined');
+                    field.validateTaskSortKey(key, 'group by function undefined');
                 };
                 expect(t).toThrow(Error);
-                expect(t).toThrowError('"undefined" is not a valid sort key, from expression: "undefined"');
+                expect(t).toThrowError(
+                    '"undefined" is not a valid sort key, from expression: "group by function undefined"',
+                );
             });
 
             it('should forbid NaN sort key', () => {
                 const key = NaN;
                 const t = () => {
-                    field.validateTaskSortKey(key, 'NaN');
+                    field.validateTaskSortKey(key, 'group by function NaN');
                 };
                 expect(t).toThrow(Error);
-                expect(t).toThrowError('"NaN (Not a Number)" is not a valid sort key, from expression: "NaN"');
+                expect(t).toThrowError(
+                    '"NaN (Not a Number)" is not a valid sort key, from expression: "group by function NaN"',
+                );
             });
         });
     });

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -239,6 +239,17 @@ describe('FunctionField - sorting', () => {
             expect(field.compareTaskSortKeys(todayDate, undated, 'today and undated')).toEqual(BEFORE);
         });
 
+        it('should sort Moment objects in ascending date order, before any undated objects', () => {
+            expect(field.compareTaskSortKeys(todayDate.moment, yesterdayDate.moment, 'today and yesterday')).toEqual(
+                AFTER,
+            );
+            expect(field.compareTaskSortKeys(todayDate.moment, tomorrowDate.moment, 'today and tomorrow')).toEqual(
+                BEFORE,
+            );
+            expect(field.compareTaskSortKeys(todayDate.moment, undated.moment, 'today and undated')).toEqual(BEFORE);
+            expect(field.compareTaskSortKeys(undated.moment, todayDate.moment, 'undated and today')).toEqual(AFTER);
+        });
+
         it('should refuse to compare values of different types (other than null)', () => {
             const valueA = 42;
             const valueB = '97';

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -178,6 +178,19 @@ describe('FunctionField - sorting', () => {
             expect(field.compareTaskSortKeys(null, 'a string', 'null and "a string"')).toEqual(BEFORE);
             expect(field.compareTaskSortKeys(false, null, 'false and null')).toEqual(AFTER);
         });
+
+        it('should sort numbers in ascending order', () => {
+            expect(field.compareTaskSortKeys(1, 1, '1 1')).toEqual(SAME);
+            // number comparison is implementing with subtraction of the two values,
+            // so we cannot just check for values -1 pr +1.
+            expect(field.compareTaskSortKeys(42, 47, '42 and 47')).toBeLessThan(0);
+            expect(field.compareTaskSortKeys(3.15634, 1.535436, '3.15634 and 1.535436')).toBeGreaterThan(0);
+        });
+
+        // TODO boolean
+        // TODO string
+        // TODO array
+        // TODO mixed types
     });
 
     describe('error-handling', () => {

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -116,6 +116,28 @@ describe('FunctionField - sorting', () => {
         });
     });
 
+    describe('validation', () => {
+        const field = new FunctionField();
+
+        describe('allowed sort key types', () => {
+            it('should accept string sort key', () => {
+                const key = 'anything';
+                expect(Object.is(field.validateTaskSortKey(key, key), key)).toEqual(true);
+            });
+        });
+
+        describe('forbidden sort key types', () => {
+            it('should forbid undefined sort key', () => {
+                const key = undefined;
+                const t = () => {
+                    field.validateTaskSortKey(key, 'undefined');
+                };
+                expect(t).toThrow(Error);
+                expect(t).toThrowError('"undefined" is not a valid sort key, from expression: "undefined"');
+            });
+        });
+    });
+
     describe('error-handling', () => {
         const field = new FunctionField();
 
@@ -172,7 +194,7 @@ describe('FunctionField - sorting', () => {
             expect(result.searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
-                    "Error: Unable to determine sort order for expression 'sort by function task.nonExistentField'""
+                    "Error: "undefined" is not a valid sort key, from expression: "sort by function task.nonExistentField"""
             `);
         });
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -276,6 +276,14 @@ describe('FunctionField - sorting', () => {
     describe('error-handling', () => {
         const field = new FunctionField();
 
+        function getQueryErrorMessage(line: string) {
+            const query = new Query(line);
+            const task = fromLine({ line: '- [ ] stuff' });
+
+            const result = query.applyQueryToTasks([task, task]);
+            return result.searchErrorMessage;
+        }
+
         it('should throw in comparator()', () => {
             // It's not possible to create a Comparator without a line,
             // so comparator() method needs to throw and report it cannot work.
@@ -313,16 +321,8 @@ The error message was:
         });
 
         it('should give a meaningful error for invalid syntax', () => {
-            // Arrange
-            const line = 'sort by function hello';
-            const query = new Query(line);
-            const task = fromLine({ line: '- [ ] stuff' });
-
-            // Act
-            const result = query.applyQueryToTasks([task, task]);
-
-            // Assert
-            expect(result.searchErrorMessage).toMatchInlineSnapshot(`
+            const searchErrorMessage = getQueryErrorMessage('sort by function hello');
+            expect(searchErrorMessage).toMatchInlineSnapshot(`
                 "Error: Search failed.
                 The error message was:
                     "ReferenceError: hello is not defined: while evaluating instruction 'sort by function hello'""

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -199,8 +199,19 @@ describe('FunctionField - sorting', () => {
         });
 
         // TODO array
-        // TODO mixed types
         // TODO TaskDates
+
+        it('should refuse to compare values of different types (other than null)', () => {
+            const valueA = 42;
+            const valueB = '97';
+            const t = () => {
+                field.compareTaskSortKeys(valueA, valueB, 'group by function something or other...');
+            };
+            expect(t).toThrow(Error);
+            expect(t).toThrowError(
+                "Unable to compare two different types: 'number' and 'string' order for expression 'group by function something or other...'",
+            );
+        });
     });
 
     describe('error-handling', () => {

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -206,6 +206,12 @@ describe('FunctionField - sorting', () => {
         const AFTER = 1;
 
         function checkAndCompareSortKeys(valueA: any, valueB: any, description: string) {
+            // A pre-condition of compareTaskSortKeys() is that the values satisfy validateTaskSortKey().
+            // By calling validateTaskSortKey() here, we ensure that any test failures from
+            // compareTaskSortKeys() are failing for the correct reason.
+            field.validateTaskSortKey(valueA, description);
+            field.validateTaskSortKey(valueB, description);
+
             return field.compareTaskSortKeys(valueA, valueB, description);
         }
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -93,6 +93,26 @@ describe('FunctionField - sorting', () => {
             const functionField = new FunctionField();
             expect(functionField.supportsSorting()).toEqual(true);
         });
+
+        it('should parse "sort by function" line', () => {
+            // Arrange
+            const field = new FunctionField();
+            const instruction = 'sort by function task.path';
+
+            // Assert
+            const sorter = field.createSorterFromLine(instruction);
+            expect(sorter).not.toBeNull();
+        });
+
+        it('should parse "sort by function reverse" line', () => {
+            // Arrange
+            const field = new FunctionField();
+            const instruction = 'sort by function reverse task.path';
+
+            // Assert
+            const sorter = field.createSorterFromLine(instruction);
+            expect(sorter).not.toBeNull();
+        });
     });
 
     describe('example functions', () => {

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -20,6 +20,7 @@ import {
     expectTaskComparesEqual,
 } from '../../CustomMatchers/CustomMatchersForSorting';
 import { fromLine } from '../../TestHelpers';
+import { Query } from '../../../src/Query/Query';
 
 window.moment = moment;
 
@@ -139,6 +140,24 @@ describe('FunctionField - sorting', () => {
                 field.createReverseSorter();
             };
             expect(t).toThrow(Error);
+        });
+
+        it('should give a meaningful error for invalid syntax', () => {
+            // Arrange
+            const line = 'sort by function hello';
+            const query = new Query(line);
+            const task = fromLine({ line: '- [ ] stuff' });
+
+            // Act
+            const result = query.applyQueryToTasks([task, task]);
+
+            // Assert
+            // TODO It would be good to include the instruction line in this error message.
+            expect(result.searchErrorMessage).toMatchInlineSnapshot(`
+                "Error: Search failed.
+                The error message was:
+                    "ReferenceError: hello is not defined""
+            `);
         });
     });
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -261,6 +261,18 @@ describe('FunctionField - sorting', () => {
                 "Unable to compare two different types: 'number' and 'string' order for expression 'group by function something or other...'",
             );
         });
+
+        it('should refuse to compare unrecognised type', () => {
+            const taskA = new TaskBuilder().description('A').build();
+            const taskB = new TaskBuilder().description('B').build();
+            const t = () => {
+                field.compareTaskSortKeys(taskA, taskB, 'two Task objects');
+            };
+            expect(t).toThrow(Error);
+            expect(t).toThrowError(
+                "Unable to determine sort order for sort key types 'Task' and 'Task' from expression 'two Task objects'",
+            );
+        });
     });
 
     describe('error-handling', () => {

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.file.folder_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.file.folder_results.approved.txt
@@ -21,19 +21,19 @@ Find tasks in files in a specific folder **and any sub-folders**.
 filter by function task.file.folder.includes( query.file.folder )
 Find tasks in files in the folder that contains the query **and any sub-folders**.
 =>
-- [ ] xyz in a/b.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/d/c.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b/_c_.md
+- [ ] xyz in 'a/b.md' in heading 'null'
+- [ ] xyz in 'a/b/c.md' in heading 'null'
+- [ ] xyz in 'a/d/c.md' in heading 'heading'
+- [ ] xyz in 'a/b/c.md' in heading 'c'
+- [ ] xyz in 'a/b/_c_.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'heading _italic text_'
 ====================================================================================
 
 
 filter by function task.file.folder === query.file.folder
 Find tasks in files in the folder that contains the query only (**not tasks in any sub-folders**).
 =>
-- [ ] xyz in a/b.md
+- [ ] xyz in 'a/b.md' in heading 'null'
 ====================================================================================
 
 

--- a/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.file.root_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomFiltering/CustomFilteringExamples.test.file_properties_task.file.root_results.approved.txt
@@ -6,8 +6,8 @@ filter by function task.file.root === '/'
 Find tasks in files in the root of the vault.
 Note that this is **case-sensitive**: capitalisation matters.
 =>
-- [ ] xyz in
-- [ ] xyz in a_b_c.md
+- [ ] xyz in '' in heading 'heading'
+- [ ] xyz in 'a_b_c.md' in heading 'a_b_c'
 - [ ] Due on 2023-06-10 📅 2023-06-10
 - [ ] Due on 2023-06-11 📅 2023-06-11
 - [ ] No due date but I have 2023-06-10 in my preceding heading

--- a/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.file.filename_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.file.filename_results.approved.txt
@@ -5,29 +5,29 @@ Results of custom sorters
 sort by function task.file.filename
 Like 'sort by filename' but includes the file extension.
 =>
-- [ ] xyz in
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a_b_c.md
-- [ ] xyz in a/b.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/d/c.md
-- [ ] xyz in e/d/c.md
+- [ ] xyz in '' in heading 'heading'
+- [ ] xyz in 'a/b/_c_.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'heading _italic text_'
+- [ ] xyz in 'a_b_c.md' in heading 'a_b_c'
+- [ ] xyz in 'a/b.md' in heading 'null'
+- [ ] xyz in 'a/b/c.md' in heading 'null'
+- [ ] xyz in 'a/b/c.md' in heading 'c'
+- [ ] xyz in 'a/d/c.md' in heading 'heading'
+- [ ] xyz in 'e/d/c.md' in heading 'heading'
 ====================================================================================
 
 
 sort by function task.file.filenameWithoutExtension
 Like 'sort by filename'.
 =>
-- [ ] xyz in
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a_b_c.md
-- [ ] xyz in a/b.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/d/c.md
-- [ ] xyz in e/d/c.md
+- [ ] xyz in '' in heading 'heading'
+- [ ] xyz in 'a/b/_c_.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'heading _italic text_'
+- [ ] xyz in 'a_b_c.md' in heading 'a_b_c'
+- [ ] xyz in 'a/b.md' in heading 'null'
+- [ ] xyz in 'a/b/c.md' in heading 'null'
+- [ ] xyz in 'a/b/c.md' in heading 'c'
+- [ ] xyz in 'a/d/c.md' in heading 'heading'
+- [ ] xyz in 'e/d/c.md' in heading 'heading'
 ====================================================================================
 

--- a/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.file.folder_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.file.folder_results.approved.txt
@@ -5,14 +5,14 @@ Results of custom sorters
 sort by function task.file.folder
 Enable sorting by the folder containing the task.
 =>
-- [ ] xyz in
-- [ ] xyz in a_b_c.md
-- [ ] xyz in a/b.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/d/c.md
-- [ ] xyz in e/d/c.md
+- [ ] xyz in '' in heading 'heading'
+- [ ] xyz in 'a_b_c.md' in heading 'a_b_c'
+- [ ] xyz in 'a/b.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'heading _italic text_'
+- [ ] xyz in 'a/b/c.md' in heading 'null'
+- [ ] xyz in 'a/b/c.md' in heading 'c'
+- [ ] xyz in 'a/d/c.md' in heading 'heading'
+- [ ] xyz in 'e/d/c.md' in heading 'heading'
 ====================================================================================
 

--- a/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.file.path_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.file.path_results.approved.txt
@@ -5,29 +5,29 @@ Results of custom sorters
 sort by function task.file.path
 Like 'Sort by path' but includes the file extension.
 =>
-- [ ] xyz in
-- [ ] xyz in a_b_c.md
-- [ ] xyz in a/b.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/d/c.md
-- [ ] xyz in e/d/c.md
+- [ ] xyz in '' in heading 'heading'
+- [ ] xyz in 'a_b_c.md' in heading 'a_b_c'
+- [ ] xyz in 'a/b.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'heading _italic text_'
+- [ ] xyz in 'a/b/c.md' in heading 'null'
+- [ ] xyz in 'a/b/c.md' in heading 'c'
+- [ ] xyz in 'a/d/c.md' in heading 'heading'
+- [ ] xyz in 'e/d/c.md' in heading 'heading'
 ====================================================================================
 
 
 sort by function task.file.pathWithoutExtension
 Like 'Sort by path'.
 =>
-- [ ] xyz in
-- [ ] xyz in a_b_c.md
-- [ ] xyz in a/b.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/d/c.md
-- [ ] xyz in e/d/c.md
+- [ ] xyz in '' in heading 'heading'
+- [ ] xyz in 'a_b_c.md' in heading 'a_b_c'
+- [ ] xyz in 'a/b.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'heading _italic text_'
+- [ ] xyz in 'a/b/c.md' in heading 'null'
+- [ ] xyz in 'a/b/c.md' in heading 'c'
+- [ ] xyz in 'a/d/c.md' in heading 'heading'
+- [ ] xyz in 'e/d/c.md' in heading 'heading'
 ====================================================================================
 

--- a/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.file.root_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.file.root_results.approved.txt
@@ -5,14 +5,14 @@ Results of custom sorters
 sort by function task.file.root
 Enable sorting by the root folder.
 =>
-- [ ] xyz in
-- [ ] xyz in a_b_c.md
-- [ ] xyz in a/b.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in a/d/c.md
-- [ ] xyz in e/d/c.md
+- [ ] xyz in '' in heading 'heading'
+- [ ] xyz in 'a_b_c.md' in heading 'a_b_c'
+- [ ] xyz in 'a/b.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'heading _italic text_'
+- [ ] xyz in 'a/b/c.md' in heading 'null'
+- [ ] xyz in 'a/b/c.md' in heading 'c'
+- [ ] xyz in 'a/d/c.md' in heading 'heading'
+- [ ] xyz in 'e/d/c.md' in heading 'heading'
 ====================================================================================
 

--- a/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.heading_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.heading_docs.approved.md
@@ -2,7 +2,7 @@
 
 
 ```javascript
-sort by function task.heading ? task.heading : ''
+sort by function task.heading
 ```
 
 - Like 'sort by heading'.

--- a/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.heading_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.heading_docs.approved.md
@@ -2,10 +2,11 @@
 
 
 ```javascript
-sort by function task.heading
+sort by function task.heading ? task.heading : ''
 ```
 
 - Like 'sort by heading'.
+- Any tasks with no preceding heading have `task.heading` values of `null`, and these tasks sort before any tasks with headings.
 
 
 <!-- placeholder to force blank line after included text -->

--- a/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.heading_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.heading_results.approved.txt
@@ -5,14 +5,14 @@ Results of custom sorters
 sort by function task.heading
 Like 'sort by heading'.
 =>
-- [ ] xyz in a_b_c.md
-- [ ] xyz in a/b/c.md
-- [ ] xyz in
-- [ ] xyz in a/d/c.md
-- [ ] xyz in e/d/c.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b.md
-- [ ] xyz in a/b/_c_.md
-- [ ] xyz in a/b/c.md
+- [ ] xyz in 'a_b_c.md' in heading 'a_b_c'
+- [ ] xyz in 'a/b/c.md' in heading 'c'
+- [ ] xyz in '' in heading 'heading'
+- [ ] xyz in 'a/d/c.md' in heading 'heading'
+- [ ] xyz in 'e/d/c.md' in heading 'heading'
+- [ ] xyz in 'a/b/_c_.md' in heading 'heading _italic text_'
+- [ ] xyz in 'a/b.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'null'
+- [ ] xyz in 'a/b/c.md' in heading 'null'
 ====================================================================================
 

--- a/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.heading_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.heading_results.approved.txt
@@ -2,7 +2,7 @@ Results of custom sorters
 
 
 
-sort by function task.heading ? task.heading : ''
+sort by function task.heading
 Like 'sort by heading'.
 Any tasks with no preceding heading have `task.heading` values of `null`, and these tasks sort before any tasks with headings.
 =>

--- a/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.heading_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.file_properties_task.heading_results.approved.txt
@@ -2,17 +2,18 @@ Results of custom sorters
 
 
 
-sort by function task.heading
+sort by function task.heading ? task.heading : ''
 Like 'sort by heading'.
+Any tasks with no preceding heading have `task.heading` values of `null`, and these tasks sort before any tasks with headings.
 =>
+- [ ] xyz in 'a/b.md' in heading 'null'
+- [ ] xyz in 'a/b/_c_.md' in heading 'null'
+- [ ] xyz in 'a/b/c.md' in heading 'null'
 - [ ] xyz in 'a_b_c.md' in heading 'a_b_c'
 - [ ] xyz in 'a/b/c.md' in heading 'c'
 - [ ] xyz in '' in heading 'heading'
 - [ ] xyz in 'a/d/c.md' in heading 'heading'
 - [ ] xyz in 'e/d/c.md' in heading 'heading'
 - [ ] xyz in 'a/b/_c_.md' in heading 'heading _italic text_'
-- [ ] xyz in 'a/b.md' in heading 'null'
-- [ ] xyz in 'a/b/_c_.md' in heading 'null'
-- [ ] xyz in 'a/b/c.md' in heading 'null'
 ====================================================================================
 

--- a/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.ts
+++ b/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.ts
@@ -153,8 +153,7 @@ describe('file properties', () => {
             'task.heading',
             [
                 [
-                    // TODO Remove the need to check whether heading is null - sort nulls before other values
-                    "sort by function task.heading ? task.heading : ''",
+                    'sort by function task.heading',
                     "Like 'sort by heading'",
                     'Any tasks with no preceding heading have `task.heading` values of `null`, and these tasks sort before any tasks with headings.',
                 ],

--- a/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.ts
+++ b/tests/Scripting/ScriptingReference/CustomSorting/CustomSortingExamples.test.ts
@@ -149,7 +149,18 @@ describe('file properties', () => {
             tasks,
         ],
 
-        ['task.heading', [['sort by function task.heading', "Like 'sort by heading'"]], tasks],
+        [
+            'task.heading',
+            [
+                [
+                    // TODO Remove the need to check whether heading is null - sort nulls before other values
+                    "sort by function task.heading ? task.heading : ''",
+                    "Like 'sort by heading'",
+                    'Any tasks with no preceding heading have `task.heading` values of `null`, and these tasks sort before any tasks with headings.',
+                ],
+            ],
+            tasks,
+        ],
     ];
 
     it.each(testData)('%s results', (_: string, groups: QueryInstructionLineAndDescription[], tasks: Task[]) => {

--- a/tests/TestHelpers.ts
+++ b/tests/TestHelpers.ts
@@ -142,7 +142,11 @@ export class SampleTasks {
         const t = '- [ ] xyz';
 
         return allPathsAndHeadings.map(([path, heading]) => {
-            return fromLine({ line: t + ' in ' + path, path: path, precedingHeader: heading });
+            return fromLine({
+                line: `${t} in '${path}' in heading '${heading}'`,
+                path: path,
+                precedingHeader: heading,
+            });
         });
     }
 

--- a/tests/lib/TypeDetection.test.ts
+++ b/tests/lib/TypeDetection.test.ts
@@ -7,13 +7,13 @@ describe('getValueType', () => {
         expect(getValueType(true)).toEqual('boolean');
         expect(getValueType('stuff')).toEqual('string');
 
-        expect(getValueType([])).toEqual('object');
-        expect(getValueType({})).toEqual('object');
+        expect(getValueType([])).toEqual('Array');
+        expect(getValueType({})).toEqual('Object');
 
         expect(getValueType(undefined)).toEqual('undefined');
         expect(getValueType(null)).toEqual('null');
 
-        expect(getValueType(new TasksDate(null))).toEqual('object');
+        expect(getValueType(new TasksDate(null))).toEqual('TasksDate');
         // TODO "function"
         // TODO "symbol"
         // TODO "bigint"

--- a/tests/lib/TypeDetection.test.ts
+++ b/tests/lib/TypeDetection.test.ts
@@ -22,6 +22,7 @@ describe('getValueType', () => {
         expect(squared(3)).toEqual(9);
         expect(getValueType(squared)).toEqual('function');
 
-        // TODO "symbol"
+        // https://www.typescriptlang.org/docs/handbook/symbols.html
+        expect(getValueType(Symbol('key'))).toEqual('symbol');
     });
 });

--- a/tests/lib/TypeDetection.test.ts
+++ b/tests/lib/TypeDetection.test.ts
@@ -4,6 +4,9 @@ import { TasksDate } from '../../src/Scripting/TasksDate';
 describe('getValueType', () => {
     it('should name values correctly', () => {
         expect(getValueType(5)).toEqual('number');
+        expect(getValueType(Number('5'))).toEqual('number');
+        expect(getValueType(BigInt(9007199254740991))).toEqual('bigint');
+
         expect(getValueType(true)).toEqual('boolean');
         expect(getValueType('stuff')).toEqual('string');
 
@@ -16,7 +19,5 @@ describe('getValueType', () => {
         expect(getValueType(new TasksDate(null))).toEqual('TasksDate');
         // TODO "function"
         // TODO "symbol"
-        // TODO "bigint"
-        // TODO Number
     });
 });

--- a/tests/lib/TypeDetection.test.ts
+++ b/tests/lib/TypeDetection.test.ts
@@ -11,6 +11,16 @@ describe('getValueType', () => {
         expect(getValueType('stuff')).toEqual('string');
 
         expect(getValueType([])).toEqual('Array');
+        expect(getValueType(new Set([1, 2, 3]))).toEqual('Set');
+        expect(
+            getValueType(
+                new Map([
+                    [1, 'one'],
+                    [2, 'two'],
+                    [4, 'four'],
+                ]),
+            ),
+        ).toEqual('Map');
         expect(getValueType({})).toEqual('Object');
 
         expect(getValueType(undefined)).toEqual('undefined');

--- a/tests/lib/TypeDetection.test.ts
+++ b/tests/lib/TypeDetection.test.ts
@@ -17,7 +17,11 @@ describe('getValueType', () => {
         expect(getValueType(null)).toEqual('null');
 
         expect(getValueType(new TasksDate(null))).toEqual('TasksDate');
-        // TODO "function"
+
+        const squared = (x: number) => x * x;
+        expect(squared(3)).toEqual(9);
+        expect(getValueType(squared)).toEqual('function');
+
         // TODO "symbol"
     });
 });

--- a/tests/lib/TypeDetection.test.ts
+++ b/tests/lib/TypeDetection.test.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import { getValueType } from '../../src/lib/TypeDetection';
 import { TasksDate } from '../../src/Scripting/TasksDate';
 
@@ -26,6 +28,7 @@ describe('getValueType', () => {
         expect(getValueType(undefined)).toEqual('undefined');
         expect(getValueType(null)).toEqual('null');
 
+        expect(getValueType(moment('2021-06-20'))).toEqual('Moment');
         expect(getValueType(new TasksDate(null))).toEqual('TasksDate');
 
         const squared = (x: number) => x * x;

--- a/tests/lib/TypeDetection.test.ts
+++ b/tests/lib/TypeDetection.test.ts
@@ -1,0 +1,22 @@
+import { getValueType } from '../../src/lib/TypeDetection';
+import { TasksDate } from '../../src/Scripting/TasksDate';
+
+describe('getValueType', () => {
+    it('should name values correctly', () => {
+        expect(getValueType(5)).toEqual('number');
+        expect(getValueType(true)).toEqual('boolean');
+        expect(getValueType('stuff')).toEqual('string');
+
+        expect(getValueType([])).toEqual('object');
+        expect(getValueType({})).toEqual('object');
+
+        expect(getValueType(undefined)).toEqual('undefined');
+        expect(getValueType(null)).toEqual('object');
+
+        expect(getValueType(new TasksDate(null))).toEqual('object');
+        // TODO "function"
+        // TODO "symbol"
+        // TODO "bigint"
+        // TODO Number
+    });
+});

--- a/tests/lib/TypeDetection.test.ts
+++ b/tests/lib/TypeDetection.test.ts
@@ -11,7 +11,7 @@ describe('getValueType', () => {
         expect(getValueType({})).toEqual('object');
 
         expect(getValueType(undefined)).toEqual('undefined');
-        expect(getValueType(null)).toEqual('object');
+        expect(getValueType(null)).toEqual('null');
 
         expect(getValueType(new TasksDate(null))).toEqual('object');
         // TODO "function"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This is the second half of implementing `sort by function`.

All that remains now is to add support for using `query.file.path` and related in the scoring functions.

This adds:

- thorough testing of `sort by function`
- error-checking, with error messages shown to users in Tasks search results
- A sample file in the vault that shows the error message displayed for various problem uses of `sort by function`.
- sorting of `TasksDate` and `Moment` via `sort by function` is now consistent with the behaviour of `sort by due` and friends, that is, undated tasks go after all tasks with dates
- type safety of sort keys:
    - `undefined`, arrays and `NaN` values cannot be used as sort keys
    - `null` can be compared with any supported key type
    - otherwise, for safety, values of different types cannot be compared
- exceptions in the `Query` constructor are now caught and reported to users

## Motivation and Context

Finish work I started in  #2577.

## How has this been tested?

- New tests
- Exploratory testing

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
