### PR TITLE
refactor: Implement new preprocessor for Boolean searches

### DIFF
--- a/src/Query/Filter/BooleanDelimiters.ts
+++ b/src/Query/Filter/BooleanDelimiters.ts
@@ -14,15 +14,18 @@ export class BooleanDelimiters {
     public readonly closeFilterChars;
     public readonly closeFilter;
 
-    public constructor(openFilterChars: string, closeFilterChars: string) {
+    public readonly openAndCloseFilterChars;
+
+    private constructor(openFilterChars: string, closeFilterChars: string, openAndCloseFilterChars: string) {
         this.openFilterChars = openFilterChars;
         this.closeFilterChars = closeFilterChars;
+        this.openAndCloseFilterChars = openAndCloseFilterChars;
 
         this.openFilter = anyOfTheseChars(this.openFilterChars);
         this.closeFilter = anyOfTheseChars(this.closeFilterChars);
     }
 
     public static allSupportedDelimiters(): BooleanDelimiters {
-        return new BooleanDelimiters('("', ')"');
+        return new BooleanDelimiters('("', ')"', '()"');
     }
 }

--- a/src/Query/Filter/BooleanPreprocessor.ts
+++ b/src/Query/Filter/BooleanPreprocessor.ts
@@ -1,6 +1,17 @@
 import { BooleanDelimiters, anyOfTheseChars } from './BooleanDelimiters';
 
+type BooleanPreprocessorResult = {
+    parts: string[];
+    simplifiedLine: string;
+    filters: { [key: string]: string };
+};
+
 export class BooleanPreprocessor {
+    public static preprocessExpressionV2(line: string): BooleanPreprocessorResult {
+        const parts = BooleanPreprocessor.splitLine(line);
+        return BooleanPreprocessor.getFiltersAndSimplifiedLine(parts);
+    }
+
     public static splitLine(line: string) {
         const delimiters = BooleanDelimiters.allSupportedDelimiters();
 
@@ -57,5 +68,15 @@ export class BooleanPreprocessor {
             .flatMap((substring) => substring.split(openingDelimitersAndSpacesAtStartRegex))
             .flatMap((substring) => substring.split(closingDelimitersAndSpacesAtEndRegex))
             .filter((substring) => substring !== '');
+    }
+
+    private static getFiltersAndSimplifiedLine(parts: string[]) {
+        // Holds the reconstructed expression with placeholders
+        const simplifiedLine = '';
+        const filters: { [key: string]: string } = {}; // To store filter placeholders and their corresponding text
+
+        // TODO Loop to add placeholders-for-filters or operators to the simplifiedLine
+
+        return { parts, simplifiedLine, filters };
     }
 }

--- a/src/Query/Filter/BooleanPreprocessor.ts
+++ b/src/Query/Filter/BooleanPreprocessor.ts
@@ -1,7 +1,6 @@
 import { BooleanDelimiters, anyOfTheseChars } from './BooleanDelimiters';
 
 type BooleanPreprocessorResult = {
-    parts: string[];
     simplifiedLine: string;
     filters: { [key: string]: string };
 };
@@ -93,7 +92,7 @@ export class BooleanPreprocessor {
             }
         });
 
-        return { parts, simplifiedLine, filters };
+        return { simplifiedLine, filters };
     }
 
     private static isAFilter(part: string, delimiters: BooleanDelimiters) {

--- a/src/Query/Filter/BooleanPreprocessor.ts
+++ b/src/Query/Filter/BooleanPreprocessor.ts
@@ -71,12 +71,35 @@ export class BooleanPreprocessor {
     }
 
     private static getFiltersAndSimplifiedLine(parts: string[]) {
+        const delimiters = BooleanDelimiters.allSupportedDelimiters();
+
         // Holds the reconstructed expression with placeholders
-        const simplifiedLine = '';
+        let simplifiedLine = '';
+        let currentIndex = 1; // Placeholder index starts at 1
         const filters: { [key: string]: string } = {}; // To store filter placeholders and their corresponding text
 
-        // TODO Loop to add placeholders-for-filters or operators to the simplifiedLine
+        // Loop to add placeholders-for-filters or operators to the simplifiedLine
+        parts.forEach((part) => {
+            // Check if the part is an operator by matching against the regex without surrounding parentheses
+            if (!BooleanPreprocessor.isAFilter(part, delimiters)) {
+                // It's an operator, space or parenthesis, so add it directly to the simplifiedLine
+                simplifiedLine += `${part}`;
+            } else {
+                // It's a filter, replace it with a placeholder, and save it:
+                const placeholder = `f${currentIndex}`;
+                filters[placeholder] = part;
+                simplifiedLine += placeholder;
+                currentIndex++;
+            }
+        });
 
         return { parts, simplifiedLine, filters };
+    }
+
+    private static isAFilter(part: string, _delimiters: BooleanDelimiters) {
+        // TODO Make this correctly identify only filters...
+
+        // Simplifying assumption for first attempt: it's only a filter if it contains a lower case letter:
+        return /[a-z]/.exec(part) !== null;
     }
 }

--- a/src/Query/Filter/BooleanPreprocessor.ts
+++ b/src/Query/Filter/BooleanPreprocessor.ts
@@ -7,7 +7,7 @@ type BooleanPreprocessorResult = {
 };
 
 export class BooleanPreprocessor {
-    public static preprocessExpressionV2(line: string): BooleanPreprocessorResult {
+    public static preprocessExpression(line: string): BooleanPreprocessorResult {
         const parts = BooleanPreprocessor.splitLine(line);
         return BooleanPreprocessor.getFiltersAndSimplifiedLine(parts);
     }

--- a/tests/Query/Filter/BooleanDelimiters.test.ts
+++ b/tests/Query/Filter/BooleanDelimiters.test.ts
@@ -9,5 +9,7 @@ describe('BooleanDelimiters', () => {
 
         expect(delimiters.closeFilterChars).toEqual(')"');
         expect(delimiters.closeFilter).toEqual('[)"]');
+
+        expect(delimiters.openAndCloseFilterChars).toEqual('()"');
     });
 });

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_preprocess_-_rewrite.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_preprocess_-_rewrite.approved.txt
@@ -8,13 +8,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "not done",
-        ") AND (",
-        "is recurring",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND (f2)",
     "filters": {
         "f1": "not done",
@@ -30,15 +23,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "((",
-        "not done",
-        ")",
-        ") AND (",
-        "(",
-        "is recurring",
-        "))"
-    ],
     "simplifiedLine": "((f1)) AND ((f2))",
     "filters": {
         "f1": "not done",
@@ -54,13 +38,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "not done",
-        ") OR (",
-        "is recurring",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR (f2)",
     "filters": {
         "f1": "not done",
@@ -76,13 +53,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "not done",
-        ") XOR (",
-        "is recurring",
-        ")"
-    ],
     "simplifiedLine": "(f1) XOR (f2)",
     "filters": {
         "f1": "not done",
@@ -98,15 +68,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "not done",
-        ") AND",
-        " ",
-        "NOT (",
-        "is recurring",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND NOT (f2)",
     "filters": {
         "f1": "not done",
@@ -122,15 +83,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "not done",
-        ") OR",
-        " ",
-        "NOT (",
-        "is recurring",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "not done",
@@ -146,11 +98,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "NOT (",
-        "not done",
-        ")"
-    ],
     "simplifiedLine": "NOT (f1)",
     "filters": {
         "f1": "not done"
@@ -166,14 +113,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "\"",
-        "not done",
-        "\" ",
-        "AND (",
-        "is recurring",
-        ")"
-    ],
     "simplifiedLine": "\"f1\" AND (f2)",
     "filters": {
         "f1": "not done",
@@ -189,14 +128,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "\"",
-        "not done",
-        "\" ",
-        "OR (",
-        "is recurring",
-        ")"
-    ],
     "simplifiedLine": "\"f1\" OR (f2)",
     "filters": {
         "f1": "not done",
@@ -212,14 +143,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "\"",
-        "not done",
-        "\" ",
-        "XOR (",
-        "is recurring",
-        ")"
-    ],
     "simplifiedLine": "\"f1\" XOR (f2)",
     "filters": {
         "f1": "not done",
@@ -235,16 +158,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "\"",
-        "not done",
-        "\" ",
-        "AND",
-        " ",
-        "NOT (",
-        "is recurring",
-        ")"
-    ],
     "simplifiedLine": "\"f1\" AND NOT (f2)",
     "filters": {
         "f1": "not done",
@@ -260,16 +173,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "\"",
-        "not done",
-        "\" ",
-        "OR",
-        " ",
-        "NOT (",
-        "is recurring",
-        ")"
-    ],
     "simplifiedLine": "\"f1\" OR NOT (f2)",
     "filters": {
         "f1": "not done",
@@ -286,14 +189,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "not done",
-        ") AND",
-        " \"",
-        "is recurring",
-        "\""
-    ],
     "simplifiedLine": "(f1) AND \"f2\"",
     "filters": {
         "f1": "not done",
@@ -309,15 +204,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "((",
-        "not done",
-        ")",
-        ") AND",
-        " \"",
-        "is recurring",
-        "\""
-    ],
     "simplifiedLine": "((f1)) AND \"f2\"",
     "filters": {
         "f1": "not done",
@@ -333,14 +219,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "not done",
-        ") OR",
-        " \"",
-        "is recurring",
-        "\""
-    ],
     "simplifiedLine": "(f1) OR \"f2\"",
     "filters": {
         "f1": "not done",
@@ -356,14 +234,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "not done",
-        ") XOR",
-        " \"",
-        "is recurring",
-        "\""
-    ],
     "simplifiedLine": "(f1) XOR \"f2\"",
     "filters": {
         "f1": "not done",
@@ -379,16 +249,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "not done",
-        ") AND",
-        " ",
-        "NOT",
-        " \"",
-        "is recurring",
-        "\""
-    ],
     "simplifiedLine": "(f1) AND NOT \"f2\"",
     "filters": {
         "f1": "not done",
@@ -404,16 +264,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "not done",
-        ") OR",
-        " ",
-        "NOT",
-        " \"",
-        "is recurring",
-        "\""
-    ],
     "simplifiedLine": "(f1) OR NOT \"f2\"",
     "filters": {
         "f1": "not done",
@@ -430,14 +280,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "\"",
-        "HAS DUE DATE",
-        "\" ",
-        "OR (",
-        "DESCRIPTION INCLUDES SPECIAL",
-        ")"
-    ],
     "simplifiedLine": "\"f1\" OR (f2)",
     "filters": {
         "f1": "HAS DUE DATE",
@@ -453,15 +295,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "\"",
-        "description includes d1",
-        "\" ",
-        "AND",
-        " \"",
-        "description includes d2",
-        "\""
-    ],
     "simplifiedLine": "\"f1\" AND \"f2\"",
     "filters": {
         "f1": "description includes d1",
@@ -477,14 +310,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "\"",
-        "has due date",
-        "\" ",
-        "OR (",
-        "description includes special",
-        ")"
-    ],
     "simplifiedLine": "\"f1\" OR (f2)",
     "filters": {
         "f1": "has due date",
@@ -500,28 +325,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "( (",
-        "description includes 1",
-        ") AND (",
-        "description includes 2",
-        ") AND (",
-        "description includes 3",
-        ") ",
-        ") OR (",
-        " (",
-        "description includes 5",
-        ") AND (",
-        "description includes 6",
-        ") AND (",
-        "description includes 7",
-        ") ",
-        ") AND",
-        " ",
-        "NOT (",
-        "description includes 7",
-        ")"
-    ],
     "simplifiedLine": "( (f1) AND (f2) AND (f3) ) OR ( (f4) AND (f5) AND (f6) ) AND NOT (f7)",
     "filters": {
         "f1": "description includes 1",
@@ -542,16 +345,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "( (",
-        "description includes a",
-        ") AND (",
-        "description includes b",
-        ") ",
-        ") AND (",
-        "description includes c",
-        ")"
-    ],
     "simplifiedLine": "( (f1) AND (f2) ) AND (f3)",
     "filters": {
         "f1": "description includes a",
@@ -568,23 +361,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "( (",
-        "description includes a",
-        ") AND (",
-        "description includes b",
-        ") AND (",
-        "description includes c",
-        ") ",
-        ") OR (",
-        " (",
-        "description includes d",
-        ") AND (",
-        "description includes e",
-        ") AND (",
-        "description includes f",
-        ") )"
-    ],
     "simplifiedLine": "( (f1) AND (f2) AND (f3) ) OR ( (f4) AND (f5) AND (f6) )",
     "filters": {
         "f1": "description includes a",
@@ -604,16 +380,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "( (",
-        "description includes a",
-        ") OR (",
-        "description includes b",
-        ") ",
-        ") OR (",
-        "description includes c",
-        ")"
-    ],
     "simplifiedLine": "( (f1) OR (f2) ) OR (f3)",
     "filters": {
         "f1": "description includes a",
@@ -630,23 +396,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "( (",
-        "description includes a",
-        ") OR (",
-        "description includes b",
-        ") OR (",
-        "description includes c",
-        ") ",
-        ") AND (",
-        " (",
-        "description includes d",
-        ") OR (",
-        "description includes e",
-        ") OR (",
-        "description includes f",
-        ") )"
-    ],
     "simplifiedLine": "( (f1) OR (f2) OR (f3) ) AND ( (f4) OR (f5) OR (f6) )",
     "filters": {
         "f1": "description includes a",
@@ -666,27 +415,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "( (",
-        "filter by function task.description.includes('a'",
-        ")",
-        ") OR (",
-        "filter by function task.description.includes('b'",
-        ")",
-        ") OR (",
-        "filter by function task.description.includes('c'",
-        ")) ",
-        ") AND (",
-        " (",
-        "filter by function task.description.includes('d'",
-        ")",
-        ") OR (",
-        "filter by function task.description.includes('e'",
-        ")",
-        ") OR (",
-        "filter by function task.description.includes('f'",
-        ")) )"
-    ],
     "simplifiedLine": "( (f1)) OR (f2)) OR (f3)) ) AND ( (f4)) OR (f5)) OR (f6)) )",
     "filters": {
         "f1": "filter by function task.description.includes('a'",
@@ -706,18 +434,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        " ",
-        "description includes a",
-        " ",
-        ")   AND (",
-        " (",
-        "description includes b",
-        ")  AND (",
-        "description includes c",
-        ") )"
-    ],
     "simplifiedLine": "( f1 )   AND ( (f2)  AND (f3) )",
     "filters": {
         "f1": "description includes a",
@@ -734,18 +450,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        " ",
-        "description includes a",
-        " ",
-        ")   OR  (",
-        " (",
-        "description includes b",
-        ")  OR  (",
-        "description includes c",
-        ") )"
-    ],
     "simplifiedLine": "( f1 )   OR  ( (f2)  OR  (f3) )",
     "filters": {
         "f1": "description includes a",
@@ -762,16 +466,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        " ",
-        "description regex matches /(buy|order|voucher|lakeland|purchase|\\spresent)/i",
-        " ",
-        ") OR (",
-        " ",
-        "path includes Home/Shopping",
-        " )"
-    ],
     "simplifiedLine": "( f1 ) OR ( f2 )",
     "filters": {
         "f1": "description regex matches /(buy|order|voucher|lakeland|purchase|\\spresent)/i",
@@ -787,16 +481,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        " ",
-        "description regex matches /buy/i",
-        " ",
-        ") AND (",
-        " ",
-        "path includes some/sample/note.md",
-        " )"
-    ],
     "simplifiedLine": "( f1 ) AND ( f2 )",
     "filters": {
         "f1": "description regex matches /buy/i",
@@ -812,40 +496,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        " ",
-        "filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type",
-        ") ",
-        ") OR (",
-        " ",
-        "filter by function const date = task.due.moment; return date ? !date.isValid() : false;",
-        " ",
-        ") OR (",
-        " ",
-        "filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false",
-        " ",
-        ") OR (",
-        " ",
-        "filter by function task.urgency.toFixed(2) === 1.95.toFixed(2",
-        ") ",
-        ") OR (",
-        " ",
-        "filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁'",
-        ") ",
-        ") OR (",
-        " ",
-        "filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase(",
-        ") ",
-        ") OR (",
-        " ",
-        "filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false",
-        " ",
-        ") OR (",
-        " ",
-        "filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;",
-        " )"
-    ],
     "simplifiedLine": "( f1) ) OR ( f2 ) OR ( f3 ) OR ( f4) ) OR ( f5) ) OR ( f6) ) OR ( f7 ) OR ( f8 )",
     "filters": {
         "f1": "filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type",
@@ -867,40 +517,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        " ",
-        "filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type);",
-        " ",
-        ") OR (",
-        " ",
-        "filter by function const date = task.due.moment; return date ? !date.isValid() : false;",
-        " ",
-        ") OR (",
-        " ",
-        "filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false;",
-        " ",
-        ") OR (",
-        " ",
-        "filter by function task.urgency.toFixed(2) === 1.95.toFixed(2);",
-        " ",
-        ") OR (",
-        " ",
-        "filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁');",
-        " ",
-        ") OR (",
-        " ",
-        "filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase();",
-        " ",
-        ") OR (",
-        " ",
-        "filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false;",
-        " ",
-        ") OR (",
-        " ",
-        "filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;",
-        " )"
-    ],
     "simplifiedLine": "( f1 ) OR ( f2 ) OR ( f3 ) OR ( f4 ) OR ( f5 ) OR ( f6 ) OR ( f7 ) OR ( f8 )",
     "filters": {
         "f1": "filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type);",
@@ -922,13 +538,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(((((",
-        "NOT  (",
-        " ",
-        "description includes d1",
-        " ))))))"
-    ],
     "simplifiedLine": "(((((NOT  ( f1 ))))))",
     "filters": {
         "f1": "description includes d1"
@@ -943,11 +552,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(((((",
-        "description includes #context/location1",
-        ")))))"
-    ],
     "simplifiedLine": "(((((f1)))))",
     "filters": {
         "f1": "description includes #context/location1"
@@ -962,21 +566,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "((",
-        "due this week",
-        ") AND (",
-        "description includes Hello World",
-        ")",
-        ") OR",
-        " ",
-        "NOT (",
-        "(",
-        "due this week",
-        ") AND (",
-        "description includes Hello World",
-        "))"
-    ],
     "simplifiedLine": "((f1) AND (f2)) OR NOT ((f3) AND (f4))",
     "filters": {
         "f1": "due this week",
@@ -994,13 +583,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "DESCRIPTION INCLUDES wibble",
-        ") OR (",
-        "has due date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR (f2)",
     "filters": {
         "f1": "DESCRIPTION INCLUDES wibble",
@@ -1016,13 +598,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "DUE THIS WEEK",
-        ") AND (",
-        "DESCRIPTION INCLUDES HELLO WORLD",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND (f2)",
     "filters": {
         "f1": "DUE THIS WEEK",
@@ -1038,14 +613,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "HAS START DATE",
-        ") AND",
-        " \"",
-        "DESCRIPTION INCLUDES SOME",
-        "\""
-    ],
     "simplifiedLine": "(f1) AND \"f2\"",
     "filters": {
         "f1": "HAS START DATE",
@@ -1061,16 +628,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "HAS START DATE",
-        ") AND (",
-        "(",
-        "DESCRIPTION INCLUDES SOME",
-        ") OR (",
-        "HAS DUE DATE",
-        "))"
-    ],
     "simplifiedLine": "(f1) AND ((f2) OR (f3))",
     "filters": {
         "f1": "HAS START DATE",
@@ -1087,15 +644,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "HAS START DATE",
-        ") AND",
-        " ",
-        "NOT (",
-        "DESCRIPTION INCLUDES SOME",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND NOT (f2)",
     "filters": {
         "f1": "HAS START DATE",
@@ -1111,16 +659,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "HAS START DATE",
-        ") OR (",
-        "(",
-        "DESCRIPTION INCLUDES SPECIAL",
-        ") AND (",
-        "HAS DUE DATE",
-        "))"
-    ],
     "simplifiedLine": "(f1) OR ((f2) AND (f3))",
     "filters": {
         "f1": "HAS START DATE",
@@ -1137,15 +675,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "HAS START DATE",
-        ") OR",
-        " ",
-        "NOT (",
-        "DESCRIPTION INCLUDES SPECIAL",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "HAS START DATE",
@@ -1161,13 +690,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "HAS START DATE",
-        ") XOR (",
-        "DESCRIPTION INCLUDES SPECIAL",
-        ")"
-    ],
     "simplifiedLine": "(f1) XOR (f2)",
     "filters": {
         "f1": "HAS START DATE",
@@ -1183,15 +705,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "cancelled after 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "cancelled after 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "cancelled after 2021-12-27",
@@ -1207,15 +720,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "cancelled before 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "cancelled before 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "cancelled before 2021-12-27",
@@ -1231,15 +735,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "cancelled date is invalid",
-        ") OR",
-        " ",
-        "NOT (",
-        "cancelled date is invalid",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "cancelled date is invalid",
@@ -1255,15 +750,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "cancelled in 2021-12-27 2021-12-29",
-        ") OR",
-        " ",
-        "NOT (",
-        "cancelled in 2021-12-27 2021-12-29",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "cancelled in 2021-12-27 2021-12-29",
@@ -1279,15 +765,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "cancelled on 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "cancelled on 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "cancelled on 2021-12-27",
@@ -1303,15 +780,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "cancelled this week",
-        ") OR",
-        " ",
-        "NOT (",
-        "cancelled this week",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "cancelled this week",
@@ -1327,15 +795,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "created after 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "created after 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "created after 2021-12-27",
@@ -1351,15 +810,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "created before 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "created before 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "created before 2021-12-27",
@@ -1375,15 +825,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "created date is invalid",
-        ") OR",
-        " ",
-        "NOT (",
-        "created date is invalid",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "created date is invalid",
@@ -1399,15 +840,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "created in 2021-12-27 2021-12-29",
-        ") OR",
-        " ",
-        "NOT (",
-        "created in 2021-12-27 2021-12-29",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "created in 2021-12-27 2021-12-29",
@@ -1423,15 +855,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "created on 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "created on 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "created on 2021-12-27",
@@ -1447,15 +870,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "created this week",
-        ") OR",
-        " ",
-        "NOT (",
-        "created this week",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "created this week",
@@ -1471,15 +885,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description does not include wibble",
-        ") OR",
-        " ",
-        "NOT (",
-        "description does not include wibble",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "description does not include wibble",
@@ -1495,14 +900,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes \"hello world",
-        "\"",
-        ") OR (",
-        "description includes \"42",
-        "\")"
-    ],
     "simplifiedLine": "(f1\") OR (f2\")",
     "filters": {
         "f1": "description includes \"hello world",
@@ -1518,11 +915,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes #context/location1",
-        ")"
-    ],
     "simplifiedLine": "(f1)",
     "filters": {
         "f1": "description includes #context/location1"
@@ -1537,21 +929,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes #context/location1",
-        ") OR (",
-        "description includes #context/location2",
-        " ",
-        ") OR (",
-        "  ",
-        "description includes #context/location3",
-        " ",
-        ") OR   (",
-        "  ",
-        "description includes #context/location4",
-        " )"
-    ],
     "simplifiedLine": "(f1) OR (f2 ) OR (  f3 ) OR   (  f4 )",
     "filters": {
         "f1": "description includes #context/location1",
@@ -1569,27 +946,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes 1",
-        ")   AND   (",
-        "description includes 2",
-        ")   AND   (",
-        "description includes 3",
-        ")   AND   (",
-        "description includes 4",
-        ")   AND   (",
-        "description includes 5",
-        ")   AND   (",
-        "description includes 6",
-        ")   AND   (",
-        "description includes 7",
-        ")   AND   (",
-        "description includes 8",
-        ")   AND   (",
-        "description includes 9",
-        ")"
-    ],
     "simplifiedLine": "(f1)   AND   (f2)   AND   (f3)   AND   (f4)   AND   (f5)   AND   (f6)   AND   (f7)   AND   (f8)   AND   (f9)",
     "filters": {
         "f1": "description includes 1",
@@ -1612,15 +968,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes 1",
-        ") AND (",
-        "description includes 2",
-        ") AND (",
-        "description includes 3",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND (f2) AND (f3)",
     "filters": {
         "f1": "description includes 1",
@@ -1637,27 +984,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes 1",
-        ") AND (",
-        "description includes 2",
-        ") AND (",
-        "description includes 3",
-        ") AND (",
-        "description includes 4",
-        ") AND (",
-        "description includes 5",
-        ") AND (",
-        "description includes 6",
-        ") AND (",
-        "description includes 7",
-        ") AND (",
-        "description includes 8",
-        ") AND (",
-        "description includes 9",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND (f2) AND (f3) AND (f4) AND (f5) AND (f6) AND (f7) AND (f8) AND (f9)",
     "filters": {
         "f1": "description includes 1",
@@ -1680,15 +1006,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes AND",
-        ") OR",
-        " ",
-        "NOT (",
-        "description includes AND",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "description includes AND",
@@ -1704,13 +1021,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes SHOULD NOT BE RECOGNISED AS A BOOLEAN",
-        ")AND(",
-        "description includes BECAUSE THERE ARE NO SPACES AROUND THE 'AND' OPERATOR",
-        ")"
-    ],
     "simplifiedLine": "(f1)AND(f2)",
     "filters": {
         "f1": "description includes SHOULD NOT BE RECOGNISED AS A BOOLEAN",
@@ -1726,15 +1036,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes d1",
-        ") AND",
-        "   ",
-        "NOT (",
-        "priority medium",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND   NOT (f2)",
     "filters": {
         "f1": "description includes d1",
@@ -1750,13 +1051,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes d1",
-        ") AND (",
-        "priority medium",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND (f2)",
     "filters": {
         "f1": "description includes d1",
@@ -1772,15 +1066,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes d1",
-        ") AND",
-        " ",
-        "NOT (",
-        "description includes d2",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND NOT (f2)",
     "filters": {
         "f1": "description includes d1",
@@ -1796,15 +1081,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes d1",
-        ") OR",
-        "   ",
-        "NOT (",
-        "priority medium",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR   NOT (f2)",
     "filters": {
         "f1": "description includes d1",
@@ -1820,13 +1096,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes d1",
-        ") OR (",
-        "description includes d2",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR (f2)",
     "filters": {
         "f1": "description includes d1",
@@ -1842,15 +1111,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes d1",
-        ") OR (",
-        "description includes d2",
-        ") OR (",
-        "priority medium",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR (f2) OR (f3)",
     "filters": {
         "f1": "description includes d1",
@@ -1867,13 +1127,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes d1",
-        ") OR (",
-        "priority medium",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR (f2)",
     "filters": {
         "f1": "description includes d1",
@@ -1889,15 +1142,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes d1",
-        ") OR",
-        " ",
-        "NOT (",
-        "description includes d2",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "description includes d1",
@@ -1913,13 +1157,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes d1",
-        ") XOR (",
-        "description includes d2",
-        ")"
-    ],
     "simplifiedLine": "(f1) XOR (f2)",
     "filters": {
         "f1": "description includes d1",
@@ -1935,13 +1172,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes d1",
-        ") XOR (",
-        "priority medium",
-        ")"
-    ],
     "simplifiedLine": "(f1) XOR (f2)",
     "filters": {
         "f1": "description includes d1",
@@ -1957,13 +1187,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes line 1",
-        ") OR (",
-        "description includes line 1 continued with \\ backslash",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR (f2)",
     "filters": {
         "f1": "description includes line 1",
@@ -1979,15 +1202,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description includes wibble",
-        ") OR",
-        " ",
-        "NOT (",
-        "description includes wibble",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "description includes wibble",
@@ -2003,13 +1217,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "description regex matches /#t\\s/i",
-        ") OR (",
-        "description regex matches /#t$/i",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR (f2)",
     "filters": {
         "f1": "description regex matches /#t\\s/i",
@@ -2025,15 +1232,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "done after 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "done after 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "done after 2021-12-27",
@@ -2049,15 +1247,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "done before 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "done before 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "done before 2021-12-27",
@@ -2073,15 +1262,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "done date is invalid",
-        ") OR",
-        " ",
-        "NOT (",
-        "done date is invalid",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "done date is invalid",
@@ -2097,15 +1277,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "done in 2021-12-27 2021-12-29",
-        ") OR",
-        " ",
-        "NOT (",
-        "done in 2021-12-27 2021-12-29",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "done in 2021-12-27 2021-12-29",
@@ -2121,15 +1292,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "done on 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "done on 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "done on 2021-12-27",
@@ -2145,15 +1307,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "done this week",
-        ") OR",
-        " ",
-        "NOT (",
-        "done this week",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "done this week",
@@ -2169,15 +1322,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "done",
-        ") OR",
-        " ",
-        "NOT (",
-        "done",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "done",
@@ -2193,15 +1337,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "due after 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "due after 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "due after 2021-12-27",
@@ -2217,15 +1352,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "due before 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "due before 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "due before 2021-12-27",
@@ -2241,13 +1367,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "due before tomorrow",
-        ") AND (",
-        "is recurring",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND (f2)",
     "filters": {
         "f1": "due before tomorrow",
@@ -2263,15 +1382,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "due date is invalid",
-        ") OR",
-        " ",
-        "NOT (",
-        "due date is invalid",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "due date is invalid",
@@ -2287,15 +1397,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "due in 2021-12-27 2021-12-29",
-        ") OR",
-        " ",
-        "NOT (",
-        "due in 2021-12-27 2021-12-29",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "due in 2021-12-27 2021-12-29",
@@ -2311,15 +1412,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "due on 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "due on 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "due on 2021-12-27",
@@ -2335,13 +1427,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "due this week",
-        ") AND (",
-        "description includes Hello World",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND (f2)",
     "filters": {
         "f1": "due this week",
@@ -2357,15 +1442,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "due this week",
-        ") OR",
-        " ",
-        "NOT (",
-        "due this week",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "due this week",
@@ -2381,15 +1457,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "exclude sub-items",
-        ") OR",
-        " ",
-        "NOT (",
-        "exclude sub-items",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "exclude sub-items",
@@ -2405,15 +1472,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "filename includes wibble",
-        ") OR",
-        " ",
-        "NOT (",
-        "filename includes wibble",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "filename includes wibble",
@@ -2429,15 +1487,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "filter by function task.isDone",
-        ") OR",
-        " ",
-        "NOT (",
-        "filter by function task.isDone",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "filter by function task.isDone",
@@ -2453,15 +1502,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "folder does not include some/path",
-        ") OR",
-        " ",
-        "NOT (",
-        "folder does not include some/path",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "folder does not include some/path",
@@ -2477,15 +1517,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "folder includes AND",
-        ") OR",
-        " ",
-        "NOT (",
-        "folder includes AND",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "folder includes AND",
@@ -2501,15 +1532,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "folder includes some/path",
-        ") OR",
-        " ",
-        "NOT (",
-        "folder includes some/path",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "folder includes some/path",
@@ -2525,15 +1547,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "happens after 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "happens after 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "happens after 2021-12-27",
@@ -2549,15 +1562,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "happens before 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "happens before 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "happens before 2021-12-27",
@@ -2573,15 +1577,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "happens in 2021-12-27 2021-12-29",
-        ") OR",
-        " ",
-        "NOT (",
-        "happens in 2021-12-27 2021-12-29",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "happens in 2021-12-27 2021-12-29",
@@ -2597,15 +1592,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "happens on 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "happens on 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "happens on 2021-12-27",
@@ -2621,15 +1607,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "happens this week",
-        ") OR",
-        " ",
-        "NOT (",
-        "happens this week",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "happens this week",
@@ -2645,15 +1622,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has cancelled date",
-        ") OR",
-        " ",
-        "NOT (",
-        "has cancelled date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "has cancelled date",
@@ -2669,15 +1637,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has created date",
-        ") OR",
-        " ",
-        "NOT (",
-        "has created date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "has created date",
@@ -2693,15 +1652,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has depends on",
-        ") OR",
-        " ",
-        "NOT (",
-        "has depends on",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "has depends on",
@@ -2717,15 +1667,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has done date",
-        ") OR",
-        " ",
-        "NOT (",
-        "has done date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "has done date",
@@ -2741,16 +1682,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has due date",
-        ") OR (",
-        "(",
-        "HAS START DATE",
-        ") AND (",
-        "due after 2021-12-27",
-        "))"
-    ],
     "simplifiedLine": "(f1) OR ((f2) AND (f3))",
     "filters": {
         "f1": "has due date",
@@ -2767,15 +1698,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has due date",
-        ") OR",
-        " ",
-        "NOT (",
-        "has due date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "has due date",
@@ -2791,15 +1713,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has happens date",
-        ") OR",
-        " ",
-        "NOT (",
-        "has happens date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "has happens date",
@@ -2815,15 +1728,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has id",
-        ") OR",
-        " ",
-        "NOT (",
-        "has id",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "has id",
@@ -2839,15 +1743,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has scheduled date",
-        ") OR",
-        " ",
-        "NOT (",
-        "has scheduled date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "has scheduled date",
@@ -2863,14 +1758,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has start date",
-        ") AND",
-        " \"",
-        "description includes some",
-        "\""
-    ],
     "simplifiedLine": "(f1) AND \"f2\"",
     "filters": {
         "f1": "has start date",
@@ -2886,16 +1773,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has start date",
-        ") AND (",
-        "(",
-        "description includes some",
-        ") OR (",
-        "has due date",
-        "))"
-    ],
     "simplifiedLine": "(f1) AND ((f2) OR (f3))",
     "filters": {
         "f1": "has start date",
@@ -2912,13 +1789,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has start date",
-        ") AND (",
-        "description includes some",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND (f2)",
     "filters": {
         "f1": "has start date",
@@ -2934,15 +1804,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has start date",
-        ") AND",
-        " ",
-        "NOT (",
-        "description includes some",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND NOT (f2)",
     "filters": {
         "f1": "has start date",
@@ -2958,16 +1819,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has start date",
-        ") OR (",
-        "(",
-        "description includes special",
-        ") AND (",
-        "has due date",
-        "))"
-    ],
     "simplifiedLine": "(f1) OR ((f2) AND (f3))",
     "filters": {
         "f1": "has start date",
@@ -2984,15 +1835,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has start date",
-        ") OR",
-        " ",
-        "NOT (",
-        "description includes special",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "has start date",
@@ -3008,15 +1850,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has start date",
-        ") OR",
-        " ",
-        "NOT (",
-        "has start date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "has start date",
@@ -3032,13 +1865,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has start date",
-        ") XOR (",
-        "description includes special",
-        ")"
-    ],
     "simplifiedLine": "(f1) XOR (f2)",
     "filters": {
         "f1": "has start date",
@@ -3054,15 +1880,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has tag",
-        ") OR",
-        " ",
-        "NOT (",
-        "has tag",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "has tag",
@@ -3078,15 +1895,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "has tags",
-        ") OR",
-        " ",
-        "NOT (",
-        "has tags",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "has tags",
@@ -3102,15 +1910,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "heading does not include wibble",
-        ") OR",
-        " ",
-        "NOT (",
-        "heading does not include wibble",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "heading does not include wibble",
@@ -3126,15 +1925,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "heading includes AND",
-        ") OR",
-        " ",
-        "NOT (",
-        "heading includes AND",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "heading includes AND",
@@ -3150,15 +1940,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "heading includes wibble",
-        ") OR",
-        " ",
-        "NOT (",
-        "heading includes wibble",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "heading includes wibble",
@@ -3174,15 +1955,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "id does not include abc123",
-        ") OR",
-        " ",
-        "NOT (",
-        "id does not include abc123",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "id does not include abc123",
@@ -3198,15 +1970,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "id includes AND",
-        ") OR",
-        " ",
-        "NOT (",
-        "id includes AND",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "id includes AND",
@@ -3222,15 +1985,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "id includes abc123",
-        ") OR",
-        " ",
-        "NOT (",
-        "id includes abc123",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "id includes abc123",
@@ -3246,15 +2000,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "is blocked",
-        ") OR",
-        " ",
-        "NOT (",
-        "is blocked",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "is blocked",
@@ -3270,15 +2015,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "is blocking",
-        ") OR",
-        " ",
-        "NOT (",
-        "is blocking",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "is blocking",
@@ -3294,15 +2030,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "is not blocked",
-        ") OR",
-        " ",
-        "NOT (",
-        "is not blocked",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "is not blocked",
@@ -3318,15 +2045,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "is not blocking",
-        ") OR",
-        " ",
-        "NOT (",
-        "is not blocking",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "is not blocking",
@@ -3342,15 +2060,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "is not recurring",
-        ") OR",
-        " ",
-        "NOT (",
-        "is not recurring",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "is not recurring",
@@ -3366,16 +2075,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "is not recurring",
-        ") XOR (",
-        "(",
-        "path includes ab/c",
-        ") OR (",
-        "happens before 2021-12-27",
-        "))"
-    ],
     "simplifiedLine": "(f1) XOR ((f2) OR (f3))",
     "filters": {
         "f1": "is not recurring",
@@ -3392,15 +2091,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "is recurring",
-        ") OR",
-        " ",
-        "NOT (",
-        "is recurring",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "is recurring",
@@ -3416,15 +2106,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "no cancelled date",
-        ") OR",
-        " ",
-        "NOT (",
-        "no cancelled date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "no cancelled date",
@@ -3440,15 +2121,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "no created date",
-        ") OR",
-        " ",
-        "NOT (",
-        "no created date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "no created date",
@@ -3464,15 +2136,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "no depends on",
-        ") OR",
-        " ",
-        "NOT (",
-        "no depends on",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "no depends on",
@@ -3488,15 +2151,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "no due date",
-        ") OR",
-        " ",
-        "NOT (",
-        "no due date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "no due date",
@@ -3512,15 +2166,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "no happens date",
-        ") OR",
-        " ",
-        "NOT (",
-        "no happens date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "no happens date",
@@ -3536,15 +2181,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "no id",
-        ") OR",
-        " ",
-        "NOT (",
-        "no id",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "no id",
@@ -3560,15 +2196,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "no scheduled date",
-        ") OR",
-        " ",
-        "NOT (",
-        "no scheduled date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "no scheduled date",
@@ -3584,15 +2211,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "no start date",
-        ") OR",
-        " ",
-        "NOT (",
-        "no start date",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "no start date",
@@ -3608,15 +2226,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "no tag",
-        ") OR",
-        " ",
-        "NOT (",
-        "no tag",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "no tag",
@@ -3632,15 +2241,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "no tags",
-        ") OR",
-        " ",
-        "NOT (",
-        "no tags",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "no tags",
@@ -3656,15 +2256,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "not done",
-        ") OR",
-        " ",
-        "NOT (",
-        "not done",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "not done",
@@ -3680,15 +2271,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path does not include some/path",
-        ") OR",
-        " ",
-        "NOT (",
-        "path does not include some/path",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "path does not include some/path",
@@ -3704,14 +2286,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes ()some example(",
-        ")",
-        ") OR (",
-        "path includes ((some example",
-        ")))"
-    ],
     "simplifiedLine": "(f1)) OR (f2)))",
     "filters": {
         "f1": "path includes ()some example(",
@@ -3727,13 +2301,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes (some example",
-        ") OR (",
-        "path includes )some example(",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR (f2)",
     "filters": {
         "f1": "path includes (some example",
@@ -3749,14 +2316,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes (some example",
-        ")",
-        ") OR (",
-        "path includes )some example(",
-        ")"
-    ],
     "simplifiedLine": "(f1)) OR (f2)",
     "filters": {
         "f1": "path includes (some example",
@@ -3772,13 +2331,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes )some example(",
-        ") OR (",
-        "path includes (some example",
-        "))"
-    ],
     "simplifiedLine": "(f1) OR (f2))",
     "filters": {
         "f1": "path includes )some example(",
@@ -3794,13 +2346,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes A",
-        ") OR (",
-        "path includes Test.md",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR (f2)",
     "filters": {
         "f1": "path includes A",
@@ -3816,15 +2361,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes AND",
-        ") OR",
-        " ",
-        "NOT (",
-        "path includes AND",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "path includes AND",
@@ -3840,15 +2376,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes a",
-        ") AND",
-        " ",
-        "NOT(",
-        "path includes b",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND NOT(f2)",
     "filters": {
         "f1": "path includes a",
@@ -3864,13 +2391,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes a",
-        ") AND(",
-        "path includes b",
-        ")"
-    ],
     "simplifiedLine": "(f1) AND(f2)",
     "filters": {
         "f1": "path includes a",
@@ -3886,15 +2406,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes a",
-        ") OR",
-        " ",
-        "NOT(",
-        "path includes b",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT(f2)",
     "filters": {
         "f1": "path includes a",
@@ -3910,13 +2421,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes a",
-        ") OR(",
-        "path includes b",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR(f2)",
     "filters": {
         "f1": "path includes a",
@@ -3932,13 +2436,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes a",
-        ") XOR(",
-        "path includes b",
-        ")"
-    ],
     "simplifiedLine": "(f1) XOR(f2)",
     "filters": {
         "f1": "path includes a",
@@ -3954,13 +2451,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes a",
-        ")AND (",
-        "path includes b",
-        ")"
-    ],
     "simplifiedLine": "(f1)AND (f2)",
     "filters": {
         "f1": "path includes a",
@@ -3976,15 +2466,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes a",
-        ")AND",
-        " ",
-        "NOT(",
-        "path includes b",
-        ")"
-    ],
     "simplifiedLine": "(f1)AND NOT(f2)",
     "filters": {
         "f1": "path includes a",
@@ -4000,13 +2481,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes a",
-        ")OR (",
-        "path includes b",
-        ")"
-    ],
     "simplifiedLine": "(f1)OR (f2)",
     "filters": {
         "f1": "path includes a",
@@ -4022,15 +2496,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes a",
-        ")OR",
-        " ",
-        "NOT (",
-        "path includes b",
-        ")"
-    ],
     "simplifiedLine": "(f1)OR NOT (f2)",
     "filters": {
         "f1": "path includes a",
@@ -4046,13 +2511,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes a",
-        ")XOR (",
-        "path includes b",
-        ")"
-    ],
     "simplifiedLine": "(f1)XOR (f2)",
     "filters": {
         "f1": "path includes a",
@@ -4068,15 +2526,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "path includes some/path",
-        ") OR",
-        " ",
-        "NOT (",
-        "path includes some/path",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "path includes some/path",
@@ -4092,15 +2541,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "priority is above none",
-        ") OR",
-        " ",
-        "NOT (",
-        "priority is above none",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "priority is above none",
@@ -4116,15 +2556,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "priority is below none",
-        ") OR",
-        " ",
-        "NOT (",
-        "priority is below none",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "priority is below none",
@@ -4140,15 +2571,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "priority is high",
-        ") OR",
-        " ",
-        "NOT (",
-        "priority is high",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "priority is high",
@@ -4164,13 +2586,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "priority is highest",
-        ") OR (",
-        "priority is lowest",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR (f2)",
     "filters": {
         "f1": "priority is highest",
@@ -4186,15 +2601,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "priority is low",
-        ") OR",
-        " ",
-        "NOT (",
-        "priority is low",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "priority is low",
@@ -4210,15 +2616,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "priority is medium",
-        ") OR",
-        " ",
-        "NOT (",
-        "priority is medium",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "priority is medium",
@@ -4234,15 +2631,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "priority is none",
-        ") OR",
-        " ",
-        "NOT (",
-        "priority is none",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "priority is none",
@@ -4258,15 +2646,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "recurrence does not include wednesday",
-        ") OR",
-        " ",
-        "NOT (",
-        "recurrence does not include wednesday",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "recurrence does not include wednesday",
@@ -4282,15 +2661,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "recurrence includes wednesday",
-        ") OR",
-        " ",
-        "NOT (",
-        "recurrence includes wednesday",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "recurrence includes wednesday",
@@ -4306,15 +2676,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "root does not include some",
-        ") OR",
-        " ",
-        "NOT (",
-        "root does not include some",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "root does not include some",
@@ -4330,15 +2691,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "root includes AND",
-        ") OR",
-        " ",
-        "NOT (",
-        "root includes AND",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "root includes AND",
@@ -4354,15 +2706,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "root includes some",
-        ") OR",
-        " ",
-        "NOT (",
-        "root includes some",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "root includes some",
@@ -4378,15 +2721,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "scheduled after 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "scheduled after 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "scheduled after 2021-12-27",
@@ -4402,15 +2736,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "scheduled before 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "scheduled before 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "scheduled before 2021-12-27",
@@ -4426,15 +2751,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "scheduled date is invalid",
-        ") OR",
-        " ",
-        "NOT (",
-        "scheduled date is invalid",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "scheduled date is invalid",
@@ -4450,15 +2766,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "scheduled in 2021-12-27 2021-12-29",
-        ") OR",
-        " ",
-        "NOT (",
-        "scheduled in 2021-12-27 2021-12-29",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "scheduled in 2021-12-27 2021-12-29",
@@ -4474,15 +2781,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "scheduled on 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "scheduled on 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "scheduled on 2021-12-27",
@@ -4498,15 +2796,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "scheduled this week",
-        ") OR",
-        " ",
-        "NOT (",
-        "scheduled this week",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "scheduled this week",
@@ -4522,15 +2811,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "start date is invalid",
-        ") OR",
-        " ",
-        "NOT (",
-        "start date is invalid",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "start date is invalid",
@@ -4546,15 +2826,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "starts after 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "starts after 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "starts after 2021-12-27",
@@ -4570,15 +2841,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "starts before 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "starts before 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "starts before 2021-12-27",
@@ -4594,15 +2856,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "starts in 2021-12-27 2021-12-29",
-        ") OR",
-        " ",
-        "NOT (",
-        "starts in 2021-12-27 2021-12-29",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "starts in 2021-12-27 2021-12-29",
@@ -4618,15 +2871,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "starts on 2021-12-27",
-        ") OR",
-        " ",
-        "NOT (",
-        "starts on 2021-12-27",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "starts on 2021-12-27",
@@ -4642,15 +2886,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "starts this week",
-        ") OR",
-        " ",
-        "NOT (",
-        "starts this week",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "starts this week",
@@ -4666,15 +2901,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "status.name includes cancelled",
-        ") OR",
-        " ",
-        "NOT (",
-        "status.name includes cancelled",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "status.name includes cancelled",
@@ -4690,15 +2916,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "status.type is IN_PROGRESS",
-        ") OR",
-        " ",
-        "NOT (",
-        "status.type is IN_PROGRESS",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "status.type is IN_PROGRESS",
@@ -4714,15 +2931,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "tag does not include #sometag",
-        ") OR",
-        " ",
-        "NOT (",
-        "tag does not include #sometag",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "tag does not include #sometag",
@@ -4738,15 +2946,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "tag does not include sometag",
-        ") OR",
-        " ",
-        "NOT (",
-        "tag does not include sometag",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "tag does not include sometag",
@@ -4762,15 +2961,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "tag includes #sometag",
-        ") OR",
-        " ",
-        "NOT (",
-        "tag includes #sometag",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "tag includes #sometag",
@@ -4786,15 +2976,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "tag includes AND",
-        ") OR",
-        " ",
-        "NOT (",
-        "tag includes AND",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "tag includes AND",
@@ -4810,15 +2991,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "tag includes sometag",
-        ") OR",
-        " ",
-        "NOT (",
-        "tag includes sometag",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "tag includes sometag",
@@ -4834,15 +3006,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "tags do not include #sometag",
-        ") OR",
-        " ",
-        "NOT (",
-        "tags do not include #sometag",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "tags do not include #sometag",
@@ -4858,15 +3021,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "tags do not include sometag",
-        ") OR",
-        " ",
-        "NOT (",
-        "tags do not include sometag",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "tags do not include sometag",
@@ -4882,15 +3036,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "tags include #sometag",
-        ") OR",
-        " ",
-        "NOT (",
-        "tags include #sometag",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "tags include #sometag",
@@ -4906,15 +3051,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "(",
-        "tags include sometag",
-        ") OR",
-        " ",
-        "NOT (",
-        "tags include sometag",
-        ")"
-    ],
     "simplifiedLine": "(f1) OR NOT (f2)",
     "filters": {
         "f1": "tags include sometag",
@@ -4930,10 +3066,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "AND (description includes d1",
-        ")"
-    ],
     "simplifiedLine": "f1)",
     "filters": {
         "f1": "AND (description includes d1"
@@ -4948,12 +3080,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "NOT   (",
-        "  ",
-        "happens before blahblahblah",
-        "  )"
-    ],
     "simplifiedLine": "NOT   (  f1  )",
     "filters": {
         "f1": "happens before blahblahblah"
@@ -4968,12 +3094,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "NOT  (",
-        " ",
-        "description includes d1",
-        " )"
-    ],
     "simplifiedLine": "NOT  ( f1 )",
     "filters": {
         "f1": "description includes d1"
@@ -4988,14 +3108,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "NOT (",
-        " ",
-        "NOT (",
-        " ",
-        "is blocking",
-        " ) )"
-    ],
     "simplifiedLine": "NOT ( NOT ( f1 ) )",
     "filters": {
         "f1": "is blocking"
@@ -5010,14 +3122,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "NOT (",
-        "(",
-        "HAS START DATE",
-        ") OR (",
-        "DESCRIPTION INCLUDES SPECIAL",
-        "))"
-    ],
     "simplifiedLine": "NOT ((f1) OR (f2))",
     "filters": {
         "f1": "HAS START DATE",
@@ -5033,14 +3137,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "NOT (",
-        "(",
-        "has start date",
-        ") OR (",
-        "description includes special",
-        "))"
-    ],
     "simplifiedLine": "NOT ((f1) OR (f2))",
     "filters": {
         "f1": "has start date",
@@ -5056,11 +3152,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "NOT (",
-        "HAS START DATE",
-        ")"
-    ],
     "simplifiedLine": "NOT (f1)",
     "filters": {
         "f1": "HAS START DATE"
@@ -5075,11 +3166,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "NOT (",
-        "description blahblah d1",
-        ")"
-    ],
     "simplifiedLine": "NOT (f1)",
     "filters": {
         "f1": "description blahblah d1"
@@ -5094,11 +3180,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "NOT (",
-        "description includes d1",
-        ")"
-    ],
     "simplifiedLine": "NOT (f1)",
     "filters": {
         "f1": "description includes d1"
@@ -5113,11 +3194,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "NOT (",
-        "happens before blahblahblah",
-        ")"
-    ],
     "simplifiedLine": "NOT (f1)",
     "filters": {
         "f1": "happens before blahblahblah"
@@ -5132,11 +3208,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "NOT (",
-        "has start date",
-        ")"
-    ],
     "simplifiedLine": "NOT (f1)",
     "filters": {
         "f1": "has start date"
@@ -5151,11 +3222,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "NOT(",
-        "path includes b",
-        ")"
-    ],
     "simplifiedLine": "NOT(f1)",
     "filters": {
         "f1": "path includes b"
@@ -5170,10 +3236,6 @@ Input:
 =>
 Result:
 {
-    "parts": [
-        "OR (description includes d1",
-        ")"
-    ],
     "simplifiedLine": "f1)",
     "filters": {
         "f1": "OR (description includes d1"

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_preprocess_-_rewrite.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_preprocess_-_rewrite.approved.txt
@@ -438,8 +438,11 @@ Result:
         "DESCRIPTION INCLUDES SPECIAL",
         ")"
     ],
-    "simplifiedLine": "\"HAS DUE DATE\" OR (DESCRIPTION INCLUDES SPECIAL)",
-    "filters": {}
+    "simplifiedLine": "\"f1\" OR (f2)",
+    "filters": {
+        "f1": "HAS DUE DATE",
+        "f2": "DESCRIPTION INCLUDES SPECIAL"
+    }
 }
 
 --------------------------------------------------------
@@ -1020,8 +1023,11 @@ Result:
         "DESCRIPTION INCLUDES HELLO WORLD",
         ")"
     ],
-    "simplifiedLine": "(DUE THIS WEEK) AND (DESCRIPTION INCLUDES HELLO WORLD)",
-    "filters": {}
+    "simplifiedLine": "(f1) AND (f2)",
+    "filters": {
+        "f1": "DUE THIS WEEK",
+        "f2": "DESCRIPTION INCLUDES HELLO WORLD"
+    }
 }
 
 --------------------------------------------------------
@@ -1040,8 +1046,11 @@ Result:
         "DESCRIPTION INCLUDES SOME",
         "\""
     ],
-    "simplifiedLine": "(HAS START DATE) AND \"DESCRIPTION INCLUDES SOME\"",
-    "filters": {}
+    "simplifiedLine": "(f1) AND \"f2\"",
+    "filters": {
+        "f1": "HAS START DATE",
+        "f2": "DESCRIPTION INCLUDES SOME"
+    }
 }
 
 --------------------------------------------------------
@@ -1062,8 +1071,12 @@ Result:
         "HAS DUE DATE",
         "))"
     ],
-    "simplifiedLine": "(HAS START DATE) AND ((DESCRIPTION INCLUDES SOME) OR (HAS DUE DATE))",
-    "filters": {}
+    "simplifiedLine": "(f1) AND ((f2) OR (f3))",
+    "filters": {
+        "f1": "HAS START DATE",
+        "f2": "DESCRIPTION INCLUDES SOME",
+        "f3": "HAS DUE DATE"
+    }
 }
 
 --------------------------------------------------------
@@ -1083,8 +1096,11 @@ Result:
         "DESCRIPTION INCLUDES SOME",
         ")"
     ],
-    "simplifiedLine": "(HAS START DATE) AND NOT (DESCRIPTION INCLUDES SOME)",
-    "filters": {}
+    "simplifiedLine": "(f1) AND NOT (f2)",
+    "filters": {
+        "f1": "HAS START DATE",
+        "f2": "DESCRIPTION INCLUDES SOME"
+    }
 }
 
 --------------------------------------------------------
@@ -1105,8 +1121,12 @@ Result:
         "HAS DUE DATE",
         "))"
     ],
-    "simplifiedLine": "(HAS START DATE) OR ((DESCRIPTION INCLUDES SPECIAL) AND (HAS DUE DATE))",
-    "filters": {}
+    "simplifiedLine": "(f1) OR ((f2) AND (f3))",
+    "filters": {
+        "f1": "HAS START DATE",
+        "f2": "DESCRIPTION INCLUDES SPECIAL",
+        "f3": "HAS DUE DATE"
+    }
 }
 
 --------------------------------------------------------
@@ -1126,8 +1146,11 @@ Result:
         "DESCRIPTION INCLUDES SPECIAL",
         ")"
     ],
-    "simplifiedLine": "(HAS START DATE) OR NOT (DESCRIPTION INCLUDES SPECIAL)",
-    "filters": {}
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "HAS START DATE",
+        "f2": "DESCRIPTION INCLUDES SPECIAL"
+    }
 }
 
 --------------------------------------------------------
@@ -1145,8 +1168,11 @@ Result:
         "DESCRIPTION INCLUDES SPECIAL",
         ")"
     ],
-    "simplifiedLine": "(HAS START DATE) XOR (DESCRIPTION INCLUDES SPECIAL)",
-    "filters": {}
+    "simplifiedLine": "(f1) XOR (f2)",
+    "filters": {
+        "f1": "HAS START DATE",
+        "f2": "DESCRIPTION INCLUDES SPECIAL"
+    }
 }
 
 --------------------------------------------------------
@@ -2725,10 +2751,11 @@ Result:
         "due after 2021-12-27",
         "))"
     ],
-    "simplifiedLine": "(f1) OR ((HAS START DATE) AND (f2))",
+    "simplifiedLine": "(f1) OR ((f2) AND (f3))",
     "filters": {
         "f1": "has due date",
-        "f2": "due after 2021-12-27"
+        "f2": "HAS START DATE",
+        "f3": "due after 2021-12-27"
     }
 }
 
@@ -4991,8 +5018,11 @@ Result:
         "DESCRIPTION INCLUDES SPECIAL",
         "))"
     ],
-    "simplifiedLine": "NOT ((HAS START DATE) OR (DESCRIPTION INCLUDES SPECIAL))",
-    "filters": {}
+    "simplifiedLine": "NOT ((f1) OR (f2))",
+    "filters": {
+        "f1": "HAS START DATE",
+        "f2": "DESCRIPTION INCLUDES SPECIAL"
+    }
 }
 
 --------------------------------------------------------
@@ -5031,8 +5061,10 @@ Result:
         "HAS START DATE",
         ")"
     ],
-    "simplifiedLine": "NOT (HAS START DATE)",
-    "filters": {}
+    "simplifiedLine": "NOT (f1)",
+    "filters": {
+        "f1": "HAS START DATE"
+    }
 }
 
 --------------------------------------------------------

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_preprocess_-_rewrite.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_preprocess_-_rewrite.approved.txt
@@ -1,0 +1,5153 @@
+Results of preprocessing boolean expressions
+
+
+
+
+Input:
+'(not done) AND (is recurring)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "not done",
+        ") AND (",
+        "is recurring",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND (f2)",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'((not done)) AND ((is recurring))'
+=>
+Result:
+{
+    "parts": [
+        "((",
+        "not done",
+        ")",
+        ") AND (",
+        "(",
+        "is recurring",
+        "))"
+    ],
+    "simplifiedLine": "((f1)) AND ((f2))",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(not done) OR (is recurring)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "not done",
+        ") OR (",
+        "is recurring",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR (f2)",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(not done) XOR (is recurring)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "not done",
+        ") XOR (",
+        "is recurring",
+        ")"
+    ],
+    "simplifiedLine": "(f1) XOR (f2)",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(not done) AND NOT (is recurring)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "not done",
+        ") AND",
+        " ",
+        "NOT (",
+        "is recurring",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND NOT (f2)",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(not done) OR NOT (is recurring)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "not done",
+        ") OR",
+        " ",
+        "NOT (",
+        "is recurring",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'NOT (not done)'
+=>
+Result:
+{
+    "parts": [
+        "NOT (",
+        "not done",
+        ")"
+    ],
+    "simplifiedLine": "NOT (f1)",
+    "filters": {
+        "f1": "not done"
+    }
+}
+
+--------------------------------------------------------
+
+
+
+Input:
+'"not done" AND (is recurring)'
+=>
+Result:
+{
+    "parts": [
+        "\"",
+        "not done",
+        "\" ",
+        "AND (",
+        "is recurring",
+        ")"
+    ],
+    "simplifiedLine": "\"f1\" AND (f2)",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'"not done" OR (is recurring)'
+=>
+Result:
+{
+    "parts": [
+        "\"",
+        "not done",
+        "\" ",
+        "OR (",
+        "is recurring",
+        ")"
+    ],
+    "simplifiedLine": "\"f1\" OR (f2)",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'"not done" XOR (is recurring)'
+=>
+Result:
+{
+    "parts": [
+        "\"",
+        "not done",
+        "\" ",
+        "XOR (",
+        "is recurring",
+        ")"
+    ],
+    "simplifiedLine": "\"f1\" XOR (f2)",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'"not done" AND NOT (is recurring)'
+=>
+Result:
+{
+    "parts": [
+        "\"",
+        "not done",
+        "\" ",
+        "AND",
+        " ",
+        "NOT (",
+        "is recurring",
+        ")"
+    ],
+    "simplifiedLine": "\"f1\" AND NOT (f2)",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'"not done" OR NOT (is recurring)'
+=>
+Result:
+{
+    "parts": [
+        "\"",
+        "not done",
+        "\" ",
+        "OR",
+        " ",
+        "NOT (",
+        "is recurring",
+        ")"
+    ],
+    "simplifiedLine": "\"f1\" OR NOT (f2)",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+
+Input:
+'(not done) AND "is recurring"'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "not done",
+        ") AND",
+        " \"",
+        "is recurring",
+        "\""
+    ],
+    "simplifiedLine": "(f1) AND \"f2\"",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'((not done)) AND "is recurring"'
+=>
+Result:
+{
+    "parts": [
+        "((",
+        "not done",
+        ")",
+        ") AND",
+        " \"",
+        "is recurring",
+        "\""
+    ],
+    "simplifiedLine": "((f1)) AND \"f2\"",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(not done) OR "is recurring"'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "not done",
+        ") OR",
+        " \"",
+        "is recurring",
+        "\""
+    ],
+    "simplifiedLine": "(f1) OR \"f2\"",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(not done) XOR "is recurring"'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "not done",
+        ") XOR",
+        " \"",
+        "is recurring",
+        "\""
+    ],
+    "simplifiedLine": "(f1) XOR \"f2\"",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(not done) AND NOT "is recurring"'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "not done",
+        ") AND",
+        " ",
+        "NOT",
+        " \"",
+        "is recurring",
+        "\""
+    ],
+    "simplifiedLine": "(f1) AND NOT \"f2\"",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(not done) OR NOT "is recurring"'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "not done",
+        ") OR",
+        " ",
+        "NOT",
+        " \"",
+        "is recurring",
+        "\""
+    ],
+    "simplifiedLine": "(f1) OR NOT \"f2\"",
+    "filters": {
+        "f1": "not done",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+
+Input:
+'"HAS DUE DATE" OR (DESCRIPTION INCLUDES SPECIAL)'
+=>
+Result:
+{
+    "parts": [
+        "\"",
+        "HAS DUE DATE",
+        "\" ",
+        "OR (",
+        "DESCRIPTION INCLUDES SPECIAL",
+        ")"
+    ],
+    "simplifiedLine": "\"HAS DUE DATE\" OR (DESCRIPTION INCLUDES SPECIAL)",
+    "filters": {}
+}
+
+--------------------------------------------------------
+
+
+Input:
+'"description includes d1" AND "description includes d2"'
+=>
+Result:
+{
+    "parts": [
+        "\"",
+        "description includes d1",
+        "\" ",
+        "AND",
+        " \"",
+        "description includes d2",
+        "\""
+    ],
+    "simplifiedLine": "\"f1\" AND \"f2\"",
+    "filters": {
+        "f1": "description includes d1",
+        "f2": "description includes d2"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'"has due date" OR (description includes special)'
+=>
+Result:
+{
+    "parts": [
+        "\"",
+        "has due date",
+        "\" ",
+        "OR (",
+        "description includes special",
+        ")"
+    ],
+    "simplifiedLine": "\"f1\" OR (f2)",
+    "filters": {
+        "f1": "has due date",
+        "f2": "description includes special"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'( (description includes 1) AND (description includes 2) AND (description includes 3) ) OR ( (description includes 5) AND (description includes 6) AND (description includes 7) ) AND NOT (description includes 7)'
+=>
+Result:
+{
+    "parts": [
+        "( (",
+        "description includes 1",
+        ") AND (",
+        "description includes 2",
+        ") AND (",
+        "description includes 3",
+        ") ",
+        ") OR (",
+        " (",
+        "description includes 5",
+        ") AND (",
+        "description includes 6",
+        ") AND (",
+        "description includes 7",
+        ") ",
+        ") AND",
+        " ",
+        "NOT (",
+        "description includes 7",
+        ")"
+    ],
+    "simplifiedLine": "( (f1) AND (f2) AND (f3) ) OR ( (f4) AND (f5) AND (f6) ) AND NOT (f7)",
+    "filters": {
+        "f1": "description includes 1",
+        "f2": "description includes 2",
+        "f3": "description includes 3",
+        "f4": "description includes 5",
+        "f5": "description includes 6",
+        "f6": "description includes 7",
+        "f7": "description includes 7"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'( (description includes a) AND (description includes b) ) AND (description includes c)'
+=>
+Result:
+{
+    "parts": [
+        "( (",
+        "description includes a",
+        ") AND (",
+        "description includes b",
+        ") ",
+        ") AND (",
+        "description includes c",
+        ")"
+    ],
+    "simplifiedLine": "( (f1) AND (f2) ) AND (f3)",
+    "filters": {
+        "f1": "description includes a",
+        "f2": "description includes b",
+        "f3": "description includes c"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'( (description includes a) AND (description includes b) AND (description includes c) ) OR ( (description includes d) AND (description includes e) AND (description includes f) )'
+=>
+Result:
+{
+    "parts": [
+        "( (",
+        "description includes a",
+        ") AND (",
+        "description includes b",
+        ") AND (",
+        "description includes c",
+        ") ",
+        ") OR (",
+        " (",
+        "description includes d",
+        ") AND (",
+        "description includes e",
+        ") AND (",
+        "description includes f",
+        ") )"
+    ],
+    "simplifiedLine": "( (f1) AND (f2) AND (f3) ) OR ( (f4) AND (f5) AND (f6) )",
+    "filters": {
+        "f1": "description includes a",
+        "f2": "description includes b",
+        "f3": "description includes c",
+        "f4": "description includes d",
+        "f5": "description includes e",
+        "f6": "description includes f"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'( (description includes a) OR (description includes b) ) OR (description includes c)'
+=>
+Result:
+{
+    "parts": [
+        "( (",
+        "description includes a",
+        ") OR (",
+        "description includes b",
+        ") ",
+        ") OR (",
+        "description includes c",
+        ")"
+    ],
+    "simplifiedLine": "( (f1) OR (f2) ) OR (f3)",
+    "filters": {
+        "f1": "description includes a",
+        "f2": "description includes b",
+        "f3": "description includes c"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'( (description includes a) OR (description includes b) OR (description includes c) ) AND ( (description includes d) OR (description includes e) OR (description includes f) )'
+=>
+Result:
+{
+    "parts": [
+        "( (",
+        "description includes a",
+        ") OR (",
+        "description includes b",
+        ") OR (",
+        "description includes c",
+        ") ",
+        ") AND (",
+        " (",
+        "description includes d",
+        ") OR (",
+        "description includes e",
+        ") OR (",
+        "description includes f",
+        ") )"
+    ],
+    "simplifiedLine": "( (f1) OR (f2) OR (f3) ) AND ( (f4) OR (f5) OR (f6) )",
+    "filters": {
+        "f1": "description includes a",
+        "f2": "description includes b",
+        "f3": "description includes c",
+        "f4": "description includes d",
+        "f5": "description includes e",
+        "f6": "description includes f"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'( (filter by function task.description.includes('a')) OR (filter by function task.description.includes('b')) OR (filter by function task.description.includes('c')) ) AND ( (filter by function task.description.includes('d')) OR (filter by function task.description.includes('e')) OR (filter by function task.description.includes('f')) )'
+=>
+Result:
+{
+    "parts": [
+        "( (",
+        "filter by function task.description.includes('a'",
+        ")",
+        ") OR (",
+        "filter by function task.description.includes('b'",
+        ")",
+        ") OR (",
+        "filter by function task.description.includes('c'",
+        ")) ",
+        ") AND (",
+        " (",
+        "filter by function task.description.includes('d'",
+        ")",
+        ") OR (",
+        "filter by function task.description.includes('e'",
+        ")",
+        ") OR (",
+        "filter by function task.description.includes('f'",
+        ")) )"
+    ],
+    "simplifiedLine": "( (f1)) OR (f2)) OR (f3)) ) AND ( (f4)) OR (f5)) OR (f6)) )",
+    "filters": {
+        "f1": "filter by function task.description.includes('a'",
+        "f2": "filter by function task.description.includes('b'",
+        "f3": "filter by function task.description.includes('c'",
+        "f4": "filter by function task.description.includes('d'",
+        "f5": "filter by function task.description.includes('e'",
+        "f6": "filter by function task.description.includes('f'"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'( description includes a )   AND ( (description includes b)  AND (description includes c) )'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        " ",
+        "description includes a",
+        " ",
+        ")   AND (",
+        " (",
+        "description includes b",
+        ")  AND (",
+        "description includes c",
+        ") )"
+    ],
+    "simplifiedLine": "( f1 )   AND ( (f2)  AND (f3) )",
+    "filters": {
+        "f1": "description includes a",
+        "f2": "description includes b",
+        "f3": "description includes c"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'( description includes a )   OR  ( (description includes b)  OR  (description includes c) )'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        " ",
+        "description includes a",
+        " ",
+        ")   OR  (",
+        " (",
+        "description includes b",
+        ")  OR  (",
+        "description includes c",
+        ") )"
+    ],
+    "simplifiedLine": "( f1 )   OR  ( (f2)  OR  (f3) )",
+    "filters": {
+        "f1": "description includes a",
+        "f2": "description includes b",
+        "f3": "description includes c"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'( description regex matches /(buy|order|voucher|lakeland|purchase|\spresent)/i ) OR ( path includes Home/Shopping )'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        " ",
+        "description regex matches /(buy|order|voucher|lakeland|purchase|\\spresent)/i",
+        " ",
+        ") OR (",
+        " ",
+        "path includes Home/Shopping",
+        " )"
+    ],
+    "simplifiedLine": "( f1 ) OR ( f2 )",
+    "filters": {
+        "f1": "description regex matches /(buy|order|voucher|lakeland|purchase|\\spresent)/i",
+        "f2": "path includes Home/Shopping"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'( description regex matches /buy/i ) AND ( path includes some/sample/note.md )'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        " ",
+        "description regex matches /buy/i",
+        " ",
+        ") AND (",
+        " ",
+        "path includes some/sample/note.md",
+        " )"
+    ],
+    "simplifiedLine": "( f1 ) AND ( f2 )",
+    "filters": {
+        "f1": "description regex matches /buy/i",
+        "f2": "path includes some/sample/note.md"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'( filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type) ) OR ( filter by function const date = task.due.moment; return date ? !date.isValid() : false; ) OR ( filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false ) OR ( filter by function task.urgency.toFixed(2) === 1.95.toFixed(2) ) OR ( filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁') ) OR ( filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase() ) OR ( filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false ) OR ( filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false; )'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        " ",
+        "filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type",
+        ") ",
+        ") OR (",
+        " ",
+        "filter by function const date = task.due.moment; return date ? !date.isValid() : false;",
+        " ",
+        ") OR (",
+        " ",
+        "filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false",
+        " ",
+        ") OR (",
+        " ",
+        "filter by function task.urgency.toFixed(2) === 1.95.toFixed(2",
+        ") ",
+        ") OR (",
+        " ",
+        "filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁'",
+        ") ",
+        ") OR (",
+        " ",
+        "filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase(",
+        ") ",
+        ") OR (",
+        " ",
+        "filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false",
+        " ",
+        ") OR (",
+        " ",
+        "filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;",
+        " )"
+    ],
+    "simplifiedLine": "( f1) ) OR ( f2 ) OR ( f3 ) OR ( f4) ) OR ( f5) ) OR ( f6) ) OR ( f7 ) OR ( f8 )",
+    "filters": {
+        "f1": "filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type",
+        "f2": "filter by function const date = task.due.moment; return date ? !date.isValid() : false;",
+        "f3": "filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false",
+        "f4": "filter by function task.urgency.toFixed(2) === 1.95.toFixed(2",
+        "f5": "filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁'",
+        "f6": "filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase(",
+        "f7": "filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false",
+        "f8": "filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'( filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type); ) OR ( filter by function const date = task.due.moment; return date ? !date.isValid() : false; ) OR ( filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false; ) OR ( filter by function task.urgency.toFixed(2) === 1.95.toFixed(2); ) OR ( filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁'); ) OR ( filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase(); ) OR ( filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false; ) OR ( filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false; )'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        " ",
+        "filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type);",
+        " ",
+        ") OR (",
+        " ",
+        "filter by function const date = task.due.moment; return date ? !date.isValid() : false;",
+        " ",
+        ") OR (",
+        " ",
+        "filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false;",
+        " ",
+        ") OR (",
+        " ",
+        "filter by function task.urgency.toFixed(2) === 1.95.toFixed(2);",
+        " ",
+        ") OR (",
+        " ",
+        "filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁');",
+        " ",
+        ") OR (",
+        " ",
+        "filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase();",
+        " ",
+        ") OR (",
+        " ",
+        "filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false;",
+        " ",
+        ") OR (",
+        " ",
+        "filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;",
+        " )"
+    ],
+    "simplifiedLine": "( f1 ) OR ( f2 ) OR ( f3 ) OR ( f4 ) OR ( f5 ) OR ( f6 ) OR ( f7 ) OR ( f8 )",
+    "filters": {
+        "f1": "filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type);",
+        "f2": "filter by function const date = task.due.moment; return date ? !date.isValid() : false;",
+        "f3": "filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false;",
+        "f4": "filter by function task.urgency.toFixed(2) === 1.95.toFixed(2);",
+        "f5": "filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁');",
+        "f6": "filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase();",
+        "f7": "filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false;",
+        "f8": "filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(((((NOT  ( description includes d1 ))))))'
+=>
+Result:
+{
+    "parts": [
+        "(((((",
+        "NOT  (",
+        " ",
+        "description includes d1",
+        " ))))))"
+    ],
+    "simplifiedLine": "(((((NOT  ( f1 ))))))",
+    "filters": {
+        "f1": "description includes d1"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(((((description includes #context/location1)))))'
+=>
+Result:
+{
+    "parts": [
+        "(((((",
+        "description includes #context/location1",
+        ")))))"
+    ],
+    "simplifiedLine": "(((((f1)))))",
+    "filters": {
+        "f1": "description includes #context/location1"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'((due this week) AND (description includes Hello World)) OR NOT ((due this week) AND (description includes Hello World))'
+=>
+Result:
+{
+    "parts": [
+        "((",
+        "due this week",
+        ") AND (",
+        "description includes Hello World",
+        ")",
+        ") OR",
+        " ",
+        "NOT (",
+        "(",
+        "due this week",
+        ") AND (",
+        "description includes Hello World",
+        "))"
+    ],
+    "simplifiedLine": "((f1) AND (f2)) OR NOT ((f3) AND (f4))",
+    "filters": {
+        "f1": "due this week",
+        "f2": "description includes Hello World",
+        "f3": "due this week",
+        "f4": "description includes Hello World"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(DESCRIPTION INCLUDES wibble) OR (has due date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "DESCRIPTION INCLUDES wibble",
+        ") OR (",
+        "has due date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR (f2)",
+    "filters": {
+        "f1": "DESCRIPTION INCLUDES wibble",
+        "f2": "has due date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(DUE THIS WEEK) AND (DESCRIPTION INCLUDES HELLO WORLD)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "DUE THIS WEEK",
+        ") AND (",
+        "DESCRIPTION INCLUDES HELLO WORLD",
+        ")"
+    ],
+    "simplifiedLine": "(DUE THIS WEEK) AND (DESCRIPTION INCLUDES HELLO WORLD)",
+    "filters": {}
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(HAS START DATE) AND "DESCRIPTION INCLUDES SOME"'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "HAS START DATE",
+        ") AND",
+        " \"",
+        "DESCRIPTION INCLUDES SOME",
+        "\""
+    ],
+    "simplifiedLine": "(HAS START DATE) AND \"DESCRIPTION INCLUDES SOME\"",
+    "filters": {}
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(HAS START DATE) AND ((DESCRIPTION INCLUDES SOME) OR (HAS DUE DATE))'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "HAS START DATE",
+        ") AND (",
+        "(",
+        "DESCRIPTION INCLUDES SOME",
+        ") OR (",
+        "HAS DUE DATE",
+        "))"
+    ],
+    "simplifiedLine": "(HAS START DATE) AND ((DESCRIPTION INCLUDES SOME) OR (HAS DUE DATE))",
+    "filters": {}
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(HAS START DATE) AND NOT (DESCRIPTION INCLUDES SOME)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "HAS START DATE",
+        ") AND",
+        " ",
+        "NOT (",
+        "DESCRIPTION INCLUDES SOME",
+        ")"
+    ],
+    "simplifiedLine": "(HAS START DATE) AND NOT (DESCRIPTION INCLUDES SOME)",
+    "filters": {}
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(HAS START DATE) OR ((DESCRIPTION INCLUDES SPECIAL) AND (HAS DUE DATE))'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "HAS START DATE",
+        ") OR (",
+        "(",
+        "DESCRIPTION INCLUDES SPECIAL",
+        ") AND (",
+        "HAS DUE DATE",
+        "))"
+    ],
+    "simplifiedLine": "(HAS START DATE) OR ((DESCRIPTION INCLUDES SPECIAL) AND (HAS DUE DATE))",
+    "filters": {}
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(HAS START DATE) OR NOT (DESCRIPTION INCLUDES SPECIAL)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "HAS START DATE",
+        ") OR",
+        " ",
+        "NOT (",
+        "DESCRIPTION INCLUDES SPECIAL",
+        ")"
+    ],
+    "simplifiedLine": "(HAS START DATE) OR NOT (DESCRIPTION INCLUDES SPECIAL)",
+    "filters": {}
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(HAS START DATE) XOR (DESCRIPTION INCLUDES SPECIAL)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "HAS START DATE",
+        ") XOR (",
+        "DESCRIPTION INCLUDES SPECIAL",
+        ")"
+    ],
+    "simplifiedLine": "(HAS START DATE) XOR (DESCRIPTION INCLUDES SPECIAL)",
+    "filters": {}
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(cancelled after 2021-12-27) OR NOT (cancelled after 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "cancelled after 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "cancelled after 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "cancelled after 2021-12-27",
+        "f2": "cancelled after 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(cancelled before 2021-12-27) OR NOT (cancelled before 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "cancelled before 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "cancelled before 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "cancelled before 2021-12-27",
+        "f2": "cancelled before 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(cancelled date is invalid) OR NOT (cancelled date is invalid)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "cancelled date is invalid",
+        ") OR",
+        " ",
+        "NOT (",
+        "cancelled date is invalid",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "cancelled date is invalid",
+        "f2": "cancelled date is invalid"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(cancelled in 2021-12-27 2021-12-29) OR NOT (cancelled in 2021-12-27 2021-12-29)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "cancelled in 2021-12-27 2021-12-29",
+        ") OR",
+        " ",
+        "NOT (",
+        "cancelled in 2021-12-27 2021-12-29",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "cancelled in 2021-12-27 2021-12-29",
+        "f2": "cancelled in 2021-12-27 2021-12-29"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(cancelled on 2021-12-27) OR NOT (cancelled on 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "cancelled on 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "cancelled on 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "cancelled on 2021-12-27",
+        "f2": "cancelled on 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(cancelled this week) OR NOT (cancelled this week)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "cancelled this week",
+        ") OR",
+        " ",
+        "NOT (",
+        "cancelled this week",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "cancelled this week",
+        "f2": "cancelled this week"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(created after 2021-12-27) OR NOT (created after 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "created after 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "created after 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "created after 2021-12-27",
+        "f2": "created after 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(created before 2021-12-27) OR NOT (created before 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "created before 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "created before 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "created before 2021-12-27",
+        "f2": "created before 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(created date is invalid) OR NOT (created date is invalid)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "created date is invalid",
+        ") OR",
+        " ",
+        "NOT (",
+        "created date is invalid",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "created date is invalid",
+        "f2": "created date is invalid"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(created in 2021-12-27 2021-12-29) OR NOT (created in 2021-12-27 2021-12-29)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "created in 2021-12-27 2021-12-29",
+        ") OR",
+        " ",
+        "NOT (",
+        "created in 2021-12-27 2021-12-29",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "created in 2021-12-27 2021-12-29",
+        "f2": "created in 2021-12-27 2021-12-29"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(created on 2021-12-27) OR NOT (created on 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "created on 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "created on 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "created on 2021-12-27",
+        "f2": "created on 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(created this week) OR NOT (created this week)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "created this week",
+        ") OR",
+        " ",
+        "NOT (",
+        "created this week",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "created this week",
+        "f2": "created this week"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description does not include wibble) OR NOT (description does not include wibble)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description does not include wibble",
+        ") OR",
+        " ",
+        "NOT (",
+        "description does not include wibble",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "description does not include wibble",
+        "f2": "description does not include wibble"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes "hello world") OR (description includes "42")'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes \"hello world",
+        "\"",
+        ") OR (",
+        "description includes \"42",
+        "\")"
+    ],
+    "simplifiedLine": "(f1\") OR (f2\")",
+    "filters": {
+        "f1": "description includes \"hello world",
+        "f2": "description includes \"42"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes #context/location1)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes #context/location1",
+        ")"
+    ],
+    "simplifiedLine": "(f1)",
+    "filters": {
+        "f1": "description includes #context/location1"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes #context/location1) OR (description includes #context/location2 ) OR (  description includes #context/location3 ) OR   (  description includes #context/location4 )'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes #context/location1",
+        ") OR (",
+        "description includes #context/location2",
+        " ",
+        ") OR (",
+        "  ",
+        "description includes #context/location3",
+        " ",
+        ") OR   (",
+        "  ",
+        "description includes #context/location4",
+        " )"
+    ],
+    "simplifiedLine": "(f1) OR (f2 ) OR (  f3 ) OR   (  f4 )",
+    "filters": {
+        "f1": "description includes #context/location1",
+        "f2": "description includes #context/location2",
+        "f3": "description includes #context/location3",
+        "f4": "description includes #context/location4"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes 1)   AND   (description includes 2)   AND   (description includes 3)   AND   (description includes 4)   AND   (description includes 5)   AND   (description includes 6)   AND   (description includes 7)   AND   (description includes 8)   AND   (description includes 9)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes 1",
+        ")   AND   (",
+        "description includes 2",
+        ")   AND   (",
+        "description includes 3",
+        ")   AND   (",
+        "description includes 4",
+        ")   AND   (",
+        "description includes 5",
+        ")   AND   (",
+        "description includes 6",
+        ")   AND   (",
+        "description includes 7",
+        ")   AND   (",
+        "description includes 8",
+        ")   AND   (",
+        "description includes 9",
+        ")"
+    ],
+    "simplifiedLine": "(f1)   AND   (f2)   AND   (f3)   AND   (f4)   AND   (f5)   AND   (f6)   AND   (f7)   AND   (f8)   AND   (f9)",
+    "filters": {
+        "f1": "description includes 1",
+        "f2": "description includes 2",
+        "f3": "description includes 3",
+        "f4": "description includes 4",
+        "f5": "description includes 5",
+        "f6": "description includes 6",
+        "f7": "description includes 7",
+        "f8": "description includes 8",
+        "f9": "description includes 9"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes 1) AND (description includes 2) AND (description includes 3)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes 1",
+        ") AND (",
+        "description includes 2",
+        ") AND (",
+        "description includes 3",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND (f2) AND (f3)",
+    "filters": {
+        "f1": "description includes 1",
+        "f2": "description includes 2",
+        "f3": "description includes 3"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes 1) AND (description includes 2) AND (description includes 3) AND (description includes 4) AND (description includes 5) AND (description includes 6) AND (description includes 7) AND (description includes 8) AND (description includes 9)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes 1",
+        ") AND (",
+        "description includes 2",
+        ") AND (",
+        "description includes 3",
+        ") AND (",
+        "description includes 4",
+        ") AND (",
+        "description includes 5",
+        ") AND (",
+        "description includes 6",
+        ") AND (",
+        "description includes 7",
+        ") AND (",
+        "description includes 8",
+        ") AND (",
+        "description includes 9",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND (f2) AND (f3) AND (f4) AND (f5) AND (f6) AND (f7) AND (f8) AND (f9)",
+    "filters": {
+        "f1": "description includes 1",
+        "f2": "description includes 2",
+        "f3": "description includes 3",
+        "f4": "description includes 4",
+        "f5": "description includes 5",
+        "f6": "description includes 6",
+        "f7": "description includes 7",
+        "f8": "description includes 8",
+        "f9": "description includes 9"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes AND) OR NOT (description includes AND)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes AND",
+        ") OR",
+        " ",
+        "NOT (",
+        "description includes AND",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "description includes AND",
+        "f2": "description includes AND"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes SHOULD NOT BE RECOGNISED AS A BOOLEAN)AND(description includes BECAUSE THERE ARE NO SPACES AROUND THE 'AND' OPERATOR)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes SHOULD NOT BE RECOGNISED AS A BOOLEAN",
+        ")AND(",
+        "description includes BECAUSE THERE ARE NO SPACES AROUND THE 'AND' OPERATOR",
+        ")"
+    ],
+    "simplifiedLine": "(f1)AND(f2)",
+    "filters": {
+        "f1": "description includes SHOULD NOT BE RECOGNISED AS A BOOLEAN",
+        "f2": "description includes BECAUSE THERE ARE NO SPACES AROUND THE 'AND' OPERATOR"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes d1) AND   NOT (priority medium)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes d1",
+        ") AND",
+        "   ",
+        "NOT (",
+        "priority medium",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND   NOT (f2)",
+    "filters": {
+        "f1": "description includes d1",
+        "f2": "priority medium"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes d1) AND (priority medium)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes d1",
+        ") AND (",
+        "priority medium",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND (f2)",
+    "filters": {
+        "f1": "description includes d1",
+        "f2": "priority medium"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes d1) AND NOT (description includes d2)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes d1",
+        ") AND",
+        " ",
+        "NOT (",
+        "description includes d2",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND NOT (f2)",
+    "filters": {
+        "f1": "description includes d1",
+        "f2": "description includes d2"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes d1) OR   NOT (priority medium)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes d1",
+        ") OR",
+        "   ",
+        "NOT (",
+        "priority medium",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR   NOT (f2)",
+    "filters": {
+        "f1": "description includes d1",
+        "f2": "priority medium"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes d1) OR (description includes d2)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes d1",
+        ") OR (",
+        "description includes d2",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR (f2)",
+    "filters": {
+        "f1": "description includes d1",
+        "f2": "description includes d2"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes d1) OR (description includes d2) OR (priority medium)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes d1",
+        ") OR (",
+        "description includes d2",
+        ") OR (",
+        "priority medium",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR (f2) OR (f3)",
+    "filters": {
+        "f1": "description includes d1",
+        "f2": "description includes d2",
+        "f3": "priority medium"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes d1) OR (priority medium)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes d1",
+        ") OR (",
+        "priority medium",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR (f2)",
+    "filters": {
+        "f1": "description includes d1",
+        "f2": "priority medium"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes d1) OR NOT (description includes d2)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes d1",
+        ") OR",
+        " ",
+        "NOT (",
+        "description includes d2",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "description includes d1",
+        "f2": "description includes d2"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes d1) XOR (description includes d2)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes d1",
+        ") XOR (",
+        "description includes d2",
+        ")"
+    ],
+    "simplifiedLine": "(f1) XOR (f2)",
+    "filters": {
+        "f1": "description includes d1",
+        "f2": "description includes d2"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes d1) XOR (priority medium)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes d1",
+        ") XOR (",
+        "priority medium",
+        ")"
+    ],
+    "simplifiedLine": "(f1) XOR (f2)",
+    "filters": {
+        "f1": "description includes d1",
+        "f2": "priority medium"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes line 1) OR (description includes line 1 continued with \ backslash)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes line 1",
+        ") OR (",
+        "description includes line 1 continued with \\ backslash",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR (f2)",
+    "filters": {
+        "f1": "description includes line 1",
+        "f2": "description includes line 1 continued with \\ backslash"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description includes wibble) OR NOT (description includes wibble)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description includes wibble",
+        ") OR",
+        " ",
+        "NOT (",
+        "description includes wibble",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "description includes wibble",
+        "f2": "description includes wibble"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(description regex matches /#t\s/i) OR (description regex matches /#t$/i)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "description regex matches /#t\\s/i",
+        ") OR (",
+        "description regex matches /#t$/i",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR (f2)",
+    "filters": {
+        "f1": "description regex matches /#t\\s/i",
+        "f2": "description regex matches /#t$/i"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(done after 2021-12-27) OR NOT (done after 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "done after 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "done after 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "done after 2021-12-27",
+        "f2": "done after 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(done before 2021-12-27) OR NOT (done before 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "done before 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "done before 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "done before 2021-12-27",
+        "f2": "done before 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(done date is invalid) OR NOT (done date is invalid)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "done date is invalid",
+        ") OR",
+        " ",
+        "NOT (",
+        "done date is invalid",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "done date is invalid",
+        "f2": "done date is invalid"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(done in 2021-12-27 2021-12-29) OR NOT (done in 2021-12-27 2021-12-29)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "done in 2021-12-27 2021-12-29",
+        ") OR",
+        " ",
+        "NOT (",
+        "done in 2021-12-27 2021-12-29",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "done in 2021-12-27 2021-12-29",
+        "f2": "done in 2021-12-27 2021-12-29"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(done on 2021-12-27) OR NOT (done on 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "done on 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "done on 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "done on 2021-12-27",
+        "f2": "done on 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(done this week) OR NOT (done this week)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "done this week",
+        ") OR",
+        " ",
+        "NOT (",
+        "done this week",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "done this week",
+        "f2": "done this week"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(done) OR NOT (done)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "done",
+        ") OR",
+        " ",
+        "NOT (",
+        "done",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "done",
+        "f2": "done"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(due after 2021-12-27) OR NOT (due after 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "due after 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "due after 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "due after 2021-12-27",
+        "f2": "due after 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(due before 2021-12-27) OR NOT (due before 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "due before 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "due before 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "due before 2021-12-27",
+        "f2": "due before 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(due before tomorrow) AND (is recurring)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "due before tomorrow",
+        ") AND (",
+        "is recurring",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND (f2)",
+    "filters": {
+        "f1": "due before tomorrow",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(due date is invalid) OR NOT (due date is invalid)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "due date is invalid",
+        ") OR",
+        " ",
+        "NOT (",
+        "due date is invalid",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "due date is invalid",
+        "f2": "due date is invalid"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(due in 2021-12-27 2021-12-29) OR NOT (due in 2021-12-27 2021-12-29)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "due in 2021-12-27 2021-12-29",
+        ") OR",
+        " ",
+        "NOT (",
+        "due in 2021-12-27 2021-12-29",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "due in 2021-12-27 2021-12-29",
+        "f2": "due in 2021-12-27 2021-12-29"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(due on 2021-12-27) OR NOT (due on 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "due on 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "due on 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "due on 2021-12-27",
+        "f2": "due on 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(due this week) AND (description includes Hello World)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "due this week",
+        ") AND (",
+        "description includes Hello World",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND (f2)",
+    "filters": {
+        "f1": "due this week",
+        "f2": "description includes Hello World"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(due this week) OR NOT (due this week)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "due this week",
+        ") OR",
+        " ",
+        "NOT (",
+        "due this week",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "due this week",
+        "f2": "due this week"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(exclude sub-items) OR NOT (exclude sub-items)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "exclude sub-items",
+        ") OR",
+        " ",
+        "NOT (",
+        "exclude sub-items",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "exclude sub-items",
+        "f2": "exclude sub-items"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(filename includes wibble) OR NOT (filename includes wibble)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "filename includes wibble",
+        ") OR",
+        " ",
+        "NOT (",
+        "filename includes wibble",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "filename includes wibble",
+        "f2": "filename includes wibble"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(filter by function task.isDone) OR NOT (filter by function task.isDone)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "filter by function task.isDone",
+        ") OR",
+        " ",
+        "NOT (",
+        "filter by function task.isDone",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "filter by function task.isDone",
+        "f2": "filter by function task.isDone"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(folder does not include some/path) OR NOT (folder does not include some/path)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "folder does not include some/path",
+        ") OR",
+        " ",
+        "NOT (",
+        "folder does not include some/path",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "folder does not include some/path",
+        "f2": "folder does not include some/path"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(folder includes AND) OR NOT (folder includes AND)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "folder includes AND",
+        ") OR",
+        " ",
+        "NOT (",
+        "folder includes AND",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "folder includes AND",
+        "f2": "folder includes AND"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(folder includes some/path) OR NOT (folder includes some/path)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "folder includes some/path",
+        ") OR",
+        " ",
+        "NOT (",
+        "folder includes some/path",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "folder includes some/path",
+        "f2": "folder includes some/path"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(happens after 2021-12-27) OR NOT (happens after 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "happens after 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "happens after 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "happens after 2021-12-27",
+        "f2": "happens after 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(happens before 2021-12-27) OR NOT (happens before 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "happens before 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "happens before 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "happens before 2021-12-27",
+        "f2": "happens before 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(happens in 2021-12-27 2021-12-29) OR NOT (happens in 2021-12-27 2021-12-29)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "happens in 2021-12-27 2021-12-29",
+        ") OR",
+        " ",
+        "NOT (",
+        "happens in 2021-12-27 2021-12-29",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "happens in 2021-12-27 2021-12-29",
+        "f2": "happens in 2021-12-27 2021-12-29"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(happens on 2021-12-27) OR NOT (happens on 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "happens on 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "happens on 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "happens on 2021-12-27",
+        "f2": "happens on 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(happens this week) OR NOT (happens this week)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "happens this week",
+        ") OR",
+        " ",
+        "NOT (",
+        "happens this week",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "happens this week",
+        "f2": "happens this week"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has cancelled date) OR NOT (has cancelled date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has cancelled date",
+        ") OR",
+        " ",
+        "NOT (",
+        "has cancelled date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "has cancelled date",
+        "f2": "has cancelled date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has created date) OR NOT (has created date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has created date",
+        ") OR",
+        " ",
+        "NOT (",
+        "has created date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "has created date",
+        "f2": "has created date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has depends on) OR NOT (has depends on)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has depends on",
+        ") OR",
+        " ",
+        "NOT (",
+        "has depends on",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "has depends on",
+        "f2": "has depends on"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has done date) OR NOT (has done date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has done date",
+        ") OR",
+        " ",
+        "NOT (",
+        "has done date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "has done date",
+        "f2": "has done date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has due date) OR ((HAS START DATE) AND (due after 2021-12-27))'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has due date",
+        ") OR (",
+        "(",
+        "HAS START DATE",
+        ") AND (",
+        "due after 2021-12-27",
+        "))"
+    ],
+    "simplifiedLine": "(f1) OR ((HAS START DATE) AND (f2))",
+    "filters": {
+        "f1": "has due date",
+        "f2": "due after 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has due date) OR NOT (has due date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has due date",
+        ") OR",
+        " ",
+        "NOT (",
+        "has due date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "has due date",
+        "f2": "has due date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has happens date) OR NOT (has happens date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has happens date",
+        ") OR",
+        " ",
+        "NOT (",
+        "has happens date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "has happens date",
+        "f2": "has happens date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has id) OR NOT (has id)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has id",
+        ") OR",
+        " ",
+        "NOT (",
+        "has id",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "has id",
+        "f2": "has id"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has scheduled date) OR NOT (has scheduled date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has scheduled date",
+        ") OR",
+        " ",
+        "NOT (",
+        "has scheduled date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "has scheduled date",
+        "f2": "has scheduled date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has start date) AND "description includes some"'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has start date",
+        ") AND",
+        " \"",
+        "description includes some",
+        "\""
+    ],
+    "simplifiedLine": "(f1) AND \"f2\"",
+    "filters": {
+        "f1": "has start date",
+        "f2": "description includes some"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has start date) AND ((description includes some) OR (has due date))'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has start date",
+        ") AND (",
+        "(",
+        "description includes some",
+        ") OR (",
+        "has due date",
+        "))"
+    ],
+    "simplifiedLine": "(f1) AND ((f2) OR (f3))",
+    "filters": {
+        "f1": "has start date",
+        "f2": "description includes some",
+        "f3": "has due date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has start date) AND (description includes some)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has start date",
+        ") AND (",
+        "description includes some",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND (f2)",
+    "filters": {
+        "f1": "has start date",
+        "f2": "description includes some"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has start date) AND NOT (description includes some)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has start date",
+        ") AND",
+        " ",
+        "NOT (",
+        "description includes some",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND NOT (f2)",
+    "filters": {
+        "f1": "has start date",
+        "f2": "description includes some"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has start date) OR ((description includes special) AND (has due date))'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has start date",
+        ") OR (",
+        "(",
+        "description includes special",
+        ") AND (",
+        "has due date",
+        "))"
+    ],
+    "simplifiedLine": "(f1) OR ((f2) AND (f3))",
+    "filters": {
+        "f1": "has start date",
+        "f2": "description includes special",
+        "f3": "has due date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has start date) OR NOT (description includes special)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has start date",
+        ") OR",
+        " ",
+        "NOT (",
+        "description includes special",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "has start date",
+        "f2": "description includes special"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has start date) OR NOT (has start date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has start date",
+        ") OR",
+        " ",
+        "NOT (",
+        "has start date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "has start date",
+        "f2": "has start date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has start date) XOR (description includes special)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has start date",
+        ") XOR (",
+        "description includes special",
+        ")"
+    ],
+    "simplifiedLine": "(f1) XOR (f2)",
+    "filters": {
+        "f1": "has start date",
+        "f2": "description includes special"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has tag) OR NOT (has tag)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has tag",
+        ") OR",
+        " ",
+        "NOT (",
+        "has tag",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "has tag",
+        "f2": "has tag"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(has tags) OR NOT (has tags)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "has tags",
+        ") OR",
+        " ",
+        "NOT (",
+        "has tags",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "has tags",
+        "f2": "has tags"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(heading does not include wibble) OR NOT (heading does not include wibble)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "heading does not include wibble",
+        ") OR",
+        " ",
+        "NOT (",
+        "heading does not include wibble",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "heading does not include wibble",
+        "f2": "heading does not include wibble"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(heading includes AND) OR NOT (heading includes AND)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "heading includes AND",
+        ") OR",
+        " ",
+        "NOT (",
+        "heading includes AND",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "heading includes AND",
+        "f2": "heading includes AND"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(heading includes wibble) OR NOT (heading includes wibble)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "heading includes wibble",
+        ") OR",
+        " ",
+        "NOT (",
+        "heading includes wibble",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "heading includes wibble",
+        "f2": "heading includes wibble"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(id does not include abc123) OR NOT (id does not include abc123)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "id does not include abc123",
+        ") OR",
+        " ",
+        "NOT (",
+        "id does not include abc123",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "id does not include abc123",
+        "f2": "id does not include abc123"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(id includes AND) OR NOT (id includes AND)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "id includes AND",
+        ") OR",
+        " ",
+        "NOT (",
+        "id includes AND",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "id includes AND",
+        "f2": "id includes AND"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(id includes abc123) OR NOT (id includes abc123)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "id includes abc123",
+        ") OR",
+        " ",
+        "NOT (",
+        "id includes abc123",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "id includes abc123",
+        "f2": "id includes abc123"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(is blocked) OR NOT (is blocked)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "is blocked",
+        ") OR",
+        " ",
+        "NOT (",
+        "is blocked",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "is blocked",
+        "f2": "is blocked"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(is blocking) OR NOT (is blocking)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "is blocking",
+        ") OR",
+        " ",
+        "NOT (",
+        "is blocking",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "is blocking",
+        "f2": "is blocking"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(is not blocked) OR NOT (is not blocked)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "is not blocked",
+        ") OR",
+        " ",
+        "NOT (",
+        "is not blocked",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "is not blocked",
+        "f2": "is not blocked"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(is not blocking) OR NOT (is not blocking)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "is not blocking",
+        ") OR",
+        " ",
+        "NOT (",
+        "is not blocking",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "is not blocking",
+        "f2": "is not blocking"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(is not recurring) OR NOT (is not recurring)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "is not recurring",
+        ") OR",
+        " ",
+        "NOT (",
+        "is not recurring",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "is not recurring",
+        "f2": "is not recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(is not recurring) XOR ((path includes ab/c) OR (happens before 2021-12-27))'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "is not recurring",
+        ") XOR (",
+        "(",
+        "path includes ab/c",
+        ") OR (",
+        "happens before 2021-12-27",
+        "))"
+    ],
+    "simplifiedLine": "(f1) XOR ((f2) OR (f3))",
+    "filters": {
+        "f1": "is not recurring",
+        "f2": "path includes ab/c",
+        "f3": "happens before 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(is recurring) OR NOT (is recurring)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "is recurring",
+        ") OR",
+        " ",
+        "NOT (",
+        "is recurring",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "is recurring",
+        "f2": "is recurring"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(no cancelled date) OR NOT (no cancelled date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "no cancelled date",
+        ") OR",
+        " ",
+        "NOT (",
+        "no cancelled date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "no cancelled date",
+        "f2": "no cancelled date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(no created date) OR NOT (no created date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "no created date",
+        ") OR",
+        " ",
+        "NOT (",
+        "no created date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "no created date",
+        "f2": "no created date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(no depends on) OR NOT (no depends on)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "no depends on",
+        ") OR",
+        " ",
+        "NOT (",
+        "no depends on",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "no depends on",
+        "f2": "no depends on"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(no due date) OR NOT (no due date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "no due date",
+        ") OR",
+        " ",
+        "NOT (",
+        "no due date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "no due date",
+        "f2": "no due date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(no happens date) OR NOT (no happens date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "no happens date",
+        ") OR",
+        " ",
+        "NOT (",
+        "no happens date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "no happens date",
+        "f2": "no happens date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(no id) OR NOT (no id)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "no id",
+        ") OR",
+        " ",
+        "NOT (",
+        "no id",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "no id",
+        "f2": "no id"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(no scheduled date) OR NOT (no scheduled date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "no scheduled date",
+        ") OR",
+        " ",
+        "NOT (",
+        "no scheduled date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "no scheduled date",
+        "f2": "no scheduled date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(no start date) OR NOT (no start date)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "no start date",
+        ") OR",
+        " ",
+        "NOT (",
+        "no start date",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "no start date",
+        "f2": "no start date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(no tag) OR NOT (no tag)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "no tag",
+        ") OR",
+        " ",
+        "NOT (",
+        "no tag",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "no tag",
+        "f2": "no tag"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(no tags) OR NOT (no tags)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "no tags",
+        ") OR",
+        " ",
+        "NOT (",
+        "no tags",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "no tags",
+        "f2": "no tags"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(not done) OR NOT (not done)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "not done",
+        ") OR",
+        " ",
+        "NOT (",
+        "not done",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "not done",
+        "f2": "not done"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path does not include some/path) OR NOT (path does not include some/path)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path does not include some/path",
+        ") OR",
+        " ",
+        "NOT (",
+        "path does not include some/path",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "path does not include some/path",
+        "f2": "path does not include some/path"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes ()some example()) OR (path includes ((some example)))'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes ()some example(",
+        ")",
+        ") OR (",
+        "path includes ((some example",
+        ")))"
+    ],
+    "simplifiedLine": "(f1)) OR (f2)))",
+    "filters": {
+        "f1": "path includes ()some example(",
+        "f2": "path includes ((some example"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes (some example) OR (path includes )some example()'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes (some example",
+        ") OR (",
+        "path includes )some example(",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR (f2)",
+    "filters": {
+        "f1": "path includes (some example",
+        "f2": "path includes )some example("
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes (some example)) OR (path includes )some example()'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes (some example",
+        ")",
+        ") OR (",
+        "path includes )some example(",
+        ")"
+    ],
+    "simplifiedLine": "(f1)) OR (f2)",
+    "filters": {
+        "f1": "path includes (some example",
+        "f2": "path includes )some example("
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes )some example() OR (path includes (some example))'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes )some example(",
+        ") OR (",
+        "path includes (some example",
+        "))"
+    ],
+    "simplifiedLine": "(f1) OR (f2))",
+    "filters": {
+        "f1": "path includes )some example(",
+        "f2": "path includes (some example"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes A) OR (path includes Test.md)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes A",
+        ") OR (",
+        "path includes Test.md",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR (f2)",
+    "filters": {
+        "f1": "path includes A",
+        "f2": "path includes Test.md"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes AND) OR NOT (path includes AND)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes AND",
+        ") OR",
+        " ",
+        "NOT (",
+        "path includes AND",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "path includes AND",
+        "f2": "path includes AND"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes a) AND NOT(path includes b)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes a",
+        ") AND",
+        " ",
+        "NOT(",
+        "path includes b",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND NOT(f2)",
+    "filters": {
+        "f1": "path includes a",
+        "f2": "path includes b"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes a) AND(path includes b)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes a",
+        ") AND(",
+        "path includes b",
+        ")"
+    ],
+    "simplifiedLine": "(f1) AND(f2)",
+    "filters": {
+        "f1": "path includes a",
+        "f2": "path includes b"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes a) OR NOT(path includes b)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes a",
+        ") OR",
+        " ",
+        "NOT(",
+        "path includes b",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT(f2)",
+    "filters": {
+        "f1": "path includes a",
+        "f2": "path includes b"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes a) OR(path includes b)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes a",
+        ") OR(",
+        "path includes b",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR(f2)",
+    "filters": {
+        "f1": "path includes a",
+        "f2": "path includes b"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes a) XOR(path includes b)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes a",
+        ") XOR(",
+        "path includes b",
+        ")"
+    ],
+    "simplifiedLine": "(f1) XOR(f2)",
+    "filters": {
+        "f1": "path includes a",
+        "f2": "path includes b"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes a)AND (path includes b)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes a",
+        ")AND (",
+        "path includes b",
+        ")"
+    ],
+    "simplifiedLine": "(f1)AND (f2)",
+    "filters": {
+        "f1": "path includes a",
+        "f2": "path includes b"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes a)AND NOT(path includes b)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes a",
+        ")AND",
+        " ",
+        "NOT(",
+        "path includes b",
+        ")"
+    ],
+    "simplifiedLine": "(f1)AND NOT(f2)",
+    "filters": {
+        "f1": "path includes a",
+        "f2": "path includes b"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes a)OR (path includes b)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes a",
+        ")OR (",
+        "path includes b",
+        ")"
+    ],
+    "simplifiedLine": "(f1)OR (f2)",
+    "filters": {
+        "f1": "path includes a",
+        "f2": "path includes b"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes a)OR NOT (path includes b)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes a",
+        ")OR",
+        " ",
+        "NOT (",
+        "path includes b",
+        ")"
+    ],
+    "simplifiedLine": "(f1)OR NOT (f2)",
+    "filters": {
+        "f1": "path includes a",
+        "f2": "path includes b"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes a)XOR (path includes b)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes a",
+        ")XOR (",
+        "path includes b",
+        ")"
+    ],
+    "simplifiedLine": "(f1)XOR (f2)",
+    "filters": {
+        "f1": "path includes a",
+        "f2": "path includes b"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(path includes some/path) OR NOT (path includes some/path)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "path includes some/path",
+        ") OR",
+        " ",
+        "NOT (",
+        "path includes some/path",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "path includes some/path",
+        "f2": "path includes some/path"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(priority is above none) OR NOT (priority is above none)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "priority is above none",
+        ") OR",
+        " ",
+        "NOT (",
+        "priority is above none",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "priority is above none",
+        "f2": "priority is above none"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(priority is below none) OR NOT (priority is below none)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "priority is below none",
+        ") OR",
+        " ",
+        "NOT (",
+        "priority is below none",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "priority is below none",
+        "f2": "priority is below none"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(priority is high) OR NOT (priority is high)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "priority is high",
+        ") OR",
+        " ",
+        "NOT (",
+        "priority is high",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "priority is high",
+        "f2": "priority is high"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(priority is highest) OR (priority is lowest)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "priority is highest",
+        ") OR (",
+        "priority is lowest",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR (f2)",
+    "filters": {
+        "f1": "priority is highest",
+        "f2": "priority is lowest"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(priority is low) OR NOT (priority is low)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "priority is low",
+        ") OR",
+        " ",
+        "NOT (",
+        "priority is low",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "priority is low",
+        "f2": "priority is low"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(priority is medium) OR NOT (priority is medium)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "priority is medium",
+        ") OR",
+        " ",
+        "NOT (",
+        "priority is medium",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "priority is medium",
+        "f2": "priority is medium"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(priority is none) OR NOT (priority is none)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "priority is none",
+        ") OR",
+        " ",
+        "NOT (",
+        "priority is none",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "priority is none",
+        "f2": "priority is none"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(recurrence does not include wednesday) OR NOT (recurrence does not include wednesday)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "recurrence does not include wednesday",
+        ") OR",
+        " ",
+        "NOT (",
+        "recurrence does not include wednesday",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "recurrence does not include wednesday",
+        "f2": "recurrence does not include wednesday"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(recurrence includes wednesday) OR NOT (recurrence includes wednesday)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "recurrence includes wednesday",
+        ") OR",
+        " ",
+        "NOT (",
+        "recurrence includes wednesday",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "recurrence includes wednesday",
+        "f2": "recurrence includes wednesday"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(root does not include some) OR NOT (root does not include some)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "root does not include some",
+        ") OR",
+        " ",
+        "NOT (",
+        "root does not include some",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "root does not include some",
+        "f2": "root does not include some"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(root includes AND) OR NOT (root includes AND)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "root includes AND",
+        ") OR",
+        " ",
+        "NOT (",
+        "root includes AND",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "root includes AND",
+        "f2": "root includes AND"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(root includes some) OR NOT (root includes some)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "root includes some",
+        ") OR",
+        " ",
+        "NOT (",
+        "root includes some",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "root includes some",
+        "f2": "root includes some"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(scheduled after 2021-12-27) OR NOT (scheduled after 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "scheduled after 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "scheduled after 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "scheduled after 2021-12-27",
+        "f2": "scheduled after 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(scheduled before 2021-12-27) OR NOT (scheduled before 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "scheduled before 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "scheduled before 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "scheduled before 2021-12-27",
+        "f2": "scheduled before 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(scheduled date is invalid) OR NOT (scheduled date is invalid)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "scheduled date is invalid",
+        ") OR",
+        " ",
+        "NOT (",
+        "scheduled date is invalid",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "scheduled date is invalid",
+        "f2": "scheduled date is invalid"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(scheduled in 2021-12-27 2021-12-29) OR NOT (scheduled in 2021-12-27 2021-12-29)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "scheduled in 2021-12-27 2021-12-29",
+        ") OR",
+        " ",
+        "NOT (",
+        "scheduled in 2021-12-27 2021-12-29",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "scheduled in 2021-12-27 2021-12-29",
+        "f2": "scheduled in 2021-12-27 2021-12-29"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(scheduled on 2021-12-27) OR NOT (scheduled on 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "scheduled on 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "scheduled on 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "scheduled on 2021-12-27",
+        "f2": "scheduled on 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(scheduled this week) OR NOT (scheduled this week)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "scheduled this week",
+        ") OR",
+        " ",
+        "NOT (",
+        "scheduled this week",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "scheduled this week",
+        "f2": "scheduled this week"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(start date is invalid) OR NOT (start date is invalid)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "start date is invalid",
+        ") OR",
+        " ",
+        "NOT (",
+        "start date is invalid",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "start date is invalid",
+        "f2": "start date is invalid"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(starts after 2021-12-27) OR NOT (starts after 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "starts after 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "starts after 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "starts after 2021-12-27",
+        "f2": "starts after 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(starts before 2021-12-27) OR NOT (starts before 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "starts before 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "starts before 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "starts before 2021-12-27",
+        "f2": "starts before 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(starts in 2021-12-27 2021-12-29) OR NOT (starts in 2021-12-27 2021-12-29)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "starts in 2021-12-27 2021-12-29",
+        ") OR",
+        " ",
+        "NOT (",
+        "starts in 2021-12-27 2021-12-29",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "starts in 2021-12-27 2021-12-29",
+        "f2": "starts in 2021-12-27 2021-12-29"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(starts on 2021-12-27) OR NOT (starts on 2021-12-27)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "starts on 2021-12-27",
+        ") OR",
+        " ",
+        "NOT (",
+        "starts on 2021-12-27",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "starts on 2021-12-27",
+        "f2": "starts on 2021-12-27"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(starts this week) OR NOT (starts this week)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "starts this week",
+        ") OR",
+        " ",
+        "NOT (",
+        "starts this week",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "starts this week",
+        "f2": "starts this week"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(status.name includes cancelled) OR NOT (status.name includes cancelled)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "status.name includes cancelled",
+        ") OR",
+        " ",
+        "NOT (",
+        "status.name includes cancelled",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "status.name includes cancelled",
+        "f2": "status.name includes cancelled"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(status.type is IN_PROGRESS) OR NOT (status.type is IN_PROGRESS)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "status.type is IN_PROGRESS",
+        ") OR",
+        " ",
+        "NOT (",
+        "status.type is IN_PROGRESS",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "status.type is IN_PROGRESS",
+        "f2": "status.type is IN_PROGRESS"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(tag does not include #sometag) OR NOT (tag does not include #sometag)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "tag does not include #sometag",
+        ") OR",
+        " ",
+        "NOT (",
+        "tag does not include #sometag",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "tag does not include #sometag",
+        "f2": "tag does not include #sometag"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(tag does not include sometag) OR NOT (tag does not include sometag)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "tag does not include sometag",
+        ") OR",
+        " ",
+        "NOT (",
+        "tag does not include sometag",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "tag does not include sometag",
+        "f2": "tag does not include sometag"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(tag includes #sometag) OR NOT (tag includes #sometag)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "tag includes #sometag",
+        ") OR",
+        " ",
+        "NOT (",
+        "tag includes #sometag",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "tag includes #sometag",
+        "f2": "tag includes #sometag"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(tag includes AND) OR NOT (tag includes AND)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "tag includes AND",
+        ") OR",
+        " ",
+        "NOT (",
+        "tag includes AND",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "tag includes AND",
+        "f2": "tag includes AND"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(tag includes sometag) OR NOT (tag includes sometag)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "tag includes sometag",
+        ") OR",
+        " ",
+        "NOT (",
+        "tag includes sometag",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "tag includes sometag",
+        "f2": "tag includes sometag"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(tags do not include #sometag) OR NOT (tags do not include #sometag)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "tags do not include #sometag",
+        ") OR",
+        " ",
+        "NOT (",
+        "tags do not include #sometag",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "tags do not include #sometag",
+        "f2": "tags do not include #sometag"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(tags do not include sometag) OR NOT (tags do not include sometag)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "tags do not include sometag",
+        ") OR",
+        " ",
+        "NOT (",
+        "tags do not include sometag",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "tags do not include sometag",
+        "f2": "tags do not include sometag"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(tags include #sometag) OR NOT (tags include #sometag)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "tags include #sometag",
+        ") OR",
+        " ",
+        "NOT (",
+        "tags include #sometag",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "tags include #sometag",
+        "f2": "tags include #sometag"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'(tags include sometag) OR NOT (tags include sometag)'
+=>
+Result:
+{
+    "parts": [
+        "(",
+        "tags include sometag",
+        ") OR",
+        " ",
+        "NOT (",
+        "tags include sometag",
+        ")"
+    ],
+    "simplifiedLine": "(f1) OR NOT (f2)",
+    "filters": {
+        "f1": "tags include sometag",
+        "f2": "tags include sometag"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'AND (description includes d1)'
+=>
+Result:
+{
+    "parts": [
+        "AND (description includes d1",
+        ")"
+    ],
+    "simplifiedLine": "f1)",
+    "filters": {
+        "f1": "AND (description includes d1"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'NOT   (  happens before blahblahblah  )'
+=>
+Result:
+{
+    "parts": [
+        "NOT   (",
+        "  ",
+        "happens before blahblahblah",
+        "  )"
+    ],
+    "simplifiedLine": "NOT   (  f1  )",
+    "filters": {
+        "f1": "happens before blahblahblah"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'NOT  ( description includes d1 )'
+=>
+Result:
+{
+    "parts": [
+        "NOT  (",
+        " ",
+        "description includes d1",
+        " )"
+    ],
+    "simplifiedLine": "NOT  ( f1 )",
+    "filters": {
+        "f1": "description includes d1"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'NOT ( NOT ( is blocking ) )'
+=>
+Result:
+{
+    "parts": [
+        "NOT (",
+        " ",
+        "NOT (",
+        " ",
+        "is blocking",
+        " ) )"
+    ],
+    "simplifiedLine": "NOT ( NOT ( f1 ) )",
+    "filters": {
+        "f1": "is blocking"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'NOT ((HAS START DATE) OR (DESCRIPTION INCLUDES SPECIAL))'
+=>
+Result:
+{
+    "parts": [
+        "NOT (",
+        "(",
+        "HAS START DATE",
+        ") OR (",
+        "DESCRIPTION INCLUDES SPECIAL",
+        "))"
+    ],
+    "simplifiedLine": "NOT ((HAS START DATE) OR (DESCRIPTION INCLUDES SPECIAL))",
+    "filters": {}
+}
+
+--------------------------------------------------------
+
+
+Input:
+'NOT ((has start date) OR (description includes special))'
+=>
+Result:
+{
+    "parts": [
+        "NOT (",
+        "(",
+        "has start date",
+        ") OR (",
+        "description includes special",
+        "))"
+    ],
+    "simplifiedLine": "NOT ((f1) OR (f2))",
+    "filters": {
+        "f1": "has start date",
+        "f2": "description includes special"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'NOT (HAS START DATE)'
+=>
+Result:
+{
+    "parts": [
+        "NOT (",
+        "HAS START DATE",
+        ")"
+    ],
+    "simplifiedLine": "NOT (HAS START DATE)",
+    "filters": {}
+}
+
+--------------------------------------------------------
+
+
+Input:
+'NOT (description blahblah d1)'
+=>
+Result:
+{
+    "parts": [
+        "NOT (",
+        "description blahblah d1",
+        ")"
+    ],
+    "simplifiedLine": "NOT (f1)",
+    "filters": {
+        "f1": "description blahblah d1"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'NOT (description includes d1)'
+=>
+Result:
+{
+    "parts": [
+        "NOT (",
+        "description includes d1",
+        ")"
+    ],
+    "simplifiedLine": "NOT (f1)",
+    "filters": {
+        "f1": "description includes d1"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'NOT (happens before blahblahblah)'
+=>
+Result:
+{
+    "parts": [
+        "NOT (",
+        "happens before blahblahblah",
+        ")"
+    ],
+    "simplifiedLine": "NOT (f1)",
+    "filters": {
+        "f1": "happens before blahblahblah"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'NOT (has start date)'
+=>
+Result:
+{
+    "parts": [
+        "NOT (",
+        "has start date",
+        ")"
+    ],
+    "simplifiedLine": "NOT (f1)",
+    "filters": {
+        "f1": "has start date"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'NOT(path includes b)'
+=>
+Result:
+{
+    "parts": [
+        "NOT(",
+        "path includes b",
+        ")"
+    ],
+    "simplifiedLine": "NOT(f1)",
+    "filters": {
+        "f1": "path includes b"
+    }
+}
+
+--------------------------------------------------------
+
+
+Input:
+'OR (description includes d1)'
+=>
+Result:
+{
+    "parts": [
+        "OR (description includes d1",
+        ")"
+    ],
+    "simplifiedLine": "f1)",
+    "filters": {
+        "f1": "OR (description includes d1"
+    }
+}
+
+--------------------------------------------------------
+
+

--- a/tests/Query/Filter/BooleanField.test.ts
+++ b/tests/Query/Filter/BooleanField.test.ts
@@ -339,6 +339,10 @@ describe('boolean query - exhaustive tests', () => {
         verifyBooleanExpressionPreprocessing(BooleanField.preprocessExpressionV1);
     });
 
+    it('preprocess - rewrite', () => {
+        verifyBooleanExpressionPreprocessing(BooleanPreprocessor.preprocessExpressionV2);
+    });
+
     it('explain', () => {
         verifyBooleanExpressionExplanation();
     });

--- a/tests/Query/Filter/BooleanField.test.ts
+++ b/tests/Query/Filter/BooleanField.test.ts
@@ -340,7 +340,7 @@ describe('boolean query - exhaustive tests', () => {
     });
 
     it('preprocess - rewrite', () => {
-        verifyBooleanExpressionPreprocessing(BooleanPreprocessor.preprocessExpressionV2);
+        verifyBooleanExpressionPreprocessing(BooleanPreprocessor.preprocessExpression);
     });
 
     it('explain', () => {

--- a/tests/Query/Filter/BooleanPreprocessor.test.ts
+++ b/tests/Query/Filter/BooleanPreprocessor.test.ts
@@ -9,13 +9,15 @@ describe('BooleanPreprocessor', () => {
         it('single sub-expression', () => {
             expect(split('(not done)')).toMatchInlineSnapshot(`
                 {
-                  "filters": {},
+                  "filters": {
+                    "f1": "not done",
+                  },
                   "parts": [
                     "(",
                     "not done",
                     ")",
                   ],
-                  "simplifiedLine": "",
+                  "simplifiedLine": "(f1)",
                 }
             `);
         });
@@ -23,7 +25,10 @@ describe('BooleanPreprocessor', () => {
         it('simple AND', () => {
             expect(split('(done) AND (has done date)')).toMatchInlineSnapshot(`
                 {
-                  "filters": {},
+                  "filters": {
+                    "f1": "done",
+                    "f2": "has done date",
+                  },
                   "parts": [
                     "(",
                     "done",
@@ -31,7 +36,7 @@ describe('BooleanPreprocessor', () => {
                     "has done date",
                     ")",
                   ],
-                  "simplifiedLine": "",
+                  "simplifiedLine": "(f1) AND (f2)",
                 }
             `);
         });
@@ -39,7 +44,10 @@ describe('BooleanPreprocessor', () => {
         it('simple AND NOT', () => {
             expect(split('(done) AND  NOT (has done date)')).toMatchInlineSnapshot(`
                 {
-                  "filters": {},
+                  "filters": {
+                    "f1": "done",
+                    "f2": "has done date",
+                  },
                   "parts": [
                     "(",
                     "done",
@@ -49,7 +57,7 @@ describe('BooleanPreprocessor', () => {
                     "has done date",
                     ")",
                   ],
-                  "simplifiedLine": "",
+                  "simplifiedLine": "(f1) AND  NOT (f2)",
                 }
             `);
         });
@@ -57,7 +65,10 @@ describe('BooleanPreprocessor', () => {
         it('simple OR', () => {
             expect(split('(done) OR (has done date)')).toMatchInlineSnapshot(`
                 {
-                  "filters": {},
+                  "filters": {
+                    "f1": "done",
+                    "f2": "has done date",
+                  },
                   "parts": [
                     "(",
                     "done",
@@ -65,7 +76,7 @@ describe('BooleanPreprocessor', () => {
                     "has done date",
                     ")",
                   ],
-                  "simplifiedLine": "",
+                  "simplifiedLine": "(f1) OR (f2)",
                 }
             `);
         });
@@ -73,7 +84,10 @@ describe('BooleanPreprocessor', () => {
         it('simple OR NOT', () => {
             expect(split('(done) OR  NOT (has done date)')).toMatchInlineSnapshot(`
                 {
-                  "filters": {},
+                  "filters": {
+                    "f1": "done",
+                    "f2": "has done date",
+                  },
                   "parts": [
                     "(",
                     "done",
@@ -83,7 +97,7 @@ describe('BooleanPreprocessor', () => {
                     "has done date",
                     ")",
                   ],
-                  "simplifiedLine": "",
+                  "simplifiedLine": "(f1) OR  NOT (f2)",
                 }
             `);
         });
@@ -91,7 +105,10 @@ describe('BooleanPreprocessor', () => {
         it('simple XOR', () => {
             expect(split('"done" XOR "has done date"')).toMatchInlineSnapshot(`
                 {
-                  "filters": {},
+                  "filters": {
+                    "f1": "done",
+                    "f2": "has done date",
+                  },
                   "parts": [
                     """,
                     "done",
@@ -101,7 +118,7 @@ describe('BooleanPreprocessor', () => {
                     "has done date",
                     """,
                   ],
-                  "simplifiedLine": "",
+                  "simplifiedLine": ""f1" XOR "f2"",
                 }
             `);
         });
@@ -109,13 +126,15 @@ describe('BooleanPreprocessor', () => {
         it('simple unary NOT', () => {
             expect(split('NOT  (not done)')).toMatchInlineSnapshot(`
                 {
-                  "filters": {},
+                  "filters": {
+                    "f1": "not done",
+                  },
                   "parts": [
                     "NOT  (",
                     "not done",
                     ")",
                   ],
-                  "simplifiedLine": "",
+                  "simplifiedLine": "NOT  (f1)",
                 }
             `);
         });
@@ -125,7 +144,10 @@ describe('BooleanPreprocessor', () => {
         it('simple AND - but spaces missing around AND', () => {
             expect(split('(done)AND(has done date)')).toMatchInlineSnapshot(`
                 {
-                  "filters": {},
+                  "filters": {
+                    "f1": "done",
+                    "f2": "has done date",
+                  },
                   "parts": [
                     "(",
                     "done",
@@ -133,7 +155,7 @@ describe('BooleanPreprocessor', () => {
                     "has done date",
                     ")",
                   ],
-                  "simplifiedLine": "",
+                  "simplifiedLine": "(f1)AND(f2)",
                 }
             `);
         });
@@ -141,13 +163,15 @@ describe('BooleanPreprocessor', () => {
         it('simple unary NOT - but spaces missing after NOT', () => {
             expect(split('NOT(not done)')).toMatchInlineSnapshot(`
                 {
-                  "filters": {},
+                  "filters": {
+                    "f1": "not done",
+                  },
                   "parts": [
                     "NOT(",
                     "not done",
                     ")",
                   ],
-                  "simplifiedLine": "",
+                  "simplifiedLine": "NOT(f1)",
                 }
             `);
         });
@@ -157,7 +181,9 @@ describe('BooleanPreprocessor', () => {
         it('redundant ( surrounding unary NOT', () => {
             expect(split('(((((NOT  ( description includes d1 ))))))')).toMatchInlineSnapshot(`
                 {
-                  "filters": {},
+                  "filters": {
+                    "f1": "description includes d1",
+                  },
                   "parts": [
                     "(((((",
                     "NOT  (",
@@ -165,7 +191,7 @@ describe('BooleanPreprocessor', () => {
                     "description includes d1",
                     " ))))))",
                   ],
-                  "simplifiedLine": "",
+                  "simplifiedLine": "(((((NOT  ( f1 ))))))",
                 }
             `);
         });
@@ -173,7 +199,9 @@ describe('BooleanPreprocessor', () => {
         it('redundant " surrounding unary NOT', () => {
             expect(split('"""""NOT  " description includes d1 """"""')).toMatchInlineSnapshot(`
                 {
-                  "filters": {},
+                  "filters": {
+                    "f1": "description includes d1",
+                  },
                   "parts": [
                     """"""",
                     "NOT",
@@ -182,7 +210,7 @@ describe('BooleanPreprocessor', () => {
                     "description includes d1",
                     " """"""",
                   ],
-                  "simplifiedLine": "",
+                  "simplifiedLine": """"""NOT  " f1 """"""",
                 }
             `);
         });

--- a/tests/Query/Filter/BooleanPreprocessor.test.ts
+++ b/tests/Query/Filter/BooleanPreprocessor.test.ts
@@ -1,13 +1,13 @@
 import { BooleanPreprocessor } from '../../../src/Query/Filter/BooleanPreprocessor';
 
-function split(line: string) {
+function preprocess(line: string) {
     return BooleanPreprocessor.preprocessExpression(line);
 }
 
 describe('BooleanPreprocessor', () => {
     describe('single operators - surrounded by at least one space', () => {
         it('single sub-expression', () => {
-            expect(split('(not done)')).toMatchInlineSnapshot(`
+            expect(preprocess('(not done)')).toMatchInlineSnapshot(`
                 {
                   "filters": {
                     "f1": "not done",
@@ -18,7 +18,7 @@ describe('BooleanPreprocessor', () => {
         });
 
         it('simple AND', () => {
-            expect(split('(done) AND (has done date)')).toMatchInlineSnapshot(`
+            expect(preprocess('(done) AND (has done date)')).toMatchInlineSnapshot(`
                 {
                   "filters": {
                     "f1": "done",
@@ -30,7 +30,7 @@ describe('BooleanPreprocessor', () => {
         });
 
         it('simple AND - filters capitalised', () => {
-            expect(split('(DONE) AND (HAS DONE DATE)')).toMatchInlineSnapshot(`
+            expect(preprocess('(DONE) AND (HAS DONE DATE)')).toMatchInlineSnapshot(`
                 {
                   "filters": {
                     "f1": "DONE",
@@ -42,7 +42,7 @@ describe('BooleanPreprocessor', () => {
         });
 
         it('simple AND NOT', () => {
-            expect(split('(done) AND  NOT (has done date)')).toMatchInlineSnapshot(`
+            expect(preprocess('(done) AND  NOT (has done date)')).toMatchInlineSnapshot(`
                 {
                   "filters": {
                     "f1": "done",
@@ -54,7 +54,7 @@ describe('BooleanPreprocessor', () => {
         });
 
         it('simple OR', () => {
-            expect(split('(done) OR (has done date)')).toMatchInlineSnapshot(`
+            expect(preprocess('(done) OR (has done date)')).toMatchInlineSnapshot(`
                 {
                   "filters": {
                     "f1": "done",
@@ -66,7 +66,7 @@ describe('BooleanPreprocessor', () => {
         });
 
         it('simple OR NOT', () => {
-            expect(split('(done) OR  NOT (has done date)')).toMatchInlineSnapshot(`
+            expect(preprocess('(done) OR  NOT (has done date)')).toMatchInlineSnapshot(`
                 {
                   "filters": {
                     "f1": "done",
@@ -78,7 +78,7 @@ describe('BooleanPreprocessor', () => {
         });
 
         it('simple XOR', () => {
-            expect(split('"done" XOR "has done date"')).toMatchInlineSnapshot(`
+            expect(preprocess('"done" XOR "has done date"')).toMatchInlineSnapshot(`
                 {
                   "filters": {
                     "f1": "done",
@@ -90,7 +90,7 @@ describe('BooleanPreprocessor', () => {
         });
 
         it('simple unary NOT', () => {
-            expect(split('NOT  (not done)')).toMatchInlineSnapshot(`
+            expect(preprocess('NOT  (not done)')).toMatchInlineSnapshot(`
                 {
                   "filters": {
                     "f1": "not done",
@@ -103,7 +103,7 @@ describe('BooleanPreprocessor', () => {
 
     describe('single operators - missing spaces around operator', () => {
         it('simple AND - but spaces missing around AND', () => {
-            expect(split('(done)AND(has done date)')).toMatchInlineSnapshot(`
+            expect(preprocess('(done)AND(has done date)')).toMatchInlineSnapshot(`
                 {
                   "filters": {
                     "f1": "done",
@@ -115,7 +115,7 @@ describe('BooleanPreprocessor', () => {
         });
 
         it('simple unary NOT - but spaces missing after NOT', () => {
-            expect(split('NOT(not done)')).toMatchInlineSnapshot(`
+            expect(preprocess('NOT(not done)')).toMatchInlineSnapshot(`
                 {
                   "filters": {
                     "f1": "not done",
@@ -128,14 +128,14 @@ describe('BooleanPreprocessor', () => {
 
     describe('filters ending with delimiters', () => {
         it('swallows last character if filter ends with closing delimiter character )', () => {
-            const result = split('"description includes (maybe)"');
+            const result = preprocess('"description includes (maybe)"');
             // TODO Fix imbalanced delimiters by requiring the same delimiter set to be used in Boolean lines.
             expect(result.simplifiedLine).toEqual('"f1)"');
             expect(result.filters['f1']).toEqual('description includes (maybe');
         });
 
         it('swallows last character if filter ends with closing delimiter character "', () => {
-            const result = split('(description includes "maybe")');
+            const result = preprocess('(description includes "maybe")');
             // TODO Fix imbalanced delimiters by requiring the same delimiter set to be used in Boolean lines.
             expect(result.simplifiedLine).toEqual('(f1")');
             expect(result.filters['f1']).toEqual('description includes "maybe');
@@ -144,7 +144,7 @@ describe('BooleanPreprocessor', () => {
 
     describe('extra delimiters', () => {
         it('redundant ( surrounding unary NOT', () => {
-            expect(split('(((((NOT  ( description includes d1 ))))))')).toMatchInlineSnapshot(`
+            expect(preprocess('(((((NOT  ( description includes d1 ))))))')).toMatchInlineSnapshot(`
                 {
                   "filters": {
                     "f1": "description includes d1",
@@ -155,7 +155,7 @@ describe('BooleanPreprocessor', () => {
         });
 
         it('redundant " surrounding unary NOT', () => {
-            expect(split('"""""NOT  " description includes d1 """"""')).toMatchInlineSnapshot(`
+            expect(preprocess('"""""NOT  " description includes d1 """"""')).toMatchInlineSnapshot(`
                 {
                   "filters": {
                     "f1": "description includes d1",

--- a/tests/Query/Filter/BooleanPreprocessor.test.ts
+++ b/tests/Query/Filter/BooleanPreprocessor.test.ts
@@ -12,11 +12,6 @@ describe('BooleanPreprocessor', () => {
                   "filters": {
                     "f1": "not done",
                   },
-                  "parts": [
-                    "(",
-                    "not done",
-                    ")",
-                  ],
                   "simplifiedLine": "(f1)",
                 }
             `);
@@ -29,13 +24,6 @@ describe('BooleanPreprocessor', () => {
                     "f1": "done",
                     "f2": "has done date",
                   },
-                  "parts": [
-                    "(",
-                    "done",
-                    ") AND (",
-                    "has done date",
-                    ")",
-                  ],
                   "simplifiedLine": "(f1) AND (f2)",
                 }
             `);
@@ -48,13 +36,6 @@ describe('BooleanPreprocessor', () => {
                     "f1": "DONE",
                     "f2": "HAS DONE DATE",
                   },
-                  "parts": [
-                    "(",
-                    "DONE",
-                    ") AND (",
-                    "HAS DONE DATE",
-                    ")",
-                  ],
                   "simplifiedLine": "(f1) AND (f2)",
                 }
             `);
@@ -67,15 +48,6 @@ describe('BooleanPreprocessor', () => {
                     "f1": "done",
                     "f2": "has done date",
                   },
-                  "parts": [
-                    "(",
-                    "done",
-                    ") AND",
-                    "  ",
-                    "NOT (",
-                    "has done date",
-                    ")",
-                  ],
                   "simplifiedLine": "(f1) AND  NOT (f2)",
                 }
             `);
@@ -88,13 +60,6 @@ describe('BooleanPreprocessor', () => {
                     "f1": "done",
                     "f2": "has done date",
                   },
-                  "parts": [
-                    "(",
-                    "done",
-                    ") OR (",
-                    "has done date",
-                    ")",
-                  ],
                   "simplifiedLine": "(f1) OR (f2)",
                 }
             `);
@@ -107,15 +72,6 @@ describe('BooleanPreprocessor', () => {
                     "f1": "done",
                     "f2": "has done date",
                   },
-                  "parts": [
-                    "(",
-                    "done",
-                    ") OR",
-                    "  ",
-                    "NOT (",
-                    "has done date",
-                    ")",
-                  ],
                   "simplifiedLine": "(f1) OR  NOT (f2)",
                 }
             `);
@@ -128,15 +84,6 @@ describe('BooleanPreprocessor', () => {
                     "f1": "done",
                     "f2": "has done date",
                   },
-                  "parts": [
-                    """,
-                    "done",
-                    "" ",
-                    "XOR",
-                    " "",
-                    "has done date",
-                    """,
-                  ],
                   "simplifiedLine": ""f1" XOR "f2"",
                 }
             `);
@@ -148,11 +95,6 @@ describe('BooleanPreprocessor', () => {
                   "filters": {
                     "f1": "not done",
                   },
-                  "parts": [
-                    "NOT  (",
-                    "not done",
-                    ")",
-                  ],
                   "simplifiedLine": "NOT  (f1)",
                 }
             `);
@@ -167,13 +109,6 @@ describe('BooleanPreprocessor', () => {
                     "f1": "done",
                     "f2": "has done date",
                   },
-                  "parts": [
-                    "(",
-                    "done",
-                    ")AND(",
-                    "has done date",
-                    ")",
-                  ],
                   "simplifiedLine": "(f1)AND(f2)",
                 }
             `);
@@ -185,11 +120,6 @@ describe('BooleanPreprocessor', () => {
                   "filters": {
                     "f1": "not done",
                   },
-                  "parts": [
-                    "NOT(",
-                    "not done",
-                    ")",
-                  ],
                   "simplifiedLine": "NOT(f1)",
                 }
             `);
@@ -219,13 +149,6 @@ describe('BooleanPreprocessor', () => {
                   "filters": {
                     "f1": "description includes d1",
                   },
-                  "parts": [
-                    "(((((",
-                    "NOT  (",
-                    " ",
-                    "description includes d1",
-                    " ))))))",
-                  ],
                   "simplifiedLine": "(((((NOT  ( f1 ))))))",
                 }
             `);
@@ -237,14 +160,6 @@ describe('BooleanPreprocessor', () => {
                   "filters": {
                     "f1": "description includes d1",
                   },
-                  "parts": [
-                    """"""",
-                    "NOT",
-                    "  "",
-                    " ",
-                    "description includes d1",
-                    " """"""",
-                  ],
                   "simplifiedLine": """"""NOT  " f1 """"""",
                 }
             `);

--- a/tests/Query/Filter/BooleanPreprocessor.test.ts
+++ b/tests/Query/Filter/BooleanPreprocessor.test.ts
@@ -196,6 +196,22 @@ describe('BooleanPreprocessor', () => {
         });
     });
 
+    describe('filters ending with delimiters', () => {
+        it('swallows last character if filter ends with closing delimiter character )', () => {
+            const result = split('"description includes (maybe)"');
+            // TODO Fix imbalanced delimiters by requiring the same delimiter set to be used in Boolean lines.
+            expect(result.simplifiedLine).toEqual('"f1)"');
+            expect(result.filters['f1']).toEqual('description includes (maybe');
+        });
+
+        it('swallows last character if filter ends with closing delimiter character "', () => {
+            const result = split('(description includes "maybe")');
+            // TODO Fix imbalanced delimiters by requiring the same delimiter set to be used in Boolean lines.
+            expect(result.simplifiedLine).toEqual('(f1")');
+            expect(result.filters['f1']).toEqual('description includes "maybe');
+        });
+    });
+
     describe('extra delimiters', () => {
         it('redundant ( surrounding unary NOT', () => {
             expect(split('(((((NOT  ( description includes d1 ))))))')).toMatchInlineSnapshot(`

--- a/tests/Query/Filter/BooleanPreprocessor.test.ts
+++ b/tests/Query/Filter/BooleanPreprocessor.test.ts
@@ -1,94 +1,122 @@
 import { BooleanPreprocessor } from '../../../src/Query/Filter/BooleanPreprocessor';
 
 function split(line: string) {
-    return BooleanPreprocessor.splitLine(line);
+    return BooleanPreprocessor.preprocessExpressionV2(line);
 }
 
 describe('BooleanPreprocessor', () => {
     describe('single operators - surrounded by at least one space', () => {
         it('single sub-expression', () => {
             expect(split('(not done)')).toMatchInlineSnapshot(`
-                [
-                  "(",
-                  "not done",
-                  ")",
-                ]
+                {
+                  "filters": {},
+                  "parts": [
+                    "(",
+                    "not done",
+                    ")",
+                  ],
+                  "simplifiedLine": "",
+                }
             `);
         });
 
         it('simple AND', () => {
             expect(split('(done) AND (has done date)')).toMatchInlineSnapshot(`
-                [
-                  "(",
-                  "done",
-                  ") AND (",
-                  "has done date",
-                  ")",
-                ]
+                {
+                  "filters": {},
+                  "parts": [
+                    "(",
+                    "done",
+                    ") AND (",
+                    "has done date",
+                    ")",
+                  ],
+                  "simplifiedLine": "",
+                }
             `);
         });
 
         it('simple AND NOT', () => {
             expect(split('(done) AND  NOT (has done date)')).toMatchInlineSnapshot(`
-                [
-                  "(",
-                  "done",
-                  ") AND",
-                  "  ",
-                  "NOT (",
-                  "has done date",
-                  ")",
-                ]
+                {
+                  "filters": {},
+                  "parts": [
+                    "(",
+                    "done",
+                    ") AND",
+                    "  ",
+                    "NOT (",
+                    "has done date",
+                    ")",
+                  ],
+                  "simplifiedLine": "",
+                }
             `);
         });
 
         it('simple OR', () => {
             expect(split('(done) OR (has done date)')).toMatchInlineSnapshot(`
-                [
-                  "(",
-                  "done",
-                  ") OR (",
-                  "has done date",
-                  ")",
-                ]
+                {
+                  "filters": {},
+                  "parts": [
+                    "(",
+                    "done",
+                    ") OR (",
+                    "has done date",
+                    ")",
+                  ],
+                  "simplifiedLine": "",
+                }
             `);
         });
 
         it('simple OR NOT', () => {
             expect(split('(done) OR  NOT (has done date)')).toMatchInlineSnapshot(`
-                [
-                  "(",
-                  "done",
-                  ") OR",
-                  "  ",
-                  "NOT (",
-                  "has done date",
-                  ")",
-                ]
+                {
+                  "filters": {},
+                  "parts": [
+                    "(",
+                    "done",
+                    ") OR",
+                    "  ",
+                    "NOT (",
+                    "has done date",
+                    ")",
+                  ],
+                  "simplifiedLine": "",
+                }
             `);
         });
 
         it('simple XOR', () => {
             expect(split('"done" XOR "has done date"')).toMatchInlineSnapshot(`
-                [
-                  """,
-                  "done",
-                  "" ",
-                  "XOR",
-                  " "",
-                  "has done date",
-                  """,
-                ]
+                {
+                  "filters": {},
+                  "parts": [
+                    """,
+                    "done",
+                    "" ",
+                    "XOR",
+                    " "",
+                    "has done date",
+                    """,
+                  ],
+                  "simplifiedLine": "",
+                }
             `);
         });
 
         it('simple unary NOT', () => {
             expect(split('NOT  (not done)')).toMatchInlineSnapshot(`
-                [
-                  "NOT  (",
-                  "not done",
-                  ")",
-                ]
+                {
+                  "filters": {},
+                  "parts": [
+                    "NOT  (",
+                    "not done",
+                    ")",
+                  ],
+                  "simplifiedLine": "",
+                }
             `);
         });
     });
@@ -96,23 +124,31 @@ describe('BooleanPreprocessor', () => {
     describe('single operators - missing spaces around operator', () => {
         it('simple AND - but spaces missing around AND', () => {
             expect(split('(done)AND(has done date)')).toMatchInlineSnapshot(`
-                [
-                  "(",
-                  "done",
-                  ")AND(",
-                  "has done date",
-                  ")",
-                ]
+                {
+                  "filters": {},
+                  "parts": [
+                    "(",
+                    "done",
+                    ")AND(",
+                    "has done date",
+                    ")",
+                  ],
+                  "simplifiedLine": "",
+                }
             `);
         });
 
         it('simple unary NOT - but spaces missing after NOT', () => {
             expect(split('NOT(not done)')).toMatchInlineSnapshot(`
-                [
-                  "NOT(",
-                  "not done",
-                  ")",
-                ]
+                {
+                  "filters": {},
+                  "parts": [
+                    "NOT(",
+                    "not done",
+                    ")",
+                  ],
+                  "simplifiedLine": "",
+                }
             `);
         });
     });
@@ -120,26 +156,34 @@ describe('BooleanPreprocessor', () => {
     describe('extra delimiters', () => {
         it('redundant ( surrounding unary NOT', () => {
             expect(split('(((((NOT  ( description includes d1 ))))))')).toMatchInlineSnapshot(`
-                [
-                  "(((((",
-                  "NOT  (",
-                  " ",
-                  "description includes d1",
-                  " ))))))",
-                ]
+                {
+                  "filters": {},
+                  "parts": [
+                    "(((((",
+                    "NOT  (",
+                    " ",
+                    "description includes d1",
+                    " ))))))",
+                  ],
+                  "simplifiedLine": "",
+                }
             `);
         });
 
         it('redundant " surrounding unary NOT', () => {
             expect(split('"""""NOT  " description includes d1 """"""')).toMatchInlineSnapshot(`
-                [
-                  """"""",
-                  "NOT",
-                  "  "",
-                  " ",
-                  "description includes d1",
-                  " """"""",
-                ]
+                {
+                  "filters": {},
+                  "parts": [
+                    """"""",
+                    "NOT",
+                    "  "",
+                    " ",
+                    "description includes d1",
+                    " """"""",
+                  ],
+                  "simplifiedLine": "",
+                }
             `);
         });
     });

--- a/tests/Query/Filter/BooleanPreprocessor.test.ts
+++ b/tests/Query/Filter/BooleanPreprocessor.test.ts
@@ -44,7 +44,10 @@ describe('BooleanPreprocessor', () => {
         it('simple AND - filters capitalised', () => {
             expect(split('(DONE) AND (HAS DONE DATE)')).toMatchInlineSnapshot(`
                 {
-                  "filters": {},
+                  "filters": {
+                    "f1": "DONE",
+                    "f2": "HAS DONE DATE",
+                  },
                   "parts": [
                     "(",
                     "DONE",
@@ -52,7 +55,7 @@ describe('BooleanPreprocessor', () => {
                     "HAS DONE DATE",
                     ")",
                   ],
-                  "simplifiedLine": "(DONE) AND (HAS DONE DATE)",
+                  "simplifiedLine": "(f1) AND (f2)",
                 }
             `);
         });

--- a/tests/Query/Filter/BooleanPreprocessor.test.ts
+++ b/tests/Query/Filter/BooleanPreprocessor.test.ts
@@ -41,6 +41,22 @@ describe('BooleanPreprocessor', () => {
             `);
         });
 
+        it('simple AND - filters capitalised', () => {
+            expect(split('(DONE) AND (HAS DONE DATE)')).toMatchInlineSnapshot(`
+                {
+                  "filters": {},
+                  "parts": [
+                    "(",
+                    "DONE",
+                    ") AND (",
+                    "HAS DONE DATE",
+                    ")",
+                  ],
+                  "simplifiedLine": "(DONE) AND (HAS DONE DATE)",
+                }
+            `);
+        });
+
         it('simple AND NOT', () => {
             expect(split('(done) AND  NOT (has done date)')).toMatchInlineSnapshot(`
                 {

--- a/tests/Query/Filter/BooleanPreprocessor.test.ts
+++ b/tests/Query/Filter/BooleanPreprocessor.test.ts
@@ -1,7 +1,7 @@
 import { BooleanPreprocessor } from '../../../src/Query/Filter/BooleanPreprocessor';
 
 function split(line: string) {
-    return BooleanPreprocessor.preprocessExpressionV2(line);
+    return BooleanPreprocessor.preprocessExpression(line);
 }
 
 describe('BooleanPreprocessor', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

*Note: this is labelled as a refactor as the new code is not yet used in the Tasks plugin.*

This extends `BooleanPreprocessor` to add a more sophisticated implementation for preprocessing Boolean/combined filters.

<!--- Describe your changes in detail -->
- Add `BooleanPreprocessorResult
- Add `BooleanPreprocessor.preprocessExpression()`

This change - and especially the new method `isAFilter()` - is the result of several weeks and many, many hours of trying to maintain existing working searches, whilst also adding support for filters that contain the following characters:

- `(`
- `)`
- `"`

### Caveats

The one current caveat with this implementation is that it does not work for filters the **end** with any of the characters `()"`, as they are swallowed up and treated as delimiters.

So for example, this filter:

```
(description includes "maybe")
```

is interpreted as this simplified line - note the stray `"`:

```
(f1")
```

where `f1` is this - note the missing `"`:

```
description includes "maybe
```
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Likely the last refactor before addressing:

- https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1308
- https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1500

## How has this been tested?

- Adding and updating tests
- Diffing the output of these two files:
    - `BooleanField.test.boolean_query_-_exhaustive_tests_preprocess.approved.txt`
    - `BooleanField.test.boolean_query_-_exhaustive_tests_preprocess_-_rewrite.approved.txt`

## Screenshots (if appropriate)

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
