### PR TITLE
test: add Edit Task modal snapshot test

### DIFF
--- a/tests/Renderer/TaskLineRenderer.test.ts
+++ b/tests/Renderer/TaskLineRenderer.test.ts
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
-import * as prettier from 'prettier';
 
 import { DebugSettings } from '../../src/Config/DebugSettings';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
@@ -15,6 +14,7 @@ import { TaskLineRenderer } from '../../src/Renderer/TaskLineRenderer';
 import type { Task } from '../../src/Task/Task';
 import { TaskRegularExpressions } from '../../src/Task/TaskRegularExpressions';
 import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
+import { prettifyHTML } from '../TestingTools/HTMLHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { fromLine } from '../TestingTools/TestHelpers';
 
@@ -544,13 +544,7 @@ describe('Visualise HTML', () => {
         const taskAsMarkdown = `<!--
 ${task.toFileLineString()}
 -->\n\n`;
-        const taskAsHTML = listItem.outerHTML;
-        const prettyHTML = prettier.format(taskAsHTML, {
-            parser: 'html',
-            bracketSameLine: true,
-            htmlWhitespaceSensitivity: 'ignore',
-            printWidth: 120,
-        });
+        const prettyHTML = prettifyHTML(listItem.outerHTML);
 
         verifyWithFileExtension(taskAsMarkdown + prettyHTML, 'html');
     }

--- a/tests/TestingTools/HTMLHelpers.ts
+++ b/tests/TestingTools/HTMLHelpers.ts
@@ -1,0 +1,10 @@
+import * as prettier from 'prettier';
+
+export function prettifyHTML(modalHTML: string) {
+    return prettier.format(modalHTML, {
+        parser: 'html',
+        bracketSameLine: true,
+        htmlWhitespaceSensitivity: 'ignore',
+        printWidth: 120,
+    });
+}

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
@@ -1,7 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Edit Modal HTML snapshot tests should match snapshot 1`] = `
-"<div>
+<div>
   <div class="tasks-modal">
     <form class="with-accesskeys">
       <div class="tasks-modal-section">
@@ -246,5 +243,3 @@ exports[`Edit Modal HTML snapshot tests should match snapshot 1`] = `
     </form>
   </div>
 </div>
-"
-`;

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -11,6 +11,7 @@ import EditTask from '../../src/ui/EditTask.svelte';
 import { DateFallback } from '../../src/Task/DateFallback';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { resetSettings, updateSettings } from '../../src/Config/Settings';
+import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
 import { verifyAllCombinations3Async } from '../TestingTools/CombinationApprovalsAsync';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { StatusRegistry } from '../../src/Statuses/StatusRegistry';
@@ -536,6 +537,6 @@ describe('Edit Modal HTML snapshot tests', () => {
             htmlWhitespaceSensitivity: 'ignore',
             printWidth: 120,
         });
-        expect(prettyHTML).toMatchSnapshot();
+        verifyWithFileExtension(prettyHTML, 'html');
     });
 });

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -1,20 +1,20 @@
 /**
  * @jest-environment jsdom
  */
-import { type RenderResult, fireEvent, render } from '@testing-library/svelte';
 import { describe, expect, it } from '@jest/globals';
+import { type RenderResult, fireEvent, render } from '@testing-library/svelte';
 import moment from 'moment';
-import * as prettier from 'prettier';
 import { taskFromLine } from '../../src/Commands/CreateOrEditTaskParser';
-import type { Task } from '../../src/Task/Task';
-import EditTask from '../../src/ui/EditTask.svelte';
-import { DateFallback } from '../../src/Task/DateFallback';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { resetSettings, updateSettings } from '../../src/Config/Settings';
+import { StatusRegistry } from '../../src/Statuses/StatusRegistry';
+import { DateFallback } from '../../src/Task/DateFallback';
+import type { Task } from '../../src/Task/Task';
+import EditTask from '../../src/ui/EditTask.svelte';
 import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
 import { verifyAllCombinations3Async } from '../TestingTools/CombinationApprovalsAsync';
+import { prettifyHTML } from '../TestingTools/HTMLHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
-import { StatusRegistry } from '../../src/Statuses/StatusRegistry';
 
 window.moment = moment;
 /**
@@ -530,13 +530,7 @@ describe('Edit Modal HTML snapshot tests', () => {
         const allTasks = [task];
         const { container } = renderAndCheckModal(task, onSubmit, allTasks);
 
-        const modalHTML = container.innerHTML;
-        const prettyHTML = prettier.format(modalHTML, {
-            parser: 'html',
-            bracketSameLine: true,
-            htmlWhitespaceSensitivity: 'ignore',
-            printWidth: 120,
-        });
+        const prettyHTML = prettifyHTML(container.innerHTML);
         verifyWithFileExtension(prettyHTML, 'html');
     });
 });

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -4,6 +4,7 @@
 import { type RenderResult, fireEvent, render } from '@testing-library/svelte';
 import { describe, expect, it } from '@jest/globals';
 import moment from 'moment';
+import * as prettier from 'prettier';
 import { taskFromLine } from '../../src/Commands/CreateOrEditTaskParser';
 import type { Task } from '../../src/Task/Task';
 import EditTask from '../../src/ui/EditTask.svelte';
@@ -518,5 +519,23 @@ describe('Exhaustive editing', () => {
             setCreatedDateValues,
             initialTaskLineValues,
         );
+    });
+});
+
+describe('Edit Modal HTML snapshot tests', () => {
+    it('should match snapshot', () => {
+        const task = taskFromLine({ line: '- [ ] absolutely to do', path: '' });
+        const onSubmit = () => {};
+        const allTasks = [task];
+        const { container } = renderAndCheckModal(task, onSubmit, allTasks);
+
+        const modalHTML = container.innerHTML;
+        const prettyHTML = prettier.format(modalHTML, {
+            parser: 'html',
+            bracketSameLine: true,
+            htmlWhitespaceSensitivity: 'ignore',
+            printWidth: 120,
+        });
+        expect(prettyHTML).toMatchSnapshot();
     });
 });

--- a/tests/ui/__snapshots__/EditTask.test.ts.snap
+++ b/tests/ui/__snapshots__/EditTask.test.ts.snap
@@ -1,0 +1,250 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Edit Modal HTML snapshot tests should match snapshot 1`] = `
+"<div>
+  <div class="tasks-modal">
+    <form class="with-accesskeys">
+      <div class="tasks-modal-section">
+        <label for="description">
+          Descrip
+          <span class="accesskey">t</span>
+          ion
+        </label>
+        <textarea
+          id="description"
+          class="tasks-modal-description"
+          placeholder="Take out the trash"
+          accesskey="t"></textarea>
+      </div>
+      <div class="tasks-modal-section tasks-modal-priorities">
+        <label for="priority-none">Priority</label>
+        <span>
+          <input type="radio" id="priority-lowest" value="lowest" accesskey="o" />
+          <label for="priority-lowest">
+            <span>L</span>
+            <span class="accesskey">o</span>
+            <span>west</span>
+            <span>⏬</span>
+          </label>
+        </span>
+        <span>
+          <input type="radio" id="priority-low" value="low" accesskey="l" />
+          <label for="priority-low">
+            <span></span>
+            <span class="accesskey">L</span>
+            <span>ow</span>
+            <span>🔽</span>
+          </label>
+        </span>
+        <span>
+          <input type="radio" id="priority-none" value="none" accesskey="n" />
+          <label for="priority-none">
+            <span></span>
+            <span class="accesskey">N</span>
+            <span>ormal</span>
+          </label>
+        </span>
+        <span>
+          <input type="radio" id="priority-medium" value="medium" accesskey="m" />
+          <label for="priority-medium">
+            <span></span>
+            <span class="accesskey">M</span>
+            <span>edium</span>
+            <span>🔼</span>
+          </label>
+        </span>
+        <span>
+          <input type="radio" id="priority-high" value="high" accesskey="h" />
+          <label for="priority-high">
+            <span></span>
+            <span class="accesskey">H</span>
+            <span>igh</span>
+            <span>⏫</span>
+          </label>
+        </span>
+        <span>
+          <input type="radio" id="priority-highest" value="highest" accesskey="i" />
+          <label for="priority-highest">
+            <span>H</span>
+            <span class="accesskey">i</span>
+            <span>ghest</span>
+            <span>🔺</span>
+          </label>
+        </span>
+      </div>
+      <div class="tasks-modal-section tasks-modal-dates">
+        <label for="recurrence" class="accesskey-first">Recurs</label>
+        <input id="recurrence" type="text" class="input" placeholder="Try 'every 2 weeks on Thursday'." accesskey="r" />
+        <code class="results">
+          🔁
+          <i>not recurring</i>
+        </code>
+      </div>
+      <hr />
+      <div class="tasks-modal-section tasks-modal-dates">
+        <label for="due" class="accesskey-first">Due</label>
+        <input
+          id="due"
+          type="text"
+          class="input"
+          placeholder="Try 'Monday' or 'tomorrow', or [td|tm|yd|tw|nw|we] then space."
+          accesskey="d" />
+        <code class="results">
+          📅
+          <i>no due date</i>
+        </code>
+        <label for="scheduled" class="accesskey-first">Scheduled</label>
+        <input
+          id="scheduled"
+          type="text"
+          class="input"
+          placeholder="Try 'Monday' or 'tomorrow', or [td|tm|yd|tw|nw|we] then space."
+          accesskey="s" />
+        <code class="results">
+          ⏳
+          <i>no scheduled date</i>
+        </code>
+        <label for="start">
+          St
+          <span class="accesskey">a</span>
+          rt
+        </label>
+        <input
+          id="start"
+          type="text"
+          class="input"
+          placeholder="Try 'Monday' or 'tomorrow', or [td|tm|yd|tw|nw|we] then space."
+          accesskey="a" />
+        <code class="results">
+          🛫
+          <i>no start date</i>
+        </code>
+        <div>
+          <label for="forwardOnly">
+            Only
+            <span class="accesskey-first">future</span>
+            dates:
+          </label>
+          <input
+            id="forwardOnly"
+            type="checkbox"
+            class="input task-list-item-checkbox tasks-modal-checkbox"
+            accesskey="f" />
+        </div>
+      </div>
+      <hr />
+      <div class="tasks-modal-section tasks-modal-dates">
+        <label for="blockedBy" class="accesskey-first">Before this</label>
+        <span class="input">
+          <input
+            accesskey="b"
+            id="blockedBy"
+            class="input"
+            type="text"
+            placeholder="Search for tasks that the task being edited depends on..." />
+          <iframe
+            style="
+              display: block;
+              position: absolute;
+              top: 0;
+              left: 0;
+              width: 100%;
+              height: 100%;
+              overflow: hidden;
+              border: 0;
+              opacity: 0;
+              pointer-events: none;
+              z-index: -1;
+            "
+            aria-hidden="true"
+            tabindex="-1"
+            src="about:blank"></iframe>
+        </span>
+        <div class="task-dependencies-container results"></div>
+        <label for="blocking">
+          Aft
+          <span class="accesskey">e</span>
+          r this
+        </label>
+        <span class="input">
+          <input
+            accesskey="e"
+            id="blocking"
+            class="input"
+            type="text"
+            placeholder="Search for tasks that depend on this task being done..." />
+          <iframe
+            style="
+              display: block;
+              position: absolute;
+              top: 0;
+              left: 0;
+              width: 100%;
+              height: 100%;
+              overflow: hidden;
+              border: 0;
+              opacity: 0;
+              pointer-events: none;
+              z-index: -1;
+            "
+            aria-hidden="true"
+            tabindex="-1"
+            src="about:blank"></iframe>
+        </span>
+        <div class="task-dependencies-container results"></div>
+      </div>
+      <hr />
+      <div class="tasks-modal-section">
+        <label for="status">
+          Stat
+          <span class="accesskey">u</span>
+          s
+        </label>
+        <select id="status-type" class="dropdown" accesskey="u">
+          <option value=" ">Todo [ ]</option>
+          <option value="/">In Progress [/]</option>
+          <option value="x">Done [x]</option>
+          <option value="-">Cancelled [-]</option>
+        </select>
+      </div>
+      <div class="tasks-modal-section tasks-modal-dates">
+        <label for="created">Created</label>
+        <input
+          id="created"
+          type="text"
+          class="input"
+          placeholder="Try 'Monday' or 'tomorrow', or [td|tm|yd|tw|nw|we] then space." />
+        <code class="results">
+          ➕
+          <i>no created date</i>
+        </code>
+        <label for="done">Done</label>
+        <input
+          id="done"
+          type="text"
+          class="input"
+          placeholder="Try 'Monday' or 'tomorrow', or [td|tm|yd|tw|nw|we] then space." />
+        <code class="results">
+          ✅
+          <i>no done date</i>
+        </code>
+        <label for="cancelled">Cancelled</label>
+        <input
+          id="cancelled"
+          type="text"
+          class="input"
+          placeholder="Try 'Monday' or 'tomorrow', or [td|tm|yd|tw|nw|we] then space." />
+        <code class="results">
+          ❌
+          <i>no cancelled date</i>
+        </code>
+      </div>
+      <div class="tasks-modal-section tasks-modal-buttons">
+        <button type="submit" class="mod-cta">Apply</button>
+        <button type="button">Cancel</button>
+      </div>
+    </form>
+  </div>
+</div>
+"
+`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add HTML snapshot test to verify/void changes in the Edit Task modal.

## Motivation and Context

Have a "state" test of the task modal. So far we had only "action" tests - task editing (field change -> changed task) & task rendering (task -> field with correct task data).

## How has this been tested?

Snapshot test =)


## Types of changes

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)


## Checklist


- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
