### PR TITLE
fix: Enable Tasks to read "no entry" emoji from Emoji Shortcodes plugin

### DIFF
--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -69,7 +69,7 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
     doneDateSymbol: '✅',
     cancelledDateSymbol: '❌',
     recurrenceSymbol: '🔁',
-    dependsOnSymbol: '⛔️',
+    dependsOnSymbol: '⛔️', // TODO Remove Variant Selector 16 from this string
     idSymbol: '🆔',
     TaskFormatRegularExpressions: {
         // The following regex's end with `$` because they will be matched and
@@ -83,7 +83,10 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
         doneDateRegex: /✅ *(\d{4}-\d{2}-\d{2})$/u,
         cancelledDateRegex: /❌ *(\d{4}-\d{2}-\d{2})$/u,
         recurrenceRegex: /🔁 ?([a-zA-Z0-9, !]+)$/iu,
-        dependsOnRegex: new RegExp('⛔️ *(' + taskIdRegex.source + '( *, *' + taskIdRegex.source + ' *)*)$', 'iu'),
+        dependsOnRegex: new RegExp(
+            '⛔\uFE0F? *(' + taskIdRegex.source + '( *, *' + taskIdRegex.source + ' *)*)$',
+            'iu',
+        ),
         idRegex: new RegExp('🆔 *(' + taskIdRegex.source + ')$', 'iu'),
     },
 } as const;

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -5,7 +5,11 @@ import moment from 'moment';
 import type { Settings } from '../../src/Config/Settings';
 import { DefaultTaskSerializer } from '../../src/TaskSerializer';
 import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
-import { DEFAULT_SYMBOLS, type DefaultTaskSerializerSymbols } from '../../src/TaskSerializer/DefaultTaskSerializer';
+import {
+    DEFAULT_SYMBOLS,
+    type DefaultTaskSerializerSymbols,
+    allTaskPluginEmojis,
+} from '../../src/TaskSerializer/DefaultTaskSerializer';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { Priority } from '../../src/Task/Priority';
 
@@ -29,6 +33,19 @@ function hasVariantSelector16(text: string) {
     const vs16Regex = /\uFE0F/u;
     return text.match(vs16Regex) !== null;
 }
+
+describe('validate emojis', () => {
+    // If these tests fail, paste the problem emoji in to https://apps.timwhitlock.info/unicode/inspect
+    it.each(allTaskPluginEmojis())('emoji does not contain Variant Selector 16: "%s"', (emoji: string) => {
+        if (emoji === DEFAULT_SYMBOLS.dependsOnSymbol) {
+            // TODO Remove the VS16 from the dependsOn symbol:
+            //      see https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2693
+            expect(hasVariantSelector16(emoji)).toBe(true);
+        } else {
+            expect(hasVariantSelector16(emoji)).toBe(false);
+        }
+    });
+});
 
 // NEW_TASK_FIELD_EDIT_REQUIRED
 

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -88,7 +88,7 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
             });
 
             it('should parse a high priority with Variant Selector 16', () => {
-                // This test showed the existing of https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2273
+                // This test showed the existence of https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2273
                 const line = '⏫️'; // There is a hidden Variant Selector 16 character at the end of this string
                 expect(hasVariantSelector16(line)).toBe(true);
 
@@ -107,6 +107,23 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
         describe('should parse depends on', () => {
             it('should parse depends on one task', () => {
                 const id = `${dependsOnSymbol} F12345`;
+                const taskDetails = deserialize(id);
+                expect(taskDetails).toMatchTaskDetails({ dependsOn: ['F12345'] });
+            });
+
+            it.failing('should parse depends on one task - without Variant Selector 16', () => {
+                // This test showed the existence of https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2693
+                const id = '⛔ F12345';
+                expect(hasVariantSelector16(id)).toBe(false);
+
+                const taskDetails = deserialize(id);
+                expect(taskDetails).toMatchTaskDetails({ dependsOn: ['F12345'] });
+            });
+
+            it('should parse depends on one task - with Variant Selector 16', () => {
+                const id = '⛔️ F12345'; // There is a hidden Variant Selector 16 character at the end of this string
+                expect(hasVariantSelector16(id)).toBe(true);
+
                 const taskDetails = deserialize(id);
                 expect(taskDetails).toMatchTaskDetails({ dependsOn: ['F12345'] });
             });

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -128,7 +128,7 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
                 expect(taskDetails).toMatchTaskDetails({ dependsOn: ['F12345'] });
             });
 
-            it.failing('should parse depends on one task - without Variant Selector 16', () => {
+            it('should parse depends on one task - without Variant Selector 16', () => {
                 // This test showed the existence of https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2693
                 const id = '⛔ F12345';
                 expect(hasVariantSelector16(id)).toBe(false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Enable Tasks to read dependsOn emoji - ⛔ - that do not have the Variant Selector 16 (VS16) character.

That invisible character was accidentally included in the Tasks plugin source code, meaning Tasks would only parse dependsOn values with that character.

_Note: This does not yet stop Tasks writing out VS16 for this emoji - I will do that as a separate PR as it's quite a large change._

## Motivation and Context

Fix #2693.


## How has this been tested?

- Adding new tests, which initially failed
- Exploratory testing to confirm that I could reproduce the bug before the fix, and that it was fixed afterwars
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
