### PR TITLE
feat: Provide better Boolean help messages

### DIFF
--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -266,6 +266,8 @@ The instruction was converted to the following simplified line:
     ${parseResult.simplifiedLine}
 Where the sub-expressions in the simplified line are:
 ${expressions}
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 `;
         return FilterOrErrorMessage.fromError(line, fullMessage);
     }

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -262,10 +262,13 @@ export class BooleanField extends Field {
 
         const simpleMessage = this.helpMessageFromSimpleError(line, errorMessage);
         const fullMessage = `${simpleMessage}
+
 The instruction was converted to the following simplified line:
     ${parseResult.simplifiedLine}
+
 Where the sub-expressions in the simplified line are:
 ${expressions}
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 `;
@@ -275,6 +278,7 @@ For help, see:
     private helpMessageFromSimpleError(line: string, errorMessage: string) {
         return `Could not interpret the following instruction as a Boolean combination:
     ${line}
+
 The error message is:
     ${errorMessage}`;
     }

--- a/src/Query/Filter/BooleanPreprocessor.ts
+++ b/src/Query/Filter/BooleanPreprocessor.ts
@@ -1,6 +1,6 @@
 import { BooleanDelimiters, anyOfTheseChars } from './BooleanDelimiters';
 
-type BooleanPreprocessorResult = {
+export type BooleanPreprocessorResult = {
     simplifiedLine: string;
     filters: { [key: string]: string };
 };

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
@@ -389,6 +389,8 @@ Where the sub-expressions in the simplified line are:
     'f4': 'filter by function task.description.includes('d''
     'f5': 'filter by function task.description.includes('e''
     'f6': 'filter by function task.description.includes('f''
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -471,6 +473,8 @@ Where the sub-expressions in the simplified line are:
     'f6': 'filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase('
     'f7': 'filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false'
     'f8': 'filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -884,6 +888,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'description includes "hello world'
     'f2': 'description includes "42'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -996,6 +1002,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'description includes SHOULD NOT BE RECOGNISED AS A BOOLEAN'
     'f2': 'description includes BECAUSE THERE ARE NO SPACES AROUND THE 'AND' OPERATOR'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2236,6 +2244,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes ()some example('
     'f2': 'path includes ((some example'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2267,6 +2277,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes (some example'
     'f2': 'path includes )some example('
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2285,6 +2297,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes )some example('
     'f2': 'path includes (some example'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2330,6 +2344,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2348,6 +2364,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2366,6 +2384,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2384,6 +2404,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2402,6 +2424,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2420,6 +2444,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2438,6 +2464,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2456,6 +2484,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2474,6 +2504,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -2492,6 +2524,8 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -3052,6 +3086,8 @@ The instruction was converted to the following simplified line:
     f1)
 Where the sub-expressions in the simplified line are:
     'f1': 'AND (description includes d1'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -3069,6 +3105,8 @@ The instruction was converted to the following simplified line:
     NOT   (  f1  )
 Where the sub-expressions in the simplified line are:
     'f1': 'happens before blahblahblah'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -3151,6 +3189,8 @@ The instruction was converted to the following simplified line:
     NOT (f1)
 Where the sub-expressions in the simplified line are:
     'f1': 'description blahblah d1'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -3180,6 +3220,8 @@ The instruction was converted to the following simplified line:
     NOT (f1)
 Where the sub-expressions in the simplified line are:
     'f1': 'happens before blahblahblah'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -3209,6 +3251,8 @@ The instruction was converted to the following simplified line:
     NOT(f1)
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes b'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------
@@ -3226,6 +3270,8 @@ The instruction was converted to the following simplified line:
     f1)
 Where the sub-expressions in the simplified line are:
     'f1': 'OR (description includes d1'
+For help, see:
+    https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
 
 --------------------------------------------------------

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
@@ -376,7 +376,10 @@ Input:
 '( (filter by function task.description.includes('a')) OR (filter by function task.description.includes('b')) OR (filter by function task.description.includes('c')) ) AND ( (filter by function task.description.includes('d')) OR (filter by function task.description.includes('e')) OR (filter by function task.description.includes('f')) )'
 =>
 Result:
-malformed boolean query -- Invalid token (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    ( (filter by function task.description.includes('a')) OR (filter by function task.description.includes('b')) OR (filter by function task.description.includes('c')) ) AND ( (filter by function task.description.includes('d')) OR (filter by function task.description.includes('e')) OR (filter by function task.description.includes('f')) )
+The error message is:
+    malformed boolean query -- Invalid token (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -443,7 +446,10 @@ Input:
 '( filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type) ) OR ( filter by function const date = task.due.moment; return date ? !date.isValid() : false; ) OR ( filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false ) OR ( filter by function task.urgency.toFixed(2) === 1.95.toFixed(2) ) OR ( filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁') ) OR ( filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase() ) OR ( filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false ) OR ( filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false; )'
 =>
 Result:
-malformed boolean query -- Invalid token (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    ( filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type) ) OR ( filter by function const date = task.due.moment; return date ? !date.isValid() : false; ) OR ( filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false ) OR ( filter by function task.urgency.toFixed(2) === 1.95.toFixed(2) ) OR ( filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁') ) OR ( filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase() ) OR ( filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false ) OR ( filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false; )
+The error message is:
+    malformed boolean query -- Invalid token (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -847,7 +853,10 @@ Input:
 '(description includes "hello world") OR (description includes "42")'
 =>
 Result:
-malformed boolean query -- Unexpected character: " (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (description includes "hello world") OR (description includes "42")
+The error message is:
+    malformed boolean query -- Unexpected character: " (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -950,7 +959,10 @@ Input:
 '(description includes SHOULD NOT BE RECOGNISED AS A BOOLEAN)AND(description includes BECAUSE THERE ARE NO SPACES AROUND THE 'AND' OPERATOR)'
 =>
 Result:
-malformed boolean query -- Unexpected character: A. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (description includes SHOULD NOT BE RECOGNISED AS A BOOLEAN)AND(description includes BECAUSE THERE ARE NO SPACES AROUND THE 'AND' OPERATOR)
+The error message is:
+    malformed boolean query -- Unexpected character: A. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2181,7 +2193,10 @@ Input:
 '(path includes ()some example()) OR (path includes ((some example)))'
 =>
 Result:
-malformed boolean query -- Invalid token (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes ()some example()) OR (path includes ((some example)))
+The error message is:
+    malformed boolean query -- Invalid token (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2203,7 +2218,10 @@ Input:
 '(path includes (some example)) OR (path includes )some example()'
 =>
 Result:
-malformed boolean query -- Invalid token (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes (some example)) OR (path includes )some example()
+The error message is:
+    malformed boolean query -- Invalid token (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2212,7 +2230,10 @@ Input:
 '(path includes )some example() OR (path includes (some example))'
 =>
 Result:
-malformed boolean query -- Invalid token (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes )some example() OR (path includes (some example))
+The error message is:
+    malformed boolean query -- Invalid token (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2248,7 +2269,10 @@ Input:
 '(path includes a) AND NOT(path includes b)'
 =>
 Result:
-malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes a) AND NOT(path includes b)
+The error message is:
+    malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2257,7 +2281,10 @@ Input:
 '(path includes a) AND(path includes b)'
 =>
 Result:
-malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes a) AND(path includes b)
+The error message is:
+    malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2266,7 +2293,10 @@ Input:
 '(path includes a) OR NOT(path includes b)'
 =>
 Result:
-malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes a) OR NOT(path includes b)
+The error message is:
+    malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2275,7 +2305,10 @@ Input:
 '(path includes a) OR(path includes b)'
 =>
 Result:
-malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes a) OR(path includes b)
+The error message is:
+    malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2284,7 +2317,10 @@ Input:
 '(path includes a) XOR(path includes b)'
 =>
 Result:
-malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes a) XOR(path includes b)
+The error message is:
+    malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2293,7 +2329,10 @@ Input:
 '(path includes a)AND (path includes b)'
 =>
 Result:
-malformed boolean query -- Unexpected character: A. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes a)AND (path includes b)
+The error message is:
+    malformed boolean query -- Unexpected character: A. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2302,7 +2341,10 @@ Input:
 '(path includes a)AND NOT(path includes b)'
 =>
 Result:
-malformed boolean query -- Unexpected character: A. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes a)AND NOT(path includes b)
+The error message is:
+    malformed boolean query -- Unexpected character: A. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2311,7 +2353,10 @@ Input:
 '(path includes a)OR (path includes b)'
 =>
 Result:
-malformed boolean query -- Unexpected character: O. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes a)OR (path includes b)
+The error message is:
+    malformed boolean query -- Unexpected character: O. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2320,7 +2365,10 @@ Input:
 '(path includes a)OR NOT (path includes b)'
 =>
 Result:
-malformed boolean query -- Unexpected character: O. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes a)OR NOT (path includes b)
+The error message is:
+    malformed boolean query -- Unexpected character: O. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2329,7 +2377,10 @@ Input:
 '(path includes a)XOR (path includes b)'
 =>
 Result:
-malformed boolean query -- Unexpected character: X. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    (path includes a)XOR (path includes b)
+The error message is:
+    malformed boolean query -- Unexpected character: X. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2881,7 +2932,10 @@ Input:
 'AND (description includes d1)'
 =>
 Result:
-malformed boolean query -- Invalid token (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    AND (description includes d1)
+The error message is:
+    malformed boolean query -- Invalid token (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -2890,7 +2944,10 @@ Input:
 'NOT   (  happens before blahblahblah  )'
 =>
 Result:
-couldn't parse sub-expression 'happens before blahblahblah': do not understand happens date
+Could not interpret the following instruction as a Boolean combination:
+    NOT   (  happens before blahblahblah  )
+The error message is:
+    couldn't parse sub-expression 'happens before blahblahblah': do not understand happens date
 
 --------------------------------------------------------
 
@@ -2964,7 +3021,10 @@ Input:
 'NOT (description blahblah d1)'
 =>
 Result:
-couldn't parse sub-expression 'description blahblah d1'
+Could not interpret the following instruction as a Boolean combination:
+    NOT (description blahblah d1)
+The error message is:
+    couldn't parse sub-expression 'description blahblah d1'
 
 --------------------------------------------------------
 
@@ -2985,7 +3045,10 @@ Input:
 'NOT (happens before blahblahblah)'
 =>
 Result:
-couldn't parse sub-expression 'happens before blahblahblah': do not understand happens date
+Could not interpret the following instruction as a Boolean combination:
+    NOT (happens before blahblahblah)
+The error message is:
+    couldn't parse sub-expression 'happens before blahblahblah': do not understand happens date
 
 --------------------------------------------------------
 
@@ -3006,7 +3069,10 @@ Input:
 'NOT(path includes b)'
 =>
 Result:
-malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    NOT(path includes b)
+The error message is:
+    malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
 
 --------------------------------------------------------
 
@@ -3015,7 +3081,10 @@ Input:
 'OR (description includes d1)'
 =>
 Result:
-malformed boolean query -- Invalid token (check the documentation for guidelines)
+Could not interpret the following instruction as a Boolean combination:
+    OR (description includes d1)
+The error message is:
+    malformed boolean query -- Invalid token (check the documentation for guidelines)
 
 --------------------------------------------------------
 

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
@@ -378,10 +378,13 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     ( (filter by function task.description.includes('a')) OR (filter by function task.description.includes('b')) OR (filter by function task.description.includes('c')) ) AND ( (filter by function task.description.includes('d')) OR (filter by function task.description.includes('e')) OR (filter by function task.description.includes('f')) )
+
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     ( (f1)) OR (f2)) OR (f3)) ) AND ( (f4)) OR (f5)) OR (f6)) )
+
 Where the sub-expressions in the simplified line are:
     'f1': 'filter by function task.description.includes('a''
     'f2': 'filter by function task.description.includes('b''
@@ -389,6 +392,7 @@ Where the sub-expressions in the simplified line are:
     'f4': 'filter by function task.description.includes('d''
     'f5': 'filter by function task.description.includes('e''
     'f6': 'filter by function task.description.includes('f''
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -460,10 +464,13 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     ( filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type) ) OR ( filter by function const date = task.due.moment; return date ? !date.isValid() : false; ) OR ( filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false ) OR ( filter by function task.urgency.toFixed(2) === 1.95.toFixed(2) ) OR ( filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁') ) OR ( filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase() ) OR ( filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false ) OR ( filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false; )
+
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     ( f1) ) OR ( f2 ) OR ( f3 ) OR ( f4) ) OR ( f5) ) OR ( f6) ) OR ( f7 ) OR ( f8 )
+
 Where the sub-expressions in the simplified line are:
     'f1': 'filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type'
     'f2': 'filter by function const date = task.due.moment; return date ? !date.isValid() : false;'
@@ -473,6 +480,7 @@ Where the sub-expressions in the simplified line are:
     'f6': 'filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase('
     'f7': 'filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false'
     'f8': 'filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -881,13 +889,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (description includes "hello world") OR (description includes "42")
+
 The error message is:
     malformed boolean query -- Unexpected character: " (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1") OR (f2")
+
 Where the sub-expressions in the simplified line are:
     'f1': 'description includes "hello world'
     'f2': 'description includes "42'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -995,13 +1007,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (description includes SHOULD NOT BE RECOGNISED AS A BOOLEAN)AND(description includes BECAUSE THERE ARE NO SPACES AROUND THE 'AND' OPERATOR)
+
 The error message is:
     malformed boolean query -- Unexpected character: A. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1)AND(f2)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'description includes SHOULD NOT BE RECOGNISED AS A BOOLEAN'
     'f2': 'description includes BECAUSE THERE ARE NO SPACES AROUND THE 'AND' OPERATOR'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2237,13 +2253,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes ()some example()) OR (path includes ((some example)))
+
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1)) OR (f2)))
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes ()some example('
     'f2': 'path includes ((some example'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2270,13 +2290,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes (some example)) OR (path includes )some example()
+
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1)) OR (f2)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes (some example'
     'f2': 'path includes )some example('
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2290,13 +2314,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes )some example() OR (path includes (some example))
+
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1) OR (f2))
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes )some example('
     'f2': 'path includes (some example'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2337,13 +2365,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes a) AND NOT(path includes b)
+
 The error message is:
     malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1) AND NOT(f2)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2357,13 +2389,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes a) AND(path includes b)
+
 The error message is:
     malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1) AND(f2)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2377,13 +2413,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes a) OR NOT(path includes b)
+
 The error message is:
     malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1) OR NOT(f2)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2397,13 +2437,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes a) OR(path includes b)
+
 The error message is:
     malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1) OR(f2)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2417,13 +2461,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes a) XOR(path includes b)
+
 The error message is:
     malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1) XOR(f2)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2437,13 +2485,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes a)AND (path includes b)
+
 The error message is:
     malformed boolean query -- Unexpected character: A. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1)AND (f2)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2457,13 +2509,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes a)AND NOT(path includes b)
+
 The error message is:
     malformed boolean query -- Unexpected character: A. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1)AND NOT(f2)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2477,13 +2533,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes a)OR (path includes b)
+
 The error message is:
     malformed boolean query -- Unexpected character: O. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1)OR (f2)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2497,13 +2557,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes a)OR NOT (path includes b)
+
 The error message is:
     malformed boolean query -- Unexpected character: O. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1)OR NOT (f2)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -2517,13 +2581,17 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     (path includes a)XOR (path includes b)
+
 The error message is:
     malformed boolean query -- Unexpected character: X. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     (f1)XOR (f2)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes a'
     'f2': 'path includes b'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -3080,12 +3148,16 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     AND (description includes d1)
+
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     f1)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'AND (description includes d1'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -3099,12 +3171,16 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     NOT   (  happens before blahblahblah  )
+
 The error message is:
     couldn't parse sub-expression 'happens before blahblahblah': do not understand happens date
+
 The instruction was converted to the following simplified line:
     NOT   (  f1  )
+
 Where the sub-expressions in the simplified line are:
     'f1': 'happens before blahblahblah'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -3183,12 +3259,16 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     NOT (description blahblah d1)
+
 The error message is:
     couldn't parse sub-expression 'description blahblah d1'
+
 The instruction was converted to the following simplified line:
     NOT (f1)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'description blahblah d1'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -3214,12 +3294,16 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     NOT (happens before blahblahblah)
+
 The error message is:
     couldn't parse sub-expression 'happens before blahblahblah': do not understand happens date
+
 The instruction was converted to the following simplified line:
     NOT (f1)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'happens before blahblahblah'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -3245,12 +3329,16 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     NOT(path includes b)
+
 The error message is:
     malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     NOT(f1)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes b'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
@@ -3264,12 +3352,16 @@ Input:
 Result:
 Could not interpret the following instruction as a Boolean combination:
     OR (description includes d1)
+
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+
 The instruction was converted to the following simplified line:
     f1)
+
 Where the sub-expressions in the simplified line are:
     'f1': 'OR (description includes d1'
+
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
@@ -380,6 +380,16 @@ Could not interpret the following instruction as a Boolean combination:
     ( (filter by function task.description.includes('a')) OR (filter by function task.description.includes('b')) OR (filter by function task.description.includes('c')) ) AND ( (filter by function task.description.includes('d')) OR (filter by function task.description.includes('e')) OR (filter by function task.description.includes('f')) )
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    ( (f1)) OR (f2)) OR (f3)) ) AND ( (f4)) OR (f5)) OR (f6)) )
+Where the sub-expressions in the simplified line are:
+    'f1': 'filter by function task.description.includes('a''
+    'f2': 'filter by function task.description.includes('b''
+    'f3': 'filter by function task.description.includes('c''
+    'f4': 'filter by function task.description.includes('d''
+    'f5': 'filter by function task.description.includes('e''
+    'f6': 'filter by function task.description.includes('f''
+
 
 --------------------------------------------------------
 
@@ -450,6 +460,18 @@ Could not interpret the following instruction as a Boolean combination:
     ( filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type) ) OR ( filter by function const date = task.due.moment; return date ? !date.isValid() : false; ) OR ( filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false ) OR ( filter by function task.urgency.toFixed(2) === 1.95.toFixed(2) ) OR ( filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁') ) OR ( filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase() ) OR ( filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false ) OR ( filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false; )
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    ( f1) ) OR ( f2 ) OR ( f3 ) OR ( f4) ) OR ( f5) ) OR ( f6) ) OR ( f7 ) OR ( f8 )
+Where the sub-expressions in the simplified line are:
+    'f1': 'filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type'
+    'f2': 'filter by function const date = task.due.moment; return date ? !date.isValid() : false;'
+    'f3': 'filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false'
+    'f4': 'filter by function task.urgency.toFixed(2) === 1.95.toFixed(2'
+    'f5': 'filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁''
+    'f6': 'filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase('
+    'f7': 'filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false'
+    'f8': 'filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;'
+
 
 --------------------------------------------------------
 
@@ -857,6 +879,12 @@ Could not interpret the following instruction as a Boolean combination:
     (description includes "hello world") OR (description includes "42")
 The error message is:
     malformed boolean query -- Unexpected character: " (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1") OR (f2")
+Where the sub-expressions in the simplified line are:
+    'f1': 'description includes "hello world'
+    'f2': 'description includes "42'
+
 
 --------------------------------------------------------
 
@@ -963,6 +991,12 @@ Could not interpret the following instruction as a Boolean combination:
     (description includes SHOULD NOT BE RECOGNISED AS A BOOLEAN)AND(description includes BECAUSE THERE ARE NO SPACES AROUND THE 'AND' OPERATOR)
 The error message is:
     malformed boolean query -- Unexpected character: A. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1)AND(f2)
+Where the sub-expressions in the simplified line are:
+    'f1': 'description includes SHOULD NOT BE RECOGNISED AS A BOOLEAN'
+    'f2': 'description includes BECAUSE THERE ARE NO SPACES AROUND THE 'AND' OPERATOR'
+
 
 --------------------------------------------------------
 
@@ -2197,6 +2231,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes ()some example()) OR (path includes ((some example)))
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1)) OR (f2)))
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes ()some example('
+    'f2': 'path includes ((some example'
+
 
 --------------------------------------------------------
 
@@ -2222,6 +2262,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes (some example)) OR (path includes )some example()
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1)) OR (f2)
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes (some example'
+    'f2': 'path includes )some example('
+
 
 --------------------------------------------------------
 
@@ -2234,6 +2280,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes )some example() OR (path includes (some example))
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1) OR (f2))
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes )some example('
+    'f2': 'path includes (some example'
+
 
 --------------------------------------------------------
 
@@ -2273,6 +2325,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes a) AND NOT(path includes b)
 The error message is:
     malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1) AND NOT(f2)
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes a'
+    'f2': 'path includes b'
+
 
 --------------------------------------------------------
 
@@ -2285,6 +2343,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes a) AND(path includes b)
 The error message is:
     malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1) AND(f2)
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes a'
+    'f2': 'path includes b'
+
 
 --------------------------------------------------------
 
@@ -2297,6 +2361,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes a) OR NOT(path includes b)
 The error message is:
     malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1) OR NOT(f2)
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes a'
+    'f2': 'path includes b'
+
 
 --------------------------------------------------------
 
@@ -2309,6 +2379,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes a) OR(path includes b)
 The error message is:
     malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1) OR(f2)
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes a'
+    'f2': 'path includes b'
+
 
 --------------------------------------------------------
 
@@ -2321,6 +2397,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes a) XOR(path includes b)
 The error message is:
     malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1) XOR(f2)
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes a'
+    'f2': 'path includes b'
+
 
 --------------------------------------------------------
 
@@ -2333,6 +2415,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes a)AND (path includes b)
 The error message is:
     malformed boolean query -- Unexpected character: A. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1)AND (f2)
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes a'
+    'f2': 'path includes b'
+
 
 --------------------------------------------------------
 
@@ -2345,6 +2433,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes a)AND NOT(path includes b)
 The error message is:
     malformed boolean query -- Unexpected character: A. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1)AND NOT(f2)
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes a'
+    'f2': 'path includes b'
+
 
 --------------------------------------------------------
 
@@ -2357,6 +2451,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes a)OR (path includes b)
 The error message is:
     malformed boolean query -- Unexpected character: O. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1)OR (f2)
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes a'
+    'f2': 'path includes b'
+
 
 --------------------------------------------------------
 
@@ -2369,6 +2469,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes a)OR NOT (path includes b)
 The error message is:
     malformed boolean query -- Unexpected character: O. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1)OR NOT (f2)
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes a'
+    'f2': 'path includes b'
+
 
 --------------------------------------------------------
 
@@ -2381,6 +2487,12 @@ Could not interpret the following instruction as a Boolean combination:
     (path includes a)XOR (path includes b)
 The error message is:
     malformed boolean query -- Unexpected character: X. A closing parenthesis should be followed by another closing parenthesis or whitespace (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    (f1)XOR (f2)
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes a'
+    'f2': 'path includes b'
+
 
 --------------------------------------------------------
 
@@ -2936,6 +3048,11 @@ Could not interpret the following instruction as a Boolean combination:
     AND (description includes d1)
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    f1)
+Where the sub-expressions in the simplified line are:
+    'f1': 'AND (description includes d1'
+
 
 --------------------------------------------------------
 
@@ -2948,6 +3065,11 @@ Could not interpret the following instruction as a Boolean combination:
     NOT   (  happens before blahblahblah  )
 The error message is:
     couldn't parse sub-expression 'happens before blahblahblah': do not understand happens date
+The instruction was converted to the following simplified line:
+    NOT   (  f1  )
+Where the sub-expressions in the simplified line are:
+    'f1': 'happens before blahblahblah'
+
 
 --------------------------------------------------------
 
@@ -3025,6 +3147,11 @@ Could not interpret the following instruction as a Boolean combination:
     NOT (description blahblah d1)
 The error message is:
     couldn't parse sub-expression 'description blahblah d1'
+The instruction was converted to the following simplified line:
+    NOT (f1)
+Where the sub-expressions in the simplified line are:
+    'f1': 'description blahblah d1'
+
 
 --------------------------------------------------------
 
@@ -3049,6 +3176,11 @@ Could not interpret the following instruction as a Boolean combination:
     NOT (happens before blahblahblah)
 The error message is:
     couldn't parse sub-expression 'happens before blahblahblah': do not understand happens date
+The instruction was converted to the following simplified line:
+    NOT (f1)
+Where the sub-expressions in the simplified line are:
+    'f1': 'happens before blahblahblah'
+
 
 --------------------------------------------------------
 
@@ -3073,6 +3205,11 @@ Could not interpret the following instruction as a Boolean combination:
     NOT(path includes b)
 The error message is:
     malformed boolean query -- Unexpected character: (. Operators should be separated using whitespace (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    NOT(f1)
+Where the sub-expressions in the simplified line are:
+    'f1': 'path includes b'
+
 
 --------------------------------------------------------
 
@@ -3085,6 +3222,11 @@ Could not interpret the following instruction as a Boolean combination:
     OR (description includes d1)
 The error message is:
     malformed boolean query -- Invalid token (check the documentation for guidelines)
+The instruction was converted to the following simplified line:
+    f1)
+Where the sub-expressions in the simplified line are:
+    'f1': 'OR (description includes d1'
+
 
 --------------------------------------------------------
 

--- a/tests/Query/Filter/BooleanField.test.ts
+++ b/tests/Query/Filter/BooleanField.test.ts
@@ -166,7 +166,13 @@ describe('boolean query - filter', () => {
                     "Could not interpret the following instruction as a Boolean combination:
                         (description includes "hello world") OR (description includes "42")
                     The error message is:
-                        malformed boolean query -- Unexpected character: " (check the documentation for guidelines)"
+                        malformed boolean query -- Unexpected character: " (check the documentation for guidelines)
+                    The instruction was converted to the following simplified line:
+                        (f1") OR (f2")
+                    Where the sub-expressions in the simplified line are:
+                        'f1': 'description includes "hello world'
+                        'f2': 'description includes "42'
+                    "
                 `);
             });
         });

--- a/tests/Query/Filter/BooleanField.test.ts
+++ b/tests/Query/Filter/BooleanField.test.ts
@@ -172,6 +172,8 @@ describe('boolean query - filter', () => {
                     Where the sub-expressions in the simplified line are:
                         'f1': 'description includes "hello world'
                         'f2': 'description includes "42'
+                    For help, see:
+                        https://publish.obsidian.md/tasks/Queries/Combining+Filters
                     "
                 `);
             });

--- a/tests/Query/Filter/BooleanField.test.ts
+++ b/tests/Query/Filter/BooleanField.test.ts
@@ -162,9 +162,12 @@ describe('boolean query - filter', () => {
                 // This searches for words surrounded by double-quotes:
                 const filter = createValidFilter('(description includes "hello world") OR (description includes "42")');
                 // TODO Fix this:
-                expect(explanationOrError(filter)).toMatchInlineSnapshot(
-                    '"malformed boolean query -- Unexpected character: " (check the documentation for guidelines)"',
-                );
+                expect(explanationOrError(filter)).toMatchInlineSnapshot(`
+                    "Could not interpret the following instruction as a Boolean combination:
+                        (description includes "hello world") OR (description includes "42")
+                    The error message is:
+                        malformed boolean query -- Unexpected character: " (check the documentation for guidelines)"
+                `);
             });
         });
 
@@ -271,7 +274,7 @@ describe('boolean query - filter', () => {
             'should report expected error message: on "%s" - expected "%s"',
             (instruction: string, expectedError: string) => {
                 const filter = new BooleanField().createFilterOrErrorMessage(instruction);
-                expect(filter.error).toStrictEqual(expectedError);
+                expect(filter.error).toContain(expectedError);
             },
         );
 

--- a/tests/Query/Filter/BooleanField.test.ts
+++ b/tests/Query/Filter/BooleanField.test.ts
@@ -165,13 +165,17 @@ describe('boolean query - filter', () => {
                 expect(explanationOrError(filter)).toMatchInlineSnapshot(`
                     "Could not interpret the following instruction as a Boolean combination:
                         (description includes "hello world") OR (description includes "42")
+
                     The error message is:
                         malformed boolean query -- Unexpected character: " (check the documentation for guidelines)
+
                     The instruction was converted to the following simplified line:
                         (f1") OR (f2")
+
                     Where the sub-expressions in the simplified line are:
                         'f1': 'description includes "hello world'
                         'f2': 'description includes "42'
+
                     For help, see:
                         https://publish.obsidian.md/tasks/Queries/Combining+Filters
                     "


### PR DESCRIPTION
# Description

Provide meaningful information to help users trouble-shoot any problems with Boolean filters.

*Note: more improvements are coming so I am not updating the documentation yet.*

(This replaces #2760 which was created before I pushed some changes to `main`)

## Motivation and Context

Try to provide a 'help' message rather than 'error' message.

Based on: <https://twitter.com/travis_simon/status/1069074730211135488>

![image](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/4840096/9f045f72-b485-4a8e-8134-d76c14c2f463)


## How has this been tested?

- Automated tests
- Exploratory testing

## Screenshots (if appropriate)

Before:

```text
malformed boolean query -- Unexpected character: " (check the documentation for guidelines)
```


After:

```text
Could not interpret the following instruction as a Boolean combination:  
    (description includes "hello world") OR (description includes "42")  
  
The error message is:  
    malformed boolean query -- Unexpected character: " (check the documentation for guidelines)  
  
The instruction was converted to the following simplified line:  
    (f1") OR (f2")  
  
Where the sub-expressions in the simplified line are:  
    'f1': 'description includes "hello world'  
    'f2': 'description includes "42'  
  
For help, see:  
    https://publish.obsidian.md/tasks/Queries/Combining+Filters
```

## Types of changes

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
    - *Will be done later*
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
