### PR TITLE
fix: remove access keys mentions when access key setting is disabled

### DIFF
--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -631,7 +631,11 @@ Availability of access keys:
             <!-- --------------------------------------------------------------------------- -->
             <!--  Done Date  -->
             <!-- --------------------------------------------------------------------------- -->
-            <label for="done">Done (<span class="accesskey">x</span>)</label>
+            {#if withAccessKeys}
+                <label for="done">Done (<span class="accesskey">x</span>)</label>
+            {:else}
+                <label for="done">Done</label>
+            {/if}
             <DateEditor
                 id="done"
                 dateSymbol={doneDateSymbol}
@@ -644,7 +648,11 @@ Availability of access keys:
             <!-- --------------------------------------------------------------------------- -->
             <!--  Cancelled Date  -->
             <!-- --------------------------------------------------------------------------- -->
-            <label for="cancelled">Cancelled (<span class="accesskey">-</span>)</label>
+            {#if withAccessKeys}
+                <label for="cancelled">Cancelled (<span class="accesskey">-</span>)</label>
+            {:else}
+                <label for="cancelled">Cancelled</label>
+            {/if}
             <DateEditor
                 id="cancelled"
                 dateSymbol={cancelledDateSymbol}


### PR DESCRIPTION
# Description

The Cancelled and Done date have recently received access keys (`x` and `-`) and they are shown in the Edit Task modal. However when the setting `Provide access keys in dialogs` is disabled, the access keys are still shown in the Edit Task modal. This PR fixes that bug.

## Motivation and Context

Consistency of UI & behaviour.

## How has this been tested?

Manual test in demo vault. An automated unit test can be established, however I'm not sure of its necessity.

## Screenshots (if appropriate)

Provide... in settings | Before             |  After
:-------------------------:|:-------------------------:|:-------------------------:
ON | ![Снимок экрана 2024-05-02 в 13 39 29](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/e4c8a12a-fdb5-4c93-90f7-2babad2a3e7e) | ![Снимок экрана 2024-05-02 в 13 40 22](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/9f4c977f-e948-4efa-becf-3b06e38a7055)
OFF | ![Снимок экрана 2024-05-02 в 13 39 48](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/4f81f894-672e-4c09-927c-11b61b65b8e8) | ![Снимок экрана 2024-05-02 в 13 40 35](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/ed341b9d-e677-4920-bf9a-bd0634bc5070)

Note no change in `ON` row, but only in `OFF` row: `(x)` and `(-)` disappear.


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
