### PR TITLE
refactor: create DateEditor Svelte component

### DIFF
--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -2,7 +2,7 @@
     import { doAutocomplete } from '../lib/DateAbbreviations';
     import { parseTypedDateForDisplayUsingFutureDate } from '../lib/DateTools';
 
-    export let id: string;
+    export let id: 'start' | 'scheduled' | 'due' | 'done' | 'created' | 'cancelled';
     export let dateSymbol: string;
     export let date: string;
     export let parsedDate: string;

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -1,0 +1,9 @@
+<script lang='ts'>
+    export let dateSymbol: string;
+    export let parsedDate: string;
+</script>
+
+<code class="results">{dateSymbol} {@html parsedDate}</code>
+
+<style>
+</style>

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -1,6 +1,10 @@
 <script lang='ts'>
     export let dateSymbol: string;
+    export let date: string;
     export let parsedDate: string;
+    export let isDateValid: boolean;
+    export let accesskey: string | null;
+    export let placeholder: string;
 </script>
 
 <code class="results">{dateSymbol} {@html parsedDate}</code>

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -2,6 +2,7 @@
     import { doAutocomplete } from '../lib/DateAbbreviations';
     import { parseTypedDateForDisplayUsingFutureDate } from '../lib/DateTools';
 
+    export let id: string;
     export let dateSymbol: string;
     export let date: string;
     export let parsedDate: string;
@@ -12,7 +13,7 @@
 
     $: {
         date = doAutocomplete(date);
-        parsedDate = parseTypedDateForDisplayUsingFutureDate('scheduled', date, forwardOnly);
+        parsedDate = parseTypedDateForDisplayUsingFutureDate(id, date, forwardOnly);
         isDateValid = !parsedDate.includes('invalid');
     }
 </script>
@@ -20,7 +21,7 @@
 <!-- svelte-ignore a11y-accesskey -->
 <input
     bind:value={date}
-    id="scheduled"
+    id={id}
     type="text"
     class:tasks-modal-error={!isDateValid}
     class="input"

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -5,11 +5,12 @@
     export let id: 'start' | 'scheduled' | 'due' | 'done' | 'created' | 'cancelled';
     export let dateSymbol: string;
     export let date: string;
-    export let parsedDate: string;
     export let isDateValid: boolean;
     export let forwardOnly: boolean;
     export let accesskey: string | null;
     export let placeholder: string;
+
+    let parsedDate: string;
 
     $: {
         date = doAutocomplete(date);

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -1,4 +1,7 @@
 <script lang='ts'>
+    import { doAutocomplete } from '../lib/DateAbbreviations';
+    import { parseTypedDateForDisplayUsingFutureDate } from '../lib/DateTools';
+
     export let dateSymbol: string;
     export let date: string;
     export let parsedDate: string;
@@ -6,8 +9,24 @@
     export let forwardOnly: boolean;
     export let accesskey: string | null;
     export let placeholder: string;
+
+    $: {
+        date = doAutocomplete(date);
+        parsedDate = parseTypedDateForDisplayUsingFutureDate('scheduled', date, forwardOnly);
+        isDateValid = !parsedDate.includes('invalid');
+    }
 </script>
 
+<!-- svelte-ignore a11y-accesskey -->
+<input
+    bind:value={date}
+    id="scheduled"
+    type="text"
+    class:tasks-modal-error={!isDateValid}
+    class="input"
+    placeholder={placeholder}
+    accesskey={accesskey}
+/>
 <code class="results">{dateSymbol} {@html parsedDate}</code>
 
 <style>

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -8,15 +8,16 @@
     export let isDateValid: boolean;
     export let forwardOnly: boolean;
     export let accesskey: string | null;
-    export let placeholder: string;
 
     let parsedDate: string;
-
     $: {
         date = doAutocomplete(date);
         parsedDate = parseTypedDateForDisplayUsingFutureDate(id, date, forwardOnly);
         isDateValid = !parsedDate.includes('invalid');
     }
+
+    // 'weekend' abbreviation omitted due to lack of space.
+    const datePlaceholder = "Try 'Monday' or 'tomorrow', or [td|tm|yd|tw|nw|we] then space.";
 </script>
 
 <!-- svelte-ignore a11y-accesskey -->
@@ -26,7 +27,7 @@
     type="text"
     class:tasks-modal-error={!isDateValid}
     class="input"
-    placeholder={placeholder}
+    placeholder={datePlaceholder}
     accesskey={accesskey}
 />
 <code class="results">{dateSymbol} {@html parsedDate}</code>

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -3,6 +3,7 @@
     export let date: string;
     export let parsedDate: string;
     export let isDateValid: boolean;
+    export let forwardOnly: boolean;
     export let accesskey: string | null;
     export let placeholder: string;
 </script>

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -558,9 +558,9 @@ Availability of access keys:
             />
             <DateEditor
                 dateSymbol={scheduledDateSymbol}
-                date={editableTask.scheduledDate}
-                parsedDate={parsedScheduledDate}
-                isDateValid={isScheduledDateValid}
+                bind:date={editableTask.scheduledDate}
+                bind:parsedDate={parsedScheduledDate}
+                bind:isDateValid={isScheduledDateValid}
                 accesskey={accesskey("s")}
                 placeholder={datePlaceholder}
             />

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -548,7 +548,6 @@ Availability of access keys:
                 bind:isDateValid={isScheduledDateValid}
                 forwardOnly={editableTask.forwardOnly}
                 accesskey={accesskey("s")}
-                placeholder={datePlaceholder}
             />
 
             <!-- --------------------------------------------------------------------------- -->

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -61,7 +61,6 @@
     let parsedStartDate: string = '';
     let isStartDateValid: boolean = true;
 
-    let parsedScheduledDate: string = '';
     let isScheduledDateValid: boolean = true;
 
     let parsedDueDate: string = '';
@@ -546,7 +545,6 @@ Availability of access keys:
                 id='scheduled'
                 dateSymbol={scheduledDateSymbol}
                 bind:date={editableTask.scheduledDate}
-                bind:parsedDate={parsedScheduledDate}
                 bind:isDateValid={isScheduledDateValid}
                 forwardOnly={editableTask.forwardOnly}
                 accesskey={accesskey("s")}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -58,7 +58,6 @@
     let parsedCreatedDate: string = '';
     let isCreatedDateValid: boolean = true;
 
-    let parsedStartDate: string = '';
     let isStartDateValid: boolean = true;
 
     let isScheduledDateValid: boolean = true;
@@ -169,13 +168,6 @@
     $: isDescriptionValid = editableTask.description.trim() !== '';
 
     // NEW_TASK_FIELD_EDIT_REQUIRED
-    $: {
-        editableTask.startDate = doAutocomplete(editableTask.startDate);
-        parsedStartDate = parseTypedDateForDisplayUsingFutureDate('start', editableTask.startDate, editableTask.forwardOnly);
-        isStartDateValid = !parsedStartDate.includes('invalid');
-    }
-
-
     $: {
         editableTask.dueDate = doAutocomplete(editableTask.dueDate);
         parsedDueDate = parseTypedDateForDisplayUsingFutureDate('due', editableTask.dueDate, editableTask.forwardOnly);
@@ -554,17 +546,14 @@ Availability of access keys:
             <!--  Start Date  -->
             <!-- --------------------------------------------------------------------------- -->
             <label for="start">St<span class="accesskey">a</span>rt</label>
-            <!-- svelte-ignore a11y-accesskey -->
-            <input
-                bind:value={editableTask.startDate}
-                id="start"
-                type="text"
-                class:tasks-modal-error={!isStartDateValid}
-                class="input"
-                placeholder={datePlaceholder}
+            <DateEditor
+                id='start'
+                dateSymbol={startDateSymbol}
+                bind:date={editableTask.startDate}
+                bind:isDateValid={isStartDateValid}
+                forwardOnly={editableTask.forwardOnly}
                 accesskey={accesskey("a")}
             />
-            <code class="results">{startDateSymbol} {@html parsedStartDate}</code>
 
             <!-- --------------------------------------------------------------------------- -->
             <!--  Only future dates  -->

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -556,7 +556,14 @@ Availability of access keys:
                 placeholder={datePlaceholder}
                 accesskey={accesskey("s")}
             />
-            <DateEditor dateSymbol={scheduledDateSymbol} parsedDate={parsedScheduledDate} />
+            <DateEditor
+                dateSymbol={scheduledDateSymbol}
+                date={editableTask.scheduledDate}
+                parsedDate={parsedScheduledDate}
+                isDateValid={isScheduledDateValid}
+                accesskey={accesskey("s")}
+                placeholder={datePlaceholder}
+            />
 
             <!-- --------------------------------------------------------------------------- -->
             <!--  Start Date  -->

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -491,7 +491,6 @@ Availability of access keys:
             <!--  Scheduled Date  -->
             <!-- --------------------------------------------------------------------------- -->
             <label for="scheduled" class="accesskey-first">Scheduled</label>
-            <!-- removing the bind in bind:isDateValid is not changing behaviour or test results-->
             <DateEditor
                 id='scheduled'
                 dateSymbol={scheduledDateSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -561,6 +561,7 @@ Availability of access keys:
                 bind:date={editableTask.scheduledDate}
                 bind:parsedDate={parsedScheduledDate}
                 bind:isDateValid={isScheduledDateValid}
+                forwardOnly={editableTask.forwardOnly}
                 accesskey={accesskey("s")}
                 placeholder={datePlaceholder}
             />

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
     import { onMount } from 'svelte';
-    import { parseTypedDateForDisplayUsingFutureDate, parseTypedDateForSaving } from '../lib/DateTools';
+    import { parseTypedDateForSaving } from '../lib/DateTools';
     import { Recurrence } from '../Task/Recurrence';
     import { getSettings, TASK_FORMATS } from '../Config/Settings';
     import { GlobalFilter } from '../Config/GlobalFilter';
     import { Status } from '../Statuses/Status';
     import { Task } from '../Task/Task';
-    import { doAutocomplete } from '../lib/DateAbbreviations';
     import { TasksDate } from '../Scripting/TasksDate';
     import { addDependencyToParent, ensureTaskHasId, generateUniqueId, removeDependency } from "../Task/TaskDependency";
     import { replaceTaskWithTasks } from "../Obsidian/File";
@@ -68,7 +67,6 @@
 
     let isDoneDateValid: boolean = true;
 
-    let parsedCancelledDate: string = '';
     let isCancelledDateValid: boolean = true;
 
     let addGlobalFilterOnSave: boolean = false;
@@ -78,10 +76,6 @@
     let originalBlocking: Task[] = [];
 
     let mountComplete = false;
-
-    // 'weekend' abbreviation omitted due to lack of space.
-    let datePlaceholder =
-        "Try 'Monday' or 'tomorrow', or [td|tm|yd|tw|nw|we] then space.";
 
     const priorityOptions: {
             value: typeof editableTask.priority,
@@ -165,12 +159,6 @@
     $: isDescriptionValid = editableTask.description.trim() !== '';
 
     // NEW_TASK_FIELD_EDIT_REQUIRED
-    $: {
-        editableTask.cancelledDate = doAutocomplete(editableTask.cancelledDate);
-        parsedCancelledDate = parseTypedDateForDisplayUsingFutureDate('cancelled', editableTask.cancelledDate, editableTask.forwardOnly);
-        isCancelledDateValid = !parsedCancelledDate.includes('invalid');
-    }
-
     $: {
         isRecurrenceValid = true;
         if (!editableTask.recurrenceRule) {
@@ -621,15 +609,14 @@ Availability of access keys:
             <!--  Cancelled Date  -->
             <!-- --------------------------------------------------------------------------- -->
             <label for="cancelled">Cancelled</label>
-            <input
-                bind:value={editableTask.cancelledDate}
-                id="cancelled"
-                type="text"
-                class:tasks-modal-error={!isCancelledDateValid}
-                class="input"
-                placeholder={datePlaceholder}
+            <DateEditor
+                id='cancelled'
+                dateSymbol={cancelledDateSymbol}
+                bind:date={editableTask.cancelledDate}
+                bind:isDateValid={isCancelledDateValid}
+                forwardOnly={editableTask.forwardOnly}
+                accesskey={null}
             />
-            <code class="results">{cancelledDateSymbol} {@html parsedCancelledDate}</code>
         </div>
 
         <div class="tasks-modal-section tasks-modal-buttons">

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -176,11 +176,6 @@
         isStartDateValid = !parsedStartDate.includes('invalid');
     }
 
-    $: {
-        editableTask.scheduledDate = doAutocomplete(editableTask.scheduledDate);
-        parsedScheduledDate = parseTypedDateForDisplayUsingFutureDate('scheduled', editableTask.scheduledDate, editableTask.forwardOnly);
-        isScheduledDateValid = !parsedScheduledDate.includes('invalid');
-    }
 
     $: {
         editableTask.dueDate = doAutocomplete(editableTask.dueDate);
@@ -546,16 +541,6 @@ Availability of access keys:
             <!--  Scheduled Date  -->
             <!-- --------------------------------------------------------------------------- -->
             <label for="scheduled" class="accesskey-first">Scheduled</label>
-            <!-- svelte-ignore a11y-accesskey -->
-            <input
-                bind:value={editableTask.scheduledDate}
-                id="scheduled"
-                type="text"
-                class:tasks-modal-error={!isScheduledDateValid}
-                class="input"
-                placeholder={datePlaceholder}
-                accesskey={accesskey("s")}
-            />
             <DateEditor
                 dateSymbol={scheduledDateSymbol}
                 bind:date={editableTask.scheduledDate}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -543,6 +543,7 @@ Availability of access keys:
             <label for="scheduled" class="accesskey-first">Scheduled</label>
             <!-- removing the bind in bind:parsedDate & bind:isDateValid is not changing behaviour or test results-->
             <DateEditor
+                id='scheduled'
                 dateSymbol={scheduledDateSymbol}
                 bind:date={editableTask.scheduledDate}
                 bind:parsedDate={parsedScheduledDate}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -66,7 +66,6 @@
     let parsedRecurrence: string = '';
     let isRecurrenceValid: boolean = true;
 
-    let parsedDoneDate: string = '';
     let isDoneDateValid: boolean = true;
 
     let parsedCancelledDate: string = '';
@@ -166,12 +165,6 @@
     $: isDescriptionValid = editableTask.description.trim() !== '';
 
     // NEW_TASK_FIELD_EDIT_REQUIRED
-    $: {
-        editableTask.doneDate = doAutocomplete(editableTask.doneDate);
-        parsedDoneDate = parseTypedDateForDisplayUsingFutureDate('done', editableTask.doneDate, editableTask.forwardOnly);
-        isDoneDateValid = !parsedDoneDate.includes('invalid');
-    }
-
     $: {
         editableTask.cancelledDate = doAutocomplete(editableTask.cancelledDate);
         parsedCancelledDate = parseTypedDateForDisplayUsingFutureDate('cancelled', editableTask.cancelledDate, editableTask.forwardOnly);
@@ -615,15 +608,14 @@ Availability of access keys:
             <!--  Done Date  -->
             <!-- --------------------------------------------------------------------------- -->
             <label for="done">Done</label>
-            <input
-                bind:value={editableTask.doneDate}
-                id="done"
-                type="text"
-                class:tasks-modal-error={!isDoneDateValid}
-                class="input"
-                placeholder={datePlaceholder}
+            <DateEditor
+                id='done'
+                dateSymbol={doneDateSymbol}
+                bind:date={editableTask.doneDate}
+                bind:isDateValid={isDoneDateValid}
+                forwardOnly={editableTask.forwardOnly}
+                accesskey={null}
             />
-            <code class="results">{doneDateSymbol} {@html parsedDoneDate}</code>
 
             <!-- --------------------------------------------------------------------------- -->
             <!--  Cancelled Date  -->

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -541,6 +541,7 @@ Availability of access keys:
             <!--  Scheduled Date  -->
             <!-- --------------------------------------------------------------------------- -->
             <label for="scheduled" class="accesskey-first">Scheduled</label>
+            <!-- removing the bind in bind:parsedDate & bind:isDateValid is not changing behaviour or test results-->
             <DateEditor
                 dateSymbol={scheduledDateSymbol}
                 bind:date={editableTask.scheduledDate}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -54,20 +54,15 @@
 
     let isDescriptionValid: boolean = true;
 
+    let isCancelledDateValid: boolean = true;
     let isCreatedDateValid: boolean = true;
-
-    let isStartDateValid: boolean = true;
-
-    let isScheduledDateValid: boolean = true;
-
+    let isDoneDateValid: boolean = true;
     let isDueDateValid: boolean = true;
+    let isScheduledDateValid: boolean = true;
+    let isStartDateValid: boolean = true;
 
     let parsedRecurrence: string = '';
     let isRecurrenceValid: boolean = true;
-
-    let isDoneDateValid: boolean = true;
-
-    let isCancelledDateValid: boolean = true;
 
     let addGlobalFilterOnSave: boolean = false;
     let withAccessKeys: boolean = true;

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -10,6 +10,7 @@
     import { TasksDate } from '../Scripting/TasksDate';
     import { addDependencyToParent, ensureTaskHasId, generateUniqueId, removeDependency } from "../Task/TaskDependency";
     import { replaceTaskWithTasks } from "../Obsidian/File";
+    import DateEditor from './DateEditor.svelte';
     import type { EditableTask } from "./EditableTask";
     import Dependency from "./Dependency.svelte";
     import { Priority } from '../Task/Priority';
@@ -555,7 +556,7 @@ Availability of access keys:
                 placeholder={datePlaceholder}
                 accesskey={accesskey("s")}
             />
-            <code class="results">{scheduledDateSymbol} {@html parsedScheduledDate}</code>
+            <DateEditor dateSymbol={scheduledDateSymbol} parsedDate={parsedScheduledDate} />
 
             <!-- --------------------------------------------------------------------------- -->
             <!--  Start Date  -->

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -62,7 +62,6 @@
 
     let isScheduledDateValid: boolean = true;
 
-    let parsedDueDate: string = '';
     let isDueDateValid: boolean = true;
 
     let parsedRecurrence: string = '';
@@ -168,12 +167,6 @@
     $: isDescriptionValid = editableTask.description.trim() !== '';
 
     // NEW_TASK_FIELD_EDIT_REQUIRED
-    $: {
-        editableTask.dueDate = doAutocomplete(editableTask.dueDate);
-        parsedDueDate = parseTypedDateForDisplayUsingFutureDate('due', editableTask.dueDate, editableTask.forwardOnly);
-        isDueDateValid = !parsedDueDate.includes('invalid');
-    }
-
     $: {
         editableTask.doneDate = doAutocomplete(editableTask.doneDate);
         parsedDoneDate = parseTypedDateForDisplayUsingFutureDate('done', editableTask.doneDate, editableTask.forwardOnly);
@@ -516,17 +509,14 @@ Availability of access keys:
             <!--  Due Date  -->
             <!-- --------------------------------------------------------------------------- -->
             <label for="due" class="accesskey-first">Due</label>
-            <!-- svelte-ignore a11y-accesskey -->
-            <input
-                bind:value={editableTask.dueDate}
-                id="due"
-                type="text"
-                class="input"
-                class:tasks-modal-error={!isDueDateValid}
-                placeholder={datePlaceholder}
+            <DateEditor
+                id='due'
+                dateSymbol={dueDateSymbol}
+                bind:date={editableTask.dueDate}
+                bind:isDateValid={isDueDateValid}
+                forwardOnly={editableTask.forwardOnly}
                 accesskey={accesskey("d")}
             />
-            <code class="results">{dueDateSymbol} {@html parsedDueDate}</code>
 
             <!-- --------------------------------------------------------------------------- -->
             <!--  Scheduled Date  -->

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -55,7 +55,6 @@
 
     let isDescriptionValid: boolean = true;
 
-    let parsedCreatedDate: string = '';
     let isCreatedDateValid: boolean = true;
 
     let isStartDateValid: boolean = true;
@@ -171,12 +170,6 @@
         editableTask.doneDate = doAutocomplete(editableTask.doneDate);
         parsedDoneDate = parseTypedDateForDisplayUsingFutureDate('done', editableTask.doneDate, editableTask.forwardOnly);
         isDoneDateValid = !parsedDoneDate.includes('invalid');
-    }
-
-    $: {
-        editableTask.createdDate = doAutocomplete(editableTask.createdDate);
-        parsedCreatedDate = parseTypedDateForDisplayUsingFutureDate('created', editableTask.createdDate, editableTask.forwardOnly);
-        isCreatedDateValid = !parsedCreatedDate.includes('invalid');
     }
 
     $: {
@@ -609,15 +602,14 @@ Availability of access keys:
             <!--  Created Date  -->
             <!-- --------------------------------------------------------------------------- -->
             <label for="created">Created</label>
-            <input
-                bind:value={editableTask.createdDate}
-                id="created"
-                type="text"
-                class:tasks-modal-error={!isCreatedDateValid}
-                class="input"
-                placeholder={datePlaceholder}
+            <DateEditor
+                id='created'
+                dateSymbol={createdDateSymbol}
+                bind:date={editableTask.createdDate}
+                bind:isDateValid={isCreatedDateValid}
+                forwardOnly={editableTask.forwardOnly}
+                accesskey={null}
             />
-            <code class="results">{createdDateSymbol} {@html parsedCreatedDate}</code>
 
             <!-- --------------------------------------------------------------------------- -->
             <!--  Done Date  -->

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -540,7 +540,7 @@ Availability of access keys:
             <!--  Scheduled Date  -->
             <!-- --------------------------------------------------------------------------- -->
             <label for="scheduled" class="accesskey-first">Scheduled</label>
-            <!-- removing the bind in bind:parsedDate & bind:isDateValid is not changing behaviour or test results-->
+            <!-- removing the bind in bind:isDateValid is not changing behaviour or test results-->
             <DateEditor
                 id='scheduled'
                 dateSymbol={scheduledDateSymbol}


### PR DESCRIPTION


# Description

Done by pairing with @claremacrae 

- Introduce <DateEditor/> Svelte component to reduce repetition in `EditTask.svelte`

## Motivation and Context

- Reduce repetition
- Enable future usability improvements to date editing

## How has this been tested?

- Unit tests
- Exploratory tests

## Types of changes
Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
