### PR TITLE
fix: Dataview-format parses 'Task.id' and 'Task.dependsOn' same as emoji

### DIFF
--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -86,7 +86,7 @@ export const DATAVIEW_SYMBOLS = {
         doneDateRegex: toInlineFieldRegex(/completion:: *(\d{4}-\d{2}-\d{2})/),
         cancelledDateRegex: toInlineFieldRegex(/cancelled:: *(\d{4}-\d{2}-\d{2})/),
         recurrenceRegex: toInlineFieldRegex(/repeat:: *([a-zA-Z0-9, !]+)/),
-        dependsOnRegex: toInlineFieldRegex(/dependsOn:: *([a-z0-9]+( *, *[a-z0-9]+ *)*)$/),
+        dependsOnRegex: toInlineFieldRegex(/dependsOn:: *([a-z0-9]+( *, *[a-z0-9]+ *)*)/),
         idRegex: toInlineFieldRegex(/id:: *([a-z0-9]+)/),
     },
 } as const;

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -87,7 +87,7 @@ export const DATAVIEW_SYMBOLS = {
         cancelledDateRegex: toInlineFieldRegex(/cancelled:: *(\d{4}-\d{2}-\d{2})/),
         recurrenceRegex: toInlineFieldRegex(/repeat:: *([a-zA-Z0-9, !]+)/),
         dependsOnRegex: toInlineFieldRegex(/dependsOn:: *([a-z0-9]+( *, *[a-z0-9]+ *)*)/),
-        idRegex: toInlineFieldRegex(/id:: *([a-z0-9]+)/),
+        idRegex: toInlineFieldRegex(/id:: *([a-zA-Z0-9]+)/),
     },
 } as const;
 

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -86,7 +86,7 @@ export const DATAVIEW_SYMBOLS = {
         doneDateRegex: toInlineFieldRegex(/completion:: *(\d{4}-\d{2}-\d{2})/),
         cancelledDateRegex: toInlineFieldRegex(/cancelled:: *(\d{4}-\d{2}-\d{2})/),
         recurrenceRegex: toInlineFieldRegex(/repeat:: *([a-zA-Z0-9, !]+)/),
-        dependsOnRegex: toInlineFieldRegex(/dependsOn:: *([a-z0-9]+( *, *[a-z0-9]+ *)*)/),
+        dependsOnRegex: toInlineFieldRegex(/dependsOn:: *([a-zA-Z0-9]+( *, *[a-z0-9]+ *)*)/),
         idRegex: toInlineFieldRegex(/id:: *([a-zA-Z0-9]+)/),
     },
 } as const;

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -86,7 +86,7 @@ export const DATAVIEW_SYMBOLS = {
         doneDateRegex: toInlineFieldRegex(/completion:: *(\d{4}-\d{2}-\d{2})/),
         cancelledDateRegex: toInlineFieldRegex(/cancelled:: *(\d{4}-\d{2}-\d{2})/),
         recurrenceRegex: toInlineFieldRegex(/repeat:: *([a-zA-Z0-9, !]+)/),
-        dependsOnRegex: toInlineFieldRegex(/dependsOn:: *([a-zA-Z0-9]+( *, *[a-z0-9]+ *)*)/),
+        dependsOnRegex: toInlineFieldRegex(/dependsOn:: *([a-zA-Z0-9]+( *, *[a-zA-Z0-9]+ *)*)/),
         idRegex: toInlineFieldRegex(/id:: *([a-zA-Z0-9]+)/),
     },
 } as const;

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -289,6 +289,18 @@ describe('DataviewTaskSerializer', () => {
             expect(serialized).toEqual(' #hello #world #task');
         });
 
+        it('should serialize depends on', () => {
+            const task = new TaskBuilder().description('').dependsOn(['123456', 'abc123']).build();
+            const serialized = serialize(task);
+            expect(serialized).toEqual('  [dependsOn:: 123456,abc123]');
+        });
+
+        it('should serialize id', () => {
+            const task = new TaskBuilder().description('').id('abcdef').build();
+            const serialized = serialize(task);
+            expect(serialized).toEqual('  [id:: abcdef]');
+        });
+
         it('should serialize a fully populated task', () => {
             const task = TaskBuilder.createFullyPopulatedTask();
             const serialized = serialize(task);

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -52,7 +52,7 @@ describe('DataviewTaskSerializer', () => {
             });
         });
 
-        it.failing('should parse depends on one task', () => {
+        it('should parse depends on one task', () => {
             const id = '[dependsOn:: F12345]';
             const taskDetails = deserialize(id);
             expect(taskDetails).toMatchTaskDetails({ dependsOn: ['F12345'] });

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -58,7 +58,7 @@ describe('DataviewTaskSerializer', () => {
             expect(taskDetails).toMatchTaskDetails({ dependsOn: ['F12345'] });
         });
 
-        it.failing('should parse depends on two tasks', () => {
+        it('should parse depends on two tasks', () => {
             const id = '[dependsOn:: 123456,abC123]';
             const taskDetails = deserialize(id);
             expect(taskDetails).toMatchTaskDetails({ dependsOn: ['123456', 'abC123'] });

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -52,13 +52,13 @@ describe('DataviewTaskSerializer', () => {
             });
         });
 
-        it.failing('should parse depends on one task', () => {
+        it('should parse depends on one task', () => {
             const id = '[dependsOn:: 123456]';
             const taskDetails = deserialize(id);
             expect(taskDetails).toMatchTaskDetails({ dependsOn: ['123456'] });
         });
 
-        it.failing('should parse depends on two tasks', () => {
+        it('should parse depends on two tasks', () => {
             const id = '[dependsOn:: 123456,abc123]';
             const taskDetails = deserialize(id);
             expect(taskDetails).toMatchTaskDetails({ dependsOn: ['123456', 'abc123'] });

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -70,7 +70,7 @@ describe('DataviewTaskSerializer', () => {
             expect(taskDetails).toMatchTaskDetails({ id: 'pqrd0f' });
         });
 
-        it.failing('should parse id with capitals', () => {
+        it('should parse id with capitals', () => {
             const id = '[id:: Abcd0f]';
             const taskDetails = deserialize(id);
             expect(taskDetails).toMatchTaskDetails({ id: 'Abcd0f' });

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -52,6 +52,30 @@ describe('DataviewTaskSerializer', () => {
             });
         });
 
+        it.failing('should parse depends on one task', () => {
+            const id = '[dependsOn:: 123456]';
+            const taskDetails = deserialize(id);
+            expect(taskDetails).toMatchTaskDetails({ dependsOn: ['123456'] });
+        });
+
+        it.failing('should parse depends on two tasks', () => {
+            const id = '[dependsOn:: 123456,abc123]';
+            const taskDetails = deserialize(id);
+            expect(taskDetails).toMatchTaskDetails({ dependsOn: ['123456', 'abc123'] });
+        });
+
+        it('should parse id with lower-case and numbers', () => {
+            const id = '[id:: pqrd0f]';
+            const taskDetails = deserialize(id);
+            expect(taskDetails).toMatchTaskDetails({ id: 'pqrd0f' });
+        });
+
+        it.failing('should parse id with capitals', () => {
+            const id = '[id:: Abcd0f]';
+            const taskDetails = deserialize(id);
+            expect(taskDetails).toMatchTaskDetails({ id: 'Abcd0f' });
+        });
+
         it('should parse a task with multiple fields and tags', () => {
             const taskDetails = deserialize(
                 'Wobble [priority::high] #tag1 [completion:: 2024-09-04] #tag2  [due::2025-10-05] #tag3 [scheduled::2022-07-02] #tag4 [start::2023-08-03] #tag5  [repeat::every day]  #tag6 #tag7 #tag8 #tag9 #tag10',

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -52,16 +52,16 @@ describe('DataviewTaskSerializer', () => {
             });
         });
 
-        it('should parse depends on one task', () => {
-            const id = '[dependsOn:: 123456]';
+        it.failing('should parse depends on one task', () => {
+            const id = '[dependsOn:: F12345]';
             const taskDetails = deserialize(id);
-            expect(taskDetails).toMatchTaskDetails({ dependsOn: ['123456'] });
+            expect(taskDetails).toMatchTaskDetails({ dependsOn: ['F12345'] });
         });
 
-        it('should parse depends on two tasks', () => {
-            const id = '[dependsOn:: 123456,abc123]';
+        it.failing('should parse depends on two tasks', () => {
+            const id = '[dependsOn:: 123456,abC123]';
             const taskDetails = deserialize(id);
-            expect(taskDetails).toMatchTaskDetails({ dependsOn: ['123456', 'abc123'] });
+            expect(taskDetails).toMatchTaskDetails({ dependsOn: ['123456', 'abC123'] });
         });
 
         it('should parse id with lower-case and numbers', () => {

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -84,7 +84,13 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
             expect(taskDetails).toMatchTaskDetails({ dependsOn: ['123456', 'abc123'] });
         });
 
-        it('should parse id', () => {
+        it('should parse id with lower-case and numbers', () => {
+            const id = `${idSymbol} pqrd0f`;
+            const taskDetails = deserialize(id);
+            expect(taskDetails).toMatchTaskDetails({ id: 'pqrd0f' });
+        });
+
+        it('should parse id with capitals', () => {
             const id = `${idSymbol} Abcd0f`;
             const taskDetails = deserialize(id);
             expect(taskDetails).toMatchTaskDetails({ id: 'Abcd0f' });

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -73,15 +73,15 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
         });
 
         it('should parse depends on one task', () => {
-            const id = `${dependsOnSymbol} 123456`;
+            const id = `${dependsOnSymbol} F12345`;
             const taskDetails = deserialize(id);
-            expect(taskDetails).toMatchTaskDetails({ dependsOn: ['123456'] });
+            expect(taskDetails).toMatchTaskDetails({ dependsOn: ['F12345'] });
         });
 
         it('should parse depends on two tasks', () => {
-            const id = `${dependsOnSymbol} 123456,abc123`;
+            const id = `${dependsOnSymbol} 123456,abC123`;
             const taskDetails = deserialize(id);
-            expect(taskDetails).toMatchTaskDetails({ dependsOn: ['123456', 'abc123'] });
+            expect(taskDetails).toMatchTaskDetails({ dependsOn: ['123456', 'abC123'] });
         });
 
         it('should parse id with lower-case and numbers', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Several fixes to the parsing of ids and dependsOn values in dataview format.

- `dependsOn` is now read
- `dependsOn` now allows capitals in IDs
- `id` now allows capitals in IDs

This makes these fields consistent with the parsing of Tasks Emoji format.

## Motivation and Context

Fixes #2667, and some other issues found when writing tests
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

- Adding new tests, which initially failed
- Exploratory testing, including confirming that the sample markdown in #2667 now works.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
    - _This was a fix to a not-yet released feature._

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
