### PR TITLE
refactor: group CSS classes

### DIFF
--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -38,15 +38,11 @@
         margin-left: 0.67em;
         top: 2px;
     }
-}
 
-.tasks-modal-section {
     input[type="text"] {
         width: 100%;
     }
-}
 
-.tasks-modal-section {
     textarea {
         width: 100%;
         min-height: calc(var(--input-height) * 2);

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -61,16 +61,12 @@
     display: grid;
     grid-template-columns: 4em 8em 8em 8em;
     grid-column-gap: 1.33em;
-}
 
-.tasks-modal-priorities {
     span {
         line-height: 1.41;
         white-space: nowrap;
     }
-}
 
-.tasks-modal-priorities {
     label {
         border-radius: var(--input-radius);
         padding: 2px 3px;
@@ -78,28 +74,20 @@
         grid-row-start: 1;
         grid-row-end: 7;
     }
-}
 
-.tasks-modal-priorities {
     input + label {
         font-size: var(--font-ui-small);
     }
-}
 
-.tasks-modal-priorities {
     input:focus + label {
         box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
         border-color: var(--background-modifier-border-focus);
     }
-}
 
-.tasks-modal-priorities {
     input:checked + label > span {
         font-weight: bold;
     }
-}
 
-.tasks-modal-priorities {
     input:not(:checked) + label > span:nth-child(4) {
         filter: grayscale(100%) opacity(60%);
     }

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -63,35 +63,46 @@
     grid-column-gap: 1.33em;
 }
 
-.tasks-modal-priorities span {
-    line-height: 1.41;
-    white-space: nowrap;
+.tasks-modal-priorities {
+    span {
+        line-height: 1.41;
+        white-space: nowrap;
+    }
 }
 
-.tasks-modal-priorities label {
-    border-radius: var(--input-radius);
-    padding: 2px 3px;
-    grid-column: 1;
-    grid-row-start: 1;
-    grid-row-end: 7;
+.tasks-modal-priorities {
+    label {
+        border-radius: var(--input-radius);
+        padding: 2px 3px;
+        grid-column: 1;
+        grid-row-start: 1;
+        grid-row-end: 7;
+    }
 }
 
-
-.tasks-modal-priorities input + label {
-    font-size: var(--font-ui-small);
+.tasks-modal-priorities {
+    input + label {
+        font-size: var(--font-ui-small);
+    }
 }
 
-.tasks-modal-priorities input:focus + label {
-    box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
-    border-color: var(--background-modifier-border-focus);
+.tasks-modal-priorities {
+    input:focus + label {
+        box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
+        border-color: var(--background-modifier-border-focus);
+    }
 }
 
-.tasks-modal-priorities input:checked + label > span {
-    font-weight: bold;
+.tasks-modal-priorities {
+    input:checked + label > span {
+        font-weight: bold;
+    }
 }
 
-.tasks-modal-priorities input:not(:checked) + label > span:nth-child(4) {
-    filter: grayscale(100%) opacity(60%);
+.tasks-modal-priorities {
+    input:not(:checked) + label > span:nth-child(4) {
+        filter: grayscale(100%) opacity(60%);
+    }
 }
 
 .tasks-modal-dates {

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -145,16 +145,12 @@
     .tasks-modal-error {
         border: 1px solid red !important;
     }
-}
 
-.tasks-modal {
     .tasks-modal-warning {
         color: var(--text-warning) !important;
         background-color: rgba(var(--background-modifier-warning-rgb), 0.2) !important;
     }
-}
 
-.tasks-modal {
     button:disabled {
         pointer-events: none !important;
         opacity: 0.3 !important;

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -14,10 +14,11 @@
 }
 
 .tasks-modal {
-    .with-accesskeys .accesskey-first::first-letter,
-    .with-accesskeys .accesskey {
-        text-decoration: underline;
-        text-underline-offset: 1pt;
+    .with-accesskeys {
+        .accesskey-first::first-letter, .accesskey {
+            text-decoration: underline;
+            text-underline-offset: 1pt;
+        }
     }
 }
 

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -141,18 +141,24 @@
     justify-content: space-between;
 }
 
-.tasks-modal-error {
-    border: 1px solid red !important;
+.tasks-modal {
+    .tasks-modal-error {
+        border: 1px solid red !important;
+    }
 }
 
-.tasks-modal-warning {
-    color: var(--text-warning) !important;
-    background-color: rgba(var(--background-modifier-warning-rgb), 0.2) !important;
+.tasks-modal {
+    .tasks-modal-warning {
+        color: var(--text-warning) !important;
+        background-color: rgba(var(--background-modifier-warning-rgb), 0.2) !important;
+    }
 }
 
-.tasks-modal button:disabled {
-    pointer-events: none !important;
-    opacity: 0.3 !important;
+.tasks-modal {
+    button:disabled {
+        pointer-events: none !important;
+        opacity: 0.3 !important;
+    }
 }
 
 @media (max-width: 649px) {

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -33,24 +33,32 @@
     column-gap: .5em;
 }
 
-.tasks-modal label + input[type="checkbox"] {
-    margin-left: 0.67em;
-    top: 2px;
+.tasks-modal {
+    label + input[type="checkbox"] {
+        margin-left: 0.67em;
+        top: 2px;
+    }
 }
 
-.tasks-modal input[type="text"] {
-    width: 100%;
+.tasks-modal {
+    input[type="text"] {
+        width: 100%;
+    }
 }
 
-.tasks-modal textarea {
-    width: 100%;
-    min-height: calc(var(--input-height) * 2);
-    resize: vertical;
+.tasks-modal {
+    textarea {
+        width: 100%;
+        min-height: calc(var(--input-height) * 2);
+        resize: vertical;
+    }
 }
 
-.tasks-modal hr {
-    margin: 0.35rem 0;
-    padding-bottom: 0.5rem;
+.tasks-modal {
+    hr {
+        margin: 0.35rem 0;
+        padding-bottom: 0.5rem;
+    }
 }
 
 .tasks-modal-priorities {

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -1,8 +1,8 @@
-.tasks-modal-section + .tasks-modal-section {
-    margin-top: 8px;
-}
-
 .tasks-modal-section {
+    + .tasks-modal-section {
+        margin-top: 8px;
+    }
+
     label {
         display: inline-block;
         margin-bottom: 4px;

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -160,6 +160,7 @@
         grid-template-columns: 4em 7.5em 5em;
         margin-bottom: -10px;
     }
+
     .tasks-modal-priorities > label {
         grid-row: 1 / span 7;
     }
@@ -174,15 +175,19 @@
             grid-column: 1;
         }
     }
+
     .tasks-modal-dates > label {
         margin: 0;
     }
+
     .tasks-modal-dates > .input, .tasks-modal-dates > .results {
         grid-column: 1;
     }
+
     .tasks-modal-dates > div {
         grid-column-end: 1;
     }
+
     .tasks-modal-status {
         display: block;
     }
@@ -195,9 +200,11 @@
             width: auto;
         }
     }
+
     .tasks-modal-priorities {
         grid-template-columns: 4em auto;
     }
+
     .tasks-modal-priorities > label {
         grid-row: 1 / span 7;
     }
@@ -208,6 +215,7 @@
         grid-template-columns: 1fr;
         margin-bottom: 0;
     }
+
     .tasks-modal-priorities > label {
         grid-row: 1;
     }

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -13,10 +13,12 @@
     }
 }
 
-.tasks-modal .with-accesskeys .accesskey-first::first-letter,
-.tasks-modal .with-accesskeys .accesskey {
-    text-decoration: underline;
-    text-underline-offset: 1pt;
+.tasks-modal {
+    .with-accesskeys .accesskey-first::first-letter,
+    .with-accesskeys .accesskey {
+        text-decoration: underline;
+        text-underline-offset: 1pt;
+    }
 }
 
 .tasks-modal-buttons {

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -7,10 +7,10 @@
         display: inline-block;
         margin-bottom: 4px;
     }
-}
 
-.tasks-modal-section label > span {
-    display: inline-block;
+    label > span {
+        display: inline-block;
+    }
 }
 
 .tasks-modal .with-accesskeys .accesskey-first::first-letter,

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -33,20 +33,20 @@
     column-gap: .5em;
 }
 
-.tasks-modal {
+.tasks-modal-section {
     label + input[type="checkbox"] {
         margin-left: 0.67em;
         top: 2px;
     }
 }
 
-.tasks-modal {
+.tasks-modal-section {
     input[type="text"] {
         width: 100%;
     }
 }
 
-.tasks-modal {
+.tasks-modal-section {
     textarea {
         width: 100%;
         min-height: calc(var(--input-height) * 2);

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -2,9 +2,11 @@
     margin-top: 8px;
 }
 
-.tasks-modal-section label {
-    display: inline-block;
-    margin-bottom: 4px;
+.tasks-modal-section {
+    label {
+        display: inline-block;
+        margin-bottom: 4px;
+    }
 }
 
 .tasks-modal-section label > span {


### PR DESCRIPTION
# Description

Pure refactoring - nest CSS classes by their parent

## Motivation and Context

Improve readability and make changes and reasoning about CSS classes in `EditTask.scss` simpler.

## How has this been tested?

Visual test in demo vault.

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - CSS not covered by unit tests

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
