### PR TITLE
fix: Improve auto-suggest for dataview task format

### DIFF
--- a/docs/Editing/Auto-Suggest.md
+++ b/docs/Editing/Auto-Suggest.md
@@ -50,7 +50,7 @@ Here is a more detailed walk through of the creation of a new task, which can be
     - use the up/down keyboard keys and then type `Return` or `Enter`
     - type a few more characters, to make the menu items more specific. For example, type `pri` to show all the options for setting the task's priority.
 
-    **Note**: When the `⏎` item is shown at the top of the menu, it is given as a default option to enter a new line instead of choosing a suggestion. It is only shown when there is no concrete match.
+    **Note**: When the `⏎` item is shown at the top of the menu, it is given as a default option to enter a new line instead of choosing a suggestion. It is only shown when there is no concrete match when using the [[Tasks Emoji Format]].
 
 3. Here we selected the 'high priority' item, and so now the menu is updated to show the next most likely items you might want to add. We are going to select 'recurring (repeat)' from this menu:
 

--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -78,7 +78,6 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
             line: currentCursor.line,
             ch: value.insertAt ?? currentCursor.ch,
         };
-        console.log('Fromch: ', value.insertAt ?? currentCursor.ch);
         const replaceTo = value.insertSkip
             ? {
                   line: currentCursor.line,

--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -78,6 +78,7 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
             line: currentCursor.line,
             ch: value.insertAt ?? currentCursor.ch,
         };
+        console.log('Fromch: ', value.insertAt ?? currentCursor.ch);
         const replaceTo = value.insertSkip
             ? {
                   line: currentCursor.line,

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -26,7 +26,6 @@ export function makeDefaultSuggestionBuilder(
     return (line: string, cursorPos: number, settings: Settings): SuggestInfo[] => {
         let suggestions: SuggestInfo[] = [];
 
-        console.log('Mode', settings.taskFormat);
         // Step 1: add date suggestions if relevant
         suggestions = suggestions.concat(
             addDatesSuggestions(line, cursorPos, settings, datePrefixRegex, maxGenericSuggestions),

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -444,7 +444,10 @@ function isAnyBracketOpen(line: string, brackets: [opening_bracket: string, clos
  * @param brackets - A listed of tuples that defines bracket pairs.
  * @returns The last open bracket in line among the given bracket pairs. If no such bracket exists, return null.
  */
-function lastOpenBracket(line: string, brackets: [opening_bracket: string, closing_bracket: string][]): string | null {
+export function lastOpenBracket(
+    line: string,
+    brackets: [opening_bracket: string, closing_bracket: string][],
+): string | null {
     if (brackets.length === 0) {
         return null;
     }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -105,6 +105,7 @@ function addTaskPropertySuggestions(
                         ? `${prioritySymbol} priority`
                         : `${prioritySymbol} ${priorityText.toLowerCase()} priority`,
                 appendText: `${prioritySymbol}${postfix}`,
+                insertSkip: dataviewMode ? insertSkip : undefined,
             });
         }
     }
@@ -122,6 +123,7 @@ function addTaskPropertySuggestions(
             textToMatch: `${symbols.createdDateSymbol} created`,
             displayText: `${symbols.createdDateSymbol} created today (${formattedDate})`,
             appendText: `${symbols.createdDateSymbol} ${formattedDate}` + postfix,
+            insertSkip: dataviewMode ? insertSkip : undefined,
         });
     }
 

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -26,6 +26,7 @@ export function makeDefaultSuggestionBuilder(
     return (line: string, cursorPos: number, settings: Settings): SuggestInfo[] => {
         let suggestions: SuggestInfo[] = [];
 
+        console.log('Mode', settings.taskFormat);
         // Step 1: add date suggestions if relevant
         suggestions = suggestions.concat(
             addDatesSuggestions(line, cursorPos, settings, datePrefixRegex, maxGenericSuggestions),

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -78,7 +78,7 @@ function addTaskPropertySuggestions(
         Object.values(symbols.prioritySymbols).some((value) => value.length > 0 && line.includes(value));
 
     const genericSuggestions: SuggestInfo[] = [];
-    const gap = _settings.taskFormat == 'dataview' ? '' : ' ';
+    const postfixGap = _settings.taskFormat == 'dataview' ? '' : ' ';
 
     // NEW_TASK_FIELD_EDIT_REQUIRED
     if (!line.includes(symbols.dueDateSymbol))
@@ -97,47 +97,19 @@ function addTaskPropertySuggestions(
             appendText: `${symbols.scheduledDateSymbol} `,
         });
     if (!hasPriority(line)) {
-        if (_settings.taskFormat == 'dataview') {
+        const prioritySymbols: { [key: string]: string } = symbols.prioritySymbols;
+        const priorityTexts = ['High', 'Medium', 'Low', 'Highest', 'Lowest'];
+
+        for (let i = 0; i < priorityTexts.length; i++) {
+            const priorityText = priorityTexts[i];
+            const prioritySymbol = prioritySymbols[priorityText];
+
             genericSuggestions.push({
-                displayText: `${symbols.prioritySymbols.High} priority`,
-                appendText: `${symbols.prioritySymbols.High}`,
-            });
-            genericSuggestions.push({
-                displayText: `${symbols.prioritySymbols.Medium} priority`,
-                appendText: `${symbols.prioritySymbols.Medium}`,
-            });
-            genericSuggestions.push({
-                displayText: `${symbols.prioritySymbols.Low} priority`,
-                appendText: `${symbols.prioritySymbols.Low}`,
-            });
-            genericSuggestions.push({
-                displayText: `${symbols.prioritySymbols.Highest} priority`,
-                appendText: `${symbols.prioritySymbols.Highest}`,
-            });
-            genericSuggestions.push({
-                displayText: `${symbols.prioritySymbols.Lowest} priority`,
-                appendText: `${symbols.prioritySymbols.Lowest}`,
-            });
-        } else {
-            genericSuggestions.push({
-                displayText: `${symbols.prioritySymbols.High} high priority`,
-                appendText: `${symbols.prioritySymbols.High} `,
-            });
-            genericSuggestions.push({
-                displayText: `${symbols.prioritySymbols.Medium} medium priority`,
-                appendText: `${symbols.prioritySymbols.Medium} `,
-            });
-            genericSuggestions.push({
-                displayText: `${symbols.prioritySymbols.Low} low priority`,
-                appendText: `${symbols.prioritySymbols.Low} `,
-            });
-            genericSuggestions.push({
-                displayText: `${symbols.prioritySymbols.Highest} highest priority`,
-                appendText: `${symbols.prioritySymbols.Highest} `,
-            });
-            genericSuggestions.push({
-                displayText: `${symbols.prioritySymbols.Lowest} lowest priority`,
-                appendText: `${symbols.prioritySymbols.Lowest} `,
+                displayText:
+                    _settings.taskFormat == 'dataview'
+                        ? `${prioritySymbol} priority`
+                        : `${prioritySymbol} ${priorityText.toLowerCase()} priority`,
+                appendText: `${prioritySymbol}${postfixGap}`,
             });
         }
     }
@@ -154,7 +126,7 @@ function addTaskPropertySuggestions(
             // We don't want this to match when the user types "today"
             textToMatch: `${symbols.createdDateSymbol} created`,
             displayText: `${symbols.createdDateSymbol} created today (${formattedDate})`,
-            appendText: `${symbols.createdDateSymbol} ${formattedDate}` + gap,
+            appendText: `${symbols.createdDateSymbol} ${formattedDate}` + postfixGap,
         });
     }
 
@@ -218,7 +190,7 @@ function addDatesSuggestions(
         'next month',
         'next year',
     ];
-    const gap = settings.taskFormat == 'dataview' ? '' : ' ';
+    const postfixGap = settings.taskFormat == 'dataview' ? '' : ' ';
     const results: SuggestInfo[] = [];
     const dateRegex = new RegExp(`(${datePrefixRegex})\\s*([0-9a-zA-Z ]*)`, 'ug');
     const dateMatch = matchByPosition(line, dateRegex, cursorPos);
@@ -270,7 +242,7 @@ function addDatesSuggestions(
             results.push({
                 suggestionType: 'match',
                 displayText: `${match} (${formattedDate})`,
-                appendText: `${datePrefix} ${formattedDate}` + gap,
+                appendText: `${datePrefix} ${formattedDate}` + postfixGap,
                 insertAt: dateMatch.index,
                 insertSkip: dateMatch[0].length,
             });
@@ -303,7 +275,7 @@ function addRecurrenceSuggestions(line: string, cursorPos: number, settings: Set
         'every week on Friday',
         'every week on Saturday',
     ];
-    const gap = settings.taskFormat == 'dataview' ? '' : ' ';
+    const postfixGap = settings.taskFormat == 'dataview' ? '' : ' ';
     const results: SuggestInfo[] = [];
     const recurrenceRegex = new RegExp(`(${recurrenceSymbol})\\s*([0-9a-zA-Z ]*)`, 'ug');
     const recurrenceMatch = matchByPosition(line, recurrenceRegex, cursorPos);
@@ -321,7 +293,7 @@ function addRecurrenceSuggestions(line: string, cursorPos: number, settings: Set
                 dueDate: null,
             })?.toText();
             if (parsedRecurrence) {
-                const appendedText = `${recurrencePrefix} ${parsedRecurrence}` + gap;
+                const appendedText = `${recurrencePrefix} ${parsedRecurrence}` + postfixGap;
                 results.push({
                     suggestionType: 'match',
                     displayText: `✅ ${parsedRecurrence}`,
@@ -363,7 +335,7 @@ function addRecurrenceSuggestions(line: string, cursorPos: number, settings: Set
             results.push({
                 suggestionType: 'match',
                 displayText: `${match}`,
-                appendText: `${recurrencePrefix} ${match}` + gap,
+                appendText: `${recurrencePrefix} ${match}` + postfixGap,
                 insertAt: recurrenceMatch.index,
                 insertSkip: recurrenceMatch[0].length,
             });

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -42,11 +42,20 @@ export function makeDefaultSuggestionBuilder(
         // rather than insert a suggestion
         if (suggestions.length > 0 && !suggestions.some((value) => value.suggestionType === 'match')) {
             // No actual match, only default ones
-            suggestions.unshift({
-                suggestionType: 'empty',
-                displayText: '⏎',
-                appendText: '\n',
-            });
+            if (settings.taskFormat == 'dataview') {
+                suggestions.unshift({
+                    // suggestionType: 'empty',
+                    displayText: '⏎',
+                    appendText: ' ',
+                    insertAt: cursorPos + 1,
+                });
+            } else {
+                suggestions.unshift({
+                    suggestionType: 'empty',
+                    displayText: '⏎',
+                    appendText: '\n',
+                });
+            }
         }
 
         // Either way, after all the aggregations above, never suggest more than the max items
@@ -69,6 +78,7 @@ function addTaskPropertySuggestions(
         Object.values(symbols.prioritySymbols).some((value) => value.length > 0 && line.includes(value));
 
     const genericSuggestions: SuggestInfo[] = [];
+    const gap = _settings.taskFormat == 'dataview' ? '' : ' ';
 
     // NEW_TASK_FIELD_EDIT_REQUIRED
     if (!line.includes(symbols.dueDateSymbol))
@@ -87,27 +97,51 @@ function addTaskPropertySuggestions(
             appendText: `${symbols.scheduledDateSymbol} `,
         });
     if (!hasPriority(line)) {
-        genericSuggestions.push({
-            displayText: `${symbols.prioritySymbols.High} high priority`,
-            appendText: `${symbols.prioritySymbols.High} `,
-        });
-        genericSuggestions.push({
-            displayText: `${symbols.prioritySymbols.Medium} medium priority`,
-            appendText: `${symbols.prioritySymbols.Medium} `,
-        });
-        genericSuggestions.push({
-            displayText: `${symbols.prioritySymbols.Low} low priority`,
-            appendText: `${symbols.prioritySymbols.Low} `,
-        });
-        genericSuggestions.push({
-            displayText: `${symbols.prioritySymbols.Highest} highest priority`,
-            appendText: `${symbols.prioritySymbols.Highest} `,
-        });
-        genericSuggestions.push({
-            displayText: `${symbols.prioritySymbols.Lowest} lowest priority`,
-            appendText: `${symbols.prioritySymbols.Lowest} `,
-        });
+        if (_settings.taskFormat == 'dataview') {
+            genericSuggestions.push({
+                displayText: `${symbols.prioritySymbols.High} priority`,
+                appendText: `${symbols.prioritySymbols.High}`,
+            });
+            genericSuggestions.push({
+                displayText: `${symbols.prioritySymbols.Medium} priority`,
+                appendText: `${symbols.prioritySymbols.Medium}`,
+            });
+            genericSuggestions.push({
+                displayText: `${symbols.prioritySymbols.Low} priority`,
+                appendText: `${symbols.prioritySymbols.Low}`,
+            });
+            genericSuggestions.push({
+                displayText: `${symbols.prioritySymbols.Highest} priority`,
+                appendText: `${symbols.prioritySymbols.Highest}`,
+            });
+            genericSuggestions.push({
+                displayText: `${symbols.prioritySymbols.Lowest} priority`,
+                appendText: `${symbols.prioritySymbols.Lowest}`,
+            });
+        } else {
+            genericSuggestions.push({
+                displayText: `${symbols.prioritySymbols.High} high priority`,
+                appendText: `${symbols.prioritySymbols.High} `,
+            });
+            genericSuggestions.push({
+                displayText: `${symbols.prioritySymbols.Medium} medium priority`,
+                appendText: `${symbols.prioritySymbols.Medium} `,
+            });
+            genericSuggestions.push({
+                displayText: `${symbols.prioritySymbols.Low} low priority`,
+                appendText: `${symbols.prioritySymbols.Low} `,
+            });
+            genericSuggestions.push({
+                displayText: `${symbols.prioritySymbols.Highest} highest priority`,
+                appendText: `${symbols.prioritySymbols.Highest} `,
+            });
+            genericSuggestions.push({
+                displayText: `${symbols.prioritySymbols.Lowest} lowest priority`,
+                appendText: `${symbols.prioritySymbols.Lowest} `,
+            });
+        }
     }
+
     if (!line.includes(symbols.recurrenceSymbol))
         genericSuggestions.push({
             displayText: `${symbols.recurrenceSymbol} recurring (repeat)`,
@@ -120,7 +154,7 @@ function addTaskPropertySuggestions(
             // We don't want this to match when the user types "today"
             textToMatch: `${symbols.createdDateSymbol} created`,
             displayText: `${symbols.createdDateSymbol} created today (${formattedDate})`,
-            appendText: `${symbols.createdDateSymbol} ${formattedDate} `,
+            appendText: `${symbols.createdDateSymbol} ${formattedDate}` + gap,
         });
     }
 
@@ -184,7 +218,7 @@ function addDatesSuggestions(
         'next month',
         'next year',
     ];
-
+    const gap = settings.taskFormat == 'dataview' ? '' : ' ';
     const results: SuggestInfo[] = [];
     const dateRegex = new RegExp(`(${datePrefixRegex})\\s*([0-9a-zA-Z ]*)`, 'ug');
     const dateMatch = matchByPosition(line, dateRegex, cursorPos);
@@ -236,7 +270,7 @@ function addDatesSuggestions(
             results.push({
                 suggestionType: 'match',
                 displayText: `${match} (${formattedDate})`,
-                appendText: `${datePrefix} ${formattedDate} `,
+                appendText: `${datePrefix} ${formattedDate}` + gap,
                 insertAt: dateMatch.index,
                 insertSkip: dateMatch[0].length,
             });
@@ -269,7 +303,7 @@ function addRecurrenceSuggestions(line: string, cursorPos: number, settings: Set
         'every week on Friday',
         'every week on Saturday',
     ];
-
+    const gap = settings.taskFormat == 'dataview' ? '' : ' ';
     const results: SuggestInfo[] = [];
     const recurrenceRegex = new RegExp(`(${recurrenceSymbol})\\s*([0-9a-zA-Z ]*)`, 'ug');
     const recurrenceMatch = matchByPosition(line, recurrenceRegex, cursorPos);
@@ -287,7 +321,7 @@ function addRecurrenceSuggestions(line: string, cursorPos: number, settings: Set
                 dueDate: null,
             })?.toText();
             if (parsedRecurrence) {
-                const appendedText = `${recurrencePrefix} ${parsedRecurrence} `;
+                const appendedText = `${recurrencePrefix} ${parsedRecurrence}` + gap;
                 results.push({
                     suggestionType: 'match',
                     displayText: `✅ ${parsedRecurrence}`,
@@ -329,7 +363,7 @@ function addRecurrenceSuggestions(line: string, cursorPos: number, settings: Set
             results.push({
                 suggestionType: 'match',
                 displayText: `${match}`,
-                appendText: `${recurrencePrefix} ${match} `,
+                appendText: `${recurrencePrefix} ${match}` + gap,
                 insertAt: recurrenceMatch.index,
                 insertSkip: recurrenceMatch[0].length,
             });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -7,6 +7,7 @@ import { getSettings } from '../../src/Config/Settings';
 import type { SuggestInfo, SuggestionBuilder } from '../../src/Suggestor';
 import {
     canSuggestForLine,
+    lastOpenBracket,
     makeDefaultSuggestionBuilder,
     onlySuggestIfBracketOpen,
 } from '../../src/Suggestor/Suggestor';
@@ -281,5 +282,41 @@ describe('canSuggestForLine', () => {
     it('should suggest correctly when task is indented', () => {
         expect(canSuggestForLineWithCursor('    - [ ]|')).toEqual(false);
         expect(canSuggestForLineWithCursor('    - [ ] |')).toEqual(true);
+    });
+});
+
+describe('lastOpenBracket', () => {
+    it('should return null if there are no open brackets', () => {
+        expect(lastOpenBracket('hello world', [])).toEqual(null);
+        expect(
+            lastOpenBracket('hello world', [
+                ['(', ')'],
+                ['[', ']'],
+            ]),
+        ).toEqual(null);
+        expect(
+            lastOpenBracket('(hello world) [Hello world]', [
+                ['(', ')'],
+                ['[', ']'],
+            ]),
+        ).toEqual(null);
+        expect(
+            lastOpenBracket('([hello world)]', [
+                ['(', ')'],
+                ['[', ']'],
+            ]),
+        ).toEqual(null);
+    });
+
+    it('should return the last open bracket', () => {
+        expect(lastOpenBracket('(hello world', [['(', ')']])).toEqual('(');
+        expect(lastOpenBracket('[hello world', [['[', ']']])).toEqual('[');
+        expect(
+            lastOpenBracket('([hello world)', [
+                ['(', ')'],
+                ['[', ']'],
+            ]),
+        ).toEqual('[');
+        expect(lastOpenBracket('))))(', [['(', ')']])).toEqual('(');
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
I have optimized the function of auto-suggest in dataview task format, in dataview task format
1. removed the extra space when accepting the suggestion.
2. modified the effect of accepting the 'Enter' suggestion, now it will make the cursor jump out of the current task property.
3. fixed the duplicate words in the priority suggestion.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. when I accept the day suggestion, it will add a extra space after date, see gif below
![iShot_2024-02-17_22 31 55](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/28787183/b7d5fedf-25c4-4775-af91-64a6cc9ddd3b)

2. when I accept the 'Enter' suggestion, it will break my current task property and split the `]` to next line. see gif below
![iShot_2024-02-17_22 34 59](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/28787183/e6ab01fd-99c1-4343-a8ac-ed0ee2d76a4c)

3. below is duplicate words bug in the priority suggestion when in dataview task format
<img width="793" alt="image" src="https://github.com/obsidian-tasks-group/obsidian-tasks/assets/28787183/3d846eb4-bbd4-4d6c-abd1-8b6a9d678a20">

4. My pull request solve the 3 issue above, which is shown below:
![iShot_2024-02-17_22 46 46](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/28787183/e3f7010a-6c95-4e78-ac85-f5d9fd6d2e6a)

## How has this been tested?
For I only modify the auto-suggest action, I just test all type of suggestions, include priority, created date, due, schedule, repeat ...

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
