### PR TITLE
test: Add some tests for dependency suggestions

### DIFF
--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -451,7 +451,7 @@ function addDependsOnSuggestions(
         const newTaskToAppend = dependsOnMatch[3];
 
         // Find all Tasks, Already Added
-        let blockingTasks = [] as Task[];
+        let blockingTasks: Task[] = [];
         if (existingDependsOnIdStrings) {
             blockingTasks = allTasks.filter((task) => task.id && existingDependsOnIdStrings.includes(task.id));
         }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -453,7 +453,7 @@ function addDependsOnSuggestions(
         // Find all Tasks, Already Added
         let blockingTasks = [] as Task[];
         if (existingDependsOnIdStrings) {
-            blockingTasks = allTasks.filter((task) => task.id && existingDependsOnIdStrings.contains(task.id));
+            blockingTasks = allTasks.filter((task) => task.id && existingDependsOnIdStrings.includes(task.id));
         }
 
         if (newTaskToAppend.length >= settings.autoSuggestMinMatch) {

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -1,0 +1,65 @@
+interface SearchResult {
+    score: number;
+    matches: number[][];
+}
+
+/**
+ * A fake implementation of the function returned by prepareSimpleSearch(),
+ * so we can write tests of code that calls that function.
+ *
+ * See https://docs.obsidian.md/Reference/TypeScript+API/prepareSimpleSearch
+ * @param searchTerm
+ * @param phrase
+ */
+function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): SearchResult {
+    const regex = new RegExp(searchTerm, 'gi');
+    const matches: number[][] = [];
+    let match;
+    while ((match = regex.exec(phrase)) !== null) {
+        matches.push([match.index, match.index + match[0].length]);
+    }
+    return {
+        score: 0,
+        matches: matches,
+    };
+}
+
+describe('prepareSimpleSearch() mock', () => {
+    it('should be case-insensitive', () => {
+        const searchTerm = 'MixedCase';
+        const phrase = 'mixedcase';
+        const matches = caseInsensitiveSubstringSearch(searchTerm, phrase);
+        expect(JSON.stringify(matches, null, 4)).toMatchInlineSnapshot(`
+            "{
+                "score": 0,
+                "matches": [
+                    [
+                        0,
+                        9
+                    ]
+                ]
+            }"
+        `);
+    });
+
+    it('should find two occurrences of one string', () => {
+        const searchTerm = 'gues';
+        const phrase = 'Guestimate the number of guests';
+        const matches = caseInsensitiveSubstringSearch(searchTerm, phrase);
+        expect(JSON.stringify(matches, null, 4)).toMatchInlineSnapshot(`
+            "{
+                "score": 0,
+                "matches": [
+                    [
+                        0,
+                        4
+                    ],
+                    [
+                        25,
+                        29
+                    ]
+                ]
+            }"
+        `);
+    });
+});

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -1,3 +1,8 @@
+/**
+ * @file This file tests our fake implementation of Obsidian's {@link prepareSimpleSearch}.
+ *       Additional fake search functions may be added in the future.
+ */
+
 import { prepareSimpleSearch } from '../__mocks__/obsidian';
 
 function simpleSearchShouldNotMatch(searchTerm: string, phrase: string) {

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -11,7 +11,7 @@ interface SearchResult {
  * @param searchTerm
  * @param phrase
  */
-function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): SearchResult {
+function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): SearchResult | null {
     // Support multi-word search terms:
     const searchTerms = searchTerm.split(/\s+/);
     let matches: number[][] = [];
@@ -32,13 +32,24 @@ function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): Sea
         return a[0] - b[0];
     });
 
-    return {
-        score: 0,
-        matches: matches,
-    };
+    if (matches.length > 0) {
+        return {
+            score: 0,
+            matches: matches,
+        };
+    } else {
+        return null;
+    }
 }
 
 describe('prepareSimpleSearch() mock', () => {
+    it('should return null if no match', () => {
+        const searchTerm = 'NOT PRESENT';
+        const phrase = 'aaaaaaaaaaaaaaaaa';
+        const matches = caseInsensitiveSubstringSearch(searchTerm, phrase);
+        expect(matches).toBeNull();
+    });
+
     it('should be case-insensitive', () => {
         const searchTerm = 'MixedCase';
         const phrase = 'mixedcase';

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -12,6 +12,11 @@ interface SearchResult {
  * @param phrase
  */
 function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): SearchResult | null {
+    // Don't try and search for empty strings or just spaces:
+    if (!searchTerm.trim()) {
+        return null;
+    }
+
     // Support multi-word search terms:
     const searchTerms = searchTerm.split(/\s+/);
     let matches: number[][] = [];
@@ -48,6 +53,13 @@ function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): Sea
 }
 
 describe('prepareSimpleSearch() mock', () => {
+    it('should return null if search term is only spaces', () => {
+        const searchTerm = ' ';
+        const phrase = 'a b c';
+        const matches = caseInsensitiveSubstringSearch(searchTerm, phrase);
+        expect(matches).toBeNull();
+    });
+
     it('should return null if no match', () => {
         const searchTerm = 'NOT PRESENT';
         const phrase = 'aaaaaaaaaaaaaaaaa';

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -1,4 +1,4 @@
-import { caseInsensitiveSubstringSearch, prepareSimpleSearch } from '../__mocks__/obsidian';
+import { prepareSimpleSearch } from '../__mocks__/obsidian';
 
 describe('prepareSimpleSearch() fake', () => {
     it('should provide prepareSimpleSearch() function to do the search', () => {
@@ -24,21 +24,24 @@ describe('caseInsensitiveSubstringSearch', () => {
     it('should return null if search term is only spaces', () => {
         const searchTerm = ' ';
         const phrase = 'a b c';
-        const matches = caseInsensitiveSubstringSearch(searchTerm, phrase);
+        const fn = prepareSimpleSearch(searchTerm);
+        const matches = fn(phrase);
         expect(matches).toBeNull();
     });
 
     it('should return null if no match', () => {
         const searchTerm = 'NOT PRESENT';
         const phrase = 'aaaaaaaaaaaaaaaaa';
-        const matches = caseInsensitiveSubstringSearch(searchTerm, phrase);
+        const fn = prepareSimpleSearch(searchTerm);
+        const matches = fn(phrase);
         expect(matches).toBeNull();
     });
 
     it('should be case-insensitive', () => {
         const searchTerm = 'MixedCase';
         const phrase = 'mixedcase';
-        const matches = caseInsensitiveSubstringSearch(searchTerm, phrase);
+        const fn = prepareSimpleSearch(searchTerm);
+        const matches = fn(phrase);
         expect(JSON.stringify(matches, null, 4)).toMatchInlineSnapshot(`
             "{
                 "score": 0,
@@ -55,7 +58,8 @@ describe('caseInsensitiveSubstringSearch', () => {
     it('should find two occurrences of one string', () => {
         const searchTerm = 'gues';
         const phrase = 'Guestimate the number of guests';
-        const matches = caseInsensitiveSubstringSearch(searchTerm, phrase);
+        const fn = prepareSimpleSearch(searchTerm);
+        const matches = fn(phrase);
         expect(JSON.stringify(matches, null, 4)).toMatchInlineSnapshot(`
             "{
                 "score": 0,
@@ -76,7 +80,8 @@ describe('caseInsensitiveSubstringSearch', () => {
     it('should support search terms with multiple words', () => {
         const searchTerm = 'make foo';
         const phrase = 'Make the food - duplicate search words: FOOD MAKE';
-        const matches = caseInsensitiveSubstringSearch(searchTerm, phrase);
+        const fn = prepareSimpleSearch(searchTerm);
+        const matches = fn(phrase);
         expect(JSON.stringify(matches, null, 4)).toMatchInlineSnapshot(`
             "{
                 "score": 0,
@@ -105,7 +110,8 @@ describe('caseInsensitiveSubstringSearch', () => {
     it('should require all words in query to be found', () => {
         const searchTerm = 'make ZZZ';
         const phrase = 'make aaaaaaa';
-        const matches = caseInsensitiveSubstringSearch(searchTerm, phrase);
+        const fn = prepareSimpleSearch(searchTerm);
+        const matches = fn(phrase);
         expect(matches).toBeNull();
     });
 });

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -44,9 +44,7 @@ describe('prepareSimpleSearch() fake', () => {
     it('should be case-insensitive', () => {
         const searchTerm = 'MixedCase';
         const phrase = 'mixedcase';
-        const fn = prepareSimpleSearch(searchTerm);
-        const matches = fn(phrase);
-        expect(JSON.stringify(matches, null, 4)).toMatchInlineSnapshot(`
+        expect(simpleSearchResultAsJSON(searchTerm, phrase)).toMatchInlineSnapshot(`
             "{
                 "score": 0,
                 "matches": [
@@ -62,9 +60,7 @@ describe('prepareSimpleSearch() fake', () => {
     it('should find two occurrences of one string', () => {
         const searchTerm = 'gues';
         const phrase = 'Guestimate the number of guests';
-        const fn = prepareSimpleSearch(searchTerm);
-        const matches = fn(phrase);
-        expect(JSON.stringify(matches, null, 4)).toMatchInlineSnapshot(`
+        expect(simpleSearchResultAsJSON(searchTerm, phrase)).toMatchInlineSnapshot(`
             "{
                 "score": 0,
                 "matches": [
@@ -84,9 +80,7 @@ describe('prepareSimpleSearch() fake', () => {
     it('should support search terms with multiple words', () => {
         const searchTerm = 'make foo';
         const phrase = 'Make the food - duplicate search words: FOOD MAKE';
-        const fn = prepareSimpleSearch(searchTerm);
-        const matches = fn(phrase);
-        expect(JSON.stringify(matches, null, 4)).toMatchInlineSnapshot(`
+        expect(simpleSearchResultAsJSON(searchTerm, phrase)).toMatchInlineSnapshot(`
             "{
                 "score": 0,
                 "matches": [

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -52,7 +52,33 @@ function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): Sea
         : null;
 }
 
+export function prepareSimpleSearch(query: string): (text: string) => SearchResult | null {
+    return function (text: string): SearchResult | null {
+        return caseInsensitiveSubstringSearch(query, text);
+    };
+}
+
 describe('prepareSimpleSearch() mock', () => {
+    it('should provide prepareSimpleSearch() function to do the search', () => {
+        const searchTerm = 'hello';
+        const phrase = 'hello world';
+        const fn = prepareSimpleSearch(searchTerm);
+        const matches = fn(phrase);
+        expect(JSON.stringify(matches, null, 4)).toMatchInlineSnapshot(`
+            "{
+                "score": 0,
+                "matches": [
+                    [
+                        0,
+                        5
+                    ]
+                ]
+            }"
+        `);
+    });
+});
+
+describe('caseInsensitiveSubstringSearch', () => {
     it('should return null if search term is only spaces', () => {
         const searchTerm = ' ';
         const phrase = 'a b c';

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -1,64 +1,6 @@
-interface SearchResult {
-    score: number;
-    matches: number[][];
-}
+import { caseInsensitiveSubstringSearch, prepareSimpleSearch } from '../__mocks__/obsidian';
 
-/**
- * A fake implementation of the function returned by prepareSimpleSearch(),
- * so we can write tests of code that calls that function.
- *
- * See https://docs.obsidian.md/Reference/TypeScript+API/prepareSimpleSearch
- * @param searchTerm
- * @param phrase
- */
-function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): SearchResult | null {
-    // Don't try and search for empty strings or just spaces:
-    if (!searchTerm.trim()) {
-        return null;
-    }
-
-    // Support multi-word search terms:
-    const searchTerms = searchTerm.split(/\s+/);
-    let matches: number[][] = [];
-
-    for (const term of searchTerms) {
-        const regex = new RegExp(term, 'gi');
-        let match;
-        let termFound = false;
-        while ((match = regex.exec(phrase)) !== null) {
-            matches.push([match.index, match.index + match[0].length]);
-            termFound = true;
-        }
-
-        // We require all search terms to be found.
-        if (!termFound) {
-            return null;
-        }
-    }
-
-    // Sort matches by start index and then by end index
-    matches = matches.sort((a, b) => {
-        if (a[0] === b[0]) {
-            return a[1] - b[1];
-        }
-        return a[0] - b[0];
-    });
-
-    return matches.length > 0
-        ? {
-              score: 0,
-              matches: matches,
-          }
-        : null;
-}
-
-export function prepareSimpleSearch(query: string): (text: string) => SearchResult | null {
-    return function (text: string): SearchResult | null {
-        return caseInsensitiveSubstringSearch(query, text);
-    };
-}
-
-describe('prepareSimpleSearch() mock', () => {
+describe('prepareSimpleSearch() fake', () => {
     it('should provide prepareSimpleSearch() function to do the search', () => {
         const searchTerm = 'hello';
         const phrase = 'hello world';

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -32,14 +32,12 @@ function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): Sea
         return a[0] - b[0];
     });
 
-    if (matches.length > 0) {
-        return {
-            score: 0,
-            matches: matches,
-        };
-    } else {
-        return null;
-    }
+    return matches.length > 0
+        ? {
+              score: 0,
+              matches: matches,
+          }
+        : null;
 }
 
 describe('prepareSimpleSearch() mock', () => {

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -34,9 +34,7 @@ describe('prepareSimpleSearch() fake', () => {
     it('should return null if no match', () => {
         const searchTerm = 'NOT PRESENT';
         const phrase = 'aaaaaaaaaaaaaaaaa';
-        const fn = prepareSimpleSearch(searchTerm);
-        const matches = fn(phrase);
-        expect(matches).toBeNull();
+        simpleSearchShouldNotMatch(searchTerm, phrase);
     });
 
     it('should be case-insensitive', () => {
@@ -112,8 +110,6 @@ describe('prepareSimpleSearch() fake', () => {
     it('should require all words in query to be found', () => {
         const searchTerm = 'make ZZZ';
         const phrase = 'make aaaaaaa';
-        const fn = prepareSimpleSearch(searchTerm);
-        const matches = fn(phrase);
-        expect(matches).toBeNull();
+        simpleSearchShouldNotMatch(searchTerm, phrase);
     });
 });

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -6,13 +6,17 @@ function simpleSearchShouldNotMatch(searchTerm: string, phrase: string) {
     expect(matches).toBeNull();
 }
 
+function simpleSearchResultAsJSON(searchTerm: string, phrase: string) {
+    const fn = prepareSimpleSearch(searchTerm);
+    const matches = fn(phrase);
+    return JSON.stringify(matches, null, 4);
+}
+
 describe('prepareSimpleSearch() fake', () => {
     it('should provide prepareSimpleSearch() function to do the search', () => {
         const searchTerm = 'hello';
         const phrase = 'hello world';
-        const fn = prepareSimpleSearch(searchTerm);
-        const matches = fn(phrase);
-        expect(JSON.stringify(matches, null, 4)).toMatchInlineSnapshot(`
+        expect(simpleSearchResultAsJSON(searchTerm, phrase)).toMatchInlineSnapshot(`
             "{
                 "score": 0,
                 "matches": [

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -12,11 +12,16 @@ interface SearchResult {
  * @param phrase
  */
 function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): SearchResult {
-    const regex = new RegExp(searchTerm, 'gi');
+    // Support multi-word search terms:
+    const searchTerms = searchTerm.split(/\s+/);
     const matches: number[][] = [];
-    let match;
-    while ((match = regex.exec(phrase)) !== null) {
-        matches.push([match.index, match.index + match[0].length]);
+
+    for (const term of searchTerms) {
+        const regex = new RegExp(term, 'gi');
+        let match;
+        while ((match = regex.exec(phrase)) !== null) {
+            matches.push([match.index, match.index + match[0].length]);
+        }
     }
     return {
         score: 0,
@@ -57,6 +62,35 @@ describe('prepareSimpleSearch() mock', () => {
                     [
                         25,
                         29
+                    ]
+                ]
+            }"
+        `);
+    });
+
+    it('should support search terms with multiple words', () => {
+        const searchTerm = 'make foo';
+        const phrase = 'Make the food - duplicate search words: FOOD MAKE';
+        const matches = caseInsensitiveSubstringSearch(searchTerm, phrase);
+        expect(JSON.stringify(matches, null, 4)).toMatchInlineSnapshot(`
+            "{
+                "score": 0,
+                "matches": [
+                    [
+                        0,
+                        4
+                    ],
+                    [
+                        45,
+                        49
+                    ],
+                    [
+                        9,
+                        12
+                    ],
+                    [
+                        40,
+                        43
                     ]
                 ]
             }"

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -1,5 +1,11 @@
 import { prepareSimpleSearch } from '../__mocks__/obsidian';
 
+function simpleSearchShouldNotMatch(searchTerm: string, phrase: string) {
+    const fn = prepareSimpleSearch(searchTerm);
+    const matches = fn(phrase);
+    expect(matches).toBeNull();
+}
+
 describe('prepareSimpleSearch() fake', () => {
     it('should provide prepareSimpleSearch() function to do the search', () => {
         const searchTerm = 'hello';
@@ -22,9 +28,7 @@ describe('prepareSimpleSearch() fake', () => {
     it('should return null if search term is only spaces', () => {
         const searchTerm = ' ';
         const phrase = 'a b c';
-        const fn = prepareSimpleSearch(searchTerm);
-        const matches = fn(phrase);
-        expect(matches).toBeNull();
+        simpleSearchShouldNotMatch(searchTerm, phrase);
     });
 
     it('should return null if no match', () => {

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -19,8 +19,15 @@ function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): Sea
     for (const term of searchTerms) {
         const regex = new RegExp(term, 'gi');
         let match;
+        let termFound = false;
         while ((match = regex.exec(phrase)) !== null) {
             matches.push([match.index, match.index + match[0].length]);
+            termFound = true;
+        }
+
+        // We require all search terms to be found.
+        if (!termFound) {
+            return null;
         }
     }
 
@@ -113,5 +120,12 @@ describe('prepareSimpleSearch() mock', () => {
                 ]
             }"
         `);
+    });
+
+    it('should require all words in query to be found', () => {
+        const searchTerm = 'make ZZZ';
+        const phrase = 'make aaaaaaa';
+        const matches = caseInsensitiveSubstringSearch(searchTerm, phrase);
+        expect(matches).toBeNull();
     });
 });

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -14,7 +14,7 @@ interface SearchResult {
 function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): SearchResult {
     // Support multi-word search terms:
     const searchTerms = searchTerm.split(/\s+/);
-    const matches: number[][] = [];
+    let matches: number[][] = [];
 
     for (const term of searchTerms) {
         const regex = new RegExp(term, 'gi');
@@ -23,6 +23,15 @@ function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): Sea
             matches.push([match.index, match.index + match[0].length]);
         }
     }
+
+    // Sort matches by start index and then by end index
+    matches = matches.sort((a, b) => {
+        if (a[0] === b[0]) {
+            return a[1] - b[1];
+        }
+        return a[0] - b[0];
+    });
+
     return {
         score: 0,
         matches: matches,
@@ -81,16 +90,16 @@ describe('prepareSimpleSearch() mock', () => {
                         4
                     ],
                     [
-                        45,
-                        49
-                    ],
-                    [
                         9,
                         12
                     ],
                     [
                         40,
                         43
+                    ],
+                    [
+                        45,
+                        49
                     ]
                 ]
             }"

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -12,6 +12,10 @@ function simpleSearchResultAsJSON(searchTerm: string, phrase: string) {
     return JSON.stringify(matches, null, 4);
 }
 
+// Note: The matches values shown below were obtained by  adding console.log()
+//       calls in searchDescriptionWithoutTags() to inspect the results of Obsidian's own
+//       prepareSimpleSearch(), and then ensuring our fake version gave the same matches values.
+//       No attempt has been made to reproduce the Obsidian-generated score.
 describe('prepareSimpleSearch() fake', () => {
     it('should provide prepareSimpleSearch() function to do the search', () => {
         const searchTerm = 'hello';

--- a/tests/Obsidian/ObsidianSearchFacilities.test.ts
+++ b/tests/Obsidian/ObsidianSearchFacilities.test.ts
@@ -18,9 +18,7 @@ describe('prepareSimpleSearch() fake', () => {
             }"
         `);
     });
-});
 
-describe('caseInsensitiveSubstringSearch', () => {
     it('should return null if search term is only spaces', () => {
         const searchTerm = ' ';
         const phrase = 'a b c';

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -86,11 +86,11 @@ describe.each([
         return buildSuggestions(line, line.length - 1, originalSettings, allTasks);
     }
 
-    function shouldStartWithSuggestionsEqualling(line: string, expectedSuggestions: string[]) {
+    function shouldStartWithSuggestionsEqualling(line: string, expectedSuggestions: string[], allTasks: Task[] = []) {
         // Validate the test itself:
         expect(expectedSuggestions).not.toHaveLength(0);
 
-        const suggestions = buildSuggestionsForEndOfLine(line);
+        const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
         expectedSuggestions.forEach((expectedSuggestion, index) => {
             expect(suggestions[index].displayText).toEqual(expectedSuggestion);
         });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -176,13 +176,14 @@ describe.each([
     });
 
     describe('suggestions for dependency fields', () => {
-        it('offers task suggestions for tasks too possible depend on', () => {
+        it('should offer to depend on only task in vault, and include its filename in suggestion', () => {
             // Arrange
             const line = `- [ ] some task ${dependsOnSymbol} `;
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
+            const descriptionPlusFileName = 'Do exercises - From: fileName.md';
 
             const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, [taskToDependOn]);
-            expect(suggestions[0].displayText).toContain(taskToDependOn.descriptionWithoutTags);
+            expect(suggestions[0].displayText).toEqual(descriptionPlusFileName);
         });
     });
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -86,6 +86,16 @@ describe.each([
         return buildSuggestions(line, line.length - 1, originalSettings, allTasks);
     }
 
+    function shouldStartWithSuggestionsContaining(line: string, expectedSubstrings: string[], allTasks: Task[] = []) {
+        // Validate the test itself:
+        expect(expectedSubstrings).not.toHaveLength(0);
+
+        const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
+        expectedSubstrings.forEach((expectedSuggestion, index) => {
+            expect(suggestions[index].displayText).toContain(expectedSuggestion);
+        });
+    }
+
     function shouldStartWithSuggestionsEqualling(line: string, expectedSuggestions: string[], allTasks: Task[] = []) {
         // Validate the test itself:
         expect(expectedSuggestions).not.toHaveLength(0);
@@ -137,9 +147,7 @@ describe.each([
     it('offers specific due date completions', () => {
         // Arrange
         const line = `- [ ] some task ${dueDateSymbol} to`;
-        const suggestions = buildSuggestionsForEndOfLine(line);
-        expect(suggestions[0].displayText).toContain('today');
-        expect(suggestions[1].displayText).toContain('tomorrow');
+        shouldStartWithSuggestionsContaining(line, ['today', 'tomorrow']);
     });
 
     it('offers generic recurrence completions', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -96,17 +96,15 @@ describe.each([
 
     it('offers basic completion options for an empty task', () => {
         // Arrange
-        const originalSettings = getSettings();
         const line = '- [ ] ';
-        const suggestions: SuggestInfo[] = buildSuggestions(line, 5, originalSettings, [] as Task[]);
+        const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
         verifyAsJson(suggestions);
     });
 
     it('offers generic due date completions', () => {
         // Arrange
-        const originalSettings = getSettings();
         const line = `- [ ] some task ${dueDateSymbol}`;
-        const suggestions: SuggestInfo[] = buildSuggestions(line, 17, originalSettings, [] as Task[]);
+        const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
         expect(suggestions[0].displayText).toContain('today');
         expect(suggestions[1].displayText).toContain('tomorrow');
         expect(suggestions.length).toEqual(6);
@@ -114,18 +112,16 @@ describe.each([
 
     it('offers specific due date completions', () => {
         // Arrange
-        const originalSettings = getSettings();
         const line = `- [ ] some task ${dueDateSymbol} to`;
-        const suggestions: SuggestInfo[] = buildSuggestions(line, 20, originalSettings, [] as Task[]);
+        const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
         expect(suggestions[0].displayText).toContain('today');
         expect(suggestions[1].displayText).toContain('tomorrow');
     });
 
     it('offers generic recurrence completions', () => {
         // Arrange
-        const originalSettings = getSettings();
         const line = `- [ ] some task ${recurrenceSymbol}`;
-        const suggestions: SuggestInfo[] = buildSuggestions(line, 17, originalSettings, [] as Task[]);
+        const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
         expect(suggestions[0].displayText).toEqual('every');
         expect(suggestions[1].displayText).toEqual('every day');
         expect(suggestions[2].displayText).toEqual('every week');
@@ -133,9 +129,8 @@ describe.each([
 
     it('offers specific recurrence completions', () => {
         // Arrange
-        const originalSettings = getSettings();
         const line = `- [ ] some task ${recurrenceSymbol} every w`;
-        const suggestions: SuggestInfo[] = buildSuggestions(line, 25, originalSettings, [] as Task[]);
+        const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
         expect(suggestions[0].displayText).toEqual('every week');
         expect(suggestions[1].displayText).toEqual('every week on Sunday');
         expect(suggestions[2].displayText).toEqual('every week on Monday');
@@ -158,13 +153,12 @@ describe.each([
 
     it('matches created property suggestion when user types "created" but not "today"', () => {
         // Arrange
-        const originalSettings = getSettings();
         let line = '- [ ] some task cr';
-        let suggestions: SuggestInfo[] = buildSuggestions(line, 18, originalSettings, [] as Task[]);
+        let suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
         expect(suggestions[0].displayText).toEqual(`${createdDateSymbol} created today (2022-07-11)`);
 
         line = '- [ ] some task tod';
-        suggestions = buildSuggestions(line, 19, originalSettings, [] as Task[]);
+        suggestions = buildSuggestionsForEndOfLine(line);
         if (name === 'emoji') {
             // The first suggestion is new line
             expect(suggestions[0].suggestionType).toEqual('empty');

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -88,6 +88,7 @@ describe.each([
         idSymbol,
         dependsOnSymbol,
     } = symbols;
+
     it('offers basic completion options for an empty task', () => {
         // Arrange
         const originalSettings = getSettings();
@@ -149,9 +150,11 @@ describe.each([
         // Arrange
         const originalSettings = getSettings();
         originalSettings.autoSuggestMinMatch = 2;
+
         let line = `- [ ] some task ${recurrenceSymbol} e`;
         let suggestions: SuggestInfo[] = buildSuggestions(line, 19, originalSettings, [] as Task[]);
         expect(suggestions.length).toEqual(0);
+
         line = `- [ ] some task ${recurrenceSymbol} ev`;
         suggestions = buildSuggestions(line, 20, originalSettings, [] as Task[]);
         expect(suggestions[0].displayText).toEqual('every');

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -111,14 +111,14 @@ describe.each([
     it('offers basic completion options for an empty task', () => {
         // Arrange
         const line = '- [ ] ';
-        const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
+        const suggestions = buildSuggestionsForEndOfLine(line);
         verifyAsJson(suggestions);
     });
 
     it('offers generic due date completions', () => {
         // Arrange
         const line = `- [ ] some task ${dueDateSymbol}`;
-        const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
+        const suggestions = buildSuggestionsForEndOfLine(line);
         expect(suggestions[0].displayText).toContain('today');
         expect(suggestions[1].displayText).toContain('tomorrow');
         expect(suggestions.length).toEqual(6);
@@ -127,7 +127,7 @@ describe.each([
     it('offers specific due date completions', () => {
         // Arrange
         const line = `- [ ] some task ${dueDateSymbol} to`;
-        const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
+        const suggestions = buildSuggestionsForEndOfLine(line);
         expect(suggestions[0].displayText).toContain('today');
         expect(suggestions[1].displayText).toContain('tomorrow');
     });
@@ -135,7 +135,7 @@ describe.each([
     it('offers generic recurrence completions', () => {
         // Arrange
         const line = `- [ ] some task ${recurrenceSymbol}`;
-        const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
+        const suggestions = buildSuggestionsForEndOfLine(line);
         expect(suggestions[0].displayText).toEqual('every');
         expect(suggestions[1].displayText).toEqual('every day');
         expect(suggestions[2].displayText).toEqual('every week');
@@ -144,7 +144,7 @@ describe.each([
     it('offers specific recurrence completions', () => {
         // Arrange
         const line = `- [ ] some task ${recurrenceSymbol} every w`;
-        const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
+        const suggestions = buildSuggestionsForEndOfLine(line);
         expect(suggestions[0].displayText).toEqual('every week');
         expect(suggestions[1].displayText).toEqual('every week on Sunday');
         expect(suggestions[2].displayText).toEqual('every week on Monday');
@@ -156,7 +156,7 @@ describe.each([
         originalSettings.autoSuggestMinMatch = 2;
 
         let line = `- [ ] some task ${recurrenceSymbol} e`;
-        let suggestions: SuggestInfo[] = buildSuggestions(line, 19, originalSettings, [] as Task[]);
+        let suggestions = buildSuggestions(line, 19, originalSettings, [] as Task[]);
         expect(suggestions.length).toEqual(0);
 
         line = `- [ ] some task ${recurrenceSymbol} ev`;
@@ -168,7 +168,7 @@ describe.each([
     it('matches created property suggestion when user types "created" but not "today"', () => {
         // Arrange
         let line = '- [ ] some task cr';
-        let suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
+        let suggestions = buildSuggestionsForEndOfLine(line);
         expect(suggestions[0].displayText).toEqual(`${createdDateSymbol} created today (2022-07-11)`);
 
         line = '- [ ] some task tod';
@@ -191,7 +191,7 @@ describe.each([
         it('should offer "id" then "depends on" if user typed "id"', () => {
             const line = '- [ ] some task id';
 
-            const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
+            const suggestions = buildSuggestionsForEndOfLine(line);
             expect(suggestions[0].displayText).toEqual(`${idSymbol} Task ID`);
             expect(suggestions[1].displayText).toEqual(`${dependsOnSymbol} Task depends on ID`);
         });
@@ -199,7 +199,7 @@ describe.each([
         it('should offer to generate unique id if the id symbol is already present', () => {
             const line = `- [ ] some task ${idSymbol}`;
 
-            const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
+            const suggestions = buildSuggestionsForEndOfLine(line);
             expect(suggestions[0].displayText).toEqual('Auto Generate Unique ID');
         });
 
@@ -208,7 +208,7 @@ describe.each([
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
             const descriptionPlusFileName = 'Do exercises - From: fileName.md';
 
-            const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, [taskToDependOn]);
+            const suggestions = buildSuggestionsForEndOfLine(line, [taskToDependOn]);
             expect(suggestions[0].displayText).toEqual(descriptionPlusFileName);
         });
 
@@ -228,20 +228,20 @@ describe.each([
 
             it('should suggest all tasks when there is no existing ID after dependsOn', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} `;
-                const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, allTasks);
+                const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
                 expect(suggestions[0].displayText).toEqual('1 - From: file-name.md');
                 expect(suggestions[1].displayText).toEqual('2 - From: file-name.md');
             });
 
             it('should only offer tasks not already depended upon - with 1 existing dependency', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,`;
-                const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, allTasks);
+                const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
                 expect(suggestions[0].displayText).toEqual('2 - From: file-name.md');
             });
 
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,5678,`;
-                const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, allTasks);
+                const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
 
                 shouldOnlyOfferDefaultSuggestions(suggestions);
             });
@@ -263,7 +263,7 @@ describe.each([
         ];
         const markdownTable = new MarkdownTable(['Searchable Text', 'Text that is added']);
         for (const line of lines) {
-            let suggestions: SuggestInfo[] = buildSuggestions(line, line.length - 1, originalSettings, [] as Task[]);
+            let suggestions = buildSuggestions(line, line.length - 1, originalSettings, [] as Task[]);
             suggestions = maskIDSuggestionForTesting(idSymbol, suggestions);
             for (const suggestion of suggestions) {
                 // The 'new line' replacement adds a trailing space at the end of a line,

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -262,30 +262,13 @@ describe.each([
                 shouldOnlyOfferDefaultSuggestions(suggestions);
             });
 
-            it.failing('should not offer any tasks if there is not a comma after existing depends IDs', () => {
-                // TODO It's not clear whether this is really a bug that is exposed to users,
-                //      or an error in the test.
-                // The documentation says:
-                //      'To depend on multiple tasks, type a comma after the last id in an existing 'depends on' value, and select another task'
-                // However, it currently offers to complete when there is no comma at the end.
-                // This then starts searching for tasks that match 5678,
-                // which eventually reaches a call to Obsidian's prepareSimpleSearch(),
-                // that is unavailable outside the plugin.
-                // So the current mode of failure is that this test gives a traceback starting at:
-                //      (0 , obsidian_1.prepareSimpleSearch) is not a function
-                //      TypeError: (0 , obsidian_1.prepareSimpleSearch) is not a function
-                //          at searchDescriptionWithoutTags (.../obsidian-tasks/src/ui/DependencyHelpers.ts:23:47)
-                // This sometimes manifests as a bug that when the user has selected
-                // a task and pressed return the selection menu does not go away.
+            it('should not offer any tasks if there is not a comma after existing depends IDs', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,5678`;
                 const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
                 shouldOnlyOfferDefaultSuggestions(suggestions);
             });
 
-            it.failing('should not offer tasks if "IDs" are separated by spaces', () => {
-                // IDs are separated by comma with optional space.
-                // Because there is no comma between these two values, the '5678' is not
-                // an ID, and so there should be no suggestion.
+            it('should not offer tasks if "IDs" are separated by spaces', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234 5678`;
                 const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
                 shouldOnlyOfferDefaultSuggestions(suggestions);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -237,18 +237,17 @@ describe.each([
                 taskBuilder.description('2').id('5678').build(),
             ];
 
+            const suggestTask0 = '1 - From: file-name.md';
+            const suggestTask1 = '2 - From: file-name.md';
+
             it('should suggest all tasks when there is no existing ID after dependsOn', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} `;
-                shouldStartWithSuggestionsEqualling(
-                    line,
-                    ['1 - From: file-name.md', '2 - From: file-name.md'],
-                    allTasks,
-                );
+                shouldStartWithSuggestionsEqualling(line, [suggestTask0, suggestTask1], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with 1 existing dependency', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,`;
-                shouldStartWithSuggestionsEqualling(line, ['2 - From: file-name.md'], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTask1], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -237,29 +237,29 @@ describe.each([
                 taskBuilder.description('2').id('5678').build(),
             ];
 
-            const suggestTask0 = '1 - From: file-name.md';
-            const suggestTask1 = '2 - From: file-name.md';
+            const suggestTask1 = '1 - From: file-name.md';
+            const suggestTask2 = '2 - From: file-name.md';
 
             it('should suggest all tasks when there is no existing ID after dependsOn', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} `;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask0, suggestTask1], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTask1, suggestTask2], allTasks);
             });
 
             it('should offer tasks containing the search string, if given a partial ID', () => {
                 // 1 does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol} 1`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask0], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTask1], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with 1 existing dependency', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask1], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTask2], allTasks);
             });
 
             it.failing('should offer tasks when first existing dependency id has hyphen and underscore', () => {
                 // TODO hyphen and underscore are not currently recognised in this location by the auto-suggest code
                 const line = `- [ ] some task ${dependsOnSymbol} 1_2-3,`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask0, suggestTask1], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTask1, suggestTask2], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -105,10 +105,11 @@ describe.each([
 
         const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
         expectedSuggestions.forEach((expectedSuggestion, index) => {
+            const displayText = suggestions[index].displayText;
             if (useEqual) {
-                expect(suggestions[index].displayText).toEqual(expectedSuggestion);
+                expect(displayText).toEqual(expectedSuggestion);
             } else {
-                expect(suggestions[index].displayText).toContain(expectedSuggestion);
+                expect(displayText).toContain(expectedSuggestion);
             }
         });
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -79,7 +79,8 @@ describe.each([
         name === 'dataview',
     );
 
-    function buildSuggestionsForEndOfLine(line: string, originalSettings: Settings, allTasks: Task[]) {
+    function buildSuggestionsForEndOfLine(line: string, _originalSettings: Settings, allTasks: Task[]) {
+        const originalSettings = getSettings();
         return buildSuggestions(line, line.length - 1, originalSettings, allTasks);
     }
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -192,7 +192,6 @@ describe.each([
         });
 
         it('should offer to depend on only task in vault, and include its filename in suggestion if user typed "id"', () => {
-            // Arrange
             const line = `- [ ] some task ${dependsOnSymbol} `;
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
             const descriptionPlusFileName = 'Do exercises - From: fileName.md';
@@ -200,6 +199,11 @@ describe.each([
             const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, [taskToDependOn]);
             expect(suggestions[0].displayText).toEqual(descriptionPlusFileName);
         });
+
+        // TODO should not offer to depend on self
+        // TODO should not offer to depend on a task it already depends on
+        // TODO should offer tasks in current file before those in other files
+        // TODO should offer addition of additional dependencies, if user adds comma and space after first 'depends on' value
     });
 
     it('show all suggested text', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -185,8 +185,7 @@ describe.each([
             const line = `- [ ] some task ${dependsOnSymbol} `;
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
 
-            const allTasks = [taskToDependOn];
-            const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, allTasks);
+            const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, [taskToDependOn]);
             expect(suggestions[0].displayText).toContain(taskToDependOn.descriptionWithoutTags);
         });
     });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -79,6 +79,8 @@ describe.each([
         name === 'dataview',
     );
 
+    /** Build suggestions for the simple case where the cursor is at the very end of the line.
+     */
     function buildSuggestionsForEndOfLine(line: string, allTasks: Task[] = []) {
         const originalSettings = getSettings();
         return buildSuggestions(line, line.length - 1, originalSettings, allTasks);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -86,6 +86,13 @@ describe.each([
         return buildSuggestions(line, line.length - 1, originalSettings, allTasks);
     }
 
+    function shouldStartWithSuggestionsEqualling(line: string, expectedSuggestions: string[]) {
+        const suggestions = buildSuggestionsForEndOfLine(line);
+        expectedSuggestions.forEach((expectedSuggestion, index) => {
+            expect(suggestions[index].displayText).toEqual(expectedSuggestion);
+        });
+    }
+
     function shouldOnlyOfferDefaultSuggestions(suggestions: SuggestInfo[]) {
         if (name === 'emoji') {
             expect(suggestions[0].displayText).toEqual('⏎');
@@ -133,12 +140,8 @@ describe.each([
     });
 
     it('offers generic recurrence completions', () => {
-        // Arrange
         const line = `- [ ] some task ${recurrenceSymbol}`;
-        const suggestions = buildSuggestionsForEndOfLine(line);
-        expect(suggestions[0].displayText).toEqual('every');
-        expect(suggestions[1].displayText).toEqual('every day');
-        expect(suggestions[2].displayText).toEqual('every week');
+        shouldStartWithSuggestionsEqualling(line, ['every', 'every day', 'every week']);
     });
 
     it('offers specific recurrence completions', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -250,6 +250,12 @@ describe.each([
                 shouldStartWithSuggestionsEqualling(line, [suggestTask1], allTasks);
             });
 
+            it.failing('should offer tasks when first existing dependency id has hyphen and underscore', () => {
+                // TODO hyphen and underscore are not currently recognised in this location by the auto-suggest code
+                const line = `- [ ] some task ${dependsOnSymbol} 1_2-3,`;
+                shouldStartWithSuggestionsEqualling(line, [suggestTask0, suggestTask1], allTasks);
+            });
+
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,5678,`;
                 const suggestions = buildSuggestionsForEndOfLine(line, allTasks);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -176,6 +176,14 @@ describe.each([
     });
 
     describe('suggestions for dependency fields', () => {
+        it('should offer "id" then "depends on" if user typed "id"', () => {
+            const line = '- [ ] some task id';
+
+            const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
+            expect(suggestions[0].displayText).toEqual(`${idSymbol} Task ID`);
+            expect(suggestions[1].displayText).toEqual(`${dependsOnSymbol} Task depends on ID`);
+        });
+
         it('should offer to depend on only task in vault, and include its filename in suggestion', () => {
             // Arrange
             const line = `- [ ] some task ${dependsOnSymbol} `;

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -87,26 +87,33 @@ describe.each([
     }
 
     function shouldStartWithSuggestionsContaining(line: string, expectedSubstrings: string[], allTasks: Task[] = []) {
-        // Validate the test itself:
-        expect(expectedSubstrings).not.toHaveLength(0);
-
-        const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
-        expectedSubstrings.forEach((expectedSuggestion, index) => {
-            expect(suggestions[index].displayText).toContain(expectedSuggestion);
-        });
-
-        // return the suggestions, to allow for further validation
-        return suggestions;
+        return shouldStartWithSuggestions(line, expectedSubstrings, false, allTasks);
     }
 
     function shouldStartWithSuggestionsEqualling(line: string, expectedSuggestions: string[], allTasks: Task[] = []) {
+        return shouldStartWithSuggestions(line, expectedSuggestions, true, allTasks);
+    }
+
+    function shouldStartWithSuggestions(
+        line: string,
+        expectedSuggestions: string[],
+        useEqual: boolean,
+        allTasks: Task[] = [],
+    ) {
         // Validate the test itself:
         expect(expectedSuggestions).not.toHaveLength(0);
 
         const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
         expectedSuggestions.forEach((expectedSuggestion, index) => {
-            expect(suggestions[index].displayText).toEqual(expectedSuggestion);
+            if (useEqual) {
+                expect(suggestions[index].displayText).toEqual(expectedSuggestion);
+            } else {
+                expect(suggestions[index].displayText).toContain(expectedSuggestion);
+            }
         });
+
+        // return the suggestions, to allow for further validation
+        return suggestions;
     }
 
     function shouldOnlyOfferDefaultSuggestions(suggestions: SuggestInfo[]) {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -261,6 +261,26 @@ describe.each([
                 const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
                 shouldOnlyOfferDefaultSuggestions(suggestions);
             });
+
+            it.failing('should not offer any tasks if there is not a comma after existing depends IDs', () => {
+                // TODO It's not clear whether this is really a bug that is exposed to users,
+                //      or an error in the test.
+                // The documentation says:
+                //      'To depend on multiple tasks, type a comma after the last id in an existing 'depends on' value, and select another task'
+                // However, it currently offers to complete when there is no comma at the end.
+                // This then starts searching for tasks that match 5678,
+                // which eventually reaches a call to Obsidian's prepareSimpleSearch(),
+                // that is unavailable outside the plugin.
+                // So the current mode of failure is that this test gives a traceback starting at:
+                //      (0 , obsidian_1.prepareSimpleSearch) is not a function
+                //      TypeError: (0 , obsidian_1.prepareSimpleSearch) is not a function
+                //          at searchDescriptionWithoutTags (.../obsidian-tasks/src/ui/DependencyHelpers.ts:23:47)
+                // This sometimes manifests as a bug that when the user has selected
+                // a task and pressed return the selection menu does not go away.
+                const line = `- [ ] some task ${dependsOnSymbol} 1234,5678`;
+                const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
+                shouldOnlyOfferDefaultSuggestions(suggestions);
+            });
         });
     });
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -116,16 +116,6 @@ describe.each([
         expect(suggestions[1].displayText).toContain('tomorrow');
     });
 
-    it('offers task suggestions for tasks too possible depend on', () => {
-        // Arrange
-        const originalSettings = getSettings();
-        const line = `- [ ] some task ${dependsOnSymbol} `;
-        const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
-
-        const suggestions: SuggestInfo[] = buildSuggestions(line, line.length - 1, originalSettings, [taskToDependOn]);
-        expect(suggestions[0].displayText).toContain(taskToDependOn.descriptionWithoutTags);
-    });
-
     it('offers generic recurrence completions', () => {
         // Arrange
         const originalSettings = getSettings();
@@ -182,6 +172,20 @@ describe.each([
             expect(1).toEqual(2);
         }
         expect(suggestions[0].displayText).not.toContain('created today');
+    });
+
+    describe('suggestions for dependency fields', () => {
+        it('offers task suggestions for tasks too possible depend on', () => {
+            // Arrange
+            const originalSettings = getSettings();
+            const line = `- [ ] some task ${dependsOnSymbol} `;
+            const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
+
+            const suggestions: SuggestInfo[] = buildSuggestions(line, line.length - 1, originalSettings, [
+                taskToDependOn,
+            ]);
+            expect(suggestions[0].displayText).toContain(taskToDependOn.descriptionWithoutTags);
+        });
     });
 
     it('show all suggested text', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -5,7 +5,7 @@ import { verifyAsJson } from 'approvals/lib/Providers/Jest/JestApprovals';
 import moment from 'moment';
 import * as chrono from 'chrono-node';
 import type { Task } from 'Task/Task';
-import { type Settings, getSettings } from '../../src/Config/Settings';
+import { getSettings } from '../../src/Config/Settings';
 import type { SuggestInfo, SuggestionBuilder } from '../../src/Suggestor';
 import {
     canSuggestForLine,
@@ -79,7 +79,7 @@ describe.each([
         name === 'dataview',
     );
 
-    function buildSuggestionsForEndOfLine(line: string, _originalSettings: Settings, allTasks: Task[]) {
+    function buildSuggestionsForEndOfLine(line: string, allTasks: Task[]) {
         const originalSettings = getSettings();
         return buildSuggestions(line, line.length - 1, originalSettings, allTasks);
     }
@@ -182,12 +182,11 @@ describe.each([
     describe('suggestions for dependency fields', () => {
         it('offers task suggestions for tasks too possible depend on', () => {
             // Arrange
-            const originalSettings = getSettings();
             const line = `- [ ] some task ${dependsOnSymbol} `;
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
 
             const allTasks = [taskToDependOn];
-            const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, originalSettings, allTasks);
+            const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, allTasks);
             expect(suggestions[0].displayText).toContain(taskToDependOn.descriptionWithoutTags);
         });
     });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -181,9 +181,8 @@ describe.each([
             const line = `- [ ] some task ${dependsOnSymbol} `;
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
 
-            const suggestions: SuggestInfo[] = buildSuggestions(line, line.length - 1, originalSettings, [
-                taskToDependOn,
-            ]);
+            const allTasks = [taskToDependOn];
+            const suggestions: SuggestInfo[] = buildSuggestions(line, line.length - 1, originalSettings, allTasks);
             expect(suggestions[0].displayText).toContain(taskToDependOn.descriptionWithoutTags);
         });
     });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -205,8 +205,7 @@ describe.each([
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
             const descriptionPlusFileName = 'Do exercises - From: fileName.md';
 
-            const suggestions = buildSuggestionsForEndOfLine(line, [taskToDependOn]);
-            expect(suggestions[0].displayText).toEqual(descriptionPlusFileName);
+            shouldStartWithSuggestionsEqualling(line, [descriptionPlusFileName], [taskToDependOn]);
         });
 
         // TODO should not offer to depend on self
@@ -225,15 +224,16 @@ describe.each([
 
             it('should suggest all tasks when there is no existing ID after dependsOn', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} `;
-                const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
-                expect(suggestions[0].displayText).toEqual('1 - From: file-name.md');
-                expect(suggestions[1].displayText).toEqual('2 - From: file-name.md');
+                shouldStartWithSuggestionsEqualling(
+                    line,
+                    ['1 - From: file-name.md', '2 - From: file-name.md'],
+                    allTasks,
+                );
             });
 
             it('should only offer tasks not already depended upon - with 1 existing dependency', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,`;
-                const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
-                expect(suggestions[0].displayText).toEqual('2 - From: file-name.md');
+                shouldStartWithSuggestionsEqualling(line, ['2 - From: file-name.md'], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -79,7 +79,7 @@ describe.each([
         name === 'dataview',
     );
 
-    function buildSuggestionsForEndOfLine(line: string, allTasks: Task[]) {
+    function buildSuggestionsForEndOfLine(line: string, allTasks: Task[] = []) {
         const originalSettings = getSettings();
         return buildSuggestions(line, line.length - 1, originalSettings, allTasks);
     }

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -94,6 +94,9 @@ describe.each([
         expectedSubstrings.forEach((expectedSuggestion, index) => {
             expect(suggestions[index].displayText).toContain(expectedSuggestion);
         });
+
+        // return the suggestions, to allow for further validation
+        return suggestions;
     }
 
     function shouldStartWithSuggestionsEqualling(line: string, expectedSuggestions: string[], allTasks: Task[] = []) {
@@ -138,9 +141,7 @@ describe.each([
     it('offers generic due date completions', () => {
         // Arrange
         const line = `- [ ] some task ${dueDateSymbol}`;
-        const suggestions = buildSuggestionsForEndOfLine(line);
-        expect(suggestions[0].displayText).toContain('today');
-        expect(suggestions[1].displayText).toContain('tomorrow');
+        const suggestions = shouldStartWithSuggestionsContaining(line, ['today', 'tomorrow']);
         expect(suggestions.length).toEqual(6);
     });
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -176,11 +176,11 @@ describe.each([
         originalSettings.autoSuggestMinMatch = 2;
 
         let line = `- [ ] some task ${recurrenceSymbol} e`;
-        let suggestions = buildSuggestions(line, 19, originalSettings, [] as Task[]);
+        let suggestions = buildSuggestions(line, 19, originalSettings, []);
         expect(suggestions.length).toEqual(0);
 
         line = `- [ ] some task ${recurrenceSymbol} ev`;
-        suggestions = buildSuggestions(line, 20, originalSettings, [] as Task[]);
+        suggestions = buildSuggestions(line, 20, originalSettings, []);
         expect(suggestions[0].displayText).toEqual('every');
         expect(suggestions[1].displayText).toEqual('every day');
     });
@@ -297,7 +297,7 @@ describe.each([
         ];
         const markdownTable = new MarkdownTable(['Searchable Text', 'Text that is added']);
         for (const line of lines) {
-            let suggestions = buildSuggestions(line, line.length - 1, originalSettings, [] as Task[]);
+            let suggestions = buildSuggestions(line, line.length - 1, originalSettings, []);
             suggestions = maskIDSuggestionForTesting(idSymbol, suggestions);
             for (const suggestion of suggestions) {
                 // The 'new line' replacement adds a trailing space at the end of a line,
@@ -332,43 +332,43 @@ describe('onlySuggestIfBracketOpen', () => {
 
     it('should suggest if cursor at end of line with an open pair', () => {
         const settings = getSettings();
-        let suggestions = buildSuggestions(...cursorPosition('(hello world|'), settings, [] as Task[]);
+        let suggestions = buildSuggestions(...cursorPosition('(hello world|'), settings, []);
         expect(suggestions).not.toEqual(emptySuggestion);
 
-        suggestions = buildSuggestions(...cursorPosition('[hello world|'), settings, [] as Task[]);
+        suggestions = buildSuggestions(...cursorPosition('[hello world|'), settings, []);
         expect(suggestions).not.toEqual(emptySuggestion);
     });
 
     it('should suggest if cursor at end of line with an nested open pairs', () => {
         const settings = getSettings();
-        let suggestions = buildSuggestions(...cursorPosition('(((hello world))|'), settings, [] as Task[]);
+        let suggestions = buildSuggestions(...cursorPosition('(((hello world))|'), settings, []);
         expect(suggestions).not.toEqual(emptySuggestion);
 
-        suggestions = buildSuggestions(...cursorPosition('[[[hello world]]|'), settings, [] as Task[]);
+        suggestions = buildSuggestions(...cursorPosition('[[[hello world]]|'), settings, []);
         expect(suggestions).not.toEqual(emptySuggestion);
     });
 
     it('should suggest if cursor in middle of closed pair', () => {
         const settings = getSettings();
-        let suggestions = buildSuggestions(...cursorPosition('(hello world|)'), settings, [] as Task[]);
+        let suggestions = buildSuggestions(...cursorPosition('(hello world|)'), settings, []);
         expect(suggestions).not.toEqual(emptySuggestion);
 
-        suggestions = buildSuggestions(...cursorPosition('[hello world|]'), settings, [] as Task[]);
+        suggestions = buildSuggestions(...cursorPosition('[hello world|]'), settings, []);
         expect(suggestions).not.toEqual(emptySuggestion);
     });
 
     it('should suggest if there is an opening bracket after many closing brackets', () => {
-        const suggestions = buildSuggestions(...cursorPosition(']]]]]]](hello|'), getSettings(), [] as Task[]);
+        const suggestions = buildSuggestions(...cursorPosition(']]]]]]](hello|'), getSettings(), []);
         expect(suggestions).not.toEqual(emptySuggestion);
     });
 
     it('should not suggest on an empty line', () => {
-        const suggestions = buildSuggestions(...cursorPosition('|'), getSettings(), [] as Task[]);
+        const suggestions = buildSuggestions(...cursorPosition('|'), getSettings(), []);
         expect(suggestions).toEqual(emptySuggestion);
     });
 
     it("should not suggest if there's no open bracket at cursor position", () => {
-        const suggestions = buildSuggestions(...cursorPosition('(hello world)|'), getSettings(), [] as Task[]);
+        const suggestions = buildSuggestions(...cursorPosition('(hello world)|'), getSettings(), []);
         expect(suggestions).toEqual(emptySuggestion);
     });
 });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -235,13 +235,13 @@ describe.each([
 
             it('should only offer tasks not already depended upon - with 1 existing dependency', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,`;
-                const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, Array.from(allTasks));
+                const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, allTasks);
                 expect(suggestions[0].displayText).toEqual('2 - From: file-name.md');
             });
 
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,5678,`;
-                const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, Array.from(allTasks));
+                const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, allTasks);
 
                 shouldOnlyOfferDefaultSuggestions(suggestions);
             });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -87,6 +87,9 @@ describe.each([
     }
 
     function shouldStartWithSuggestionsEqualling(line: string, expectedSuggestions: string[]) {
+        // Validate the test itself:
+        expect(expectedSuggestions).not.toHaveLength(0);
+
         const suggestions = buildSuggestionsForEndOfLine(line);
         expectedSuggestions.forEach((expectedSuggestion, index) => {
             expect(suggestions[index].displayText).toEqual(expectedSuggestion);
@@ -168,11 +171,10 @@ describe.each([
     it('matches created property suggestion when user types "created" but not "today"', () => {
         // Arrange
         let line = '- [ ] some task cr';
-        let suggestions = buildSuggestionsForEndOfLine(line);
-        expect(suggestions[0].displayText).toEqual(`${createdDateSymbol} created today (2022-07-11)`);
+        shouldStartWithSuggestionsEqualling(line, [`${createdDateSymbol} created today (2022-07-11)`]);
 
         line = '- [ ] some task tod';
-        suggestions = buildSuggestionsForEndOfLine(line);
+        const suggestions = buildSuggestionsForEndOfLine(line);
         if (name === 'emoji') {
             // The first suggestion is new line
             expect(suggestions[0].suggestionType).toEqual('empty');
@@ -190,17 +192,12 @@ describe.each([
     describe('suggestions for dependency fields', () => {
         it('should offer "id" then "depends on" if user typed "id"', () => {
             const line = '- [ ] some task id';
-
-            const suggestions = buildSuggestionsForEndOfLine(line);
-            expect(suggestions[0].displayText).toEqual(`${idSymbol} Task ID`);
-            expect(suggestions[1].displayText).toEqual(`${dependsOnSymbol} Task depends on ID`);
+            shouldStartWithSuggestionsEqualling(line, [`${idSymbol} Task ID`, `${dependsOnSymbol} Task depends on ID`]);
         });
 
         it('should offer to generate unique id if the id symbol is already present', () => {
             const line = `- [ ] some task ${idSymbol}`;
-
-            const suggestions = buildSuggestionsForEndOfLine(line);
-            expect(suggestions[0].displayText).toEqual('Auto Generate Unique ID');
+            shouldStartWithSuggestionsEqualling(line, ['Auto Generate Unique ID']);
         });
 
         it('should offer to depend on only task in vault, and include its filename in suggestion if user typed "id"', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -281,6 +281,15 @@ describe.each([
                 const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
                 shouldOnlyOfferDefaultSuggestions(suggestions);
             });
+
+            it.failing('should not offer tasks if "IDs" are separated by spaces', () => {
+                // IDs are separated by comma with optional space.
+                // Because there is no comma between these two values, the '5678' is not
+                // an ID, and so there should be no suggestion.
+                const line = `- [ ] some task ${dependsOnSymbol} 1234 5678`;
+                const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
+                shouldOnlyOfferDefaultSuggestions(suggestions);
+            });
         });
     });
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -147,10 +147,7 @@ describe.each([
     it('offers specific recurrence completions', () => {
         // Arrange
         const line = `- [ ] some task ${recurrenceSymbol} every w`;
-        const suggestions = buildSuggestionsForEndOfLine(line);
-        expect(suggestions[0].displayText).toEqual('every week');
-        expect(suggestions[1].displayText).toEqual('every week on Sunday');
-        expect(suggestions[2].displayText).toEqual('every week on Monday');
+        shouldStartWithSuggestionsEqualling(line, ['every week', 'every week on Sunday', 'every week on Monday']);
     });
 
     it('respects the minimal match setting', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -86,6 +86,18 @@ describe.each([
         return buildSuggestions(line, line.length - 1, originalSettings, allTasks);
     }
 
+    function shouldOnlyOfferDefaultSuggestions(suggestions: SuggestInfo[]) {
+        if (name === 'emoji') {
+            expect(suggestions[0].displayText).toEqual('⏎');
+        } else if (name === 'dataview') {
+            expect(suggestions[0].displayText).toEqual('due:: due date');
+        } else {
+            // we should never reach here
+            // add a new case above if adding a new format
+            expect(1).toEqual(2);
+        }
+    }
+
     const {
         dueDateSymbol,
         scheduledDateSymbol,
@@ -231,15 +243,7 @@ describe.each([
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,5678,`;
                 const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, Array.from(allTasks));
 
-                if (name === 'emoji') {
-                    expect(suggestions[0].displayText).toEqual('⏎');
-                } else if (name === 'dataview') {
-                    expect(suggestions[0].displayText).toEqual('due:: due date');
-                } else {
-                    // we should never reach here
-                    // add a new case above if adding a new format
-                    expect(1).toEqual(2);
-                }
+                shouldOnlyOfferDefaultSuggestions(suggestions);
             });
         });
     });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -254,7 +254,6 @@ describe.each([
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,5678,`;
                 const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
-
                 shouldOnlyOfferDefaultSuggestions(suggestions);
             });
         });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -86,14 +86,56 @@ describe.each([
         return buildSuggestions(line, line.length - 1, originalSettings, allTasks);
     }
 
-    function shouldStartWithSuggestionsContaining(line: string, expectedSubstrings: string[], allTasks: Task[] = []) {
-        return shouldStartWithSuggestions(line, expectedSubstrings, false, allTasks);
+    /**
+     * Assert that the suggestions generated from the given line **contain** substrings specified in the
+     * {@link expectedSubstrings} array.
+     *
+     * Each suggestion must contain the corresponding substring from the {@link expectedSubstrings} array.
+     *
+     * @note Additional suggestions are allowed. This only tests the initial suggestions, as defined
+     *       by the number of elements in {@link expectedSubstrings}.
+     *
+     * @param line - The line to generate suggestions from, when the cursor is at the end of the line.
+     * @param expectedSubstrings - The array of substrings that the suggestions should **contain**.
+     * @param allTasks - Optional array of tasks to consider while generating suggestions.
+     *
+     * @returns An array of {@link SuggestInfo} suggestions generated from the line, to allow for additional testing.
+     * @see shouldStartWithSuggestionsEqualling
+     */
+    function shouldStartWithSuggestionsContaining(
+        line: string,
+        expectedSubstrings: string[],
+        allTasks: Task[] = [],
+    ): SuggestInfo[] {
+        const useEqual = false;
+        return shouldStartWithSuggestions(line, expectedSubstrings, useEqual, allTasks);
     }
 
+    /**
+     * Assert that the suggestions generated from the given line **equal** the strings specified in the
+     * {@link expectedSuggestions} array.
+     *
+     * Each suggestion must equal the corresponding string from the {@link expectedSuggestions} array.
+     *
+     * @note Additional suggestions are allowed. This only tests the initial suggestions, as defined
+     *       by the number of elements in {@link expectedSuggestions}.
+     *
+     * @param line - The line to generate suggestions from, when the cursor is at the end of the line.
+     * @param expectedSuggestions - The array of strings that the suggestions should **equal**.
+     * @param allTasks - Optional array of tasks to consider while generating suggestions.
+     *
+     * @returns An array of {@link SuggestInfo} suggestions generated from the line, to allow for additional testing.
+     * @see shouldStartWithSuggestionsContaining
+     */
     function shouldStartWithSuggestionsEqualling(line: string, expectedSuggestions: string[], allTasks: Task[] = []) {
-        return shouldStartWithSuggestions(line, expectedSuggestions, true, allTasks);
+        const useEqual = true;
+        return shouldStartWithSuggestions(line, expectedSuggestions, useEqual, allTasks);
     }
 
+    /**
+     * @note This is in implementation detail of {@link shouldStartWithSuggestionsContaining}
+     *       and {@link shouldStartWithSuggestionsEqualling}. Use them instead.
+     */
     function shouldStartWithSuggestions(
         line: string,
         expectedSuggestions: string[],

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -5,7 +5,7 @@ import { verifyAsJson } from 'approvals/lib/Providers/Jest/JestApprovals';
 import moment from 'moment';
 import * as chrono from 'chrono-node';
 import type { Task } from 'Task/Task';
-import { getSettings } from '../../src/Config/Settings';
+import { type Settings, getSettings } from '../../src/Config/Settings';
 import type { SuggestInfo, SuggestionBuilder } from '../../src/Suggestor';
 import {
     canSuggestForLine,
@@ -78,6 +78,10 @@ describe.each([
         MAX_GENERIC_SUGGESTIONS_FOR_TESTS,
         name === 'dataview',
     );
+
+    function buildSuggestionsForEndOfLine(line: string, originalSettings: Settings, allTasks: Task[]) {
+        return buildSuggestions(line, line.length - 1, originalSettings, allTasks);
+    }
 
     const {
         dueDateSymbol,
@@ -182,7 +186,7 @@ describe.each([
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
 
             const allTasks = [taskToDependOn];
-            const suggestions: SuggestInfo[] = buildSuggestions(line, line.length - 1, originalSettings, allTasks);
+            const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line, originalSettings, allTasks);
             expect(suggestions[0].displayText).toContain(taskToDependOn.descriptionWithoutTags);
         });
     });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -212,9 +212,7 @@ describe.each([
         it('should offer to depend on only task in vault, and include its filename in suggestion if user typed "id"', () => {
             const line = `- [ ] some task ${dependsOnSymbol} `;
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
-            const descriptionPlusFileName = 'Do exercises - From: fileName.md';
-
-            shouldStartWithSuggestionsEqualling(line, [descriptionPlusFileName], [taskToDependOn]);
+            shouldStartWithSuggestionsEqualling(line, ['Do exercises - From: fileName.md'], [taskToDependOn]);
         });
 
         // TODO should not offer to depend on self

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -245,6 +245,12 @@ describe.each([
                 shouldStartWithSuggestionsEqualling(line, [suggestTask0, suggestTask1], allTasks);
             });
 
+            it('should offer tasks containing the search string, if given a partial ID', () => {
+                // 1 does not match any of the existing IDs, so is presumed to be a substring to search for.
+                const line = `- [ ] some task ${dependsOnSymbol} 1`;
+                shouldStartWithSuggestionsEqualling(line, [suggestTask0], allTasks);
+            });
+
             it('should only offer tasks not already depended upon - with 1 existing dependency', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,`;
                 shouldStartWithSuggestionsEqualling(line, [suggestTask1], allTasks);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -184,7 +184,14 @@ describe.each([
             expect(suggestions[1].displayText).toEqual(`${dependsOnSymbol} Task depends on ID`);
         });
 
-        it('should offer to depend on only task in vault, and include its filename in suggestion', () => {
+        it('should offer to generate unique id if the id symbol is already present', () => {
+            const line = `- [ ] some task ${idSymbol}`;
+
+            const suggestions: SuggestInfo[] = buildSuggestionsForEndOfLine(line);
+            expect(suggestions[0].displayText).toEqual('Auto Generate Unique ID');
+        });
+
+        it('should offer to depend on only task in vault, and include its filename in suggestion if user typed "id"', () => {
             // Arrange
             const line = `- [ ] some task ${dependsOnSymbol} `;
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -123,6 +123,14 @@ function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): Sea
         : null;
 }
 
+/**
+ * A fake implementation of prepareSimpleSearch(),
+ * so we can write tests of code that calls that function.
+ * Note that the returned score is always 0.
+ *
+ * See https://docs.obsidian.md/Reference/TypeScript+API/prepareSimpleSearch
+ * @param query - the search term
+ */
 export function prepareSimpleSearch(query: string): (text: string) => SearchResult | null {
     return function (text: string): SearchResult | null {
         return caseInsensitiveSubstringSearch(query, text);

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -68,3 +68,63 @@ export class Notice {
      */
     hide(): void {}
 }
+
+interface SearchResult {
+    score: number;
+    matches: number[][];
+}
+
+/**
+ * A fake implementation of the function returned by prepareSimpleSearch(),
+ * so we can write tests of code that calls that function.
+ *
+ * See https://docs.obsidian.md/Reference/TypeScript+API/prepareSimpleSearch
+ * @param searchTerm
+ * @param phrase
+ */
+export function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): SearchResult | null {
+    // Don't try and search for empty strings or just spaces:
+    if (!searchTerm.trim()) {
+        return null;
+    }
+
+    // Support multi-word search terms:
+    const searchTerms = searchTerm.split(/\s+/);
+    let matches: number[][] = [];
+
+    for (const term of searchTerms) {
+        const regex = new RegExp(term, 'gi');
+        let match;
+        let termFound = false;
+        while ((match = regex.exec(phrase)) !== null) {
+            matches.push([match.index, match.index + match[0].length]);
+            termFound = true;
+        }
+
+        // We require all search terms to be found.
+        if (!termFound) {
+            return null;
+        }
+    }
+
+    // Sort matches by start index and then by end index
+    matches = matches.sort((a, b) => {
+        if (a[0] === b[0]) {
+            return a[1] - b[1];
+        }
+        return a[0] - b[0];
+    });
+
+    return matches.length > 0
+        ? {
+              score: 0,
+              matches: matches,
+          }
+        : null;
+}
+
+export function prepareSimpleSearch(query: string): (text: string) => SearchResult | null {
+    return function (text: string): SearchResult | null {
+        return caseInsensitiveSubstringSearch(query, text);
+    };
+}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -82,7 +82,7 @@ interface SearchResult {
  * @param searchTerm
  * @param phrase
  */
-export function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): SearchResult | null {
+function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): SearchResult | null {
     // Don't try and search for empty strings or just spaces:
     if (!searchTerm.trim()) {
         return null;

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -75,7 +75,7 @@ interface SearchResult {
 }
 
 /**
- * An implementation detail of our fail {@link prepareSimpleSearch} - see below.
+ * An implementation detail of our fake {@link prepareSimpleSearch} - see below.
  *
  * See https://docs.obsidian.md/Reference/TypeScript+API/prepareSimpleSearch
  * @param searchTerm

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -75,8 +75,7 @@ interface SearchResult {
 }
 
 /**
- * A fake implementation of the function returned by prepareSimpleSearch(),
- * so we can write tests of code that calls that function.
+ * An implementation detail of our fail {@link prepareSimpleSearch} - see below.
  *
  * See https://docs.obsidian.md/Reference/TypeScript+API/prepareSimpleSearch
  * @param searchTerm
@@ -117,7 +116,7 @@ function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): Sea
 
     return matches.length > 0
         ? {
-              score: 0,
+              score: 0, // this fake implementation does not support calculating scores.
               matches: matches,
           }
         : null;


### PR DESCRIPTION
# Description

## Motivation and Context

- Replace an Obsidian-specific `string.contains()` with `string.includes()` which is available when run via tests.
- Add some initial tests to capture the behaviour of auto-suggest facilities added in #2771.
- Add a fake implementation of `prepareSimpleSearch()` - with its own tests - so that I could test suggestions made for the dependsOn field.

## How has this been tested?

- Exploratory testing to confirm the actual behaviours of the tests I've added
- Automated tests

## Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
