### PR TITLE
feat: remove `Description` label from Edit Task modal

### DIFF
--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -1,5 +1,5 @@
 .tasks-modal {
-    > section:not(:first-child) {
+    section:not(:first-child) {
             margin-top: 8px;
     }
 

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -1,5 +1,5 @@
 .tasks-modal {
-    section:not(:first-child) {
+    section + section {
             margin-top: 8px;
     }
 

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -1,5 +1,5 @@
 .tasks-modal {
-    > section {
+    > section:not(:first-child) {
             margin-top: 8px;
     }
 

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -24,7 +24,6 @@
         width: 100%;
         min-height: calc(var(--input-height) * 2);
         resize: vertical;
-        margin-top: 8px;
     }
 }
 

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -427,14 +427,14 @@ Availability of access keys:
     <!--  Description  -->
     <!-- --------------------------------------------------------------------------- -->
     <section class="tasks-modal-description-section">
-        <label for="description">Descrip<span class="accesskey">t</span>ion</label>
         <!-- svelte-ignore a11y-accesskey -->
         <textarea
             bind:value={editableTask.description}
             bind:this={descriptionInput}
             id="description"
             class="tasks-modal-description"
-            placeholder="Take out the trash"
+            placeholder="Description - take out the trash"
+            aria-label="Description"
             accesskey={accesskey('t')}
             on:keydown={_onDescriptionKeyDown}
             on:paste={_removeLinebreaksFromDescription}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -433,7 +433,7 @@ Availability of access keys:
             bind:this={descriptionInput}
             id="description"
             class="tasks-modal-description"
-            placeholder="Description - take out the trash"
+            placeholder="Add a description, such as Take out the trash"
             aria-label="Description"
             accesskey={accesskey('t')}
             on:keydown={_onDescriptionKeyDown}

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
@@ -4,7 +4,7 @@
       <textarea
         id="description"
         class="tasks-modal-description"
-        placeholder="Description - take out the trash"
+        placeholder="Add a description, such as Take out the trash"
         aria-label="Description"
         accesskey="t"></textarea>
     </section>

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
@@ -1,15 +1,11 @@
 <div>
   <form class="tasks-modal with-accesskeys">
     <section class="tasks-modal-description-section">
-      <label for="description">
-        Descrip
-        <span class="accesskey">t</span>
-        ion
-      </label>
       <textarea
         id="description"
         class="tasks-modal-description"
-        placeholder="Take out the trash"
+        placeholder="Description - take out the trash"
+        aria-label="Description"
         accesskey="t"></textarea>
     </section>
     <section class="tasks-modal-priority-section">


### PR DESCRIPTION
# Description

- Remove the `Description` label and shrink the space on the top of the modal

## Motivation and Context

- Make modal compact and better visible on device with small screens

## How has this been tested?

- Manual test in demo vault

## Screenshots

Before             |  After
:-------------------------:|:-------------------------:
![Снимок экрана 2024-05-07 в 14 24 23](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/370f5bf1-0426-4f5d-936f-a017e809968d) | ![Снимок экрана 2024-05-07 в 14 26 25](https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/df3a1e3d-f10b-47d2-9bc1-1e6e70d4cfc1)

## Types of changes

Internal changes:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)


## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
 - No CSS unit test available

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
