### PR TITLE
refactor:  OnCompletion (preparing to later add Delete Action)

### DIFF
--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -3,12 +3,13 @@ import type { Status } from '../Statuses/Status';
 import { StatusType } from '../Statuses/StatusConfiguration';
 import type { Task } from './Task';
 
-function handleOnCompletion(tasks: Task[], startStatus: Status, endStatus: Status): Task[] {
+function handleOnCompletion(tasks: Task[], startStatus: Status): Task[] {
     const tasksArrayLength = tasks.length;
     if (tasksArrayLength === 0) {
         return tasks;
     }
     const completedTask = tasks[tasksArrayLength - 1];
+    const endStatus = completedTask.status;
 
     const ocTrigger = ' 🏁 ';
     const taskString = completedTask.description;
@@ -33,8 +34,7 @@ function handleOnCompletion(tasks: Task[], startStatus: Status, endStatus: Statu
 }
 
 export function applyStatusAndOnCompletionAction(task: Task, newStatus: Status) {
-    const startStatus = task.status;
     const tasks = task.handleNewStatus(newStatus);
-    const endStatus = tasks[tasks.length - 1].status;
-    return handleOnCompletion(tasks, startStatus, endStatus);
+    const startStatus = task.status;
+    return handleOnCompletion(tasks, startStatus);
 }

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -1,0 +1,55 @@
+import Console from 'console';
+import type { Status } from '../Statuses/Status';
+import { StatusType } from '../Statuses/StatusConfiguration';
+import type { Task } from './Task';
+
+function handleOnCompletion(tasks: Task[], startStatus: Status, endStatus: Status): Task[] {
+    const tasksArrayLength = tasks.length;
+    const completedTask = tasks[tasksArrayLength - 1];
+    if (completedTask == undefined) {
+        console.log('Passed-in completedTask is Undefined!');
+        return tasks;
+    }
+
+    const ocTrigger = ' 🏁 ';
+    const taskString = completedTask.toString();
+
+    if (!taskString.includes(ocTrigger) || endStatus.type != StatusType.DONE || endStatus.type == startStatus.type) {
+        return tasks;
+    }
+
+    if (taskString.includes(ocTrigger)) {
+        const taskEnd = taskString.substring(taskString.indexOf(ocTrigger) + 4);
+        const ocAction = taskEnd.substring(0, taskEnd.indexOf(' '));
+        switch (ocAction) {
+            case 'Delete': {
+                if (tasksArrayLength == 2) {
+                    return [tasks[0]];
+                }
+                if (tasksArrayLength == 1) {
+                    return [];
+                }
+                break;
+            }
+            default: {
+                const errorMessage = 'Unknown "On Completion" action: ' + ocAction;
+                const console = Console;
+                console.log(errorMessage);
+                // const hint = '\nClick here to clear';
+                // const noticeMessage = errorMessage + hint;
+                // new Notice(noticeMessage, 0);
+                return tasks;
+            }
+        }
+    }
+    console.log('Uh-oh -- we should never actually get here...  :( ');
+    throw new Error('Something went wrong');
+    return tasks;
+}
+
+export function applyStatusAndOnCompletionAction(task: Task, newStatus: Status) {
+    const startStatus = task.status;
+    const tasks = task.handleNewStatus(newStatus);
+    const endStatus = tasks[tasks.length - 1].status;
+    return handleOnCompletion(tasks, startStatus, endStatus);
+}

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -3,11 +3,13 @@ import type { Status } from '../Statuses/Status';
 import { StatusType } from '../Statuses/StatusConfiguration';
 import type { Task } from './Task';
 
-function handleOnCompletion(tasks: Task[], startStatus: Status): Task[] {
+function handleOnCompletion(task: Task, tasks: Task[]): Task[] {
     const tasksArrayLength = tasks.length;
     if (tasksArrayLength === 0) {
         return tasks;
     }
+    const startStatus = task.status;
+
     const completedTask = tasks[tasksArrayLength - 1];
     const endStatus = completedTask.status;
 
@@ -35,6 +37,5 @@ function handleOnCompletion(tasks: Task[], startStatus: Status): Task[] {
 
 export function applyStatusAndOnCompletionAction(task: Task, newStatus: Status) {
     const tasks = task.handleNewStatus(newStatus);
-    const startStatus = task.status;
-    return handleOnCompletion(tasks, startStatus);
+    return handleOnCompletion(task, tasks);
 }

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -8,18 +8,18 @@ export function handleOnCompletion(task: Task, tasks: Task[]): Task[] {
     }
     const startStatus = task.status;
 
-    const completedTask = tasks[tasksArrayLength - 1];
-    const endStatus = completedTask.status;
+    const changedStatusTask = tasks[tasksArrayLength - 1];
+    const endStatus = changedStatusTask.status;
 
     const ocTrigger = ' 🏁 ';
-    const taskString = completedTask.description;
+    const taskString = changedStatusTask.description;
 
     if (!taskString.includes(ocTrigger) || endStatus.type !== StatusType.DONE || endStatus.type === startStatus.type) {
         return tasks;
     }
 
     if (taskString.includes('🏁 Delete')) {
-        return tasks.filter((task) => task !== completedTask);
+        return tasks.filter((task) => task !== changedStatusTask);
     }
     // const errorMessage = 'Unknown "On Completion" action: ' + ocAction;
     const errorMessage = 'Unknown "On Completion" action';

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -37,7 +37,6 @@ function handleOnCompletion(tasks: Task[], startStatus: Status, endStatus: Statu
     }
     console.log('Uh-oh -- we should never actually get here...  :( ');
     throw new Error('Something went wrong');
-    return tasks;
 }
 
 export function applyStatusAndOnCompletionAction(task: Task, newStatus: Status) {

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -5,16 +5,15 @@ import type { Task } from './Task';
 
 function handleOnCompletion(tasks: Task[], startStatus: Status, endStatus: Status): Task[] {
     const tasksArrayLength = tasks.length;
-    const completedTask = tasks[tasksArrayLength - 1];
-    if (completedTask == undefined) {
-        console.log('Passed-in completedTask is Undefined!');
+    if (tasksArrayLength === 0) {
         return tasks;
     }
+    const completedTask = tasks[tasksArrayLength - 1];
 
     const ocTrigger = ' 🏁 ';
     const taskString = completedTask.toString();
 
-    if (!taskString.includes(ocTrigger) || endStatus.type != StatusType.DONE || endStatus.type == startStatus.type) {
+    if (!taskString.includes(ocTrigger) || endStatus.type !== StatusType.DONE || endStatus.type === startStatus.type) {
         return tasks;
     }
 

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -17,8 +17,10 @@ function handleOnCompletion(tasks: Task[], startStatus: Status, endStatus: Statu
         return tasks;
     }
 
-    const taskEnd = taskString.substring(taskString.indexOf(ocTrigger) + 4);
-    const ocAction = taskEnd.substring(0, taskEnd.indexOf(' '));
+    let ocAction = '';
+    if (taskString.includes('🏁 Delete')) {
+        ocAction = 'Delete';
+    }
     switch (ocAction) {
         case 'Delete': {
             return tasks.filter((task) => task !== completedTask);

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -23,13 +23,7 @@ function handleOnCompletion(tasks: Task[], startStatus: Status, endStatus: Statu
         const ocAction = taskEnd.substring(0, taskEnd.indexOf(' '));
         switch (ocAction) {
             case 'Delete': {
-                if (tasksArrayLength == 2) {
-                    return [tasks[0]];
-                }
-                if (tasksArrayLength == 1) {
-                    return [];
-                }
-                break;
+                return tasks.filter((task) => task !== completedTask);
             }
             default: {
                 const errorMessage = 'Unknown "On Completion" action: ' + ocAction;

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -17,26 +17,24 @@ function handleOnCompletion(tasks: Task[], startStatus: Status, endStatus: Statu
         return tasks;
     }
 
-    if (taskString.includes(ocTrigger)) {
-        const taskEnd = taskString.substring(taskString.indexOf(ocTrigger) + 4);
-        const ocAction = taskEnd.substring(0, taskEnd.indexOf(' '));
-        switch (ocAction) {
-            case 'Delete': {
-                return tasks.filter((task) => task !== completedTask);
-            }
-            default: {
-                const errorMessage = 'Unknown "On Completion" action: ' + ocAction;
-                const console = Console;
-                console.log(errorMessage);
-                // const hint = '\nClick here to clear';
-                // const noticeMessage = errorMessage + hint;
-                // new Notice(noticeMessage, 0);
-                return tasks;
-            }
+    const taskEnd = taskString.substring(taskString.indexOf(ocTrigger) + 4);
+    const ocAction = taskEnd.substring(0, taskEnd.indexOf(' '));
+    switch (ocAction) {
+        case 'Delete': {
+            return tasks.filter((task) => task !== completedTask);
+        }
+        default: {
+            const errorMessage = 'Unknown "On Completion" action: ' + ocAction;
+            const console = Console;
+            console.log(errorMessage);
+            // const hint = '\nClick here to clear';
+            // const noticeMessage = errorMessage + hint;
+            // new Notice(noticeMessage, 0);
+            return tasks;
         }
     }
-    console.log('Uh-oh -- we should never actually get here...  :( ');
-    throw new Error('Something went wrong');
+    // console.log('Uh-oh -- we should never actually get here...  :( ');
+    // throw new Error('Something went wrong');
 }
 
 export function applyStatusAndOnCompletionAction(task: Task, newStatus: Status) {

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -17,24 +17,17 @@ function handleOnCompletion(tasks: Task[], startStatus: Status, endStatus: Statu
         return tasks;
     }
 
-    let ocAction = '';
     if (taskString.includes('🏁 Delete')) {
-        ocAction = 'Delete';
+        return tasks.filter((task) => task !== completedTask);
     }
-    switch (ocAction) {
-        case 'Delete': {
-            return tasks.filter((task) => task !== completedTask);
-        }
-        default: {
-            const errorMessage = 'Unknown "On Completion" action: ' + ocAction;
-            const console = Console;
-            console.log(errorMessage);
-            // const hint = '\nClick here to clear';
-            // const noticeMessage = errorMessage + hint;
-            // new Notice(noticeMessage, 0);
-            return tasks;
-        }
-    }
+    // const errorMessage = 'Unknown "On Completion" action: ' + ocAction;
+    const errorMessage = 'Unknown "On Completion" action';
+    const console = Console;
+    console.log(errorMessage);
+    return tasks;
+    // const hint = '\nClick here to clear';
+    // const noticeMessage = errorMessage + hint;
+    // new Notice(noticeMessage, 0);
     // console.log('Uh-oh -- we should never actually get here...  :( ');
     // throw new Error('Something went wrong');
 }

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -1,4 +1,3 @@
-import Console from 'console';
 import { StatusType } from '../Statuses/StatusConfiguration';
 import type { Task } from './Task';
 
@@ -24,7 +23,6 @@ export function handleOnCompletion(task: Task, tasks: Task[]): Task[] {
     }
     // const errorMessage = 'Unknown "On Completion" action: ' + ocAction;
     const errorMessage = 'Unknown "On Completion" action';
-    const console = Console;
     console.log(errorMessage);
     return tasks;
     // const hint = '\nClick here to clear';

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -1,9 +1,8 @@
 import Console from 'console';
-import type { Status } from '../Statuses/Status';
 import { StatusType } from '../Statuses/StatusConfiguration';
 import type { Task } from './Task';
 
-function handleOnCompletion(task: Task, tasks: Task[]): Task[] {
+export function handleOnCompletion(task: Task, tasks: Task[]): Task[] {
     const tasksArrayLength = tasks.length;
     if (tasksArrayLength === 0) {
         return tasks;
@@ -33,9 +32,4 @@ function handleOnCompletion(task: Task, tasks: Task[]): Task[] {
     // new Notice(noticeMessage, 0);
     // console.log('Uh-oh -- we should never actually get here...  :( ');
     // throw new Error('Something went wrong');
-}
-
-export function applyStatusAndOnCompletionAction(task: Task, newStatus: Status) {
-    const tasks = task.handleNewStatus(newStatus);
-    return handleOnCompletion(task, tasks);
 }

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -11,7 +11,7 @@ function handleOnCompletion(tasks: Task[], startStatus: Status, endStatus: Statu
     const completedTask = tasks[tasksArrayLength - 1];
 
     const ocTrigger = ' 🏁 ';
-    const taskString = completedTask.toString();
+    const taskString = completedTask.description;
 
     if (!taskString.includes(ocTrigger) || endStatus.type !== StatusType.DONE || endStatus.type === startStatus.type) {
         return tasks;

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -854,10 +854,19 @@ export class Task {
     }
 
     public onCompletion(completedTask: Task) {
+        const ocFlag = ' 🏁 ';
         const taskString = completedTask.toString();
-        if (!taskString.includes(' 🏁 ')) {
+        if (!taskString.includes(ocFlag)) {
             return true;
         }
+        // type ocAction = "Delete" | "Archive";
+        // const compareValue = ocFlag + ;
+        //
+        // switch (compareValue){
+        //     case 'x y':
+        //         //"some code here"
+        //         break;
+        // }
     }
 }
 

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -394,10 +394,11 @@ export class Task {
             });
             newTasks.push(nextTask);
         }
-
-        // Write next occurrence before previous occurrence.
-        newTasks.push(toggledTask);
-
+        if (this.onCompletion(toggledTask)) {
+            // Task did _not_ have a valid OnCompletion action, so:
+            // Write next occurrence before previous occurrence.
+            newTasks.push(toggledTask);
+        }
         return newTasks;
     }
 
@@ -850,6 +851,13 @@ export class Task {
      */
     public static extractHashtags(description: string): string[] {
         return description.match(TaskRegularExpressions.hashTags)?.map((tag) => tag.trim()) ?? [];
+    }
+
+    public onCompletion(completedTask: Task) {
+        const taskString = completedTask.toString();
+        if (!taskString.includes(' 🏁 ')) {
+            return true;
+        }
     }
 }
 

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -879,9 +879,10 @@ export class Task {
             // }
             default: {
                 const console = Console;
-                const errorMessage = 'Unknown On Completion action: ' + ocAction;
+                const hint = '\nClick here to clear';
+                const errorMessage = 'Unknown On Completion action: ' + ocAction + hint;
                 console.log(errorMessage);
-                new Notice(errorMessage);
+                new Notice(errorMessage, 0);
                 return true;
             }
         }

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -1,4 +1,6 @@
+import * as Console from 'console';
 import type { Moment } from 'moment';
+import { Notice } from 'obsidian';
 import { getSettings, getUserSelectedTaskFormat } from '../Config/Settings';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { StatusRegistry } from '../Statuses/StatusRegistry';
@@ -854,19 +856,35 @@ export class Task {
     }
 
     public onCompletion(completedTask: Task) {
-        const ocFlag = ' 🏁 ';
+        // enum onCompletionActions {
+        //     delete = 'Delete',
+        //     archive = 'Archive',
+        // }
         const taskString = completedTask.toString();
-        if (!taskString.includes(ocFlag)) {
+        const ocTrigger = ' 🏁 ';
+        if (!taskString.includes(ocTrigger)) {
             return true;
         }
-        // type ocAction = "Delete" | "Archive";
-        // const compareValue = ocFlag + ;
-        //
-        // switch (compareValue){
-        //     case 'x y':
-        //         //"some code here"
-        //         break;
-        // }
+        const taskEnd = taskString.substring(taskString.indexOf(ocTrigger) + 4);
+        const ocAction = taskEnd.substring(0, taskEnd.indexOf(' '));
+        switch (ocAction) {
+            case 'Delete': {
+                // All anticipated valid On Completion _Actions_ will delete the completed task
+                // Future _Actions_ that leave completed tasks in place will necessitate refactoring!
+                break;
+            }
+            // case 'Archive': {
+            //     //"some code here"
+            //     break;
+            // }
+            default: {
+                const console = Console;
+                const errorMessage = 'Unknown On Completion action: ' + ocAction;
+                console.log(errorMessage);
+                new Notice(errorMessage);
+                return true;
+            }
+        }
     }
 }
 

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -1,6 +1,4 @@
-import * as Console from 'console';
 import type { Moment } from 'moment';
-import { Notice } from 'obsidian';
 import { getSettings, getUserSelectedTaskFormat } from '../Config/Settings';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { StatusRegistry } from '../Statuses/StatusRegistry';
@@ -396,11 +394,10 @@ export class Task {
             });
             newTasks.push(nextTask);
         }
-        if (this.onCompletion(toggledTask)) {
-            // Task did _not_ have a valid OnCompletion action, so:
-            // Write next occurrence before previous occurrence.
-            newTasks.push(toggledTask);
-        }
+
+        // Write next occurrence before previous occurrence.
+        newTasks.push(toggledTask);
+
         return newTasks;
     }
 
@@ -853,39 +850,6 @@ export class Task {
      */
     public static extractHashtags(description: string): string[] {
         return description.match(TaskRegularExpressions.hashTags)?.map((tag) => tag.trim()) ?? [];
-    }
-
-    public onCompletion(completedTask: Task) {
-        // enum onCompletionActions {
-        //     delete = 'Delete',
-        //     archive = 'Archive',
-        // }
-        const taskString = completedTask.toString();
-        const ocTrigger = ' 🏁 ';
-        if (!taskString.includes(ocTrigger)) {
-            return true;
-        }
-        const taskEnd = taskString.substring(taskString.indexOf(ocTrigger) + 4);
-        const ocAction = taskEnd.substring(0, taskEnd.indexOf(' '));
-        switch (ocAction) {
-            case 'Delete': {
-                // All anticipated valid On Completion _Actions_ will delete the completed task
-                // Future _Actions_ that leave completed tasks in place will necessitate refactoring!
-                break;
-            }
-            // case 'Archive': {
-            //     //"some code here"
-            //     break;
-            // }
-            default: {
-                const console = Console;
-                const hint = '\nClick here to clear';
-                const errorMessage = 'Unknown On Completion action: ' + ocAction + hint;
-                console.log(errorMessage);
-                new Notice(errorMessage, 0);
-                return true;
-            }
-        }
     }
 }
 

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -60,7 +60,7 @@ function handleOnCompletion(tasks: Task[], startStatus: Status, endStatus: Statu
     return tasks;
 }
 
-function applyStatusAndActOnCompletion(task: Task) {
+function applyStatusAndOnCompletionAction(task: Task) {
     const startStatus = task.status;
     const tasks = task.handleNewStatus(Status.makeDone());
     const endStatus = tasks[tasks.length - 1].status;
@@ -78,7 +78,7 @@ describe('OnCompletion', () => {
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
-        const returnedTasks = applyStatusAndActOnCompletion(task);
+        const returnedTasks = applyStatusAndOnCompletionAction(task);
 
         // Assert
         expect(returnedTasks.length).toEqual(1);
@@ -99,7 +99,7 @@ describe('OnCompletion', () => {
         expect(task.status.type).toEqual(StatusType.DONE);
 
         // Act
-        const returnedTasks = applyStatusAndActOnCompletion(task);
+        const returnedTasks = applyStatusAndOnCompletionAction(task);
 
         // Assert
         expect(returnedTasks.length).toEqual(1);
@@ -115,7 +115,7 @@ describe('OnCompletion', () => {
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
-        const tasks = applyStatusAndActOnCompletion(task);
+        const tasks = applyStatusAndOnCompletionAction(task);
 
         // Assert
         expect(tasks.length).toEqual(1);
@@ -136,7 +136,7 @@ describe('OnCompletion', () => {
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
-        const tasks = applyStatusAndActOnCompletion(task);
+        const tasks = applyStatusAndOnCompletionAction(task);
 
         // Assert
         expect(tasks.length).toEqual(2);
@@ -154,7 +154,7 @@ describe('OnCompletion', () => {
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
-        const tasks = applyStatusAndActOnCompletion(task);
+        const tasks = applyStatusAndOnCompletionAction(task);
 
         // Assert
         expect(tasks).toEqual([]);
@@ -172,7 +172,7 @@ describe('OnCompletion', () => {
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
-        const tasks = applyStatusAndActOnCompletion(task);
+        const tasks = applyStatusAndOnCompletionAction(task);
 
         // Assert
         expect(tasks.length).toEqual(1);

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
-// import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
+import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
 // import { getSettings, resetSettings, updateSettings } from '../../src/Config/Settings';
 import { Status } from '../../src/Statuses/Status';
 import { StatusType } from '../../src/Statuses/StatusConfiguration';
@@ -24,7 +24,7 @@ afterEach(() => {
 });
 
 describe('OnCompletion', () => {
-    it('should not impact a non-recurring task lacking an OC trigger/action', () => {
+    it('should not impact a non-recurring task with no OC trigger/action', () => {
         // Arrange
         const dueDate = '2024-02-10';
         const task = new TaskBuilder().description('A non-recurring, no OC trigger task').dueDate(dueDate).build();
@@ -56,93 +56,46 @@ describe('OnCompletion', () => {
         expect(tasks.length).toEqual(0);
     });
 
-    // it('should have no impact a recurring task with no OC trigger and action', () => {
-    //     // Arrange
-    //     const dueDate = '2024-02-10';
-    //     const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
-    //     const task = new TaskBuilder().recurrence(recurrence).dueDate(dueDate).build();
-    //     expect(task.status.type).toEqual(StatusType.TODO);
-    //
-    //     // Act
-    //     const tasks = task.handleNewStatus(Status.makeDone());
-    //
-    //     // Assert
-    //     expect(tasks.length).toEqual(2);
-    //     expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(`
-    //         "- [ ] my description 🔁 every day 📅 2024-02-11
-    //         - [x] my description 🔁 every day 📅 2024-02-10 ✅ 2024-02-11"
-    //     `);
-    // });
-    // it('should not an OC trigger and valid action', () => {
-    //     // Arrange
-    //     const dueDate = '2024-02-10';
-    //     const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
-    //     const task = new TaskBuilder().recurrence(recurrence).dueDate(dueDate).build();
-    //     expect(task.status.type).toEqual(StatusType.TODO);
-    //
-    //     // Act
-    //     const tasks = task.handleNewStatus(Status.makeDone());
-    //
-    //     // Assert
-    //     expect(tasks.length).toEqual(2);
-    //     expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(`
-    //         "- [ ] my description 🔁 every day 📅 2024-02-11
-    //         - [x] my description 🔁 every day 📅 2024-02-10 ✅ 2024-02-11"
-    //     `);
-    // });
-    //
-    // it('should delete a non-recurring task if trigger and Delete action are present)', () => {
-    //     // Arrange
-    //     const dueDate = '2024-02-10';
-    //     const task = new TaskBuilder().description('delete me upon completion 🏁 Delete').dueDate(dueDate).build();
-    //     const tasks = task.handleNewStatus(Status.makeDone());
-    //
-    //     // Act
-    //     const newTasks = onCompletion(tasks);
-    //
-    //     // Assert
-    //     expect(newTasks == 'None');
-    // });
-    //
-    // it('should delete (after new) recurring task if trigger and Delete action are present', () => {
-    //     // Arrange
-    //     const dueDate = '2024-02-10';
-    //     const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
-    //     const task = new TaskBuilder()
-    //         .description('delete me upon completion 🏁 Delete')
-    //         .recurrence(recurrence)
-    //         .dueDate(dueDate)
-    //         .build();
-    //     // updateSettings({ recurrenceOnNextLine: false });
-    //     const tasks = task.handleNewStatus(Status.makeDone());
-    //
-    //     // Act
-    //     const newTasks = onCompletion(tasks);
-    //
-    //     // Assert
-    //     expect(toLines(newTasks).join('\n')).toMatchInlineSnapshot(
-    //         '"- [ ] delete me upon completion 🏁 Delete 🔁 every day 📅 2024-02-11"',
-    //     );
-    // });
-    //
-    // it('should delete (before new) recurring task if trigger and Delete action are present', () => {
-    //     // Arrange
-    //     const dueDate = '2024-02-10';
-    //     const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
-    //     const task = new TaskBuilder()
-    //         .description('delete me upon completion 🏁 Delete')
-    //         .recurrence(recurrence)
-    //         .dueDate(dueDate)
-    //         .build();
-    //     // updateSettings({ recurrenceOnNextLine: true });
-    //     const tasks = task.handleNewStatus(Status.makeDone());
-    //
-    //     // Act
-    //     const newTasks = onCompletion(tasks);
-    //
-    //     // Assert
-    //     expect(toLines(newTasks).join('\n')).toMatchInlineSnapshot(
-    //         '"- [ ] delete me upon completion 🏁 Delete 🔁 every day 📅 2024-02-11"',
-    //     );
-    // });
+    it('should not impact a recurring task with no OC trigger/action', () => {
+        // Arrange
+        const dueDate = '2024-02-10';
+        const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
+        const task = new TaskBuilder()
+            .description('A recurring task with no OC trigger')
+            .recurrence(recurrence)
+            .dueDate(dueDate)
+            .build();
+        expect(task.status.type).toEqual(StatusType.TODO);
+
+        // Act
+        const tasks = task.handleNewStatus(Status.makeDone());
+
+        // Assert
+        expect(tasks.length).toEqual(2);
+        expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(`
+            "- [ ] A recurring task with no OC trigger 🔁 every day 📅 2024-02-11
+            - [x] A recurring task with no OC trigger 🔁 every day 📅 2024-02-10 ✅ 2024-02-11"
+        `);
+    });
+
+    it('should delete a recurring task with OC trigger/action', () => {
+        // Arrange
+        const dueDate = '2024-02-10';
+        const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
+        const task = new TaskBuilder()
+            .description('A recurring task with OC trigger 🏁 WHATEVER')
+            .recurrence(recurrence)
+            .dueDate(dueDate)
+            .build();
+        expect(task.status.type).toEqual(StatusType.TODO);
+
+        // Act
+        const tasks = task.handleNewStatus(Status.makeDone());
+
+        // Assert
+        expect(tasks.length).toEqual(1);
+        expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(
+            '"- [ ] A recurring task with OC trigger 🏁 WHATEVER 🔁 every day 📅 2024-02-11"',
+        );
+    });
 });

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import moment from 'moment';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { StatusType } from '../../src/Statuses/StatusConfiguration';
+import { Status } from '../../src/Statuses/Status';
+import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
+import { toLines } from '../TestingTools/TestHelpers';
+
+window.moment = moment;
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-02-11'));
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
+
+describe('OnCompletion', () => {
+    it('should be able to complete recurring task', () => {
+        // Arrange
+        const dueDate = '2024-02-10';
+        const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
+        const task = new TaskBuilder().recurrence(recurrence).dueDate(dueDate).build();
+        expect(task.status.type).toEqual(StatusType.TODO);
+
+        // Act
+        const tasks = task.handleNewStatus(Status.makeDone());
+
+        // Assert
+        expect(tasks.length).toEqual(2);
+        expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(`
+            "- [ ] my description 🔁 every day 📅 2024-02-11
+            - [x] my description 🔁 every day 📅 2024-02-10 ✅ 2024-02-11"
+        `);
+    });
+});

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -100,7 +100,7 @@ describe('OnCompletion', () => {
         `);
     });
 
-    // TODO:  is there a better way to handle the following?  does an 'empty' Task exist?
+    // TODO is there a better way to handle the following?  does an 'empty' Task exist?
     it('should return an empty Array for a non-recurring task with Delete Action', () => {
         // Arrange
         const dueDate = '2024-02-10';
@@ -145,7 +145,7 @@ describe('OnCompletion', () => {
         expect(tasks.length).toEqual(0);
     });
 
-    it('should retain the task when going from TODO to IN_PROGRESS', () => {
+    it('should return the task when going from TODO to IN_PROGRESS', () => {
         // Arrange
         const dueDate = '2024-02-10';
         const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
@@ -163,7 +163,7 @@ describe('OnCompletion', () => {
         expect(tasks[0].status.type).toEqual(StatusType.IN_PROGRESS);
     });
 
-    it('should retain the task when going from one DONE status to another DONE status', () => {
+    it('should return the task when going from one DONE status to another DONE status', () => {
         // Arrange
         const done1 = new Status(new StatusConfiguration('x', 'done', ' ', true, StatusType.DONE));
         const done2 = new Status(new StatusConfiguration('X', 'DONE', ' ', true, StatusType.DONE));
@@ -176,5 +176,16 @@ describe('OnCompletion', () => {
         expect(tasks.length).toEqual(1);
         expect(tasks[0].status.symbol).toEqual('X');
         expect(tasks[0].status.type).toEqual(StatusType.DONE);
+    });
+
+    it('should return a task featuring the On Completion flag trigger but an empty string Action', () => {
+        // Arrange
+        const task = new TaskBuilder().description('A non-recurring task with 🏁    ').build();
+
+        // Act
+        const tasks = applyStatusAndOnCompletionAction(task, Status.makeDone());
+
+        // Assert
+        expect(tasks.length).toEqual(1);
     });
 });

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -7,7 +7,8 @@ import { Status } from '../../src/Statuses/Status';
 import { StatusConfiguration, StatusType } from '../../src/Statuses/StatusConfiguration';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { toLines } from '../TestingTools/TestHelpers';
-import { applyStatusAndOnCompletionAction } from '../../src/Task/OnCompletion';
+import type { Task } from '../../src/Task/Task';
+import { handleOnCompletion } from '../../src/Task/OnCompletion';
 
 window.moment = moment;
 
@@ -20,6 +21,11 @@ afterEach(() => {
     jest.useRealTimers();
     // resetSettings();
 });
+
+export function applyStatusAndOnCompletionAction(task: Task, newStatus: Status) {
+    const tasks = task.handleNewStatus(newStatus);
+    return handleOnCompletion(task, tasks);
+}
 
 describe('OnCompletion', () => {
     it('should just return task if Action is not recognized', () => {

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -24,6 +24,25 @@ afterEach(() => {
 });
 
 describe('OnCompletion', () => {
+    it('should log and issue Alert for invalid OC action', () => {
+        // Arrange
+        const dueDate = '2024-02-10';
+        const task = new TaskBuilder()
+            .description('A non-recurring task with invalid OC trigger 🏁 WHATEVER')
+            .dueDate(dueDate)
+            .build();
+        expect(task.status.type).toEqual(StatusType.TODO);
+
+        // Act
+        const tasks = task.handleNewStatus(Status.makeDone());
+
+        // Assert
+        expect(tasks.length).toEqual(1);
+        expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(
+            '"- [x] A non-recurring task with invalid OC trigger 🏁 WHATEVER 📅 2024-02-10 ✅ 2024-02-11"',
+        );
+    });
+
     it('should not impact a non-recurring task with no OC trigger/action', () => {
         // Arrange
         const dueDate = '2024-02-10';
@@ -40,13 +59,10 @@ describe('OnCompletion', () => {
         );
     });
 
-    it('should delete a non-recurring task with OC trigger/action', () => {
+    it('should handle non-recurring task with OC Delete action', () => {
         // Arrange
         const dueDate = '2024-02-10';
-        const task = new TaskBuilder()
-            .description('A non-recurring task with OC trigger 🏁 WHATEVER')
-            .dueDate(dueDate)
-            .build();
+        const task = new TaskBuilder().description('A non-recurring task with 🏁 Delete').dueDate(dueDate).build();
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
@@ -78,12 +94,12 @@ describe('OnCompletion', () => {
         `);
     });
 
-    it('should delete a recurring task with OC trigger/action', () => {
+    it('should handle a recurring task with OC Delete action', () => {
         // Arrange
         const dueDate = '2024-02-10';
         const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
         const task = new TaskBuilder()
-            .description('A recurring task with OC trigger 🏁 WHATEVER')
+            .description('A recurring task with 🏁 Delete')
             .recurrence(recurrence)
             .dueDate(dueDate)
             .build();
@@ -95,7 +111,7 @@ describe('OnCompletion', () => {
         // Assert
         expect(tasks.length).toEqual(1);
         expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(
-            '"- [ ] A recurring task with OC trigger 🏁 WHATEVER 🔁 every day 📅 2024-02-11"',
+            '"- [ ] A recurring task with 🏁 Delete 🔁 every day 📅 2024-02-11"',
         );
     });
 });

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -2,11 +2,14 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
-import { TaskBuilder } from '../TestingTools/TaskBuilder';
-import { StatusType } from '../../src/Statuses/StatusConfiguration';
+// import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
+// import { getSettings, resetSettings, updateSettings } from '../../src/Config/Settings';
 import { Status } from '../../src/Statuses/Status';
-import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
+import { StatusType } from '../../src/Statuses/StatusConfiguration';
+// import type { Task } from '../../src/Task/Task';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { toLines } from '../TestingTools/TestHelpers';
+// import { onCompletion } from '../src/Task/OnCompletion';
 
 window.moment = moment;
 
@@ -17,24 +20,129 @@ beforeEach(() => {
 
 afterEach(() => {
     jest.useRealTimers();
+    // resetSettings();
 });
 
 describe('OnCompletion', () => {
-    it('should be able to complete recurring task', () => {
+    it('should not impact a non-recurring task lacking an OC trigger/action', () => {
         // Arrange
         const dueDate = '2024-02-10';
-        const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
-        const task = new TaskBuilder().recurrence(recurrence).dueDate(dueDate).build();
+        const task = new TaskBuilder().description('A non-recurring, no OC trigger task').dueDate(dueDate).build();
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
         const tasks = task.handleNewStatus(Status.makeDone());
 
         // Assert
-        expect(tasks.length).toEqual(2);
-        expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(`
-            "- [ ] my description 🔁 every day 📅 2024-02-11
-            - [x] my description 🔁 every day 📅 2024-02-10 ✅ 2024-02-11"
-        `);
+        expect(tasks.length).toEqual(1);
+        expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(
+            '"- [x] A non-recurring, no OC trigger task 📅 2024-02-10 ✅ 2024-02-11"',
+        );
     });
+
+    it('should delete a non-recurring task with OC trigger/action', () => {
+        // Arrange
+        const dueDate = '2024-02-10';
+        const task = new TaskBuilder()
+            .description('A non-recurring task with OC trigger 🏁 WHATEVER')
+            .dueDate(dueDate)
+            .build();
+        expect(task.status.type).toEqual(StatusType.TODO);
+
+        // Act
+        const tasks = task.handleNewStatus(Status.makeDone());
+
+        // Assert
+        expect(tasks.length).toEqual(0);
+    });
+
+    // it('should have no impact a recurring task with no OC trigger and action', () => {
+    //     // Arrange
+    //     const dueDate = '2024-02-10';
+    //     const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
+    //     const task = new TaskBuilder().recurrence(recurrence).dueDate(dueDate).build();
+    //     expect(task.status.type).toEqual(StatusType.TODO);
+    //
+    //     // Act
+    //     const tasks = task.handleNewStatus(Status.makeDone());
+    //
+    //     // Assert
+    //     expect(tasks.length).toEqual(2);
+    //     expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(`
+    //         "- [ ] my description 🔁 every day 📅 2024-02-11
+    //         - [x] my description 🔁 every day 📅 2024-02-10 ✅ 2024-02-11"
+    //     `);
+    // });
+    // it('should not an OC trigger and valid action', () => {
+    //     // Arrange
+    //     const dueDate = '2024-02-10';
+    //     const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
+    //     const task = new TaskBuilder().recurrence(recurrence).dueDate(dueDate).build();
+    //     expect(task.status.type).toEqual(StatusType.TODO);
+    //
+    //     // Act
+    //     const tasks = task.handleNewStatus(Status.makeDone());
+    //
+    //     // Assert
+    //     expect(tasks.length).toEqual(2);
+    //     expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(`
+    //         "- [ ] my description 🔁 every day 📅 2024-02-11
+    //         - [x] my description 🔁 every day 📅 2024-02-10 ✅ 2024-02-11"
+    //     `);
+    // });
+    //
+    // it('should delete a non-recurring task if trigger and Delete action are present)', () => {
+    //     // Arrange
+    //     const dueDate = '2024-02-10';
+    //     const task = new TaskBuilder().description('delete me upon completion 🏁 Delete').dueDate(dueDate).build();
+    //     const tasks = task.handleNewStatus(Status.makeDone());
+    //
+    //     // Act
+    //     const newTasks = onCompletion(tasks);
+    //
+    //     // Assert
+    //     expect(newTasks == 'None');
+    // });
+    //
+    // it('should delete (after new) recurring task if trigger and Delete action are present', () => {
+    //     // Arrange
+    //     const dueDate = '2024-02-10';
+    //     const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
+    //     const task = new TaskBuilder()
+    //         .description('delete me upon completion 🏁 Delete')
+    //         .recurrence(recurrence)
+    //         .dueDate(dueDate)
+    //         .build();
+    //     // updateSettings({ recurrenceOnNextLine: false });
+    //     const tasks = task.handleNewStatus(Status.makeDone());
+    //
+    //     // Act
+    //     const newTasks = onCompletion(tasks);
+    //
+    //     // Assert
+    //     expect(toLines(newTasks).join('\n')).toMatchInlineSnapshot(
+    //         '"- [ ] delete me upon completion 🏁 Delete 🔁 every day 📅 2024-02-11"',
+    //     );
+    // });
+    //
+    // it('should delete (before new) recurring task if trigger and Delete action are present', () => {
+    //     // Arrange
+    //     const dueDate = '2024-02-10';
+    //     const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
+    //     const task = new TaskBuilder()
+    //         .description('delete me upon completion 🏁 Delete')
+    //         .recurrence(recurrence)
+    //         .dueDate(dueDate)
+    //         .build();
+    //     // updateSettings({ recurrenceOnNextLine: true });
+    //     const tasks = task.handleNewStatus(Status.makeDone());
+    //
+    //     // Act
+    //     const newTasks = onCompletion(tasks);
+    //
+    //     // Assert
+    //     expect(toLines(newTasks).join('\n')).toMatchInlineSnapshot(
+    //         '"- [ ] delete me upon completion 🏁 Delete 🔁 every day 📅 2024-02-11"',
+    //     );
+    // });
 });

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -180,7 +180,7 @@ describe('OnCompletion', () => {
 
     it('should return a task featuring the On Completion flag trigger but an empty string Action', () => {
         // Arrange
-        const task = new TaskBuilder().description('A non-recurring task with 🏁    ').build();
+        const task = new TaskBuilder().description('A non-recurring task with 🏁').build();
 
         // Act
         const tasks = applyStatusAndOnCompletionAction(task, Status.makeDone());

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -6,7 +6,7 @@ import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
 // import { getSettings, resetSettings, updateSettings } from '../../src/Config/Settings';
 import { Status } from '../../src/Statuses/Status';
 import { StatusType } from '../../src/Statuses/StatusConfiguration';
-// import type { Task } from '../../src/Task/Task';
+import type { Task } from '../../src/Task/Task';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { toLines } from '../TestingTools/TestHelpers';
 // import { onCompletion } from '../src/Task/OnCompletion';
@@ -23,6 +23,10 @@ afterEach(() => {
     // resetSettings();
 });
 
+function applyStatusAndActOnCompletion(task: Task) {
+    return task.handleNewStatus(Status.makeDone());
+}
+
 describe('OnCompletion', () => {
     it('should log and issue Alert for invalid OC action', () => {
         // Arrange
@@ -34,7 +38,7 @@ describe('OnCompletion', () => {
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
-        const tasks = task.handleNewStatus(Status.makeDone());
+        const tasks = applyStatusAndActOnCompletion(task);
 
         // Assert
         expect(tasks.length).toEqual(1);
@@ -50,7 +54,7 @@ describe('OnCompletion', () => {
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
-        const tasks = task.handleNewStatus(Status.makeDone());
+        const tasks = applyStatusAndActOnCompletion(task);
 
         // Assert
         expect(tasks.length).toEqual(1);
@@ -66,7 +70,7 @@ describe('OnCompletion', () => {
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
-        const tasks = task.handleNewStatus(Status.makeDone());
+        const tasks = applyStatusAndActOnCompletion(task);
 
         // Assert
         expect(tasks.length).toEqual(0);
@@ -84,7 +88,7 @@ describe('OnCompletion', () => {
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
-        const tasks = task.handleNewStatus(Status.makeDone());
+        const tasks = applyStatusAndActOnCompletion(task);
 
         // Assert
         expect(tasks.length).toEqual(2);
@@ -106,7 +110,7 @@ describe('OnCompletion', () => {
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
-        const tasks = task.handleNewStatus(Status.makeDone());
+        const tasks = applyStatusAndActOnCompletion(task);
 
         // Assert
         expect(tasks.length).toEqual(1);

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -1,15 +1,14 @@
 /**
  * @jest-environment jsdom
  */
+// import Console from 'console';
 import moment from 'moment';
 import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
-// import { getSettings, resetSettings, updateSettings } from '../../src/Config/Settings';
 import { Status } from '../../src/Statuses/Status';
 import { StatusType } from '../../src/Statuses/StatusConfiguration';
 import type { Task } from '../../src/Task/Task';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { toLines } from '../TestingTools/TestHelpers';
-// import { onCompletion } from '../src/Task/OnCompletion';
 
 window.moment = moment;
 
@@ -23,34 +22,70 @@ afterEach(() => {
     // resetSettings();
 });
 
+function handleOnCompletion(tasks: Task[]): Task[] {
+    const tasksArrayLength = tasks.length;
+    const completedTask = tasks[tasksArrayLength - 1];
+    if (completedTask == undefined) {
+        console.log('Passed-in completedTask is Undefined!');
+        return tasks;
+    }
+    const taskString = completedTask.toString();
+    const ocTrigger = ' 🏁 ';
+    if (taskString.includes(ocTrigger)) {
+        const taskEnd = taskString.substring(taskString.indexOf(ocTrigger) + 4);
+        const ocAction = taskEnd.substring(0, taskEnd.indexOf(' '));
+        switch (ocAction) {
+            case 'Delete': {
+                if (tasksArrayLength == 2) {
+                    return [tasks[0]];
+                }
+                if (tasksArrayLength == 1) {
+                    return [];
+                }
+                break;
+            }
+            default: {
+                // const console = Console;
+                // const hint = '\nClick here to clear';
+                // const errorMessage = 'Unknown "On Completion" action: ' + ocAction + hint;
+                // console.log(errorMessage);
+                // new Notice(errorMessage, 0);
+                return tasks;
+            }
+        }
+    }
+    return tasks;
+}
+
 function applyStatusAndActOnCompletion(task: Task) {
-    return task.handleNewStatus(Status.makeDone());
+    const tasks = task.handleNewStatus(Status.makeDone());
+    return handleOnCompletion(tasks);
 }
 
 describe('OnCompletion', () => {
-    it('should log and issue Alert for invalid OC action', () => {
+    it('should just return task if Action is not recognized', () => {
         // Arrange
         const dueDate = '2024-02-10';
         const task = new TaskBuilder()
-            .description('A non-recurring task with invalid OC trigger 🏁 WHATEVER')
+            .description('A non-recurring task with invalid OC trigger 🏁 INVALID_ACTION')
             .dueDate(dueDate)
             .build();
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
-        const tasks = applyStatusAndActOnCompletion(task);
+        const returnedTasks = applyStatusAndActOnCompletion(task);
 
         // Assert
-        expect(tasks.length).toEqual(1);
-        expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(
-            '"- [x] A non-recurring task with invalid OC trigger 🏁 WHATEVER 📅 2024-02-10 ✅ 2024-02-11"',
+        expect(returnedTasks.length).toEqual(1);
+        expect(toLines(returnedTasks).join('\n')).toMatchInlineSnapshot(
+            '"- [x] A non-recurring task with invalid OC trigger 🏁 INVALID_ACTION 📅 2024-02-10 ✅ 2024-02-11"',
         );
     });
 
-    it('should not impact a non-recurring task with no OC trigger/action', () => {
+    it('should just return trigger-less, non-recurring task', () => {
         // Arrange
         const dueDate = '2024-02-10';
-        const task = new TaskBuilder().description('A non-recurring, no OC trigger task').dueDate(dueDate).build();
+        const task = new TaskBuilder().description('A non-recurring task with no trigger').dueDate(dueDate).build();
         expect(task.status.type).toEqual(StatusType.TODO);
 
         // Act
@@ -59,29 +94,16 @@ describe('OnCompletion', () => {
         // Assert
         expect(tasks.length).toEqual(1);
         expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(
-            '"- [x] A non-recurring, no OC trigger task 📅 2024-02-10 ✅ 2024-02-11"',
+            '"- [x] A non-recurring task with no trigger 📅 2024-02-10 ✅ 2024-02-11"',
         );
     });
 
-    it('should handle non-recurring task with OC Delete action', () => {
-        // Arrange
-        const dueDate = '2024-02-10';
-        const task = new TaskBuilder().description('A non-recurring task with 🏁 Delete').dueDate(dueDate).build();
-        expect(task.status.type).toEqual(StatusType.TODO);
-
-        // Act
-        const tasks = applyStatusAndActOnCompletion(task);
-
-        // Assert
-        expect(tasks.length).toEqual(0);
-    });
-
-    it('should not impact a recurring task with no OC trigger/action', () => {
+    it('should just return trigger-less recurring task', () => {
         // Arrange
         const dueDate = '2024-02-10';
         const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
         const task = new TaskBuilder()
-            .description('A recurring task with no OC trigger')
+            .description('A recurring task with no trigger')
             .recurrence(recurrence)
             .dueDate(dueDate)
             .build();
@@ -93,12 +115,26 @@ describe('OnCompletion', () => {
         // Assert
         expect(tasks.length).toEqual(2);
         expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(`
-            "- [ ] A recurring task with no OC trigger 🔁 every day 📅 2024-02-11
-            - [x] A recurring task with no OC trigger 🔁 every day 📅 2024-02-10 ✅ 2024-02-11"
+            "- [ ] A recurring task with no trigger 🔁 every day 📅 2024-02-11
+            - [x] A recurring task with no trigger 🔁 every day 📅 2024-02-10 ✅ 2024-02-11"
         `);
     });
 
-    it('should handle a recurring task with OC Delete action', () => {
+    // TODO:  is there a better way to handle the following?  does an 'empty' Task exist?
+    it('should return an empty Array for a non-recurring task with Delete Action', () => {
+        // Arrange
+        const dueDate = '2024-02-10';
+        const task = new TaskBuilder().description('A non-recurring task with 🏁 Delete').dueDate(dueDate).build();
+        expect(task.status.type).toEqual(StatusType.TODO);
+
+        // Act
+        const tasks = applyStatusAndActOnCompletion(task);
+
+        // Assert
+        expect(tasks).toEqual([]);
+    });
+
+    it('should return only the next instance of a recurring task with Delete action', () => {
         // Arrange
         const dueDate = '2024-02-10';
         const recurrence = new RecurrenceBuilder().rule('every day').dueDate(dueDate).build();
@@ -113,7 +149,7 @@ describe('OnCompletion', () => {
         const tasks = applyStatusAndActOnCompletion(task);
 
         // Assert
-        expect(tasks.length).toEqual(1);
+        // expect(tasks.length).toEqual(1);
         expect(toLines(tasks).join('\n')).toMatchInlineSnapshot(
             '"- [ ] A recurring task with 🏁 Delete 🔁 every day 📅 2024-02-11"',
         );

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -1,14 +1,13 @@
 /**
  * @jest-environment jsdom
  */
-import Console from 'console';
 import moment from 'moment';
 import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
 import { Status } from '../../src/Statuses/Status';
 import { StatusConfiguration, StatusType } from '../../src/Statuses/StatusConfiguration';
-import type { Task } from '../../src/Task/Task';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { toLines } from '../TestingTools/TestHelpers';
+import { applyStatusAndOnCompletionAction } from '../../src/Task/OnCompletion';
 
 window.moment = moment;
 
@@ -21,57 +20,6 @@ afterEach(() => {
     jest.useRealTimers();
     // resetSettings();
 });
-
-function handleOnCompletion(tasks: Task[], startStatus: Status, endStatus: Status): Task[] {
-    const tasksArrayLength = tasks.length;
-    const completedTask = tasks[tasksArrayLength - 1];
-    if (completedTask == undefined) {
-        console.log('Passed-in completedTask is Undefined!');
-        return tasks;
-    }
-
-    const ocTrigger = ' 🏁 ';
-    const taskString = completedTask.toString();
-
-    if (!taskString.includes(ocTrigger) || endStatus.type != StatusType.DONE || endStatus.type == startStatus.type) {
-        return tasks;
-    }
-
-    if (taskString.includes(ocTrigger)) {
-        const taskEnd = taskString.substring(taskString.indexOf(ocTrigger) + 4);
-        const ocAction = taskEnd.substring(0, taskEnd.indexOf(' '));
-        switch (ocAction) {
-            case 'Delete': {
-                if (tasksArrayLength == 2) {
-                    return [tasks[0]];
-                }
-                if (tasksArrayLength == 1) {
-                    return [];
-                }
-                break;
-            }
-            default: {
-                const errorMessage = 'Unknown "On Completion" action: ' + ocAction;
-                const console = Console;
-                console.log(errorMessage);
-                // const hint = '\nClick here to clear';
-                // const noticeMessage = errorMessage + hint;
-                // new Notice(noticeMessage, 0);
-                return tasks;
-            }
-        }
-    }
-    console.log('Uh-oh -- we should never actually get here...  :( ');
-    throw new Error('Something went wrong');
-    return tasks;
-}
-
-function applyStatusAndOnCompletionAction(task: Task, newStatus: Status) {
-    const startStatus = task.status;
-    const tasks = task.handleNewStatus(newStatus);
-    const endStatus = tasks[tasks.length - 1].status;
-    return handleOnCompletion(tasks, startStatus, endStatus);
-}
 
 describe('OnCompletion', () => {
     it('should just return task if Action is not recognized', () => {


### PR DESCRIPTION
# Description

Since migrating functionality out of `Tasks.ts` and into `OnCompletion.test.ts` during pairing session, I've fixed code and existing tests.
Also renamed existing tests to (hopefully) make their purposes clearer.
Added failing test for NOT executing _OnCompletion_ feature's actions on already-DONE tasks
Added code to make the above test pass.

## How has this been tested?

Tasks plugin's existing tests are passing, plus those within `OnCompletion.test.ts`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:   None as yet.

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.  NOT YET
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.  NOT YET
- [?] My change has _adequate_ [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
