### PR TITLE
fix!!: Sort invalid dates before valid ones in query results

### DIFF
--- a/docs/Queries/Sorting.md
+++ b/docs/Queries/Sorting.md
@@ -124,6 +124,17 @@ sort by function task.status.nextSymbol
 
 ## Sort by Dates in Tasks
 
+### How dates are sorted
+
+When sorting tasks by date, such as with `sort by due`, tasks are sorted in this order:
+
+1. Tasks with **invalid** `due` dates come first
+2. Tasks with valid `due` dates, **earliest** to **latest**
+3. Tasks with **no due date** come last.
+
+> [!NOTE]
+> Prior to Tasks X.Y.Z, tasks with invalid dates were sorted **after** the tasks with valid dates.
+
 ### Done Date
 
 - `sort by done` (the date when the task was done)

--- a/docs/Support and Help/Breaking Changes.md
+++ b/docs/Support and Help/Breaking Changes.md
@@ -27,3 +27,4 @@ To help users updating across multiple Tasks releases, we collect here links to 
   - The meaning of final backslash (`\`) characters on query lines [[Line Continuations#Appendix Updating pre-5.0.0 searches with trailing backslashes|has changed]].
 - Tasks [X.Y.Z](https://github.com/obsidian-tasks-group/obsidian-tasks/releases/tag/X.Y.Z) (21 January 2024):
   - Code snippets used to change the look of the edit and postpone buttons must be changed, as explained in [[How to style buttons]], which gives several examples.
+  - When sorting tasks, invalid dates are now sorted before valid dates. See [[Sorting#How dates are sorted]].

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Invalid dates with Sorting and Grouping.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Invalid dates with Sorting and Grouping.md
@@ -45,9 +45,9 @@ hide task count
 
 ### Sort by due - built-in
 
-The invalid task should be before the dated ones.
+The invalid task is sorted before the dated ones, since Tasks X.Y.Z.
 
-[Bug report](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2589): **`sort by due` and similar should put tasks with invalid dates before the tasks with valid dates.**
+==FIXED==: [Bug report](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2589): **`sort by due` and similar should put tasks with invalid dates before the tasks with valid dates.**
 
 ```tasks
 sort by due

--- a/src/lib/DateTools.ts
+++ b/src/lib/DateTools.ts
@@ -10,9 +10,9 @@ export function compareByDate(a: moment.Moment | null, b: moment.Moment | null):
     }
 
     if (a.isValid() && !b.isValid()) {
-        return -1;
-    } else if (!a.isValid() && b.isValid()) {
         return 1;
+    } else if (!a.isValid() && b.isValid()) {
+        return -1;
     }
 
     if (a.isAfter(b)) {

--- a/tests/lib/DateTools.test.ts
+++ b/tests/lib/DateTools.test.ts
@@ -29,7 +29,7 @@ describe('compareBy', () => {
 
         expectDateComparesBefore(invalidDate, null); // invalid dates sort before no date
         expectDateComparesEqual(invalidDate, invalidDate);
-        expectDateComparesAfter(invalidDate, earlierDate); // invalid dates sort after valid ones
-        expectDateComparesBefore(laterDate, invalidDate); // invalid dates sort after valid ones
+        expectDateComparesBefore(invalidDate, earlierDate); // invalid dates sort before valid ones
+        expectDateComparesAfter(laterDate, invalidDate); // invalid dates sort before valid ones
     });
 });

--- a/tests/lib/DateTools.test.ts
+++ b/tests/lib/DateTools.test.ts
@@ -30,5 +30,6 @@ describe('compareBy', () => {
         expectDateComparesBefore(invalidDate, null); // invalid dates sort before no date
         expectDateComparesEqual(invalidDate, invalidDate);
         expectDateComparesAfter(invalidDate, earlierDate); // invalid dates sort after valid ones
+        expectDateComparesBefore(laterDate, invalidDate); // invalid dates sort after valid ones
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- `sort by due` - and sort by other date fields - now puts tasks with an invalid date before the valid ones, so invalid dates are more visible in long lists.
- update documentation to record this change

I'm treating this as a **breaking change** because it does change search results, although I am confident it is an improvement.

## Motivation and Context

Fix #2589.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Updating existing tests
- Exploratory testing

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
