### PR TITLE
fix: enable edit task modal to save multiple tasks

### DIFF
--- a/src/Obsidian/File.ts
+++ b/src/Obsidian/File.ts
@@ -65,7 +65,7 @@ export const replaceTaskWithTasks = async ({
     logStartOfTaskEdit(logger, codeLocation, originalTask);
     logEndOfTaskEdit(logger, codeLocation, newTasks);
 
-    tryRepetitive({
+    await tryRepetitive({
         originalTask,
         newTasks,
         vault,
@@ -118,7 +118,7 @@ const tryRepetitive = async ({
 }): Promise<void> => {
     const logger = getFileLogger();
     logger.debug(`tryRepetitive after ${previousTries} previous tries`);
-    const retry = () => {
+    const retry = async () => {
         if (previousTries > 10) {
             const message = `Tasks: Could not find the correct task line to update.
 
@@ -142,8 +142,8 @@ Recommendations:
 
         const timeout = Math.min(Math.pow(10, previousTries), 100); // 1, 10, 100, 100, 100, ...
         logger.debug(`timeout = ${timeout}`);
-        setTimeout(() => {
-            tryRepetitive({
+        setTimeout(async () => {
+            await tryRepetitive({
                 originalTask,
                 newTasks,
                 vault,
@@ -167,9 +167,11 @@ Recommendations:
     } catch (e) {
         if (e instanceof WarningWorthRetrying) {
             if (e.message) warnAndNotice(e.message);
-            return retry();
+            await retry();
+            return;
         } else if (e instanceof RetryWithoutWarning) {
-            return retry();
+            await retry();
+            return;
         } else if (e instanceof Error) {
             errorAndNotice(e.message);
         }


### PR DESCRIPTION
# Description

Fix async awaits in File.ts. This has been suspected to be a problem for some time but we didn't have a way to test it.

It turned out to fix #2638.

## Motivation and Context

Fixes #2638.

## How has this been tested?

Exploratory testing and running relevant smoke tests.

## Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
