### PR TITLE
feat: Further improve Boolean help messages

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/Filters/Boolean Combinations.md
+++ b/resources/sample_vaults/Tasks-Demo/Filters/Boolean Combinations.md
@@ -202,3 +202,24 @@ hide backlinks
 (filter by function task.tags.join(',').toUpperCase().includes('#YY'); ) AND \
 (filter by function task.tags.join(',').toUpperCase().includes('#ZZ'); )
 ```
+
+#### Workaround 3: port the Boolean logic to JavaScript
+
+We can instead migrate the Boolean operators to JavaScript:
+
+- `AND` -> `&&`
+- `OR` -> `||`
+- `NOT` -> `!`
+
+Like this:
+
+```tasks
+ignore global query
+explain
+hide backlinks
+
+filter by function \
+    task.tags.join(',').toUpperCase().includes('#XX') && \
+    task.tags.join(',').toUpperCase().includes('#YY') && \
+    task.tags.join(',').toUpperCase().includes('#ZZ')
+```

--- a/resources/sample_vaults/Tasks-Demo/Filters/Boolean Combinations.md
+++ b/resources/sample_vaults/Tasks-Demo/Filters/Boolean Combinations.md
@@ -25,14 +25,20 @@ Full documentation is available: see [Combining Filters](https://publish.obsidia
 ### AND - XX and YY
 
 ```tasks
-not done
+ignore global query
+explain
+hide backlinks
+
 (tags includes #XX) AND (tags includes #YY)
 ```
 
 ### AND - XX and YY and ZZ
 
 ```tasks
-not done
+ignore global query
+explain
+hide backlinks
+
 (tags includes #XX) AND (tags includes #YY) AND (tags includes #ZZ)
 ```
 
@@ -41,7 +47,10 @@ not done
 ### OR - XX OR YY
 
 ```tasks
-not done
+ignore global query
+explain
+hide backlinks
+
 (tags includes #XX) OR (tags includes #YY)
 ```
 
@@ -52,7 +61,10 @@ not done
 ### XOR
 
 ```tasks
-not done
+ignore global query
+explain
+hide backlinks
+
 (tags includes #XX) XOR (tags includes #YY)
 ```
 
@@ -62,7 +74,10 @@ Note the inclusion of 'task 7'. Combining multiple `XOR` does not give the expec
 See [this question and its answers](https://electronics.stackexchange.com/questions/93713/how-is-an-xor-with-more-than-2-inputs-supposed-to-work).
 
 ```tasks
-not done
+ignore global query
+explain
+hide backlinks
+
 (tags includes #XX) XOR (tags includes #YY) XOR (tags includes #ZZ)
 ```
 
@@ -71,14 +86,20 @@ not done
 Matching only one of 3 filters - version 1:
 
 ```tasks
-not done
+ignore global query
+explain
+hide backlinks
+
 ( (tags includes #XX) AND (tags does not include #YY) AND (tags does not include #ZZ) ) OR ( (tags includes #YY) AND (tags does not include #XX) AND (tags does not include #ZZ) ) OR ( (tags includes #ZZ) AND (tags does not include #XX) AND (tags does not include #YY) )
 ```
 
 Matching only one of 3 filters - version 2:
 
 ```tasks
-not done
+ignore global query
+explain
+hide backlinks
+
 (tags includes #XX) XOR (tags includes #YY) XOR (tags includes #ZZ)
 NOT ( (tags includes #XX) AND (tags includes #YY) AND (tags includes #ZZ) )
 ```

--- a/resources/sample_vaults/Tasks-Demo/Filters/Boolean Combinations.md
+++ b/resources/sample_vaults/Tasks-Demo/Filters/Boolean Combinations.md
@@ -161,7 +161,6 @@ ignore global query
 explain
 hide backlinks
 
-limit 1
 (filter by function task.tags.join(',').toUpperCase().includes('#XX')) AND \
 (filter by function task.tags.join(',').toUpperCase().includes('#YY')) AND \
 (filter by function task.tags.join(',').toUpperCase().includes('#ZZ'))
@@ -185,7 +184,6 @@ ignore global query
 explain
 hide backlinks
 
-limit 1
 [filter by function task.tags.join(',').toUpperCase().includes('#XX')] AND \
 [filter by function task.tags.join(',').toUpperCase().includes('#YY')] AND \
 [filter by function task.tags.join(',').toUpperCase().includes('#ZZ')]
@@ -200,7 +198,6 @@ ignore global query
 explain
 hide backlinks
 
-limit 1
 (filter by function task.tags.join(',').toUpperCase().includes('#XX'); ) AND \
 (filter by function task.tags.join(',').toUpperCase().includes('#YY'); ) AND \
 (filter by function task.tags.join(',').toUpperCase().includes('#ZZ'); )

--- a/resources/sample_vaults/Tasks-Demo/Filters/Boolean Combinations.md
+++ b/resources/sample_vaults/Tasks-Demo/Filters/Boolean Combinations.md
@@ -103,3 +103,68 @@ hide backlinks
 (tags includes #XX) XOR (tags includes #YY) XOR (tags includes #ZZ)
 NOT ( (tags includes #XX) AND (tags includes #YY) AND (tags includes #ZZ) )
 ```
+
+## Error Cases
+
+These examples demonstrate the error messages for various problem scenarios.
+
+### Extra delimiter in user query
+
+```tasks
+ignore global query
+explain
+hide backlinks
+
+(tags includes #XX) AND (tags includes #YY))
+```
+
+### Missing delimiter at end of user query
+
+```tasks
+ignore global query
+explain
+hide backlinks
+
+(tags includes #XX) AND (tags includes #YY
+```
+
+### Delimiter swallowed by Tasks' parsing code
+
+#### The Problem
+
+```tasks
+ignore global query
+explain
+hide backlinks
+
+limit 1
+(filter by function task.tags.join(',').toUpperCase().includes('#XX')) AND \
+(filter by function task.tags.join(',').toUpperCase().includes('#YY')) AND \
+(filter by function task.tags.join(',').toUpperCase().includes('#ZZ'))
+```
+
+#### Workaround 1: use a different delimiter
+
+```tasks
+ignore global query
+explain
+hide backlinks
+
+limit 1
+[filter by function task.tags.join(',').toUpperCase().includes('#XX')] AND \
+[filter by function task.tags.join(',').toUpperCase().includes('#YY')] AND \
+[filter by function task.tags.join(',').toUpperCase().includes('#ZZ')]
+```
+
+#### Workaround 2: add semicolons to filter by function
+
+```tasks
+ignore global query
+explain
+hide backlinks
+
+limit 1
+(filter by function task.tags.join(',').toUpperCase().includes('#XX'); ) AND \
+(filter by function task.tags.join(',').toUpperCase().includes('#YY'); ) AND \
+(filter by function task.tags.join(',').toUpperCase().includes('#ZZ'); )
+```

--- a/resources/sample_vaults/Tasks-Demo/Filters/Boolean Combinations.md
+++ b/resources/sample_vaults/Tasks-Demo/Filters/Boolean Combinations.md
@@ -110,6 +110,12 @@ These examples demonstrate the error messages for various problem scenarios.
 
 ### Extra delimiter in user query
 
+The Boolean line ends with a stray extra `)`.
+
+This is just an invalid query, and the extra `)` needs to be removed.
+
+This can be spotted in the error output by looking at the delimiters on the `simplified line` in the output:
+
 ```tasks
 ignore global query
 explain
@@ -119,6 +125,12 @@ hide backlinks
 ```
 
 ### Missing delimiter at end of user query
+
+Here, the final `)` is missing from the end of the Boolean line.
+
+Tasks checks that first and last character on Boolean lines, to ensure that consistent delimiters are used.
+
+In this particular case, the error message is not overly helpful.
 
 ```tasks
 ignore global query
@@ -131,6 +143,18 @@ hide backlinks
 ### Delimiter swallowed by Tasks' parsing code
 
 #### The Problem
+
+In this example, each of the filters ends with a `)`, which is also the closing delimiter character in this Boolean line.
+
+Looking at the error message shows the error `SyntaxError: missing ) after argument list`.
+
+Basically, it was really hard to come up with an algorithm that allowed brackets inside filters, and allowed nested brackets in the Boolean logic.
+
+We have settled on an algorithm that greedily matches all delimeters just around the operators (`AND`, `OR` etc)
+
+This situation is most common with `filter by function`, as often JavaScript functions are then called.
+
+Read on for two different ways to fix this problem.
 
 ```tasks
 ignore global query
@@ -145,6 +169,17 @@ limit 1
 
 #### Workaround 1: use a different delimiter
 
+The following delimiter characters are available:
+
+- `(....)`
+- `[....]`
+- `{....}`
+- `"...."`
+
+We can choose any one of those delimiters sets, so long as we use the same delimiters for all sub-expressions on the line.
+
+Here, we adjust the expression to use `[....]` instead of `(....)`:
+
 ```tasks
 ignore global query
 explain
@@ -157,6 +192,8 @@ limit 1
 ```
 
 #### Workaround 2: add semicolons to filter by function
+
+Our other option for fixing the error is to add semicolons (`;`) at the end of each sub-expression, to put non-space character between the `)` in the `filter by function` expression and the `) AND`:
 
 ```tasks
 ignore global query

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -293,10 +293,7 @@ For help, see:
     private stringifySubExpressionStatus(line: string) {
         const parsedField = parseFilter(line);
         if (!parsedField) {
-            let filterStatus;
-            filterStatus = 'ERROR:';
-            filterStatus += '\n           do not understand query';
-            return filterStatus;
+            return 'ERROR:\n           do not understand query';
         }
         if (parsedField?.error) {
             let filterStatus;

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -282,8 +282,12 @@ For help, see:
     private stringifySubExpressionsForErrorMessage(filters: { [p: string]: string }) {
         return Object.entries(filters)
             .map(([key, value]) => {
+                // Tell the user whether the sub-expression is valid, to work out which ones need fixing.
                 const parsedField = parseFilter(value);
-                const filterStatus = parsedField?.error ? 'ERROR' : 'OK';
+                let filterStatus = parsedField?.error ? 'ERROR:' : 'OK';
+                if (parsedField?.error) {
+                    filterStatus += '\n' + parsedField?.error;
+                }
                 return `    '${key}': '${value}'
         => ${filterStatus}`;
             })

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -295,10 +295,10 @@ For help, see:
         if (!parsedField) {
             return 'ERROR:\n           do not understand query';
         }
-        if (parsedField?.error) {
+        if (parsedField.error) {
             // In case the error message has more than one line, we split it in to separate lines,
             // apply some standard/tidy indentation, and join the lines again:
-            const formattedFilterStatus = parsedField?.error
+            const formattedFilterStatus = parsedField.error
                 .split('\n')
                 .map((line) => line.trim())
                 .join('\n           ');

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -296,6 +296,8 @@ For help, see:
             return 'ERROR:\n           do not understand query';
         }
         if (parsedField?.error) {
+            // In case the error message has more than one line, we split it in to separate lines,
+            // apply some standard/tidy indentation, and join the lines again:
             const formattedFilterStatus = parsedField?.error
                 .split('\n')
                 .map((line) => line.trim())

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -281,9 +281,9 @@ For help, see:
 
     private stringifySubExpressionsForErrorMessage(filters: { [p: string]: string }) {
         return Object.entries(filters)
-            .map(([key, value]) => {
+            .map(([placeholder, line]) => {
                 // Tell the user whether the sub-expression is valid, to work out which ones need fixing.
-                const parsedField = parseFilter(value);
+                const parsedField = parseFilter(line);
                 let filterStatus = 'OK';
                 if (!parsedField) {
                     filterStatus = 'ERROR:';
@@ -297,7 +297,7 @@ For help, see:
                         .join('\n           ');
                     filterStatus += `\n           ${formattedFilterStatus}`;
                 }
-                return `    '${key}': '${value}'
+                return `    '${placeholder}': '${line}'
         => ${filterStatus}`;
             })
             .join('\n');

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -282,7 +282,10 @@ For help, see:
     private stringifySubExpressionsForErrorMessage(filters: { [p: string]: string }) {
         return Object.entries(filters)
             .map(([key, value]) => {
-                return `    '${key}': '${value}'`;
+                const parsedField = parseFilter(value);
+                const filterStatus = parsedField?.error ? 'ERROR' : 'OK';
+                return `    '${key}': '${value}'
+        => ${filterStatus}`;
             })
             .join('\n');
     }

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -296,14 +296,11 @@ For help, see:
             return 'ERROR:\n           do not understand query';
         }
         if (parsedField?.error) {
-            let filterStatus;
-            filterStatus = 'ERROR:';
             const formattedFilterStatus = parsedField?.error
                 .split('\n')
                 .map((line) => line.trim())
                 .join('\n           ');
-            filterStatus += `\n           ${formattedFilterStatus}`;
-            return filterStatus;
+            return `ERROR:\n           ${formattedFilterStatus}`;
         }
         return 'OK';
     }

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -1,5 +1,5 @@
-import { parse as boonParse } from 'boon-js';
 import type { PostfixExpression } from 'boon-js';
+import { parse as boonParse } from 'boon-js';
 import type { Token } from 'boon-js/lib/types';
 
 import { parseFilter } from '../FilterParser';
@@ -262,11 +262,7 @@ export class BooleanField extends Field {
      */
     private helpMessage(line: string, errorMessage: string, parseResult: BooleanPreprocessorResult) {
         const filters: { [key: string]: string } = parseResult.filters;
-        const expressions = Object.entries(filters)
-            .map(([key, value]) => {
-                return `    '${key}': '${value}'`;
-            })
-            .join('\n');
+        const expressions = this.stringifySubExpressionsForErrorMessage(filters);
 
         const simpleMessage = this.helpMessageFromSimpleError(line, errorMessage);
         const fullMessage = `${simpleMessage}
@@ -281,6 +277,14 @@ For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 `;
         return FilterOrErrorMessage.fromError(line, fullMessage);
+    }
+
+    private stringifySubExpressionsForErrorMessage(filters: { [p: string]: string }) {
+        return Object.entries(filters)
+            .map(([key, value]) => {
+                return `    '${key}': '${value}'`;
+            })
+            .join('\n');
     }
 
     private helpMessageFromSimpleError(line: string, errorMessage: string) {

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -284,8 +284,12 @@ For help, see:
             .map(([key, value]) => {
                 // Tell the user whether the sub-expression is valid, to work out which ones need fixing.
                 const parsedField = parseFilter(value);
-                let filterStatus = parsedField?.error ? 'ERROR:' : 'OK';
-                if (parsedField?.error) {
+                let filterStatus = 'OK';
+                if (!parsedField) {
+                    filterStatus = 'ERROR:';
+                    filterStatus += '\n           do not understand query';
+                } else if (parsedField?.error) {
+                    filterStatus = 'ERROR:';
                     const filterError = parsedField?.error ?? '';
                     const formattedFilterStatus = filterError
                         .split('\n')

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -286,7 +286,12 @@ For help, see:
                 const parsedField = parseFilter(value);
                 let filterStatus = parsedField?.error ? 'ERROR:' : 'OK';
                 if (parsedField?.error) {
-                    filterStatus += '\n' + parsedField?.error;
+                    const filterError = parsedField?.error ?? '';
+                    const formattedFilterStatus = filterError
+                        .split('\n')
+                        .map((line) => line.trim())
+                        .join('\n           ');
+                    filterStatus += `\n           ${formattedFilterStatus}`;
                 }
                 return `    '${key}': '${value}'
         => ${filterStatus}`;

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -298,7 +298,7 @@ For help, see:
         if (parsedField?.error) {
             let filterStatus;
             filterStatus = 'ERROR:';
-            const filterError = parsedField?.error ?? '';
+            const filterError = parsedField?.error;
             const formattedFilterStatus = filterError
                 .split('\n')
                 .map((line) => line.trim())

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -283,24 +283,29 @@ For help, see:
         return Object.entries(filters)
             .map(([placeholder, line]) => {
                 // Tell the user whether the sub-expression is valid, to work out which ones need fixing.
-                const parsedField = parseFilter(line);
-                let filterStatus = 'OK';
-                if (!parsedField) {
-                    filterStatus = 'ERROR:';
-                    filterStatus += '\n           do not understand query';
-                } else if (parsedField?.error) {
-                    filterStatus = 'ERROR:';
-                    const filterError = parsedField?.error ?? '';
-                    const formattedFilterStatus = filterError
-                        .split('\n')
-                        .map((line) => line.trim())
-                        .join('\n           ');
-                    filterStatus += `\n           ${formattedFilterStatus}`;
-                }
+                const filterStatus = this.stringifySubExpressionStatus(line);
                 return `    '${placeholder}': '${line}'
         => ${filterStatus}`;
             })
             .join('\n');
+    }
+
+    private stringifySubExpressionStatus(line: string) {
+        const parsedField = parseFilter(line);
+        let filterStatus = 'OK';
+        if (!parsedField) {
+            filterStatus = 'ERROR:';
+            filterStatus += '\n           do not understand query';
+        } else if (parsedField?.error) {
+            filterStatus = 'ERROR:';
+            const filterError = parsedField?.error ?? '';
+            const formattedFilterStatus = filterError
+                .split('\n')
+                .map((line) => line.trim())
+                .join('\n           ');
+            filterStatus += `\n           ${formattedFilterStatus}`;
+        }
+        return filterStatus;
     }
 
     private helpMessageFromSimpleError(line: string, errorMessage: string) {

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -283,9 +283,8 @@ For help, see:
         return Object.entries(filters)
             .map(([placeholder, line]) => {
                 // Tell the user whether the sub-expression is valid, to work out which ones need fixing.
-                const filterStatus = this.stringifySubExpressionStatus(line);
                 return `    '${placeholder}': '${line}'
-        => ${filterStatus}`;
+        => ${this.stringifySubExpressionStatus(line)}`;
             })
             .join('\n');
     }

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -297,7 +297,8 @@ For help, see:
             filterStatus = 'ERROR:';
             filterStatus += '\n           do not understand query';
             return filterStatus;
-        } else if (parsedField?.error) {
+        }
+        if (parsedField?.error) {
             filterStatus = 'ERROR:';
             const filterError = parsedField?.error ?? '';
             const formattedFilterStatus = filterError

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -298,8 +298,7 @@ For help, see:
         if (parsedField?.error) {
             let filterStatus;
             filterStatus = 'ERROR:';
-            const filterError = parsedField?.error;
-            const formattedFilterStatus = filterError
+            const formattedFilterStatus = parsedField?.error
                 .split('\n')
                 .map((line) => line.trim())
                 .join('\n           ');

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -296,6 +296,7 @@ For help, see:
         if (!parsedField) {
             filterStatus = 'ERROR:';
             filterStatus += '\n           do not understand query';
+            return filterStatus;
         } else if (parsedField?.error) {
             filterStatus = 'ERROR:';
             const filterError = parsedField?.error ?? '';
@@ -304,6 +305,7 @@ For help, see:
                 .map((line) => line.trim())
                 .join('\n           ');
             filterStatus += `\n           ${formattedFilterStatus}`;
+            return filterStatus;
         }
         return filterStatus;
     }

--- a/src/Query/Filter/BooleanField.ts
+++ b/src/Query/Filter/BooleanField.ts
@@ -292,13 +292,14 @@ For help, see:
 
     private stringifySubExpressionStatus(line: string) {
         const parsedField = parseFilter(line);
-        let filterStatus = 'OK';
         if (!parsedField) {
+            let filterStatus;
             filterStatus = 'ERROR:';
             filterStatus += '\n           do not understand query';
             return filterStatus;
         }
         if (parsedField?.error) {
+            let filterStatus;
             filterStatus = 'ERROR:';
             const filterError = parsedField?.error ?? '';
             const formattedFilterStatus = filterError
@@ -308,7 +309,7 @@ For help, see:
             filterStatus += `\n           ${formattedFilterStatus}`;
             return filterStatus;
         }
-        return filterStatus;
+        return 'OK';
     }
 
     private helpMessageFromSimpleError(line: string, errorMessage: string) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -17,7 +17,7 @@ import { continueLines } from './Scanner';
 import { SearchInfo } from './SearchInfo';
 import { Sort } from './Sort/Sort';
 import type { Sorter } from './Sort/Sorter';
-import type { Statement } from './Statement';
+import { Statement } from './Statement';
 
 export class Query implements IQuery {
     /** Note: source is the raw source, before expanding any placeholders */
@@ -74,7 +74,7 @@ export class Query implements IQuery {
                     message = 'Unknown error';
                 }
 
-                this.setError(message, line);
+                this.setError(message, line, statement);
                 return;
             }
         });
@@ -114,7 +114,7 @@ export class Query implements IQuery {
             case this.parseFilter(line, statement):
                 break;
             default:
-                this.setError('do not understand query', line);
+                this.setError('do not understand query', line, statement);
         }
     }
 
@@ -240,9 +240,16 @@ ${source}`;
         return this._error;
     }
 
-    private setError(message: string, line: string) {
-        this._error = `${message}
-Problem line: "${line}"`;
+    private setError(message: string, _line: string, statement: Statement) {
+        if (statement.allLinesIdentical()) {
+            this._error = `${message}
+Problem line: "${statement.rawInstruction}"`;
+        } else {
+            this._error = `${message}
+Problem statement:
+${statement.explainStatement('    ')}
+`;
+        }
     }
 
     public get ignoreGlobalQuery(): boolean {
@@ -331,7 +338,7 @@ Problem line: "${line}"`;
                     this._taskLayoutOptions.setVisibility(TaskLayoutComponent.DependsOn, !hide);
                     break;
                 default:
-                    this.setError('do not understand hide/show option', line);
+                    this.setError('do not understand hide/show option', line, new Statement(line, line));
             }
         }
     }
@@ -346,7 +353,7 @@ Problem line: "${line}"`;
 
                 this._filters.push(filterOrError.filter);
             } else {
-                this.setError(filterOrError.error ?? 'Unknown error', line);
+                this.setError(filterOrError.error ?? 'Unknown error', line, statement);
             }
             return true;
         }
@@ -356,7 +363,7 @@ Problem line: "${line}"`;
     private parseLimit(line: string): void {
         const limitMatch = line.match(this.limitRegexp);
         if (limitMatch === null) {
-            this.setError('do not understand query limit', line);
+            this.setError('do not understand query limit', line, new Statement(line, line));
             return;
         }
 

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -74,7 +74,7 @@ export class Query implements IQuery {
                     message = 'Unknown error';
                 }
 
-                this.setError(message, line, statement);
+                this.setError(message, statement);
                 return;
             }
         });
@@ -114,7 +114,7 @@ export class Query implements IQuery {
             case this.parseFilter(line, statement):
                 break;
             default:
-                this.setError('do not understand query', line, statement);
+                this.setError('do not understand query', statement);
         }
     }
 
@@ -240,7 +240,7 @@ ${source}`;
         return this._error;
     }
 
-    private setError(message: string, _line: string, statement: Statement) {
+    private setError(message: string, statement: Statement) {
         if (statement.allLinesIdentical()) {
             this._error = `${message}
 Problem line: "${statement.rawInstruction}"`;
@@ -338,7 +338,7 @@ ${statement.explainStatement('    ')}
                     this._taskLayoutOptions.setVisibility(TaskLayoutComponent.DependsOn, !hide);
                     break;
                 default:
-                    this.setError('do not understand hide/show option', line, new Statement(line, line));
+                    this.setError('do not understand hide/show option', new Statement(line, line));
             }
         }
     }
@@ -353,7 +353,7 @@ ${statement.explainStatement('    ')}
 
                 this._filters.push(filterOrError.filter);
             } else {
-                this.setError(filterOrError.error ?? 'Unknown error', line, statement);
+                this.setError(filterOrError.error ?? 'Unknown error', statement);
             }
             return true;
         }
@@ -363,7 +363,7 @@ ${statement.explainStatement('    ')}
     private parseLimit(line: string): void {
         const limitMatch = line.match(this.limitRegexp);
         if (limitMatch === null) {
-            this.setError('do not understand query limit', line, new Statement(line, line));
+            this.setError('do not understand query limit', new Statement(line, line));
             return;
         }
 

--- a/src/Query/Statement.ts
+++ b/src/Query/Statement.ts
@@ -81,4 +81,11 @@ ${indent}${nextLine}`;
 
         return result;
     }
+
+    public allLinesIdentical() {
+        return (
+            this._rawInstruction === this._anyContinuationLinesRemoved &&
+            this._rawInstruction === this._anyPlaceholdersExpanded
+        );
+    }
 }

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
@@ -383,17 +383,35 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'filter by function task.description.includes('a''
-        => ERROR
+        => ERROR:
+Error: Failed parsing expression "task.description.includes('a'".
+The error message was:
+    "SyntaxError: missing ) after argument list"
     'f2': 'filter by function task.description.includes('b''
-        => ERROR
+        => ERROR:
+Error: Failed parsing expression "task.description.includes('b'".
+The error message was:
+    "SyntaxError: missing ) after argument list"
     'f3': 'filter by function task.description.includes('c''
-        => ERROR
+        => ERROR:
+Error: Failed parsing expression "task.description.includes('c'".
+The error message was:
+    "SyntaxError: missing ) after argument list"
     'f4': 'filter by function task.description.includes('d''
-        => ERROR
+        => ERROR:
+Error: Failed parsing expression "task.description.includes('d'".
+The error message was:
+    "SyntaxError: missing ) after argument list"
     'f5': 'filter by function task.description.includes('e''
-        => ERROR
+        => ERROR:
+Error: Failed parsing expression "task.description.includes('e'".
+The error message was:
+    "SyntaxError: missing ) after argument list"
     'f6': 'filter by function task.description.includes('f''
-        => ERROR
+        => ERROR:
+Error: Failed parsing expression "task.description.includes('f'".
+The error message was:
+    "SyntaxError: missing ) after argument list"
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -475,17 +493,29 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type'
-        => ERROR
+        => ERROR:
+Error: Failed parsing expression "! 'NON_TASK,CANCELLED'.includes(task.status.type".
+The error message was:
+    "SyntaxError: missing ) after argument list"
     'f2': 'filter by function const date = task.due.moment; return date ? !date.isValid() : false;'
         => OK
     'f3': 'filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false'
         => OK
     'f4': 'filter by function task.urgency.toFixed(2) === 1.95.toFixed(2'
-        => ERROR
+        => ERROR:
+Error: Failed parsing expression "task.urgency.toFixed(2) === 1.95.toFixed(2".
+The error message was:
+    "SyntaxError: missing ) after argument list"
     'f5': 'filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁''
-        => ERROR
+        => ERROR:
+Error: Failed parsing expression "(!task.isRecurring) && task.originalMarkdown.includes('🔁'".
+The error message was:
+    "SyntaxError: missing ) after argument list"
     'f6': 'filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase('
-        => ERROR
+        => ERROR:
+Error: Failed parsing expression "task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase(".
+The error message was:
+    "SyntaxError: Unexpected token '}'"
     'f7': 'filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false'
         => OK
     'f8': 'filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;'
@@ -3103,7 +3133,12 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'AND (description includes d1'
-        => ERROR
+        => ERROR:
+Could not interpret the following instruction as a Boolean combination:
+    AND (description includes d1
+
+The error message is:
+    All filters in a Boolean instruction must be inside one of these pairs of delimiter characters: (...) or [...] or {...} or "...". Combinations of those delimiters are no longer supported.
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -3127,7 +3162,8 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'happens before blahblahblah'
-        => ERROR
+        => ERROR:
+do not understand happens date
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -3252,7 +3288,8 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'happens before blahblahblah'
-        => ERROR
+        => ERROR:
+do not understand happens date
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -3300,7 +3337,12 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'OR (description includes d1'
-        => ERROR
+        => ERROR:
+Could not interpret the following instruction as a Boolean combination:
+    OR (description includes d1
+
+The error message is:
+    All filters in a Boolean instruction must be inside one of these pairs of delimiter characters: (...) or [...] or {...} or "...". Combinations of those delimiters are no longer supported.
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
@@ -383,11 +383,17 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'filter by function task.description.includes('a''
+        => ERROR
     'f2': 'filter by function task.description.includes('b''
+        => ERROR
     'f3': 'filter by function task.description.includes('c''
+        => ERROR
     'f4': 'filter by function task.description.includes('d''
+        => ERROR
     'f5': 'filter by function task.description.includes('e''
+        => ERROR
     'f6': 'filter by function task.description.includes('f''
+        => ERROR
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -469,13 +475,21 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type'
+        => ERROR
     'f2': 'filter by function const date = task.due.moment; return date ? !date.isValid() : false;'
+        => OK
     'f3': 'filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false'
+        => OK
     'f4': 'filter by function task.urgency.toFixed(2) === 1.95.toFixed(2'
+        => ERROR
     'f5': 'filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁''
+        => ERROR
     'f6': 'filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase('
+        => ERROR
     'f7': 'filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false'
+        => OK
     'f8': 'filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;'
+        => OK
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -2236,7 +2250,9 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes ()some example('
+        => OK
     'f2': 'path includes ((some example'
+        => OK
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -2273,7 +2289,9 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes (some example'
+        => OK
     'f2': 'path includes )some example('
+        => OK
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -2297,7 +2315,9 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'path includes )some example('
+        => OK
     'f2': 'path includes (some example'
+        => OK
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -3083,6 +3103,7 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'AND (description includes d1'
+        => ERROR
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -3106,6 +3127,7 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'happens before blahblahblah'
+        => ERROR
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -3194,6 +3216,7 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'description blahblah d1'
+        => OK
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -3229,6 +3252,7 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'happens before blahblahblah'
+        => ERROR
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -3276,6 +3300,7 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'OR (description includes d1'
+        => ERROR
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
@@ -384,34 +384,34 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'filter by function task.description.includes('a''
         => ERROR:
-Error: Failed parsing expression "task.description.includes('a'".
-The error message was:
-    "SyntaxError: missing ) after argument list"
+           Error: Failed parsing expression "task.description.includes('a'".
+           The error message was:
+           "SyntaxError: missing ) after argument list"
     'f2': 'filter by function task.description.includes('b''
         => ERROR:
-Error: Failed parsing expression "task.description.includes('b'".
-The error message was:
-    "SyntaxError: missing ) after argument list"
+           Error: Failed parsing expression "task.description.includes('b'".
+           The error message was:
+           "SyntaxError: missing ) after argument list"
     'f3': 'filter by function task.description.includes('c''
         => ERROR:
-Error: Failed parsing expression "task.description.includes('c'".
-The error message was:
-    "SyntaxError: missing ) after argument list"
+           Error: Failed parsing expression "task.description.includes('c'".
+           The error message was:
+           "SyntaxError: missing ) after argument list"
     'f4': 'filter by function task.description.includes('d''
         => ERROR:
-Error: Failed parsing expression "task.description.includes('d'".
-The error message was:
-    "SyntaxError: missing ) after argument list"
+           Error: Failed parsing expression "task.description.includes('d'".
+           The error message was:
+           "SyntaxError: missing ) after argument list"
     'f5': 'filter by function task.description.includes('e''
         => ERROR:
-Error: Failed parsing expression "task.description.includes('e'".
-The error message was:
-    "SyntaxError: missing ) after argument list"
+           Error: Failed parsing expression "task.description.includes('e'".
+           The error message was:
+           "SyntaxError: missing ) after argument list"
     'f6': 'filter by function task.description.includes('f''
         => ERROR:
-Error: Failed parsing expression "task.description.includes('f'".
-The error message was:
-    "SyntaxError: missing ) after argument list"
+           Error: Failed parsing expression "task.description.includes('f'".
+           The error message was:
+           "SyntaxError: missing ) after argument list"
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -494,28 +494,28 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type'
         => ERROR:
-Error: Failed parsing expression "! 'NON_TASK,CANCELLED'.includes(task.status.type".
-The error message was:
-    "SyntaxError: missing ) after argument list"
+           Error: Failed parsing expression "! 'NON_TASK,CANCELLED'.includes(task.status.type".
+           The error message was:
+           "SyntaxError: missing ) after argument list"
     'f2': 'filter by function const date = task.due.moment; return date ? !date.isValid() : false;'
         => OK
     'f3': 'filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false'
         => OK
     'f4': 'filter by function task.urgency.toFixed(2) === 1.95.toFixed(2'
         => ERROR:
-Error: Failed parsing expression "task.urgency.toFixed(2) === 1.95.toFixed(2".
-The error message was:
-    "SyntaxError: missing ) after argument list"
+           Error: Failed parsing expression "task.urgency.toFixed(2) === 1.95.toFixed(2".
+           The error message was:
+           "SyntaxError: missing ) after argument list"
     'f5': 'filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁''
         => ERROR:
-Error: Failed parsing expression "(!task.isRecurring) && task.originalMarkdown.includes('🔁'".
-The error message was:
-    "SyntaxError: missing ) after argument list"
+           Error: Failed parsing expression "(!task.isRecurring) && task.originalMarkdown.includes('🔁'".
+           The error message was:
+           "SyntaxError: missing ) after argument list"
     'f6': 'filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase('
         => ERROR:
-Error: Failed parsing expression "task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase(".
-The error message was:
-    "SyntaxError: Unexpected token '}'"
+           Error: Failed parsing expression "task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase(".
+           The error message was:
+           "SyntaxError: Unexpected token '}'"
     'f7': 'filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false'
         => OK
     'f8': 'filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;'
@@ -3134,11 +3134,11 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'AND (description includes d1'
         => ERROR:
-Could not interpret the following instruction as a Boolean combination:
-    AND (description includes d1
-
-The error message is:
-    All filters in a Boolean instruction must be inside one of these pairs of delimiter characters: (...) or [...] or {...} or "...". Combinations of those delimiters are no longer supported.
+           Could not interpret the following instruction as a Boolean combination:
+           AND (description includes d1
+           
+           The error message is:
+           All filters in a Boolean instruction must be inside one of these pairs of delimiter characters: (...) or [...] or {...} or "...". Combinations of those delimiters are no longer supported.
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -3163,7 +3163,7 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'happens before blahblahblah'
         => ERROR:
-do not understand happens date
+           do not understand happens date
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -3289,7 +3289,7 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'happens before blahblahblah'
         => ERROR:
-do not understand happens date
+           do not understand happens date
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters
@@ -3338,11 +3338,11 @@ The instruction was converted to the following simplified line:
 Where the sub-expressions in the simplified line are:
     'f1': 'OR (description includes d1'
         => ERROR:
-Could not interpret the following instruction as a Boolean combination:
-    OR (description includes d1
-
-The error message is:
-    All filters in a Boolean instruction must be inside one of these pairs of delimiter characters: (...) or [...] or {...} or "...". Combinations of those delimiters are no longer supported.
+           Could not interpret the following instruction as a Boolean combination:
+           OR (description includes d1
+           
+           The error message is:
+           All filters in a Boolean instruction must be inside one of these pairs of delimiter characters: (...) or [...] or {...} or "...". Combinations of those delimiters are no longer supported.
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
@@ -3252,7 +3252,8 @@ The instruction was converted to the following simplified line:
 
 Where the sub-expressions in the simplified line are:
     'f1': 'description blahblah d1'
-        => OK
+        => ERROR:
+           do not understand query
 
 For help, see:
     https://publish.obsidian.md/tasks/Queries/Combining+Filters

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -535,7 +535,7 @@ describe('Query parsing', () => {
 
     describe('should include instruction in parsing error messages', () => {
         function getQueryError(source: string) {
-            return new Query(source).error;
+            return new Query(source, 'Example Path.md').error;
         }
 
         it('for invalid regular expression filter', () => {
@@ -608,6 +608,20 @@ Problem line: "${sourceUpperCase}"`);
 Problem line: "${source}"`);
             expect(getQueryError(sourceUpperCase)).toEqual(`do not understand query
 Problem line: "${sourceUpperCase}"`);
+        });
+
+        it('for instruction with continuation characters and placeholders', () => {
+            const source = `spaghetti includes \\
+    {{query.file.path}}`;
+
+            expect(getQueryError(source)).toEqual(`do not understand query
+Problem statement:
+    spaghetti includes \\
+        {{query.file.path}}
+     =>
+    spaghetti includes {{query.file.path}} =>
+    spaghetti includes Example Path.md
+`);
         });
     });
 

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -623,6 +623,59 @@ Problem statement:
     spaghetti includes Example Path.md
 `);
         });
+
+        it('for boolean with filter-by-function closing ) swallowed by Boolean parsing', () => {
+            const source = "( filter by function task.originalMarkdown.includes('hello') )";
+            expect(getQueryError(source)).toMatchInlineSnapshot(`
+                "Could not interpret the following instruction as a Boolean combination:
+                    ( filter by function task.originalMarkdown.includes('hello') )
+
+                The error message is:
+                    malformed boolean query -- Invalid token (check the documentation for guidelines)
+
+                The instruction was converted to the following simplified line:
+                    ( f1) )
+
+                Where the sub-expressions in the simplified line are:
+                    'f1': 'filter by function task.originalMarkdown.includes('hello''
+                        => ERROR:
+                           Error: Failed parsing expression "task.originalMarkdown.includes('hello'".
+                           The error message was:
+                           "SyntaxError: missing ) after argument list"
+
+                For help, see:
+                    https://publish.obsidian.md/tasks/Queries/Combining+Filters
+
+                Problem line: "( filter by function task.originalMarkdown.includes('hello') )""
+            `);
+        });
+
+        it.skip('for boolean with unknown instruction', () => {
+            const source = '( filename includesx {{query.file.filenameWithoutExtension}} )';
+            expect(getQueryError(source)).toMatchInlineSnapshot(`
+                "Could not interpret the following instruction as a Boolean combination:
+                    ( filename includesx Example Path )
+
+                The error message is:
+                    couldn't parse sub-expression 'filename includesx Example Path'
+
+                The instruction was converted to the following simplified line:
+                    ( f1 )
+
+                Where the sub-expressions in the simplified line are:
+                    'f1': 'filename includesx Example Path'
+                        => ERROR:
+                           do not understand query
+
+                For help, see:
+                    https://publish.obsidian.md/tasks/Queries/Combining+Filters
+
+                Problem statement:
+                    ( filename includesx {{query.file.filenameWithoutExtension}} ) =>
+                    ( filename includesx Example Path )
+                "
+            `);
+        });
     });
 
     describe('parsing placeholders', () => {

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -650,7 +650,7 @@ Problem statement:
             `);
         });
 
-        it.skip('for boolean with unknown instruction', () => {
+        it('for boolean with unknown instruction', () => {
             const source = '( filename includesx {{query.file.filenameWithoutExtension}} )';
             expect(getQueryError(source)).toMatchInlineSnapshot(`
                 "Could not interpret the following instruction as a Boolean combination:

--- a/tests/Query/Statement.test.ts
+++ b/tests/Query/Statement.test.ts
@@ -6,6 +6,8 @@ describe('Statement', () => {
 world`;
         const final = 'hello world';
         const instruction = new Statement(raw, final);
+        expect(instruction.allLinesIdentical()).toEqual(false);
+
         expect(instruction.rawInstruction).toEqual(raw);
         expect(instruction.anyContinuationLinesRemoved).toEqual('hello world');
         expect(instruction.anyPlaceholdersExpanded).toEqual('hello world');
@@ -15,6 +17,8 @@ world`;
         it('should explain simplest statement', () => {
             const instruction = 'hello world';
             const statement = new Statement(instruction, instruction);
+            expect(statement.allLinesIdentical()).toEqual(true);
+
             expect(statement.explainStatement('')).toEqual(instruction);
             expect(statement.explainStatement('  ')).toEqual('  hello world');
         });
@@ -29,7 +33,11 @@ world`;
         it('should show unexpanded and expanded placeholders, if they differ', () => {
             const instruction = '{{fake placeholder}}';
             const statement = new Statement(instruction, instruction);
+            expect(statement.allLinesIdentical()).toEqual(true);
+
             statement.recordExpandedPlaceholders('expanded placeholder');
+            expect(statement.allLinesIdentical()).toEqual(false);
+
             expect(statement.explainStatement('  ')).toEqual(`  {{fake placeholder}} =>
   expanded placeholder`);
         });


### PR DESCRIPTION

# Description

Provide more meaningful information to help users trouble-shoot any problems with Boolean filters.

*Note: more improvements are coming so I am not updating the documentation yet.*

1. When there is an error parsing a Boolean filter, show the user which sub-expressions have any problems that need fixing. (See 'Screenshots' heading below...)
2. When there is an error parsing any statement, show any continuation lines, and placeholders, to aid in locating the error in the query.
3. Add some sample problem queries to the test vault, to inspect the results of this PR.
    - See `resources/sample_vaults/Tasks-Demo/Filters/Boolean Combinations.md`
    - The new descriptive text may be useful in updating the docs for Boolean filters.

## Motivation and Context

Try to make it easier still for users to diagnose errors with:

- multi-line filters in general,
- and Boolean filters in particular.

## How has this been tested?

- Automated tests
- Exploratory testing

## Screenshots (if appropriate)

Consider the error output generated for this line:

`( filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type) ) OR ( filter by function const date = task.due.moment; return date ? !date.isValid() : false; ) OR ( filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false ) OR ( filter by function task.urgency.toFixed(2) === 1.95.toFixed(2) ) OR ( filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁') ) OR ( filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase() ) OR ( filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false ) OR ( filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false; )`

The error message will contain a list of the sub-expressions extracted.

Before this PR, that list looked like this:

```text
Where the sub-expressions in the simplified line are:
    'f1': 'filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type'
    'f2': 'filter by function const date = task.due.moment; return date ? !date.isValid() : false;'
    'f3': 'filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false'
    'f4': 'filter by function task.urgency.toFixed(2) === 1.95.toFixed(2'
    'f5': 'filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁''
    'f6': 'filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase('
    'f7': 'filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false'
    'f8': 'filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;'
```

After this PR, the list looks like this, where the `ERROR` and `OK` comments should help identify the source of any problems:

```text
Where the sub-expressions in the simplified line are:
    'f1': 'filter by function ! 'NON_TASK,CANCELLED'.includes(task.status.type'
        => ERROR:
           Error: Failed parsing expression "! 'NON_TASK,CANCELLED'.includes(task.status.type".
           The error message was:
           "SyntaxError: missing ) after argument list"
    'f2': 'filter by function const date = task.due.moment; return date ? !date.isValid() : false;'
        => OK
    'f3': 'filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false'
        => OK
    'f4': 'filter by function task.urgency.toFixed(2) === 1.95.toFixed(2'
        => ERROR:
           Error: Failed parsing expression "task.urgency.toFixed(2) === 1.95.toFixed(2".
           The error message was:
           "SyntaxError: missing ) after argument list"
    'f5': 'filter by function (!task.isRecurring) && task.originalMarkdown.includes('🔁''
        => ERROR:
           Error: Failed parsing expression "(!task.isRecurring) && task.originalMarkdown.includes('🔁'".
           The error message was:
           "SyntaxError: missing ) after argument list"
    'f6': 'filter by function task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase('
        => ERROR:
           Error: Failed parsing expression "task.file.path.toLocaleLowerCase() === 'TASKS RELEASES/4.1.0 RELEASE.MD'.toLocaleLowerCase(".
           The error message was:
           "SyntaxError: Unexpected token '}'"
    'f7': 'filter by function const taskDate = task.due.moment; const now = moment(); return taskDate?.isSame(now, 'day') || ( !taskDate && task.heading?.includes(now.format('YYYY-MM-DD')) ) || false'
        => OK
    'f8': 'filter by function const wanted = '#context/home'; return task.heading?.includes(wanted) || task.tags.find( (tag) => tag === wanted ) && true || false;'
        => OK
```

## Types of changes

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
    - *Will be done later*
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
