### PR TITLE
fix: align the look of `Priority` section in task modal with date sections

### DIFF
--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -53,8 +53,8 @@
 
 .tasks-modal-priorities {
     display: grid;
-    grid-template-columns: 4em 8em 8em 8em;
-    grid-column-gap: 1.33em;
+    grid-template-columns: 6em auto auto auto;
+    grid-column-gap: 0.5em;
 
     span {
         line-height: 1.41;

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -73,6 +73,10 @@
         font-size: var(--font-ui-small);
     }
 
+    input {
+        accent-color: var(--interactive-accent);
+    }
+
     input:focus + label {
         box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
         border-color: var(--background-modifier-border-focus);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

In Priority section:
- Use color from the Obsidian for the checked radio button (Default blue -> Obsidian violet, like the checkbox for "Only future dates")
- Align the grid that positions the priority values with the date sections

## Motivation and Context

Consistent look the edit task modal.

## How has this been tested?

Visual test in demo vault.

## Screenshots (if appropriate)

Before             |  After
:-------------------------:|:-------------------------:
![Снимок экрана 2024-05-01 в 23 56 00](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/0c7ad5ba-0a69-4093-80b3-3f3923b26291) |  ![Снимок экрана 2024-05-01 в 23 59 56](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/32d7e50b-8cf7-4d2b-9c50-7551456144fe)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - no unit test for CSS code

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
