### PR TITLE
refactor: reorder CSS classes in `EditTasks.scss`

### DIFF
--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -5,16 +5,12 @@
             text-underline-offset: 1pt;
         }
     }
-}
 
-.tasks-modal {
     hr {
         margin: 0.35rem 0;
         padding-bottom: 0.5rem;
     }
-}
 
-.tasks-modal {
     .tasks-modal-error {
         border: 1px solid red !important;
     }

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -1,3 +1,35 @@
+.tasks-modal {
+    .with-accesskeys {
+        .accesskey-first::first-letter, .accesskey {
+            text-decoration: underline;
+            text-underline-offset: 1pt;
+        }
+    }
+}
+
+.tasks-modal {
+    hr {
+        margin: 0.35rem 0;
+        padding-bottom: 0.5rem;
+    }
+}
+
+.tasks-modal {
+    .tasks-modal-error {
+        border: 1px solid red !important;
+    }
+
+    .tasks-modal-warning {
+        color: var(--text-warning) !important;
+        background-color: rgba(var(--background-modifier-warning-rgb), 0.2) !important;
+    }
+
+    button:disabled {
+        pointer-events: none !important;
+        opacity: 0.3 !important;
+    }
+}
+
 .tasks-modal-section {
     + .tasks-modal-section {
         margin-top: 8px;
@@ -10,15 +42,6 @@
 
     label > span {
         display: inline-block;
-    }
-}
-
-.tasks-modal {
-    .with-accesskeys {
-        .accesskey-first::first-letter, .accesskey {
-            text-decoration: underline;
-            text-underline-offset: 1pt;
-        }
     }
 }
 
@@ -47,13 +70,6 @@
         width: 100%;
         min-height: calc(var(--input-height) * 2);
         resize: vertical;
-    }
-}
-
-.tasks-modal {
-    hr {
-        margin: 0.35rem 0;
-        padding-bottom: 0.5rem;
     }
 }
 
@@ -139,22 +155,6 @@
     margin-bottom: -16px;
     display: flex;
     justify-content: space-between;
-}
-
-.tasks-modal {
-    .tasks-modal-error {
-        border: 1px solid red !important;
-    }
-
-    .tasks-modal-warning {
-        color: var(--text-warning) !important;
-        background-color: rgba(var(--background-modifier-warning-rgb), 0.2) !important;
-    }
-
-    button:disabled {
-        pointer-events: none !important;
-        opacity: 0.3 !important;
-    }
 }
 
 @media (max-width: 649px) {

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -39,9 +39,7 @@
     label > span {
         display: inline-block;
     }
-}
 
-.tasks-modal-section {
     label + input[type="checkbox"] {
         margin-left: 0.67em;
         top: 2px;

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -19,11 +19,6 @@
         color: var(--text-warning) !important;
         background-color: rgba(var(--background-modifier-warning-rgb), 0.2) !important;
     }
-
-    button:disabled {
-        pointer-events: none !important;
-        opacity: 0.3 !important;
-    }
 }
 
 .tasks-modal-section {
@@ -149,6 +144,11 @@
     display: grid;
     grid-template-columns: 3fr 1fr;
     column-gap: .5em;
+
+    button:disabled {
+        pointer-events: none !important;
+        opacity: 0.3 !important;
+    }
 }
 
 @media (max-width: 649px) {

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -56,17 +56,6 @@
     }
 }
 
-.tasks-modal-buttons {
-    position: sticky;
-    bottom: 0;
-    background-color: var(--modal-background);
-    padding-bottom: 16px;
-    padding-top: 16px;
-    display: grid;
-    grid-template-columns: 3fr 1fr;
-    column-gap: .5em;
-}
-
 .tasks-modal-priorities {
     display: grid;
     grid-template-columns: 4em 8em 8em 8em;
@@ -149,6 +138,17 @@
     margin-bottom: -16px;
     display: flex;
     justify-content: space-between;
+}
+
+.tasks-modal-buttons {
+    position: sticky;
+    bottom: 0;
+    background-color: var(--modal-background);
+    padding-bottom: 16px;
+    padding-top: 16px;
+    display: grid;
+    grid-template-columns: 3fr 1fr;
+    column-gap: .5em;
 }
 
 @media (max-width: 649px) {

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -41,17 +41,6 @@
     }
 }
 
-.tasks-modal-buttons {
-    position: sticky;
-    bottom: 0;
-    background-color: var(--modal-background);
-    padding-bottom: 16px;
-    padding-top: 16px;
-    display: grid;
-    grid-template-columns: 3fr 1fr;
-    column-gap: .5em;
-}
-
 .tasks-modal-section {
     label + input[type="checkbox"] {
         margin-left: 0.67em;
@@ -67,6 +56,17 @@
         min-height: calc(var(--input-height) * 2);
         resize: vertical;
     }
+}
+
+.tasks-modal-buttons {
+    position: sticky;
+    bottom: 0;
+    background-color: var(--modal-background);
+    padding-bottom: 16px;
+    padding-top: 16px;
+    display: grid;
+    grid-template-columns: 3fr 1fr;
+    column-gap: .5em;
 }
 
 .tasks-modal-priorities {


### PR DESCRIPTION
# Description

- Order CSS classes by their appearance in `EditTask.svelte`
- Pure refactoring, no change in behaviour

## Motivation and Context

- Make changes easy in the Edit Task modal
- Prepare to extract repeated behaviour in the Edit Task modal

## How has this been tested?

Visual test in demo vault.

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - No unit testing on CSS code

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
