### PR TITLE
fix: Make context menu for Postpone button work on iOS

### DIFF
--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -421,19 +421,20 @@ class QueryRenderChild extends MarkdownRenderChild {
         const buttonTooltipText = postponeButtonTitle(task, amount, timeUnit);
         const button = listItem.createEl('a', {
             cls: 'tasks-postpone' + (shortMode ? ' tasks-postpone-short-mode' : ''),
-            href: '#',
             title: buttonTooltipText,
         });
 
         button.addEventListener('click', (ev: MouseEvent) => {
             ev.preventDefault(); // suppress the default click behavior
+            ev.stopPropagation(); // suppress further event propagation
             PostponeMenu.postponeOnClickCallback(button, task, amount, timeUnit);
         });
 
         /** Open a context menu on right-click.
          */
         button.addEventListener('contextmenu', async (ev: MouseEvent) => {
-            ev.stopPropagation(); // suppress the default context menu
+            ev.preventDefault(); // suppress the default context menu
+            ev.stopPropagation(); // suppress further event propagation
             const menu = new PostponeMenu(button, task);
             menu.showAtPosition({ x: ev.clientX, y: ev.clientY });
         });

--- a/styles.css
+++ b/styles.css
@@ -55,6 +55,9 @@ ul.contains-task-list .task-list-item-checkbox {
     cursor: pointer;
     font-family: var(--font-interface);
     color: var(--text-accent);
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
 }
 
 a.tasks-edit, a.tasks-postpone {


### PR DESCRIPTION
# Description

The context menu for the "postpone" button stopped working on iOS in v6 of Obsidian Tasks.

Also, when using "long press" to evoke the context menu, various side effects could be triggered on iOS even in versions before, like selecting text or showing a default browser callout.

The bug seems to be caused by using an anchor element with a href in v6 instead of a button element, so that it could be styled the same way as the edit button.

The following changes have been made to fix the issue:
- removed the `href` attribute from the anchor tag
- set user-select  CSS  property to none to prevent the button from being selectable
- set touch-callout CSS  property to none to prevent the buttons from showing a default callout
- called `event.stopPropagation()` to prevent further handling of the event down the line

## Motivation and Context

This PR fixes #2636 which also gives some more context.

## How has this been tested?

Tested manually under Windows 11 and an old iPad with iOS 12.5.7.

It would be good if someone could test this with newer iOS and MacOS as well.

## Screenshots (if appropriate)

## Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms
- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
