### PR TITLE
feat: Add Relations Between Tasks

### DIFF
--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -74,6 +74,11 @@ export class Task {
 
     public readonly scheduledDateIsInferred: boolean;
 
+    public parent: Task | null = null;
+    public previousSibling: Task | null = null;
+    public nextSibling: Task | null = null;
+    public children: Task[] = [];
+
     private _urgency: number | null = null;
 
     constructor({

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -54,7 +54,7 @@ describe('TaskBuilder', () => {
     it('createFullyPopulatedTask() should populate every field', () => {
         const task: Task = TaskBuilder.createFullyPopulatedTask();
 
-        expect(getNullOrUnsetFields(task)).toEqual([]);
+        expect(getNullOrUnsetFields(task)).toEqual(['parent', 'previousSibling', 'nextSibling', 'children']);
         expect(getNullOrUnsetFields(task.taskLocation)).toEqual([]);
 
         expect(task.originalMarkdown).toEqual(


### PR DESCRIPTION
I want to have relations between tasks in a single page.
For example:
```
- [ ] Task 1
  - [ ] Task 2
  - [ ] Task 3
```
Task 1 is a parent task for Tasks 2 and 3. And also Tasks 2 and 3 are siblings

# Description

I have added new fields to Task class: parent, children, nextSibling, previousSibling
And added a function in Cache.getTasksFromFileContent, that initializes all the relations (sets that new fields) for all tasks in the file.

## Motivation and Context

I'm trying to improve my particular case, but I believe this is useful feature for many situations.
I want to build sequential tasks in my project. A project is a single page in obsidian vault. And I want to do all the task there one by one. And I also want to see first unfinished task for that project

For that case I could make a function filter like this:
```
filter function task.previousSibling == null || task.previousSibling.isDone() 
```

Other useful case would be hiding a task while it has any undone child.



## How has this been tested?

I didn't make unit tests for that function due to there is no tests at all for Cache.ts
I built everything locally and manually tested everything this extensive logging and lot's of corner cases
I've tested both parsing and custom function filtering.

## Screenshots (if appropriate)

## Types of changes

Changes visible to users:

- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [X] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
