### PR TITLE
refactor: move date functions to DateTools.ts

### DIFF
--- a/src/lib/DateTools.ts
+++ b/src/lib/DateTools.ts
@@ -33,7 +33,7 @@ export function compareByDate(a: moment.Moment | null, b: moment.Moment | null):
  * @param forwardDate
  * @returns the parsed date string. Includes "invalid" if {@code typedDate} was invalid.
  */
-export function parseTypedDateForDisplay(
+function parseTypedDateForDisplay(
     fieldName: 'created' | 'start' | 'scheduled' | 'due' | 'done' | 'cancelled',
     typedDate: string,
     forwardDate: Date | undefined = undefined,
@@ -48,4 +48,19 @@ export function parseTypedDateForDisplay(
         return window.moment(parsed).format('YYYY-MM-DD');
     }
     return `<i>invalid ${fieldName} date</i>`;
+}
+
+/**
+ * Like {@link parseTypedDateForDisplay} but also accounts for the 'Only future dates' setting.
+ * @param fieldName
+ * @param typedDate - what the user has entered, such as '2023-01-23' or 'tomorrow'
+ * @returns the parsed date string. Includes "invalid" if {@code typedDate} was invalid.
+ * @param forwardOnly
+ */
+export function parseTypedDateForDisplayUsingFutureDate(
+    fieldName: 'start' | 'scheduled' | 'due' | 'done' | 'created' | 'cancelled',
+    typedDate: string,
+    forwardOnly: boolean,
+): string {
+    return parseTypedDateForDisplay(fieldName, typedDate, forwardOnly ? new Date() : undefined);
 }

--- a/src/lib/DateTools.ts
+++ b/src/lib/DateTools.ts
@@ -64,3 +64,17 @@ export function parseTypedDateForDisplayUsingFutureDate(
 ): string {
     return parseTypedDateForDisplay(fieldName, typedDate, forwardOnly ? new Date() : undefined);
 }
+
+/**
+ * Read the entered value for a date field, and return the value to be saved in the edited task.
+ * @param typedDate - what the user has entered, such as '2023-01-23' or 'tomorrow'
+ * @param forwardDate
+ */
+export function parseTypedDateForSaving(typedDate: string, forwardDate: boolean): moment.Moment | null {
+    let date: moment.Moment | null = null;
+    const parsedDate = chrono.parseDate(typedDate, new Date(), { forwardDate });
+    if (parsedDate !== null) {
+        date = window.moment(parsedDate);
+    }
+    return date;
+}

--- a/src/lib/DateTools.ts
+++ b/src/lib/DateTools.ts
@@ -26,6 +26,21 @@ export function compareByDate(a: moment.Moment | null, b: moment.Moment | null):
     }
 }
 
+/*
+    MAINTENANCE NOTE on these Date functions:
+        Repetitious date-related code in this file has been extracted
+        out in to several parseTypedDateFor....() functions over time.
+
+        There is some similarity between these functions, and also
+        some subtle differences.
+
+        Future refactoring to simplify them would be welcomed.
+
+        When editing of Done date is introduced, the functions
+        parseTypedDateForDisplayUsingFutureDate() and parseTypedDateForDisplay()
+        may collapse in to a single case.
+*/
+
 /**
  * Parse and return the entered value for a date field.
  * @param fieldName

--- a/src/lib/DateTools.ts
+++ b/src/lib/DateTools.ts
@@ -1,3 +1,5 @@
+import * as chrono from 'chrono-node';
+
 export function compareByDate(a: moment.Moment | null, b: moment.Moment | null): -1 | 0 | 1 {
     if (a !== null && b === null) {
         return -1;
@@ -22,4 +24,28 @@ export function compareByDate(a: moment.Moment | null, b: moment.Moment | null):
     } else {
         return 0;
     }
+}
+
+/**
+ * Parse and return the entered value for a date field.
+ * @param fieldName
+ * @param typedDate - what the user has entered, such as '2023-01-23' or 'tomorrow'
+ * @param forwardDate
+ * @returns the parsed date string. Includes "invalid" if {@code typedDate} was invalid.
+ */
+export function parseTypedDateForDisplay(
+    fieldName: 'created' | 'start' | 'scheduled' | 'due' | 'done' | 'cancelled',
+    typedDate: string,
+    forwardDate: Date | undefined = undefined,
+): string {
+    if (!typedDate) {
+        return `<i>no ${fieldName} date</i>`;
+    }
+    const parsed = chrono.parseDate(typedDate, forwardDate, {
+        forwardDate: forwardDate != undefined,
+    });
+    if (parsed !== null) {
+        return window.moment(parsed).format('YYYY-MM-DD');
+    }
+    return `<i>invalid ${fieldName} date</i>`;
 }

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-    import * as chrono from 'chrono-node';
     import { onMount } from 'svelte';
-    import { parseTypedDateForDisplayUsingFutureDate } from '../lib/DateTools';
+    import { parseTypedDateForDisplayUsingFutureDate, parseTypedDateForSaving } from '../lib/DateTools';
     import { Recurrence } from '../Task/Recurrence';
     import { getSettings, TASK_FORMATS } from '../Config/Settings';
     import { GlobalFilter } from '../Config/GlobalFilter';
@@ -146,24 +145,6 @@
             parseTypedDateForDisplayUsingFutureDate() and parseTypedDateForDisplay()
             may collapse in to a single case.
      */
-
-    /**
-     * Read the entered value for a date field, and return the value to be saved in the edited task.
-     * @param typedDate - what the user has entered, such as '2023-01-23' or 'tomorrow'
-     * @param forwardDate
-     */
-    function parseTypedDateForSaving(typedDate: string, forwardDate: boolean): moment.Moment | null {
-        let date: moment.Moment | null = null;
-        const parsedDate = chrono.parseDate(
-            typedDate,
-            new Date(),
-            { forwardDate },
-        );
-        if (parsedDate !== null) {
-            date = window.moment(parsedDate);
-        }
-        return date;
-    }
 
     async function serialiseTaskId(task: Task) {
         if (task.id !== "") return task;

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import * as chrono from 'chrono-node';
     import { onMount } from 'svelte';
+    import { parseTypedDateForDisplay } from '../lib/DateTools';
     import { Recurrence } from '../Task/Recurrence';
     import { getSettings, TASK_FORMATS } from '../Config/Settings';
     import { GlobalFilter } from '../Config/GlobalFilter';
@@ -145,30 +146,6 @@
             parseTypedDateForDisplayUsingFutureDate() and parseTypedDateForDisplay()
             may collapse in to a single case.
      */
-
-    /**
-     * Parse and return the entered value for a date field.
-     * @param fieldName
-     * @param typedDate - what the user has entered, such as '2023-01-23' or 'tomorrow'
-     * @param forwardDate
-     * @returns the parsed date string. Includes "invalid" if {@code typedDate} was invalid.
-     */
-    function parseTypedDateForDisplay(
-        fieldName: 'created' | 'start' | 'scheduled' | 'due' | 'done' | 'cancelled',
-        typedDate: string,
-        forwardDate: Date | undefined = undefined,
-    ): string {
-        if (!typedDate) {
-            return `<i>no ${fieldName} date</i>`;
-        }
-        const parsed = chrono.parseDate(typedDate, forwardDate, {
-            forwardDate: forwardDate != undefined,
-        });
-        if (parsed !== null) {
-            return window.moment(parsed).format('YYYY-MM-DD');
-        }
-        return `<i>invalid ${fieldName} date</i>`;
-    }
 
     /**
      * Like {@link parseTypedDateForDisplay} but also accounts for the 'Only future dates' setting.

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import * as chrono from 'chrono-node';
     import { onMount } from 'svelte';
-    import { parseTypedDateForDisplay } from '../lib/DateTools';
+    import { parseTypedDateForDisplayUsingFutureDate } from '../lib/DateTools';
     import { Recurrence } from '../Task/Recurrence';
     import { getSettings, TASK_FORMATS } from '../Config/Settings';
     import { GlobalFilter } from '../Config/GlobalFilter';
@@ -146,21 +146,6 @@
             parseTypedDateForDisplayUsingFutureDate() and parseTypedDateForDisplay()
             may collapse in to a single case.
      */
-
-    /**
-     * Like {@link parseTypedDateForDisplay} but also accounts for the 'Only future dates' setting.
-     * @param fieldName
-     * @param typedDate - what the user has entered, such as '2023-01-23' or 'tomorrow'
-     * @returns the parsed date string. Includes "invalid" if {@code typedDate} was invalid.
-     * @param forwardOnly
-     */
-    function parseTypedDateForDisplayUsingFutureDate(fieldName: 'start' | 'scheduled' | 'due' | 'done' | 'created' | 'cancelled', typedDate: string, forwardOnly: boolean): string {
-        return parseTypedDateForDisplay(
-            fieldName,
-            typedDate,
-            forwardOnly ? new Date() : undefined,
-        );
-    }
 
     /**
      * Read the entered value for a date field, and return the value to be saved in the edited task.

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -150,13 +150,14 @@
     /**
      * Read the entered value for a date field, and return the value to be saved in the edited task.
      * @param typedDate - what the user has entered, such as '2023-01-23' or 'tomorrow'
+     * @param forwardDate
      */
-    function parseTypedDateForSaving(typedDate: string): moment.Moment | null {
+    function parseTypedDateForSaving(typedDate: string, forwardDate: boolean): moment.Moment | null {
         let date: moment.Moment | null = null;
         const parsedDate = chrono.parseDate(
             typedDate,
             new Date(),
-            { forwardDate: editableTask.forwardOnly },
+            { forwardDate },
         );
         if (parsedDate !== null) {
             date = window.moment(parsedDate);
@@ -356,13 +357,13 @@
             description = GlobalFilter.getInstance().prependTo(description);
         }
 
-        const startDate = parseTypedDateForSaving(editableTask.startDate);
-        const scheduledDate = parseTypedDateForSaving(editableTask.scheduledDate);
-        const dueDate = parseTypedDateForSaving(editableTask.dueDate);
+        const startDate = parseTypedDateForSaving(editableTask.startDate, editableTask.forwardOnly);
+        const scheduledDate = parseTypedDateForSaving(editableTask.scheduledDate, editableTask.forwardOnly);
+        const dueDate = parseTypedDateForSaving(editableTask.dueDate, editableTask.forwardOnly);
 
-        const cancelledDate = parseTypedDateForSaving(editableTask.cancelledDate);
-        const createdDate = parseTypedDateForSaving(editableTask.createdDate);
-        const doneDate = parseTypedDateForSaving(editableTask.doneDate);
+        const cancelledDate = parseTypedDateForSaving(editableTask.cancelledDate, editableTask.forwardOnly);
+        const createdDate = parseTypedDateForSaving(editableTask.createdDate, editableTask.forwardOnly);
+        const doneDate = parseTypedDateForSaving(editableTask.doneDate, editableTask.forwardOnly);
 
         let recurrence: Recurrence | null = null;
         if (editableTask.recurrenceRule) {

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -131,21 +131,6 @@
             accessKeyIndex: 1
         }]
 
-    /*
-        MAINTENANCE NOTE on these Date functions:
-            Repetitious date-related code in this file has been extracted
-            out in to several parseTypedDateFor....() functions over time.
-
-            There is some similarity between these functions, and also
-            some subtle differences.
-
-            Future refactoring to simplify them would be welcomed.
-
-            When editing of Done date is introduced, the functions
-            parseTypedDateForDisplayUsingFutureDate() and parseTypedDateForDisplay()
-            may collapse in to a single case.
-     */
-
     async function serialiseTaskId(task: Task) {
         if (task.id !== "") return task;
 

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -152,12 +152,13 @@
      * @param fieldName
      * @param typedDate - what the user has entered, such as '2023-01-23' or 'tomorrow'
      * @returns the parsed date string. Includes "invalid" if {@code typedDate} was invalid.
+     * @param forwardOnly
      */
-    function parseTypedDateForDisplayUsingFutureDate(fieldName: 'start' | 'scheduled' | 'due' | 'done' | 'created' | 'cancelled', typedDate: string): string {
+    function parseTypedDateForDisplayUsingFutureDate(fieldName: 'start' | 'scheduled' | 'due' | 'done' | 'created' | 'cancelled', typedDate: string, forwardOnly: boolean): string {
         return parseTypedDateForDisplay(
             fieldName,
             typedDate,
-            editableTask.forwardOnly ? new Date() : undefined,
+            forwardOnly ? new Date() : undefined,
         );
     }
 
@@ -218,37 +219,37 @@
     // NEW_TASK_FIELD_EDIT_REQUIRED
     $: {
         editableTask.startDate = doAutocomplete(editableTask.startDate);
-        parsedStartDate = parseTypedDateForDisplayUsingFutureDate('start', editableTask.startDate);
+        parsedStartDate = parseTypedDateForDisplayUsingFutureDate('start', editableTask.startDate, editableTask.forwardOnly);
         isStartDateValid = !parsedStartDate.includes('invalid');
     }
 
     $: {
         editableTask.scheduledDate = doAutocomplete(editableTask.scheduledDate);
-        parsedScheduledDate = parseTypedDateForDisplayUsingFutureDate('scheduled', editableTask.scheduledDate);
+        parsedScheduledDate = parseTypedDateForDisplayUsingFutureDate('scheduled', editableTask.scheduledDate, editableTask.forwardOnly);
         isScheduledDateValid = !parsedScheduledDate.includes('invalid');
     }
 
     $: {
         editableTask.dueDate = doAutocomplete(editableTask.dueDate);
-        parsedDueDate = parseTypedDateForDisplayUsingFutureDate('due', editableTask.dueDate);
+        parsedDueDate = parseTypedDateForDisplayUsingFutureDate('due', editableTask.dueDate, editableTask.forwardOnly);
         isDueDateValid = !parsedDueDate.includes('invalid');
     }
 
     $: {
         editableTask.doneDate = doAutocomplete(editableTask.doneDate);
-        parsedDoneDate = parseTypedDateForDisplayUsingFutureDate('done', editableTask.doneDate);
+        parsedDoneDate = parseTypedDateForDisplayUsingFutureDate('done', editableTask.doneDate, editableTask.forwardOnly);
         isDoneDateValid = !parsedDoneDate.includes('invalid');
     }
 
     $: {
         editableTask.createdDate = doAutocomplete(editableTask.createdDate);
-        parsedCreatedDate = parseTypedDateForDisplayUsingFutureDate('created', editableTask.createdDate);
+        parsedCreatedDate = parseTypedDateForDisplayUsingFutureDate('created', editableTask.createdDate, editableTask.forwardOnly);
         isCreatedDateValid = !parsedCreatedDate.includes('invalid');
     }
 
     $: {
         editableTask.cancelledDate = doAutocomplete(editableTask.cancelledDate);
-        parsedCancelledDate = parseTypedDateForDisplayUsingFutureDate('cancelled', editableTask.cancelledDate);
+        parsedCancelledDate = parseTypedDateForDisplayUsingFutureDate('cancelled', editableTask.cancelledDate, editableTask.forwardOnly);
         isCancelledDateValid = !parsedCancelledDate.includes('invalid');
     }
 


### PR DESCRIPTION
# Description

Pairing session with @claremacrae 

Move several pure functions from Svelte code to DateTools.ts

## Motivation and Context

Prepare for future refactoring of Edit Task modal.

## How has this been tested?

Unit test + smoke test (open the modal and verify it), breaking code

## Types of changes

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist


- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
