### PR TITLE
refactor: extract label generation for Edit Task modal

### DIFF
--- a/src/Scripting/Postponer.ts
+++ b/src/Scripting/Postponer.ts
@@ -1,4 +1,5 @@
 import type { Moment, unitOfTime } from 'moment';
+import { capitalizeFirstLetter } from '../lib/StringHelpers';
 import { DateFallback } from '../Task/DateFallback';
 import { Task } from '../Task/Task';
 import { TasksDate } from './TasksDate';
@@ -109,10 +110,6 @@ export function postponementSuccessMessage(postponedDate: Moment, dateFieldToPos
 export function postponeButtonTitle(task: Task, amount: number, timeUnit: unitOfTime.DurationConstructor) {
     const buttonText = postponeMenuItemTitle(task, amount, timeUnit);
     return `ℹ️ ${buttonText} (right-click for more options)`;
-}
-
-function capitalizeFirstLetter(word: string) {
-    return word.charAt(0).toUpperCase() + word.slice(1);
 }
 
 /**

--- a/src/lib/StringHelpers.ts
+++ b/src/lib/StringHelpers.ts
@@ -1,0 +1,3 @@
+export function capitalizeFirstLetter(word: string) {
+    return word.charAt(0).toUpperCase() + word.slice(1);
+}

--- a/src/lib/StringHelpers.ts
+++ b/src/lib/StringHelpers.ts
@@ -1,3 +1,3 @@
-export function capitalizeFirstLetter(word: string) {
+export function capitalizeFirstLetter(word: string): string {
     return word.charAt(0).toUpperCase() + word.slice(1);
 }

--- a/src/lib/StringHelpers.ts
+++ b/src/lib/StringHelpers.ts
@@ -1,3 +1,3 @@
-export function capitalizeFirstLetter(word: string): string {
-    return word.charAt(0).toUpperCase() + word.slice(1);
+export function capitalizeFirstLetter(text: string): string {
+    return text.charAt(0).toUpperCase() + text.slice(1);
 }

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { doAutocomplete } from '../lib/DateAbbreviations';
     import { parseTypedDateForDisplayUsingFutureDate } from '../lib/DateTools';
-    import { editTaskLabelContent } from './EditTaskHelpers';
+    import { labelContentWithAccessKey } from './EditTaskHelpers';
 
     export let id: 'start' | 'scheduled' | 'due' | 'done' | 'created' | 'cancelled';
     export let dateSymbol: string;
@@ -21,7 +21,7 @@
     const datePlaceholder = "Try 'Mon' or 'tm' then space";
 </script>
 
-<label for={id}>{@html editTaskLabelContent(id, accesskey)}</label>
+<label for={id}>{@html labelContentWithAccessKey(id, accesskey)}</label>
 <!-- svelte-ignore a11y-accesskey -->
 <input
     bind:value={date}

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { doAutocomplete } from '../lib/DateAbbreviations';
     import { parseTypedDateForDisplayUsingFutureDate } from '../lib/DateTools';
+    import { editTaskLabelContent } from './EditTaskHelpers';
 
     export let id: 'start' | 'scheduled' | 'due' | 'done' | 'created' | 'cancelled';
     export let dateSymbol: string;
@@ -18,38 +19,9 @@
 
     // 'weekend' abbreviation omitted due to lack of space.
     const datePlaceholder = "Try 'Mon' or 'tm' then space";
-
-    function dateEditorLabelContent(id: string, accessKey: string | null) {
-        if (accessKey === null) {
-            return capitalizeFirstLetter(id);
-        }
-
-        if (!id.includes(accessKey)) {
-            return `${capitalizeFirstLetter(id)} (<span class="accesskey">${accessKey}</span>)`;
-        }
-
-        const accessKeyIndex = id.indexOf(accessKey);
-        let labelContent = id.substring(0, accessKeyIndex);
-        labelContent += '<span class="accesskey">';
-
-        if (accessKeyIndex === 0) {
-            labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1).toUpperCase();
-        } else {
-            labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1);
-        }
-
-        labelContent += '</span>';
-        labelContent += id.substring(accessKeyIndex + 1);
-        labelContent = capitalizeFirstLetter(labelContent);
-        return labelContent;
-    }
-
-    function capitalizeFirstLetter(id: string) {
-        return id.charAt(0).toUpperCase() + id.slice(1);
-    }
 </script>
 
-<label for={id}>{@html dateEditorLabelContent(id, accesskey)}</label>
+<label for={id}>{@html editTaskLabelContent(id, accesskey)}</label>
 <!-- svelte-ignore a11y-accesskey -->
 <input
     bind:value={date}

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -18,8 +18,38 @@
 
     // 'weekend' abbreviation omitted due to lack of space.
     const datePlaceholder = "Try 'Mon' or 'tm' then space";
+
+    function dateEditorLabelContent(id: string, accessKey: string | null) {
+        if (accessKey === null) {
+            return capitalizeFirstLetter(id);
+        }
+
+        if (!id.includes(accessKey)) {
+            return `${capitalizeFirstLetter(id)} (<span class="accesskey">${accessKey}</span>)`;
+        }
+
+        const accessKeyIndex = id.indexOf(accessKey);
+        let labelContent = id.substring(0, accessKeyIndex);
+        labelContent += '<span class="accesskey">';
+
+        if (accessKeyIndex === 0) {
+            labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1).toUpperCase();
+        } else {
+            labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1);
+        }
+
+        labelContent += '</span>';
+        labelContent += id.substring(accessKeyIndex + 1);
+        labelContent = capitalizeFirstLetter(labelContent);
+        return labelContent;
+    }
+
+    function capitalizeFirstLetter(id: string) {
+        return id.charAt(0).toUpperCase() + id.slice(1);
+    }
 </script>
 
+<label for={id}>{@html dateEditorLabelContent(id, accesskey)}</label>
 <!-- svelte-ignore a11y-accesskey -->
 <input
     bind:value={date}

--- a/src/ui/Dependency.svelte
+++ b/src/ui/Dependency.svelte
@@ -11,8 +11,7 @@
     export let _onDescriptionKeyDown: (e: KeyboardEvent) => void;
     export let type: 'blocking' | 'blockedBy';
     export let labelText: string;
-    export let accesskey: (key: string) => string | null;
-    export let accesskeyLetter: string = '';
+    export let accesskey: string | null;
     export let placeholder: string = 'Type to search...';
 
     let search: string = '';
@@ -143,7 +142,7 @@
     }
 </script>
 
-<label for={type}>{@html editTaskLabelContent(labelText, accesskey(accesskeyLetter))}</label>
+<label for={type}>{@html editTaskLabelContent(labelText, accesskey)}</label>
 <!-- svelte-ignore a11y-accesskey -->
 <span bind:clientWidth={inputWidth}>
     <input
@@ -152,7 +151,7 @@
         on:keydown={(e) => taskKeydown(e)}
         on:focus={onFocused}
         on:blur={() => (inputFocused = false)}
-        accesskey={accesskey(accesskeyLetter)}
+        {accesskey}
         id={type}
         class="tasks-modal-dependency-input"
         type="text"

--- a/src/ui/Dependency.svelte
+++ b/src/ui/Dependency.svelte
@@ -3,12 +3,14 @@
     import type { Task } from '../Task/Task';
     import type { EditableTask } from './EditableTask';
     import { descriptionAdjustedForDependencySearch, searchForCandidateTasksForDependency } from './DependencyHelpers';
+    import { editTaskLabelContent } from './EditTaskHelpers';
 
     export let task: Task;
     export let editableTask: EditableTask;
     export let allTasks: Task[];
     export let _onDescriptionKeyDown: (e: KeyboardEvent) => void;
     export let type: 'blocking' | 'blockedBy';
+    export let labelText: string;
     export let accesskey: (key: string) => string | null;
     export let accesskeyLetter: string = '';
     export let placeholder: string = 'Type to search...';
@@ -141,6 +143,7 @@
     }
 </script>
 
+<label for={type}>{@html editTaskLabelContent(labelText, accesskey(accesskeyLetter))}</label>
 <!-- svelte-ignore a11y-accesskey -->
 <span bind:clientWidth={inputWidth}>
     <input

--- a/src/ui/Dependency.svelte
+++ b/src/ui/Dependency.svelte
@@ -3,7 +3,7 @@
     import type { Task } from '../Task/Task';
     import type { EditableTask } from './EditableTask';
     import { descriptionAdjustedForDependencySearch, searchForCandidateTasksForDependency } from './DependencyHelpers';
-    import { editTaskLabelContent } from './EditTaskHelpers';
+    import { labelContentWithAccessKey } from './EditTaskHelpers';
 
     export let task: Task;
     export let editableTask: EditableTask;
@@ -142,7 +142,7 @@
     }
 </script>
 
-<label for={type}>{@html editTaskLabelContent(labelText, accesskey)}</label>
+<label for={type}>{@html labelContentWithAccessKey(labelText, accesskey)}</label>
 <!-- svelte-ignore a11y-accesskey -->
 <span bind:clientWidth={inputWidth}>
     <input

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -14,7 +14,7 @@
 }
 
 .with-accesskeys {
-    .accesskey-first::first-letter, .accesskey {
+    .accesskey {
         text-decoration: underline;
         text-underline-offset: 1pt;
     }

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -11,12 +11,12 @@
     .tasks-modal-error {
         border: 1px solid red !important;
     }
-}
 
     .accesskey {
         text-decoration: underline;
         text-underline-offset: 1pt;
     }
+}
 
 .tasks-modal-description-section {
     textarea {

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -13,12 +13,10 @@
     }
 }
 
-.with-accesskeys {
     .accesskey {
         text-decoration: underline;
         text-underline-offset: 1pt;
     }
-}
 
 .tasks-modal-description-section {
     textarea {

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
     import { onMount } from 'svelte';
-    import { parseTypedDateForSaving } from '../lib/DateTools';
-    import { Recurrence } from '../Task/Recurrence';
-    import { TASK_FORMATS, getSettings } from '../Config/Settings';
     import { GlobalFilter } from '../Config/GlobalFilter';
-    import { Status } from '../Statuses/Status';
-    import { Task } from '../Task/Task';
-    import { TasksDate } from '../Scripting/TasksDate';
-    import { addDependencyToParent, ensureTaskHasId, generateUniqueId, removeDependency } from '../Task/TaskDependency';
+    import { TASK_FORMATS, getSettings } from '../Config/Settings';
+    import { parseTypedDateForSaving } from '../lib/DateTools';
     import { replaceTaskWithTasks } from '../Obsidian/File';
+    import { TasksDate } from '../Scripting/TasksDate';
+    import { Status } from '../Statuses/Status';
     import { Priority } from '../Task/Priority';
+    import { Recurrence } from '../Task/Recurrence';
+    import { Task } from '../Task/Task';
+    import { addDependencyToParent, ensureTaskHasId, generateUniqueId, removeDependency } from '../Task/TaskDependency';
     import DateEditor from './DateEditor.svelte';
-    import type { EditableTask } from './EditableTask';
     import Dependency from './Dependency.svelte';
+    import type { EditableTask } from './EditableTask';
 
     // These exported variables are passed in as props by TaskModal.onOpen():
     export let task: Task;
@@ -407,9 +407,7 @@
     }
 
     function generateDateEditorLabel(id: string, withAccessKey: boolean, accessKey: string): string {
-        let labelContent = dateEditorLabelContent(id, withAccessKey, accessKey);
-
-        return `<label for=${id}>${labelContent}</label>`;
+        return `<label for=${id}>${dateEditorLabelContent(id, withAccessKey, accessKey)}</label>`;
     }
 
     function capitalizeFirstLetter(id: string) {

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -392,18 +392,18 @@
         let labelContent = capitalizeFirstLetter(id);
         if (!withAccessKey) {
             return labelContent;
+        }
+
+        if (!id.includes(accessKey)) {
+            labelContent += ` (<span class="accesskey">${accessKey}</span>)`;
         } else {
-            if (!id.includes(accessKey)) {
-                labelContent += ` (<span class="accesskey">${accessKey}</span>)`;
-            } else {
-                const accessKeyIndex = id.indexOf(accessKey);
-                labelContent = id.substring(0, accessKeyIndex);
-                labelContent += `<span class="accesskey">${id
-                    .substring(accessKeyIndex, accessKeyIndex + 1)
-                    .toUpperCase()}</span>`;
-                labelContent += id.substring(accessKeyIndex + 1);
-                labelContent = capitalizeFirstLetter(labelContent);
-            }
+            const accessKeyIndex = id.indexOf(accessKey);
+            labelContent = id.substring(0, accessKeyIndex);
+            labelContent += `<span class="accesskey">${id
+                .substring(accessKeyIndex, accessKeyIndex + 1)
+                .toUpperCase()}</span>`;
+            labelContent += id.substring(accessKeyIndex + 1);
+            labelContent = capitalizeFirstLetter(labelContent);
         }
         return labelContent;
     }

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -390,7 +390,9 @@
 
     function dateEditorLabelContent(id: string, withAccessKey: boolean, accessKey: string) {
         let labelContent = capitalizeFirstLetter(id);
-        if (withAccessKey) {
+        if (!withAccessKey) {
+            return labelContent;
+        } else {
             if (!id.includes(accessKey)) {
                 labelContent += ` (<span class="accesskey">${accessKey}</span>)`;
             } else {

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -391,7 +391,9 @@
     function generateDateEditorLabel(id: string, withAccessKey: boolean, accessKey: string): string {
         let labelContent = capitalizeFirstLetter(id);
         if (withAccessKey) {
-            labelContent += ` (<span class="accesskey">${accessKey}</span>)`;
+            if (!id.includes(accessKey)) {
+                labelContent += ` (<span class="accesskey">${accessKey}</span>)`;
+            }
         }
 
         return `<label for=${id}>${labelContent}</label>`;

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -542,14 +542,7 @@ Availability of access keys:
         <!--  Only future dates  -->
         <!-- --------------------------------------------------------------------------- -->
         <div class="future-dates-only">
-            {#if withAccessKeys}
-                <label for="forwardOnly"
-                    >Only
-                    <span class="accesskey">f</span>uture dates:</label
-                >
-            {:else}
-                <label for="forwardOnly">Only future dates:</label>
-            {/if}
+            <label for="forwardOnly">{@html editTaskLabelContent('Only future dates:', accesskey('f'))}</label>
             <!-- svelte-ignore a11y-accesskey -->
             <input
                 bind:checked={editableTask.forwardOnly}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -606,11 +606,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Status  -->
         <!-- --------------------------------------------------------------------------- -->
-        {#if withAccessKeys}
-            <label for="status">Stat<span class="accesskey">u</span>s</label>
-        {:else}
-            <label for="status">Status</label>
-        {/if}
+        <label for="status">{@html editTaskLabelContent('Status', accesskey('u'))}</label>
         <!-- svelte-ignore a11y-accesskey -->
         <select
             bind:value={statusSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -388,10 +388,10 @@
         onSubmit(newTasks);
     };
 
-    function generateDateEditorLabel(id: string, withAccessKey: boolean): string {
+    function generateDateEditorLabel(id: string, withAccessKey: boolean, accessKey: string): string {
         let labelContent = capitalizeFirstLetter(id);
         if (withAccessKey) {
-            labelContent += ' (<span class="accesskey">-</span>)';
+            labelContent += ` (<span class="accesskey">${accessKey}</span>)`;
         }
 
         return `<label for=${id}>${labelContent}</label>`;
@@ -696,7 +696,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Cancelled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {@html generateDateEditorLabel('cancelled', withAccessKeys)}
+        {@html generateDateEditorLabel('cancelled', withAccessKeys, '-')}
         <DateEditor
             id="cancelled"
             dateSymbol={cancelledDateSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -387,6 +387,14 @@
         const newTasks = updatedTask.handleNewStatusWithRecurrenceInUsersOrder(editableTask.status, today);
         onSubmit(newTasks);
     };
+
+    function generateDateEditorLabel(withAccessKey: boolean): string {
+        if (withAccessKey) {
+            return '<label for="cancelled">Cancelled (<span class="accesskey">-</span>)</label>';
+        }
+
+        return '<label for="cancelled">Cancelled</label>';
+    }
 </script>
 
 <!--
@@ -683,11 +691,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Cancelled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {#if withAccessKeys}
-            <label for="cancelled">Cancelled (<span class="accesskey">-</span>)</label>
-        {:else}
-            <label for="cancelled">Cancelled</label>
-        {/if}
+        {@html generateDateEditorLabel(withAccessKeys)}
         <DateEditor
             id="cancelled"
             dateSymbol={cancelledDateSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -427,7 +427,11 @@ Availability of access keys:
     <!--  Description  -->
     <!-- --------------------------------------------------------------------------- -->
     <section class="tasks-modal-description-section">
-        <label for="description">Descrip<span class="accesskey">t</span>ion</label>
+        {#if withAccessKeys}
+            <label for="description">Descrip<span class="accesskey">t</span>ion</label>
+        {:else}
+            <label for="description">Descrip<span class="accesskey">t</span>ion</label>
+        {/if}
         <!-- svelte-ignore a11y-accesskey -->
         <textarea
             bind:value={editableTask.description}
@@ -477,7 +481,11 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Recurrence  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="recurrence" class="accesskey-first">Recurs</label>
+        {#if withAccessKeys}
+            <label for="recurrence" class="accesskey-first">Recurs</label>
+        {:else}
+            <label for="recurrence" class="accesskey-first">Recurs</label>
+        {/if}
         <!-- svelte-ignore a11y-accesskey -->
         <input
             bind:value={editableTask.recurrenceRule}
@@ -492,7 +500,11 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Due Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="due" class="accesskey-first">Due</label>
+        {#if withAccessKeys}
+            <label for="due" class="accesskey-first">Due</label>
+        {:else}
+            <label for="due" class="accesskey-first">Due</label>
+        {/if}
         <DateEditor
             id="due"
             dateSymbol={dueDateSymbol}
@@ -505,7 +517,11 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Scheduled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="scheduled" class="accesskey-first">Scheduled</label>
+        {#if withAccessKeys}
+            <label for="scheduled" class="accesskey-first">Scheduled</label>
+        {:else}
+            <label for="scheduled" class="accesskey-first">Scheduled</label>
+        {/if}
         <DateEditor
             id="scheduled"
             dateSymbol={scheduledDateSymbol}
@@ -518,7 +534,11 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Start Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="start">St<span class="accesskey">a</span>rt</label>
+        {#if withAccessKeys}
+            <label for="start">St<span class="accesskey">a</span>rt</label>
+        {:else}
+            <label for="start">St<span class="accesskey">a</span>rt</label>
+        {/if}
         <DateEditor
             id="start"
             dateSymbol={startDateSymbol}
@@ -532,10 +552,17 @@ Availability of access keys:
         <!--  Only future dates  -->
         <!-- --------------------------------------------------------------------------- -->
         <div class="future-dates-only">
-            <label for="forwardOnly"
-                >Only
-                <span class="accesskey-first">future</span> dates:</label
-            >
+            {#if withAccessKeys}
+                <label for="forwardOnly"
+                    >Only
+                    <span class="accesskey-first">future</span> dates:</label
+                >
+            {:else}
+                <label for="forwardOnly"
+                    >Only
+                    <span class="accesskey-first">future</span> dates:</label
+                >
+            {/if}
             <!-- svelte-ignore a11y-accesskey -->
             <input
                 bind:checked={editableTask.forwardOnly}
@@ -556,7 +583,11 @@ Availability of access keys:
             <!-- --------------------------------------------------------------------------- -->
             <!--  Blocked By Tasks  -->
             <!-- --------------------------------------------------------------------------- -->
-            <label for="blockedBy" class="accesskey-first">Before this</label>
+            {#if withAccessKeys}
+                <label for="blockedBy" class="accesskey-first">Before this</label>
+            {:else}
+                <label for="blockedBy" class="accesskey-first">Before this</label>
+            {/if}
             <Dependency
                 type="blockedBy"
                 {task}
@@ -571,7 +602,11 @@ Availability of access keys:
             <!-- --------------------------------------------------------------------------- -->
             <!--  Blocking Tasks  -->
             <!-- --------------------------------------------------------------------------- -->
-            <label for="blocking">Aft<span class="accesskey">e</span>r this</label>
+            {#if withAccessKeys}
+                <label for="blocking">Aft<span class="accesskey">e</span>r this</label>
+            {:else}
+                <label for="blocking">Aft<span class="accesskey">e</span>r this</label>
+            {/if}
             <Dependency
                 type="blocking"
                 {task}
@@ -592,7 +627,11 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Status  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="status">Stat<span class="accesskey">u</span>s</label>
+        {#if withAccessKeys}
+            <label for="status">Stat<span class="accesskey">u</span>s</label>
+        {:else}
+            <label for="status">Stat<span class="accesskey">u</span>s</label>
+        {/if}
         <!-- svelte-ignore a11y-accesskey -->
         <select
             bind:value={statusSymbol}
@@ -609,7 +648,11 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Created Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="created" class="accesskey-first">Created</label>
+        {#if withAccessKeys}
+            <label for="created" class="accesskey-first">Created</label>
+        {:else}
+            <label for="created" class="accesskey-first">Created</label>
+        {/if}
         <DateEditor
             id="created"
             dateSymbol={createdDateSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -462,9 +462,13 @@ Availability of access keys:
                     accesskey={accesskey(accessKey)}
                 />
                 <label for="priority-{value}">
-                    <span>{label.substring(0, accessKeyIndex)}</span><span class="accesskey"
-                        >{label.substring(accessKeyIndex, accessKeyIndex + 1)}</span
-                    ><span>{label.substring(accessKeyIndex + 1)}</span>
+                    {#if withAccessKeys}
+                        <span>{label.substring(0, accessKeyIndex)}</span><span class="accesskey"
+                            >{label.substring(accessKeyIndex, accessKeyIndex + 1)}</span
+                        ><span>{label.substring(accessKeyIndex + 1)}</span>
+                    {:else}
+                        <span>{label}</span>
+                    {/if}
                     {#if symbol && symbol.charCodeAt(0) >= 0x100}
                         <span>{symbol}</span>
                     {/if}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -389,11 +389,11 @@
     };
 
     function dateEditorLabelContent(id: string, withAccessKey: boolean, accessKey: string) {
-        let labelContent = capitalizeFirstLetter(id);
         if (!withAccessKey) {
-            return labelContent;
+            return capitalizeFirstLetter(id);
         }
 
+        let labelContent = capitalizeFirstLetter(id);
         if (!id.includes(accessKey)) {
             labelContent += ` (<span class="accesskey">${accessKey}</span>)`;
         } else {

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -585,11 +585,7 @@ Availability of access keys:
             <!-- --------------------------------------------------------------------------- -->
             <!--  Blocking Tasks  -->
             <!-- --------------------------------------------------------------------------- -->
-            {#if withAccessKeys}
-                <label for="blocking">Aft<span class="accesskey">e</span>r this</label>
-            {:else}
-                <label for="blocking">After this</label>
-            {/if}
+            <label for="blocking">{@html editTaskLabelContent('After this', accesskey('e'))}</label>
             <Dependency
                 type="blocking"
                 {task}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -400,7 +400,13 @@
         const accessKeyIndex = id.indexOf(accessKey);
         let labelContent = id.substring(0, accessKeyIndex);
         labelContent += '<span class="accesskey">';
-        labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1).toUpperCase();
+
+        if (accessKeyIndex === 0) {
+            labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1).toUpperCase();
+        } else {
+            labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1);
+        }
+
         labelContent += '</span>';
         labelContent += id.substring(accessKeyIndex + 1);
         labelContent = capitalizeFirstLetter(labelContent);
@@ -553,11 +559,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Start Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {#if withAccessKeys}
-            <label for="start">St<span class="accesskey">a</span>rt</label>
-        {:else}
-            <label for="start">Start</label>
-        {/if}
+        <label for="start">{@html dateEditorLabelContent('start', withAccessKeys, 'a')}</label>
         <DateEditor
             id="start"
             dateSymbol={startDateSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -389,12 +389,16 @@
     };
 
     function generateDateEditorLabel(id: string, withAccessKey: boolean): string {
-        let labelContent = 'Cancelled';
+        let labelContent = capitalizeFirstLetter(id);
         if (withAccessKey) {
             labelContent += ' (<span class="accesskey">-</span>)';
         }
 
         return `<label for=${id}>${labelContent}</label>`;
+    }
+
+    function capitalizeFirstLetter(id: string) {
+        return id.charAt(0).toUpperCase() + id.slice(1);
     }
 </script>
 

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -388,12 +388,12 @@
         onSubmit(newTasks);
     };
 
-    function generateDateEditorLabel(withAccessKey: boolean): string {
+    function generateDateEditorLabel(id: string, withAccessKey: boolean): string {
         if (withAccessKey) {
-            return '<label for="cancelled">Cancelled (<span class="accesskey">-</span>)</label>';
+            return `<label for=${id}>Cancelled (<span class="accesskey">-</span>)</label>`;
         }
 
-        return '<label for="cancelled">Cancelled</label>';
+        return `<label for=${id}>Cancelled</label>`;
     }
 </script>
 
@@ -691,7 +691,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Cancelled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {@html generateDateEditorLabel(withAccessKeys)}
+        {@html generateDateEditorLabel('cancelled', withAccessKeys)}
         <DateEditor
             id="cancelled"
             dateSymbol={cancelledDateSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
     import { onMount } from 'svelte';
-    import { GlobalFilter } from '../Config/GlobalFilter';
-    import { TASK_FORMATS, getSettings } from '../Config/Settings';
     import { parseTypedDateForSaving } from '../lib/DateTools';
-    import { replaceTaskWithTasks } from '../Obsidian/File';
-    import { TasksDate } from '../Scripting/TasksDate';
-    import { Status } from '../Statuses/Status';
-    import { Priority } from '../Task/Priority';
     import { Recurrence } from '../Task/Recurrence';
+    import { TASK_FORMATS, getSettings } from '../Config/Settings';
+    import { GlobalFilter } from '../Config/GlobalFilter';
+    import { Status } from '../Statuses/Status';
     import { Task } from '../Task/Task';
+    import { TasksDate } from '../Scripting/TasksDate';
     import { addDependencyToParent, ensureTaskHasId, generateUniqueId, removeDependency } from '../Task/TaskDependency';
+    import { replaceTaskWithTasks } from '../Obsidian/File';
+    import { Priority } from '../Task/Priority';
     import DateEditor from './DateEditor.svelte';
-    import Dependency from './Dependency.svelte';
     import type { EditableTask } from './EditableTask';
+    import Dependency from './Dependency.svelte';
     import { editTaskLabelContent } from './EditTaskHelpers';
 
     // These exported variables are passed in as props by TaskModal.onOpen():

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -395,7 +395,7 @@
 
         let labelContent = capitalizeFirstLetter(id);
         if (!id.includes(accessKey)) {
-            labelContent += ` (<span class="accesskey">${accessKey}</span>)`;
+            return `${capitalizeFirstLetter(id)} (<span class="accesskey">${accessKey}</span>)`;
         } else {
             const accessKeyIndex = id.indexOf(accessKey);
             labelContent = id.substring(0, accessKeyIndex);

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -486,7 +486,7 @@ Availability of access keys:
         <!--  Recurrence  -->
         <!-- --------------------------------------------------------------------------- -->
         {#if withAccessKeys}
-            <label for="recurrence" class="accesskey-first">Recurs</label>
+            <label for="recurrence"><span class="accesskey">R</span>ecurs</label>
         {:else}
             <label for="recurrence">Recurs</label>
         {/if}
@@ -505,7 +505,7 @@ Availability of access keys:
         <!--  Due Date  -->
         <!-- --------------------------------------------------------------------------- -->
         {#if withAccessKeys}
-            <label for="due" class="accesskey-first">Due</label>
+            <label for="due"><span class="accesskey">D</span>ue</label>
         {:else}
             <label for="due">Due</label>
         {/if}
@@ -522,7 +522,7 @@ Availability of access keys:
         <!--  Scheduled Date  -->
         <!-- --------------------------------------------------------------------------- -->
         {#if withAccessKeys}
-            <label for="scheduled" class="accesskey-first">Scheduled</label>
+            <label for="scheduled"><span class="accesskey">S</span>cheduled</label>
         {:else}
             <label for="scheduled">Scheduled</label>
         {/if}
@@ -559,7 +559,7 @@ Availability of access keys:
             {#if withAccessKeys}
                 <label for="forwardOnly"
                     >Only
-                    <span class="accesskey-first">future</span> dates:</label
+                    <span class="accesskey">f</span>uture dates:</label
                 >
             {:else}
                 <label for="forwardOnly">Only future dates:</label>
@@ -585,7 +585,7 @@ Availability of access keys:
             <!--  Blocked By Tasks  -->
             <!-- --------------------------------------------------------------------------- -->
             {#if withAccessKeys}
-                <label for="blockedBy" class="accesskey-first">Before this</label>
+                <label for="blockedBy"><span class="accesskey">B</span>efore this</label>
             {:else}
                 <label for="blockedBy">Before this</label>
             {/if}
@@ -650,7 +650,7 @@ Availability of access keys:
         <!--  Created Date  -->
         <!-- --------------------------------------------------------------------------- -->
         {#if withAccessKeys}
-            <label for="created" class="accesskey-first">Created</label>
+            <label for="created"><span class="accesskey">C</span>reated</label>
         {:else}
             <label for="created">Created</label>
         {/if}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -486,11 +486,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Recurrence  -->
         <!-- --------------------------------------------------------------------------- -->
-        {#if withAccessKeys}
-            <label for="recurrence"><span class="accesskey">R</span>ecurs</label>
-        {:else}
-            <label for="recurrence">Recurs</label>
-        {/if}
+        <label for="recurrence">{@html editTaskLabelContent('Recurs', accesskey('r'))}</label>
         <!-- svelte-ignore a11y-accesskey -->
         <input
             bind:value={editableTask.recurrenceRule}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -396,15 +396,15 @@
         let labelContent = capitalizeFirstLetter(id);
         if (!id.includes(accessKey)) {
             return `${capitalizeFirstLetter(id)} (<span class="accesskey">${accessKey}</span>)`;
-        } else {
-            const accessKeyIndex = id.indexOf(accessKey);
-            labelContent = id.substring(0, accessKeyIndex);
-            labelContent += `<span class="accesskey">${id
-                .substring(accessKeyIndex, accessKeyIndex + 1)
-                .toUpperCase()}</span>`;
-            labelContent += id.substring(accessKeyIndex + 1);
-            labelContent = capitalizeFirstLetter(labelContent);
         }
+
+        const accessKeyIndex = id.indexOf(accessKey);
+        labelContent = id.substring(0, accessKeyIndex);
+        labelContent += `<span class="accesskey">${id
+            .substring(accessKeyIndex, accessKeyIndex + 1)
+            .toUpperCase()}</span>`;
+        labelContent += id.substring(accessKeyIndex + 1);
+        labelContent = capitalizeFirstLetter(labelContent);
         return labelContent;
     }
 

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -459,6 +459,9 @@ Availability of access keys:
                     accesskey={accesskey(accessKey)}
                 />
                 <label for="priority-{value}">
+                    <!-- These is no need to extract this behaviour to something like labelContentWithAccessKey(),
+                    since this whole section will just go in a separate Svelte component and
+                    will not be reused elsewhere like labelContentWithAccessKey(). -->
                     {#if withAccessKeys}
                         <span>{label.substring(0, accessKeyIndex)}</span><span class="accesskey"
                             >{label.substring(accessKeyIndex, accessKeyIndex + 1)}</span

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -533,7 +533,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Due Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="due">{@html dateEditorLabelContent('due', withAccessKeys, 'd')}</label>
+        <label for="due">{@html dateEditorLabelContent('due', withAccessKeys, accesskey('d'))}</label>
         <DateEditor
             id="due"
             dateSymbol={dueDateSymbol}
@@ -546,7 +546,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Scheduled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="scheduled">{@html dateEditorLabelContent('scheduled', withAccessKeys, 's')}</label>
+        <label for="scheduled">{@html dateEditorLabelContent('scheduled', withAccessKeys, accesskey('s'))}</label>
         <DateEditor
             id="scheduled"
             dateSymbol={scheduledDateSymbol}
@@ -559,7 +559,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Start Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="start">{@html dateEditorLabelContent('start', withAccessKeys, 'a')}</label>
+        <label for="start">{@html dateEditorLabelContent('start', withAccessKeys, accesskey('a'))}</label>
         <DateEditor
             id="start"
             dateSymbol={startDateSymbol}
@@ -666,7 +666,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Created Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="created">{@html dateEditorLabelContent('created', withAccessKeys, 'c')}</label>
+        <label for="created">{@html dateEditorLabelContent('created', withAccessKeys, accesskey('c'))}</label>
         <DateEditor
             id="created"
             dateSymbol={createdDateSymbol}
@@ -679,7 +679,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Done Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="done">{@html dateEditorLabelContent('done', withAccessKeys, 'x')}</label>
+        <label for="done">{@html dateEditorLabelContent('done', withAccessKeys, accesskey('x'))}</label>
         <DateEditor
             id="done"
             dateSymbol={doneDateSymbol}
@@ -692,7 +692,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Cancelled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="cancelled">{@html dateEditorLabelContent('cancelled', withAccessKeys, '-')}</label>
+        <label for="cancelled">{@html dateEditorLabelContent('cancelled', withAccessKeys, accesskey('-'))}</label>
         <DateEditor
             id="cancelled"
             dateSymbol={cancelledDateSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -387,35 +387,6 @@
         const newTasks = updatedTask.handleNewStatusWithRecurrenceInUsersOrder(editableTask.status, today);
         onSubmit(newTasks);
     };
-
-    function dateEditorLabelContent(id: string, accessKey: string | null) {
-        if (accessKey === null) {
-            return capitalizeFirstLetter(id);
-        }
-
-        if (!id.includes(accessKey)) {
-            return `${capitalizeFirstLetter(id)} (<span class="accesskey">${accessKey}</span>)`;
-        }
-
-        const accessKeyIndex = id.indexOf(accessKey);
-        let labelContent = id.substring(0, accessKeyIndex);
-        labelContent += '<span class="accesskey">';
-
-        if (accessKeyIndex === 0) {
-            labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1).toUpperCase();
-        } else {
-            labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1);
-        }
-
-        labelContent += '</span>';
-        labelContent += id.substring(accessKeyIndex + 1);
-        labelContent = capitalizeFirstLetter(labelContent);
-        return labelContent;
-    }
-
-    function capitalizeFirstLetter(id: string) {
-        return id.charAt(0).toUpperCase() + id.slice(1);
-    }
 </script>
 
 <!--
@@ -533,7 +504,6 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Due Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="due">{@html dateEditorLabelContent('due', accesskey('d'))}</label>
         <DateEditor
             id="due"
             dateSymbol={dueDateSymbol}
@@ -546,7 +516,6 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Scheduled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="scheduled">{@html dateEditorLabelContent('scheduled', accesskey('s'))}</label>
         <DateEditor
             id="scheduled"
             dateSymbol={scheduledDateSymbol}
@@ -559,7 +528,6 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Start Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="start">{@html dateEditorLabelContent('start', accesskey('a'))}</label>
         <DateEditor
             id="start"
             dateSymbol={startDateSymbol}
@@ -666,7 +634,6 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Created Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="created">{@html dateEditorLabelContent('created', accesskey('c'))}</label>
         <DateEditor
             id="created"
             dateSymbol={createdDateSymbol}
@@ -679,7 +646,6 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Done Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="done">{@html dateEditorLabelContent('done', accesskey('x'))}</label>
         <DateEditor
             id="done"
             dateSymbol={doneDateSymbol}
@@ -692,7 +658,6 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Cancelled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="cancelled">{@html dateEditorLabelContent('cancelled', accesskey('-'))}</label>
         <DateEditor
             id="cancelled"
             dateSymbol={cancelledDateSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -407,10 +407,6 @@
         return labelContent;
     }
 
-    function generateDateEditorLabel(id: string, withAccessKey: boolean, accessKey: string): string {
-        return `<label for=${id}>${dateEditorLabelContent(id, withAccessKey, accessKey)}</label>`;
-    }
-
     function capitalizeFirstLetter(id: string) {
         return id.charAt(0).toUpperCase() + id.slice(1);
     }
@@ -531,7 +527,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Due Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {@html generateDateEditorLabel('due', withAccessKeys, 'd')}
+        <label for="due">{@html dateEditorLabelContent('due', withAccessKeys, 'd')}</label>
         <DateEditor
             id="due"
             dateSymbol={dueDateSymbol}
@@ -544,7 +540,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Scheduled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {@html generateDateEditorLabel('scheduled', withAccessKeys, 's')}
+        <label for="scheduled">{@html dateEditorLabelContent('scheduled', withAccessKeys, 's')}</label>
         <DateEditor
             id="scheduled"
             dateSymbol={scheduledDateSymbol}
@@ -668,7 +664,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Created Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {@html generateDateEditorLabel('created', withAccessKeys, 'c')}
+        <label for="created">{@html dateEditorLabelContent('created', withAccessKeys, 'c')}</label>
         <DateEditor
             id="created"
             dateSymbol={createdDateSymbol}
@@ -681,7 +677,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Done Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {@html generateDateEditorLabel('done', withAccessKeys, 'x')}
+        <label for="done">{@html dateEditorLabelContent('done', withAccessKeys, 'x')}</label>
         <DateEditor
             id="done"
             dateSymbol={doneDateSymbol}
@@ -694,7 +690,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Cancelled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {@html generateDateEditorLabel('cancelled', withAccessKeys, '-')}
+        <label for="cancelled">{@html dateEditorLabelContent('cancelled', withAccessKeys, '-')}</label>
         <DateEditor
             id="cancelled"
             dateSymbol={cancelledDateSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -13,6 +13,7 @@
     import DateEditor from './DateEditor.svelte';
     import Dependency from './Dependency.svelte';
     import type { EditableTask } from './EditableTask';
+    import { editTaskLabelContent } from './EditTaskHelpers';
 
     // These exported variables are passed in as props by TaskModal.onOpen():
     export let task: Task;
@@ -569,11 +570,7 @@ Availability of access keys:
             <!-- --------------------------------------------------------------------------- -->
             <!--  Blocked By Tasks  -->
             <!-- --------------------------------------------------------------------------- -->
-            {#if withAccessKeys}
-                <label for="blockedBy"><span class="accesskey">B</span>efore this</label>
-            {:else}
-                <label for="blockedBy">Before this</label>
-            {/if}
+            <label for="blockedBy">{@html editTaskLabelContent('Before this', accesskey('b'))}</label>
             <Dependency
                 type="blockedBy"
                 {task}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -388,8 +388,8 @@
         onSubmit(newTasks);
     };
 
-    function dateEditorLabelContent(id: string, withAccessKey: boolean, accessKey: string | null) {
-        if (!withAccessKey || accessKey === null) {
+    function dateEditorLabelContent(id: string, accessKey: string | null) {
+        if (accessKey === null) {
             return capitalizeFirstLetter(id);
         }
 
@@ -533,7 +533,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Due Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="due">{@html dateEditorLabelContent('due', withAccessKeys, accesskey('d'))}</label>
+        <label for="due">{@html dateEditorLabelContent('due', accesskey('d'))}</label>
         <DateEditor
             id="due"
             dateSymbol={dueDateSymbol}
@@ -546,7 +546,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Scheduled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="scheduled">{@html dateEditorLabelContent('scheduled', withAccessKeys, accesskey('s'))}</label>
+        <label for="scheduled">{@html dateEditorLabelContent('scheduled', accesskey('s'))}</label>
         <DateEditor
             id="scheduled"
             dateSymbol={scheduledDateSymbol}
@@ -559,7 +559,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Start Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="start">{@html dateEditorLabelContent('start', withAccessKeys, accesskey('a'))}</label>
+        <label for="start">{@html dateEditorLabelContent('start', accesskey('a'))}</label>
         <DateEditor
             id="start"
             dateSymbol={startDateSymbol}
@@ -666,7 +666,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Created Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="created">{@html dateEditorLabelContent('created', withAccessKeys, accesskey('c'))}</label>
+        <label for="created">{@html dateEditorLabelContent('created', accesskey('c'))}</label>
         <DateEditor
             id="created"
             dateSymbol={createdDateSymbol}
@@ -679,7 +679,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Done Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="done">{@html dateEditorLabelContent('done', withAccessKeys, accesskey('x'))}</label>
+        <label for="done">{@html dateEditorLabelContent('done', accesskey('x'))}</label>
         <DateEditor
             id="done"
             dateSymbol={doneDateSymbol}
@@ -692,7 +692,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Cancelled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="cancelled">{@html dateEditorLabelContent('cancelled', withAccessKeys, accesskey('-'))}</label>
+        <label for="cancelled">{@html dateEditorLabelContent('cancelled', accesskey('-'))}</label>
         <DateEditor
             id="cancelled"
             dateSymbol={cancelledDateSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -393,6 +393,14 @@
         if (withAccessKey) {
             if (!id.includes(accessKey)) {
                 labelContent += ` (<span class="accesskey">${accessKey}</span>)`;
+            } else {
+                const accessKeyIndex = id.indexOf(accessKey);
+                labelContent = id.substring(0, accessKeyIndex);
+                labelContent += `<span class="accesskey">${id
+                    .substring(accessKeyIndex, accessKeyIndex + 1)
+                    .toUpperCase()}</span>`;
+                labelContent += id.substring(accessKeyIndex + 1);
+                labelContent = capitalizeFirstLetter(labelContent);
             }
         }
 
@@ -664,11 +672,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Created Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {#if withAccessKeys}
-            <label for="created"><span class="accesskey">C</span>reated</label>
-        {:else}
-            <label for="created">Created</label>
-        {/if}
+        {@html generateDateEditorLabel('created', withAccessKeys, 'c')}
         <DateEditor
             id="created"
             dateSymbol={createdDateSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -13,7 +13,7 @@
     import DateEditor from './DateEditor.svelte';
     import type { EditableTask } from './EditableTask';
     import Dependency from './Dependency.svelte';
-    import { editTaskLabelContent } from './EditTaskHelpers';
+    import { labelContentWithAccessKey } from './EditTaskHelpers';
 
     // These exported variables are passed in as props by TaskModal.onOpen():
     export let task: Task;
@@ -428,7 +428,7 @@ Availability of access keys:
     <!--  Description  -->
     <!-- --------------------------------------------------------------------------- -->
     <section class="tasks-modal-description-section">
-        <label for="description">{@html editTaskLabelContent('Description', accesskey('t'))}</label>
+        <label for="description">{@html labelContentWithAccessKey('Description', accesskey('t'))}</label>
         <!-- svelte-ignore a11y-accesskey -->
         <textarea
             bind:value={editableTask.description}
@@ -482,7 +482,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Recurrence  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="recurrence">{@html editTaskLabelContent('Recurs', accesskey('r'))}</label>
+        <label for="recurrence">{@html labelContentWithAccessKey('Recurs', accesskey('r'))}</label>
         <!-- svelte-ignore a11y-accesskey -->
         <input
             bind:value={editableTask.recurrenceRule}
@@ -534,7 +534,7 @@ Availability of access keys:
         <!--  Only future dates  -->
         <!-- --------------------------------------------------------------------------- -->
         <div class="future-dates-only">
-            <label for="forwardOnly">{@html editTaskLabelContent('Only future dates:', accesskey('f'))}</label>
+            <label for="forwardOnly">{@html labelContentWithAccessKey('Only future dates:', accesskey('f'))}</label>
             <!-- svelte-ignore a11y-accesskey -->
             <input
                 bind:checked={editableTask.forwardOnly}
@@ -589,7 +589,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Status  -->
         <!-- --------------------------------------------------------------------------- -->
-        <label for="status">{@html editTaskLabelContent('Status', accesskey('u'))}</label>
+        <label for="status">{@html labelContentWithAccessKey('Status', accesskey('u'))}</label>
         <!-- svelte-ignore a11y-accesskey -->
         <select
             bind:value={statusSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -393,13 +393,12 @@
             return capitalizeFirstLetter(id);
         }
 
-        let labelContent = capitalizeFirstLetter(id);
         if (!id.includes(accessKey)) {
             return `${capitalizeFirstLetter(id)} (<span class="accesskey">${accessKey}</span>)`;
         }
 
         const accessKeyIndex = id.indexOf(accessKey);
-        labelContent = id.substring(0, accessKeyIndex);
+        let labelContent = id.substring(0, accessKeyIndex);
         labelContent += `<span class="accesskey">${id
             .substring(accessKeyIndex, accessKeyIndex + 1)
             .toUpperCase()}</span>`;

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -399,9 +399,9 @@
 
         const accessKeyIndex = id.indexOf(accessKey);
         let labelContent = id.substring(0, accessKeyIndex);
-        labelContent += `<span class="accesskey">${id
-            .substring(accessKeyIndex, accessKeyIndex + 1)
-            .toUpperCase()}</span>`;
+        labelContent += '<span class="accesskey">';
+        labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1).toUpperCase();
+        labelContent += '</span>';
         labelContent += id.substring(accessKeyIndex + 1);
         labelContent = capitalizeFirstLetter(labelContent);
         return labelContent;

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -562,8 +562,7 @@ Availability of access keys:
                 {editableTask}
                 {allTasks}
                 {_onDescriptionKeyDown}
-                {accesskey}
-                accesskeyLetter="b"
+                accesskey={accesskey('b')}
                 placeholder="Search for tasks that the task being edited depends on..."
             />
 
@@ -577,8 +576,7 @@ Availability of access keys:
                 {editableTask}
                 {allTasks}
                 {_onDescriptionKeyDown}
-                {accesskey}
-                accesskeyLetter="e"
+                accesskey={accesskey('e')}
                 placeholder="Search for tasks that depend on this task being done..."
             />
         {:else}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -389,11 +389,12 @@
     };
 
     function generateDateEditorLabel(id: string, withAccessKey: boolean): string {
+        let labelContent = 'Cancelled';
         if (withAccessKey) {
-            return `<label for=${id}>Cancelled (<span class="accesskey">-</span>)</label>`;
+            labelContent += ' (<span class="accesskey">-</span>)';
         }
 
-        return `<label for=${id}>Cancelled</label>`;
+        return `<label for=${id}>${labelContent}</label>`;
     }
 </script>
 

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -430,7 +430,7 @@ Availability of access keys:
         {#if withAccessKeys}
             <label for="description">Descrip<span class="accesskey">t</span>ion</label>
         {:else}
-            <label for="description">Descrip<span class="accesskey">t</span>ion</label>
+            <label for="description">Description</label>
         {/if}
         <!-- svelte-ignore a11y-accesskey -->
         <textarea
@@ -484,7 +484,7 @@ Availability of access keys:
         {#if withAccessKeys}
             <label for="recurrence" class="accesskey-first">Recurs</label>
         {:else}
-            <label for="recurrence" class="accesskey-first">Recurs</label>
+            <label for="recurrence">Recurs</label>
         {/if}
         <!-- svelte-ignore a11y-accesskey -->
         <input
@@ -503,7 +503,7 @@ Availability of access keys:
         {#if withAccessKeys}
             <label for="due" class="accesskey-first">Due</label>
         {:else}
-            <label for="due" class="accesskey-first">Due</label>
+            <label for="due">Due</label>
         {/if}
         <DateEditor
             id="due"
@@ -520,7 +520,7 @@ Availability of access keys:
         {#if withAccessKeys}
             <label for="scheduled" class="accesskey-first">Scheduled</label>
         {:else}
-            <label for="scheduled" class="accesskey-first">Scheduled</label>
+            <label for="scheduled">Scheduled</label>
         {/if}
         <DateEditor
             id="scheduled"
@@ -537,7 +537,7 @@ Availability of access keys:
         {#if withAccessKeys}
             <label for="start">St<span class="accesskey">a</span>rt</label>
         {:else}
-            <label for="start">St<span class="accesskey">a</span>rt</label>
+            <label for="start">Start</label>
         {/if}
         <DateEditor
             id="start"
@@ -558,10 +558,7 @@ Availability of access keys:
                     <span class="accesskey-first">future</span> dates:</label
                 >
             {:else}
-                <label for="forwardOnly"
-                    >Only
-                    <span class="accesskey-first">future</span> dates:</label
-                >
+                <label for="forwardOnly">Only future dates:</label>
             {/if}
             <!-- svelte-ignore a11y-accesskey -->
             <input
@@ -586,7 +583,7 @@ Availability of access keys:
             {#if withAccessKeys}
                 <label for="blockedBy" class="accesskey-first">Before this</label>
             {:else}
-                <label for="blockedBy" class="accesskey-first">Before this</label>
+                <label for="blockedBy">Before this</label>
             {/if}
             <Dependency
                 type="blockedBy"
@@ -605,7 +602,7 @@ Availability of access keys:
             {#if withAccessKeys}
                 <label for="blocking">Aft<span class="accesskey">e</span>r this</label>
             {:else}
-                <label for="blocking">Aft<span class="accesskey">e</span>r this</label>
+                <label for="blocking">After this</label>
             {/if}
             <Dependency
                 type="blocking"
@@ -630,7 +627,7 @@ Availability of access keys:
         {#if withAccessKeys}
             <label for="status">Stat<span class="accesskey">u</span>s</label>
         {:else}
-            <label for="status">Stat<span class="accesskey">u</span>s</label>
+            <label for="status">Status</label>
         {/if}
         <!-- svelte-ignore a11y-accesskey -->
         <select
@@ -651,7 +648,7 @@ Availability of access keys:
         {#if withAccessKeys}
             <label for="created" class="accesskey-first">Created</label>
         {:else}
-            <label for="created" class="accesskey-first">Created</label>
+            <label for="created">Created</label>
         {/if}
         <DateEditor
             id="created"

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -420,7 +420,7 @@ Availability of access keys:
 - -: Cancelled
 -->
 
-<form class="tasks-modal" class:with-accesskeys={withAccessKeys} on:submit|preventDefault={_onSubmit}>
+<form class="tasks-modal" on:submit|preventDefault={_onSubmit}>
     <!-- NEW_TASK_FIELD_EDIT_REQUIRED -->
 
     <!-- --------------------------------------------------------------------------- -->

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -531,11 +531,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Due Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {#if withAccessKeys}
-            <label for="due"><span class="accesskey">D</span>ue</label>
-        {:else}
-            <label for="due">Due</label>
-        {/if}
+        {@html generateDateEditorLabel('due', withAccessKeys, 'd')}
         <DateEditor
             id="due"
             dateSymbol={dueDateSymbol}
@@ -548,11 +544,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Scheduled Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {#if withAccessKeys}
-            <label for="scheduled"><span class="accesskey">S</span>cheduled</label>
-        {:else}
-            <label for="scheduled">Scheduled</label>
-        {/if}
+        {@html generateDateEditorLabel('scheduled', withAccessKeys, 's')}
         <DateEditor
             id="scheduled"
             dateSymbol={scheduledDateSymbol}
@@ -689,11 +681,7 @@ Availability of access keys:
         <!-- --------------------------------------------------------------------------- -->
         <!--  Done Date  -->
         <!-- --------------------------------------------------------------------------- -->
-        {#if withAccessKeys}
-            <label for="done">Done (<span class="accesskey">x</span>)</label>
-        {:else}
-            <label for="done">Done</label>
-        {/if}
+        {@html generateDateEditorLabel('done', withAccessKeys, 'x')}
         <DateEditor
             id="done"
             dateSymbol={doneDateSymbol}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -388,7 +388,7 @@
         onSubmit(newTasks);
     };
 
-    function generateDateEditorLabel(id: string, withAccessKey: boolean, accessKey: string): string {
+    function dateEditorLabelContent(id: string, withAccessKey: boolean, accessKey: string) {
         let labelContent = capitalizeFirstLetter(id);
         if (withAccessKey) {
             if (!id.includes(accessKey)) {
@@ -403,6 +403,11 @@
                 labelContent = capitalizeFirstLetter(labelContent);
             }
         }
+        return labelContent;
+    }
+
+    function generateDateEditorLabel(id: string, withAccessKey: boolean, accessKey: string): string {
+        let labelContent = dateEditorLabelContent(id, withAccessKey, accessKey);
 
         return `<label for=${id}>${labelContent}</label>`;
     }

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -555,9 +555,9 @@ Availability of access keys:
             <!-- --------------------------------------------------------------------------- -->
             <!--  Blocked By Tasks  -->
             <!-- --------------------------------------------------------------------------- -->
-            <label for="blockedBy">{@html editTaskLabelContent('Before this', accesskey('b'))}</label>
             <Dependency
                 type="blockedBy"
+                labelText="Before this"
                 {task}
                 {editableTask}
                 {allTasks}
@@ -570,9 +570,9 @@ Availability of access keys:
             <!-- --------------------------------------------------------------------------- -->
             <!--  Blocking Tasks  -->
             <!-- --------------------------------------------------------------------------- -->
-            <label for="blocking">{@html editTaskLabelContent('After this', accesskey('e'))}</label>
             <Dependency
                 type="blocking"
+                labelText="After this"
                 {task}
                 {editableTask}
                 {allTasks}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -388,8 +388,8 @@
         onSubmit(newTasks);
     };
 
-    function dateEditorLabelContent(id: string, withAccessKey: boolean, accessKey: string) {
-        if (!withAccessKey) {
+    function dateEditorLabelContent(id: string, withAccessKey: boolean, accessKey: string | null) {
+        if (!withAccessKey || accessKey === null) {
             return capitalizeFirstLetter(id);
         }
 

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -428,11 +428,7 @@ Availability of access keys:
     <!--  Description  -->
     <!-- --------------------------------------------------------------------------- -->
     <section class="tasks-modal-description-section">
-        {#if withAccessKeys}
-            <label for="description">Descrip<span class="accesskey">t</span>ion</label>
-        {:else}
-            <label for="description">Description</label>
-        {/if}
+        <label for="description">{@html editTaskLabelContent('Description', accesskey('t'))}</label>
         <!-- svelte-ignore a11y-accesskey -->
         <textarea
             bind:value={editableTask.description}

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -17,7 +17,7 @@ export function labelContentWithAccessKey(labelText: string, accessKey: string |
 
     const accessKeyIndex = labelText.toLowerCase().indexOf(accessKey);
     if (accessKeyIndex === -1) {
-        return `${capitalizeFirstLetter(labelText)} (<span class="accesskey">${accessKey}</span>)`;
+        return `${capitalizeFirstLetter(labelText)} (<span class="accesskey">${accessKey.toLowerCase()}</span>)`;
     }
 
     let labelContent = labelText.substring(0, accessKeyIndex);

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -3,11 +3,11 @@ export function editTaskLabelContent(id: string, accessKey: string | null) {
         return capitalizeFirstLetter(id);
     }
 
-    if (!id.includes(accessKey)) {
+    if (!id.toLowerCase().includes(accessKey)) {
         return `${capitalizeFirstLetter(id)} (<span class="accesskey">${accessKey}</span>)`;
     }
 
-    const accessKeyIndex = id.indexOf(accessKey);
+    const accessKeyIndex = id.toLowerCase().indexOf(accessKey);
     let labelContent = id.substring(0, accessKeyIndex);
     labelContent += '<span class="accesskey">';
 

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -1,0 +1,28 @@
+export function editTaskLabelContent(id: string, accessKey: string | null) {
+    if (accessKey === null) {
+        return capitalizeFirstLetter(id);
+    }
+
+    if (!id.includes(accessKey)) {
+        return `${capitalizeFirstLetter(id)} (<span class="accesskey">${accessKey}</span>)`;
+    }
+
+    const accessKeyIndex = id.indexOf(accessKey);
+    let labelContent = id.substring(0, accessKeyIndex);
+    labelContent += '<span class="accesskey">';
+
+    if (accessKeyIndex === 0) {
+        labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1).toUpperCase();
+    } else {
+        labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1);
+    }
+
+    labelContent += '</span>';
+    labelContent += id.substring(accessKeyIndex + 1);
+    labelContent = capitalizeFirstLetter(labelContent);
+    return labelContent;
+}
+
+function capitalizeFirstLetter(id: string) {
+    return id.charAt(0).toUpperCase() + id.slice(1);
+}

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -1,24 +1,24 @@
-export function editTaskLabelContent(id: string, accessKey: string | null) {
+export function editTaskLabelContent(labelText: string, accessKey: string | null) {
     if (accessKey === null) {
-        return capitalizeFirstLetter(id);
+        return capitalizeFirstLetter(labelText);
     }
 
-    if (!id.toLowerCase().includes(accessKey)) {
-        return `${capitalizeFirstLetter(id)} (<span class="accesskey">${accessKey}</span>)`;
+    if (!labelText.toLowerCase().includes(accessKey)) {
+        return `${capitalizeFirstLetter(labelText)} (<span class="accesskey">${accessKey}</span>)`;
     }
 
-    const accessKeyIndex = id.toLowerCase().indexOf(accessKey);
-    let labelContent = id.substring(0, accessKeyIndex);
+    const accessKeyIndex = labelText.toLowerCase().indexOf(accessKey);
+    let labelContent = labelText.substring(0, accessKeyIndex);
     labelContent += '<span class="accesskey">';
 
     if (accessKeyIndex === 0) {
-        labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1).toUpperCase();
+        labelContent += labelText.substring(accessKeyIndex, accessKeyIndex + 1).toUpperCase();
     } else {
-        labelContent += id.substring(accessKeyIndex, accessKeyIndex + 1);
+        labelContent += labelText.substring(accessKeyIndex, accessKeyIndex + 1);
     }
 
     labelContent += '</span>';
-    labelContent += id.substring(accessKeyIndex + 1);
+    labelContent += labelText.substring(accessKeyIndex + 1);
     labelContent = capitalizeFirstLetter(labelContent);
     return labelContent;
 }

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -15,7 +15,7 @@ export function labelContentWithAccessKey(labelText: string, accessKey: string |
         return capitalizeFirstLetter(labelText);
     }
 
-    const accessKeyIndex = labelText.toLowerCase().indexOf(accessKey);
+    const accessKeyIndex = labelText.toLowerCase().indexOf(accessKey.toLowerCase());
     if (accessKeyIndex === -1) {
         return `${capitalizeFirstLetter(labelText)} (<span class="accesskey">${accessKey.toLowerCase()}</span>)`;
     }

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -1,3 +1,5 @@
+import { capitalizeFirstLetter } from '../lib/StringHelpers';
+
 /**
  * Returns contents for a `<label>` HTML element.
  *
@@ -33,8 +35,4 @@ export function labelContentWithAccessKey(labelText: string, accessKey: string |
     labelContent += labelText.substring(accessKeyIndex + 1);
     labelContent = capitalizeFirstLetter(labelContent);
     return labelContent;
-}
-
-function capitalizeFirstLetter(id: string) {
-    return id.charAt(0).toUpperCase() + id.slice(1);
 }

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -1,3 +1,15 @@
+/**
+ * Returns contents for a `<label>` HTML element.
+ *
+ * If the {@link accessKey} is found in the label text (case-insensitive), it will be given `accesskey` class
+ * within a `<span>` HTML element. Else the access key will be added at the end of the label text,
+ * surrounded with round brackets.
+ *
+ * The first letter of the label will be capitalised.
+ *
+ * @param labelText to be displayed in the <label> HTML element.
+ * @param accessKey optional access key. Set to null if not needed.
+ */
 export function editTaskLabelContent(labelText: string, accessKey: string | null) {
     if (accessKey === null) {
         return capitalizeFirstLetter(labelText);

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -10,7 +10,7 @@
  * @param labelText to be displayed in the <label> HTML element.
  * @param accessKey optional access key. Set to null if not needed.
  */
-export function editTaskLabelContent(labelText: string, accessKey: string | null) {
+export function labelContentWithAccessKey(labelText: string, accessKey: string | null) {
     if (accessKey === null) {
         return capitalizeFirstLetter(labelText);
     }

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -15,11 +15,11 @@ export function editTaskLabelContent(labelText: string, accessKey: string | null
         return capitalizeFirstLetter(labelText);
     }
 
-    if (!labelText.toLowerCase().includes(accessKey)) {
+    const accessKeyIndex = labelText.toLowerCase().indexOf(accessKey);
+    if (accessKeyIndex === -1) {
         return `${capitalizeFirstLetter(labelText)} (<span class="accesskey">${accessKey}</span>)`;
     }
 
-    const accessKeyIndex = labelText.toLowerCase().indexOf(accessKey);
     let labelContent = labelText.substring(0, accessKeyIndex);
     labelContent += '<span class="accesskey">';
 

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
@@ -1,5 +1,5 @@
 <div>
-  <form class="tasks-modal with-accesskeys">
+  <form class="tasks-modal">
     <section class="tasks-modal-description-section">
       <label for="description">
         Descrip

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
@@ -70,7 +70,10 @@
     </section>
     <hr />
     <section class="tasks-modal-dates-section">
-      <label for="recurrence" class="accesskey-first">Recurs</label>
+      <label for="recurrence">
+        <span class="accesskey">R</span>
+        ecurs
+      </label>
       <input
         id="recurrence"
         type="text"
@@ -81,7 +84,10 @@
         🔁
         <i>not recurring</i>
       </code>
-      <label for="due" class="accesskey-first">Due</label>
+      <label for="due">
+        <span class="accesskey">D</span>
+        ue
+      </label>
       <input
         id="due"
         type="text"
@@ -92,7 +98,10 @@
         📅
         <i>no due date</i>
       </code>
-      <label for="scheduled" class="accesskey-first">Scheduled</label>
+      <label for="scheduled">
+        <span class="accesskey">S</span>
+        cheduled
+      </label>
       <input
         id="scheduled"
         type="text"
@@ -121,15 +130,18 @@
       <div class="future-dates-only">
         <label for="forwardOnly">
           Only
-          <span class="accesskey-first">future</span>
-          dates:
+          <span class="accesskey">f</span>
+          uture dates:
         </label>
         <input id="forwardOnly" type="checkbox" class="task-list-item-checkbox tasks-modal-checkbox" accesskey="f" />
       </div>
     </section>
     <hr />
     <section class="tasks-modal-dependencies-section">
-      <label for="blockedBy" class="accesskey-first">Before this</label>
+      <label for="blockedBy">
+        <span class="accesskey">B</span>
+        efore this
+      </label>
       <span>
         <input
           accesskey="b"
@@ -199,7 +211,10 @@
         <option value="x">Done [x]</option>
         <option value="-">Cancelled [-]</option>
       </select>
-      <label for="created" class="accesskey-first">Created</label>
+      <label for="created">
+        <span class="accesskey">C</span>
+        reated
+      </label>
       <input
         id="created"
         type="text"

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
@@ -1,11 +1,7 @@
 <div>
   <form class="tasks-modal">
     <section class="tasks-modal-description-section">
-      <label for="description">
-        Descrip
-        <span class="accesskey">t</span>
-        ion
-      </label>
+      <label for="description">Description</label>
       <textarea id="description" class="tasks-modal-description" placeholder="Take out the trash"></textarea>
     </section>
     <section class="tasks-modal-priority-section">
@@ -66,46 +62,38 @@
     </section>
     <hr />
     <section class="tasks-modal-dates-section">
-      <label for="recurrence" class="accesskey-first">Recurs</label>
+      <label for="recurrence">Recurs</label>
       <input id="recurrence" type="text" class="tasks-modal-date-input" placeholder="Try 'every day when done'" />
       <code class="tasks-modal-parsed-date">
         🔁
         <i>not recurring</i>
       </code>
-      <label for="due" class="accesskey-first">Due</label>
+      <label for="due">Due</label>
       <input id="due" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         📅
         <i>no due date</i>
       </code>
-      <label for="scheduled" class="accesskey-first">Scheduled</label>
+      <label for="scheduled">Scheduled</label>
       <input id="scheduled" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ⏳
         <i>no scheduled date</i>
       </code>
-      <label for="start">
-        St
-        <span class="accesskey">a</span>
-        rt
-      </label>
+      <label for="start">Start</label>
       <input id="start" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         🛫
         <i>no start date</i>
       </code>
       <div class="future-dates-only">
-        <label for="forwardOnly">
-          Only
-          <span class="accesskey-first">future</span>
-          dates:
-        </label>
+        <label for="forwardOnly">Only future dates:</label>
         <input id="forwardOnly" type="checkbox" class="task-list-item-checkbox tasks-modal-checkbox" />
       </div>
     </section>
     <hr />
     <section class="tasks-modal-dependencies-section">
-      <label for="blockedBy" class="accesskey-first">Before this</label>
+      <label for="blockedBy">Before this</label>
       <span>
         <input
           id="blockedBy"
@@ -130,11 +118,7 @@
           tabindex="-1"
           src="about:blank"></iframe>
       </span>
-      <label for="blocking">
-        Aft
-        <span class="accesskey">e</span>
-        r this
-      </label>
+      <label for="blocking">After this</label>
       <span>
         <input
           id="blocking"
@@ -162,18 +146,14 @@
     </section>
     <hr />
     <section class="tasks-modal-dates-section">
-      <label for="status">
-        Stat
-        <span class="accesskey">u</span>
-        s
-      </label>
+      <label for="status">Status</label>
       <select id="status-type" class="tasks-modal-status-selector">
         <option value=" ">Todo [ ]</option>
         <option value="/">In Progress [/]</option>
         <option value="x">Done [x]</option>
         <option value="-">Cancelled [-]</option>
       </select>
-      <label for="created" class="accesskey-first">Created</label>
+      <label for="created">Created</label>
       <input id="created" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ➕

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
@@ -9,53 +9,39 @@
       <div class="task-modal-priority-option-container">
         <input type="radio" id="priority-lowest" value="lowest" />
         <label for="priority-lowest">
-          <span>L</span>
-          <span class="accesskey">o</span>
-          <span>west</span>
+          <span>Lowest</span>
           <span>⏬</span>
         </label>
       </div>
       <div class="task-modal-priority-option-container">
         <input type="radio" id="priority-low" value="low" />
         <label for="priority-low">
-          <span></span>
-          <span class="accesskey">L</span>
-          <span>ow</span>
+          <span>Low</span>
           <span>🔽</span>
         </label>
       </div>
       <div class="task-modal-priority-option-container">
         <input type="radio" id="priority-none" value="none" />
-        <label for="priority-none">
-          <span></span>
-          <span class="accesskey">N</span>
-          <span>ormal</span>
-        </label>
+        <label for="priority-none"><span>Normal</span></label>
       </div>
       <div class="task-modal-priority-option-container">
         <input type="radio" id="priority-medium" value="medium" />
         <label for="priority-medium">
-          <span></span>
-          <span class="accesskey">M</span>
-          <span>edium</span>
+          <span>Medium</span>
           <span>🔼</span>
         </label>
       </div>
       <div class="task-modal-priority-option-container">
         <input type="radio" id="priority-high" value="high" />
         <label for="priority-high">
-          <span></span>
-          <span class="accesskey">H</span>
-          <span>igh</span>
+          <span>High</span>
           <span>⏫</span>
         </label>
       </div>
       <div class="task-modal-priority-option-container">
         <input type="radio" id="priority-highest" value="highest" />
         <label for="priority-highest">
-          <span>H</span>
-          <span class="accesskey">i</span>
-          <span>ghest</span>
+          <span>Highest</span>
           <span>🔺</span>
         </label>
       </div>

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -1,10 +1,12 @@
 import { labelContentWithAccessKey } from '../../src/ui/EditTaskHelpers';
 
 describe('labelContentWithAccessKey() tests', () => {
-    it('should add access key span if it matches the first letter and capitalise it', () => {
-        const labelContent = labelContentWithAccessKey('first letter', 'f');
-        expect(labelContent).toMatchInlineSnapshot('"<span class="accesskey">F</span>irst letter"');
-    });
+    it.each([['first letter', 'f', '<span class="accesskey">F</span>irst letter']])(
+        "label text '%s' with access key '%s' should have label content '%s'",
+        (labelText, accessKey, labelContent) => {
+            expect(labelContentWithAccessKey(labelText, accessKey)).toEqual(labelContent);
+        },
+    );
 
     it('should add access key span if it matches not the first letter', () => {
         const labelContent = labelContentWithAccessKey('make this x the access key', 'x');

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -1,34 +1,17 @@
 import { labelContentWithAccessKey } from '../../src/ui/EditTaskHelpers';
 
 describe('labelContentWithAccessKey() tests', () => {
-    it.each([['first letter', 'f', '<span class="accesskey">F</span>irst letter']])(
-        "label text '%s' with access key '%s' should have label content '%s'",
-        (labelText, accessKey, labelContent) => {
-            expect(labelContentWithAccessKey(labelText, accessKey)).toEqual(labelContent);
-        },
-    );
-
-    it('should add access key span if it matches not the first letter', () => {
-        const labelContent = labelContentWithAccessKey('make this x the access key', 'x');
-        expect(labelContent).toMatchInlineSnapshot('"Make this <span class="accesskey">x</span> the access key"');
-    });
-
-    it('should treat a capitalised access key in the same way as a regular one', () => {
-        const labelContent = labelContentWithAccessKey('make this u the access key too', 'U');
-        expect(labelContent).toMatchInlineSnapshot(
-            '"Make this u the access key too (<span class="accesskey">u</span>)"',
-        );
-    });
-
-    it('should not add access key span after the label text if the access key is not present in the label text', () => {
-        const labelContent = labelContentWithAccessKey('the last letter of the alphabet is absent here', 'z');
-        expect(labelContent).toMatchInlineSnapshot(
-            '"The last letter of the alphabet is absent here (<span class="accesskey">z</span>)"',
-        );
-    });
-
-    it('should not add access key span if the it is null, but should capitalise the first word', () => {
-        const labelContent = labelContentWithAccessKey('access key is null', null);
-        expect(labelContent).toMatchInlineSnapshot('"Access key is null"');
+    it.each([
+        ['first letter', 'f', '<span class="accesskey">F</span>irst letter'],
+        ['make this x the access key', 'x', 'Make this <span class="accesskey">x</span> the access key'],
+        ['make this u the access key too', 'U', 'Make this u the access key too (<span class="accesskey">u</span>)'],
+        [
+            'the last letter of the alphabet is absent here',
+            'z',
+            'The last letter of the alphabet is absent here (<span class="accesskey">z</span>)',
+        ],
+        ['access key is null', null, 'Access key is null'],
+    ])("label text '%s' with access key '%s' should have label content '%s'", (labelText, accessKey, labelContent) => {
+        expect(labelContentWithAccessKey(labelText, accessKey)).toEqual(labelContent);
     });
 });

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -3,31 +3,37 @@ import { labelContentWithAccessKey } from '../../src/ui/EditTaskHelpers';
 describe('labelContentWithAccessKey() tests', () => {
     it.each([
         [
+            //should make...
             'first letter is the access key f, not the second',
             'f',
             '<span class="accesskey">F</span>irst letter is the access key f, not the second',
         ],
         [
-            'make this x the access key even if it is in the middle',
+            'should make this x the access key even if it is in the middle',
             'x',
-            'Make this <span class="accesskey">x</span> the access key even if it is in the middle',
+            'Should make this <span class="accesskey">x</span> the access key even if it is in the middle',
         ],
         [
-            'make this u the access key too even if the parameter is a capital U',
-            'U',
-            'Make this u the access key too even if the parameter is a capital U (<span class="accesskey">u</span>)',
+            'should keep the Capitalised letter as the access key',
+            'C',
+            'Should keep the <span class="accesskey">C</span>apitalised letter as the access key',
         ],
         [
-            'the last letter of the alphabet is absent here',
+            'should make this y the access key too even if the parameter is a capital Y',
+            'Y',
+            'Should make this <span class="accesskey">y</span> the access key too even if the parameter is a capital Y',
+        ],
+        [
+            'should add the access key at the end of this text',
             'z',
-            'The last letter of the alphabet is absent here (<span class="accesskey">z</span>)',
+            'Should add the access key at the end of this text (<span class="accesskey">z</span>)',
         ],
         [
-            'the last letter of the alphabet is absent here even if the parameter is capital',
+            'should add the access key at the end of this text even if the parameter is capital',
             'Z',
-            'The last letter of the alphabet is absent here even if the parameter is capital (<span class="accesskey">z</span>)',
+            'Should add the access key at the end of this text even if the parameter is capital (<span class="accesskey">z</span>)',
         ],
-        ['access key is null', null, 'Access key is null'],
+        ['should not add an access key span here', null, 'Should not add an access key span here'],
     ])("label text '%s' with access key '%s' should have label content '%s'", (labelText, accessKey, labelContent) => {
         expect(labelContentWithAccessKey(labelText, accessKey)).toEqual(labelContent);
     });

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -2,9 +2,21 @@ import { labelContentWithAccessKey } from '../../src/ui/EditTaskHelpers';
 
 describe('labelContentWithAccessKey() tests', () => {
     it.each([
-        ['first letter', 'f', '<span class="accesskey">F</span>irst letter'],
-        ['make this x the access key', 'x', 'Make this <span class="accesskey">x</span> the access key'],
-        ['make this u the access key too', 'U', 'Make this u the access key too (<span class="accesskey">u</span>)'],
+        [
+            'first letter is the access key f, not the second',
+            'f',
+            '<span class="accesskey">F</span>irst letter is the access key f, not the second',
+        ],
+        [
+            'make this x the access key even if it is in the middle',
+            'x',
+            'Make this <span class="accesskey">x</span> the access key even if it is in the middle',
+        ],
+        [
+            'make this u the access key too even if the parameter is a capital U',
+            'U',
+            'Make this u the access key too even if the parameter is a capital U (<span class="accesskey">u</span>)',
+        ],
         [
             'the last letter of the alphabet is absent here',
             'z',

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -22,6 +22,11 @@ describe('labelContentWithAccessKey() tests', () => {
             'z',
             'The last letter of the alphabet is absent here (<span class="accesskey">z</span>)',
         ],
+        [
+            'the last letter of the alphabet is absent here even if the parameter is capital',
+            'Z',
+            'The last letter of the alphabet is absent here even if the parameter is capital (<span class="accesskey">z</span>)',
+        ],
         ['access key is null', null, 'Access key is null'],
     ])("label text '%s' with access key '%s' should have label content '%s'", (labelText, accessKey, labelContent) => {
         expect(labelContentWithAccessKey(labelText, accessKey)).toEqual(labelContent);

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -11,6 +11,13 @@ describe('labelContentWithAccessKey() tests', () => {
         expect(labelContent).toMatchInlineSnapshot('"Make this <span class="accesskey">x</span> the access key"');
     });
 
+    it('should treat a capitalised access key in the same way as a regular one', () => {
+        const labelContent = labelContentWithAccessKey('make this u the access key too', 'U');
+        expect(labelContent).toMatchInlineSnapshot(
+            '"Make this u the access key too (<span class="accesskey">u</span>)"',
+        );
+    });
+
     it('should not add access key span after the label text if the access key is not present in the label text', () => {
         const labelContent = labelContentWithAccessKey('the last letter of the alphabet is absent here', 'z');
         expect(labelContent).toMatchInlineSnapshot(

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -1,0 +1,25 @@
+import { labelContentWithAccessKey } from '../../src/ui/EditTaskHelpers';
+
+describe('labelContentWithAccessKey() tests', () => {
+    it('should add access key span if it matches the first letter and capitalise it', () => {
+        const labelContent = labelContentWithAccessKey('first letter', 'f');
+        expect(labelContent).toMatchInlineSnapshot('"<span class="accesskey">F</span>irst letter"');
+    });
+
+    it('should add access key span if it matches not the first letter', () => {
+        const labelContent = labelContentWithAccessKey('make this x the access key', 'x');
+        expect(labelContent).toMatchInlineSnapshot('"Make this <span class="accesskey">x</span> the access key"');
+    });
+
+    it('should not add access key span after the label text if the access key is not present in the label text', () => {
+        const labelContent = labelContentWithAccessKey('the last letter of the alphabet is absent here', 'z');
+        expect(labelContent).toMatchInlineSnapshot(
+            '"The last letter of the alphabet is absent here (<span class="accesskey">z</span>)"',
+        );
+    });
+
+    it('should not add access key span if the it is null, but should capitalise the first word', () => {
+        const labelContent = labelContentWithAccessKey('access key is null', null);
+        expect(labelContent).toMatchInlineSnapshot('"Access key is null"');
+    });
+});


### PR DESCRIPTION
# Description

Sorry for a big PR =) I can split it into several ones if needed.

- remove CSS class `accesskey-first` and unify access key declaration with `accesskey` class
- remove HTML elements declaring access keys from the modal without access keys
  - Somehow they were still in the `<label>` elements O_o
  - They were not present in `<input>` elements which inhibited the access keys
- extract `editTaskLabelContent()` function to generate the label content
  - use it everywhere except priority (there the content is different and linked with CSS styles, so no gain for now) 
- for dependencies and dates, move `<label>` to `<Dependency>` and `<DateEditor>` component respectively

## Motivation and Context

- Move HTML code generation inside the components (for `<Dependency>` and `<DateEditor>`)
- Prepare to extract Svelte components (for other Task fields/future components)

## How has this been tested?

Unit test made possible with thanks to a previous PR with @claremacrae 

Manual test at the end of the refactoring: 
- Verify that access keys are not working when disabled in Settings
- Verify that each access key focuses its field in the modal when enabled in Settings


## Types of changes

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - Couple of commits in CSS code make me say no to this

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
