### PR TITLE
fix: Test and improve behaviour of auto-suggest with dependencies

### DIFF
--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -410,7 +410,7 @@ function addRecurrenceSuggestions(
 
 function addIDSuggestion(line: string, cursorPos: number, idSymbol: string, allTasks: Task[]) {
     const results: SuggestInfo[] = [];
-    const idRegex = new RegExp(`(${idSymbol})\\s*(${taskIdRegex.source})*`, 'ug');
+    const idRegex = new RegExp(`(${idSymbol})\\s*(${taskIdRegex.source})?`, 'ug');
     const idMatch = matchIfCursorInRegex(line, idRegex, cursorPos);
 
     if (idMatch && idMatch[0].trim().length <= idSymbol.length) {

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../Config/Settings';
 import { DateParser } from '../Query/DateParser';
 import { doAutocomplete } from '../lib/DateAbbreviations';
 import { Recurrence } from '../Task/Recurrence';
-import type { DefaultTaskSerializerSymbols } from '../TaskSerializer/DefaultTaskSerializer';
+import { type DefaultTaskSerializerSymbols, taskIdRegex } from '../TaskSerializer/DefaultTaskSerializer';
 import { Task } from '../Task/Task';
 import { generateUniqueId } from '../Task/TaskDependency';
 import { GlobalFilter } from '../Config/GlobalFilter';
@@ -410,7 +410,7 @@ function addRecurrenceSuggestions(
 
 function addIDSuggestion(line: string, cursorPos: number, idSymbol: string, allTasks: Task[]) {
     const results: SuggestInfo[] = [];
-    const idRegex = new RegExp(`(${idSymbol})\\s*([0-9a-zA-Z ]*)`, 'ug');
+    const idRegex = new RegExp(`(${idSymbol})\\s*(${taskIdRegex.source})*`, 'ug');
     const idMatch = matchIfCursorInRegex(line, idRegex, cursorPos);
 
     if (idMatch && idMatch[0].trim().length <= idSymbol.length) {

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -453,7 +453,11 @@ function addDependsOnSuggestions(
         // Find all Tasks, Already Added
         let blockingTasks: Task[] = [];
         if (existingDependsOnIdStrings) {
-            blockingTasks = allTasks.filter((task) => task.id && existingDependsOnIdStrings.includes(task.id));
+            // Split the string into an array by commas, then map over it to trim whitespace from each element.
+            const idsArray = existingDependsOnIdStrings.split(',').map((id) => id.trim());
+
+            // Filter `allTasks` to only include tasks whose `id` is exactly in the `idsArray`.
+            blockingTasks = allTasks.filter((task) => task.id && idsArray.includes(task.id));
         }
 
         if (newTaskToAppend.length >= settings.autoSuggestMinMatch) {

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -1,7 +1,7 @@
 import { TaskLayoutComponent } from '../Layout/TaskLayoutOptions';
 import { Priority } from '../Task/Priority';
 import type { Task } from '../Task/Task';
-import { DefaultTaskSerializer, taskIdRegex } from './DefaultTaskSerializer';
+import { DefaultTaskSerializer, taskIdRegex, taskIdSequenceRegex } from './DefaultTaskSerializer';
 
 /**
  * Takes a regex of the form 'key:: value' and turns it into a regex that can parse
@@ -86,9 +86,7 @@ export const DATAVIEW_SYMBOLS = {
         doneDateRegex: toInlineFieldRegex(/completion:: *(\d{4}-\d{2}-\d{2})/),
         cancelledDateRegex: toInlineFieldRegex(/cancelled:: *(\d{4}-\d{2}-\d{2})/),
         recurrenceRegex: toInlineFieldRegex(/repeat:: *([a-zA-Z0-9, !]+)/),
-        dependsOnRegex: toInlineFieldRegex(
-            new RegExp('dependsOn:: *(' + taskIdRegex.source + '( *, *' + taskIdRegex.source + ' *)*)'),
-        ),
+        dependsOnRegex: toInlineFieldRegex(new RegExp('dependsOn:: *' + taskIdSequenceRegex.source)),
         idRegex: toInlineFieldRegex(new RegExp('id:: *(' + taskIdRegex.source + ')')),
     },
 } as const;

--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -86,7 +86,7 @@ export const DATAVIEW_SYMBOLS = {
         doneDateRegex: toInlineFieldRegex(/completion:: *(\d{4}-\d{2}-\d{2})/),
         cancelledDateRegex: toInlineFieldRegex(/cancelled:: *(\d{4}-\d{2}-\d{2})/),
         recurrenceRegex: toInlineFieldRegex(/repeat:: *([a-zA-Z0-9, !]+)/),
-        dependsOnRegex: toInlineFieldRegex(new RegExp('dependsOn:: *' + taskIdSequenceRegex.source)),
+        dependsOnRegex: toInlineFieldRegex(new RegExp('dependsOn:: *(' + taskIdSequenceRegex.source + ')')),
         idRegex: toInlineFieldRegex(new RegExp('id:: *(' + taskIdRegex.source + ')')),
     },
 } as const;

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -49,7 +49,7 @@ export interface DefaultTaskSerializerSymbols {
 export const taskIdRegex = /[a-zA-Z0-9-_]+/;
 
 // The allowed characters in a comma-separated sequence of task ids:
-export const taskIdSequenceRegex = new RegExp('(' + taskIdRegex.source + '( *, *' + taskIdRegex.source + ' *)*)');
+export const taskIdSequenceRegex = new RegExp(taskIdRegex.source + '( *, *' + taskIdRegex.source + ' *)*');
 
 /**
  * A symbol map for obsidian-task's default task style.
@@ -86,7 +86,7 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
         doneDateRegex: /✅ *(\d{4}-\d{2}-\d{2})$/u,
         cancelledDateRegex: /❌ *(\d{4}-\d{2}-\d{2})$/u,
         recurrenceRegex: /🔁 ?([a-zA-Z0-9, !]+)$/iu,
-        dependsOnRegex: new RegExp('⛔\uFE0F? *' + taskIdSequenceRegex.source + '$', 'iu'),
+        dependsOnRegex: new RegExp('⛔\uFE0F? *(' + taskIdSequenceRegex.source + ')$', 'iu'),
         idRegex: new RegExp('🆔 *(' + taskIdRegex.source + ')$', 'iu'),
     },
 } as const;

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -49,7 +49,7 @@ export interface DefaultTaskSerializerSymbols {
 export const taskIdRegex = /[a-zA-Z0-9-_]+/;
 
 // The allowed characters in a comma-separated sequence of task ids:
-const taskIdSequenceRegex = new RegExp('(' + taskIdRegex.source + '( *, *' + taskIdRegex.source + ' *)*)');
+export const taskIdSequenceRegex = new RegExp('(' + taskIdRegex.source + '( *, *' + taskIdRegex.source + ' *)*)');
 
 /**
  * A symbol map for obsidian-task's default task style.

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -48,6 +48,9 @@ export interface DefaultTaskSerializerSymbols {
 // The allowed characters in a single task id:
 export const taskIdRegex = /[a-zA-Z0-9-_]+/;
 
+// The allowed characters in a comma-separated sequence of task ids:
+const taskIdSequenceRegex = new RegExp('(' + taskIdRegex.source + '( *, *' + taskIdRegex.source + ' *)*)');
+
 /**
  * A symbol map for obsidian-task's default task style.
  * Uses emojis to concisely convey meaning
@@ -83,10 +86,7 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
         doneDateRegex: /✅ *(\d{4}-\d{2}-\d{2})$/u,
         cancelledDateRegex: /❌ *(\d{4}-\d{2}-\d{2})$/u,
         recurrenceRegex: /🔁 ?([a-zA-Z0-9, !]+)$/iu,
-        dependsOnRegex: new RegExp(
-            '⛔\uFE0F? *' + '(' + taskIdRegex.source + '( *, *' + taskIdRegex.source + ' *)*)' + '$',
-            'iu',
-        ),
+        dependsOnRegex: new RegExp('⛔\uFE0F? *' + taskIdSequenceRegex.source + '$', 'iu'),
         idRegex: new RegExp('🆔 *(' + taskIdRegex.source + ')$', 'iu'),
     },
 } as const;

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -84,7 +84,7 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
         cancelledDateRegex: /❌ *(\d{4}-\d{2}-\d{2})$/u,
         recurrenceRegex: /🔁 ?([a-zA-Z0-9, !]+)$/iu,
         dependsOnRegex: new RegExp(
-            '⛔\uFE0F? *(' + taskIdRegex.source + '( *, *' + taskIdRegex.source + ' *)*)$',
+            '⛔\uFE0F? *' + '(' + taskIdRegex.source + '( *, *' + taskIdRegex.source + ' *)*)' + '$',
             'iu',
         ),
         idRegex: new RegExp('🆔 *(' + taskIdRegex.source + ')$', 'iu'),

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -392,6 +392,21 @@ describe.each([
                 );
             });
 
+            it.failing('should allow punctuation in search strings', () => {
+                const peace1 = taskBuilder.description('World peace!').id('peace1').build();
+                const peace1Match = 'World peace! - From: file-name.md';
+
+                // Don't match a task that has peace present, but without the exclamation mark
+                const peace2 = taskBuilder.description('Peacefulness').id('peace2').build();
+
+                const line = `- [ ] some task ${dependsOnSymbol} xy,1234,5678,peace!`;
+                shouldStartWithSuggestionsEqualling(
+                    line,
+                    [peace1Match, defaultSuggestion],
+                    [peace1, peace2, ...allTasks],
+                );
+            });
+
             it('should not offer any tasks if there is not a comma after existing depends IDs', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,5678`;
                 const suggestions = buildSuggestionsForEndOfLine(line, allTasks);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -375,7 +375,6 @@ describe.each([
                 // 123 is only a substring of one of the ID 1234 which is already depended on, not an exat match.
                 // So it should not count as already matched.
                 shouldStartWithSuggestedTasks(line, [taskWithId123], [taskWithId123, ...allTasks]);
-                expect(allTasks.length).toBe(3);
             });
 
             it('should find non-exact matches for multi-word search strings', () => {
@@ -385,7 +384,6 @@ describe.each([
                 const line = `- [ ] some task ${dependsOnSymbol} xy,1234,5678,feed baby`;
                 // Search string 'feed baby' should match only 'Feed the baby':
                 shouldStartWithSuggestedTasks(line, [feedBaby], [feedBaby, feedCat, ...allTasks]);
-                expect(allTasks.length).toBe(3);
             });
 
             it.failing('should allow punctuation in search strings', () => {
@@ -396,7 +394,6 @@ describe.each([
 
                 const line = `- [ ] some task ${dependsOnSymbol} xy,1234,5678,peace!`;
                 shouldStartWithSuggestedTasks(line, [peace1], [peace1, peace2, ...allTasks]);
-                expect(allTasks.length).toBe(3);
             });
 
             it('should not offer any tasks if there is not a comma after existing depends IDs', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -290,25 +290,41 @@ describe.each([
             const suggestTask1234 = '1 - From: file-name.md';
             const suggestTask5678 = '2 - From: file-name.md';
 
+            // Make tests more thorough by allowing tests to ensure that there are no more dependency suggestions
+            // after the ones we supply to shouldStartWithSuggestionsEqualling():
+            const defaultSuggestion = `${dueDateSymbol} due date`;
+
             it('should suggest all tasks when there is no existing ID after dependsOn', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} `;
-                shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, suggestTask1234, suggestTask5678], allTasks);
+                shouldStartWithSuggestionsEqualling(
+                    line,
+                    [suggestTaskxy, suggestTask1234, suggestTask5678, defaultSuggestion],
+                    allTasks,
+                );
             });
 
             it('should offer tasks containing the search string, if given a partial ID', () => {
                 // 1 does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol} 1`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask1234], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTask1234, defaultSuggestion], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with 1 existing dependency', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, suggestTask5678], allTasks);
+                shouldStartWithSuggestionsEqualling(
+                    line,
+                    [suggestTaskxy, suggestTask5678, defaultSuggestion],
+                    allTasks,
+                );
             });
 
             it('should offer tasks when first existing dependency id has hyphen and underscore', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1_2-3,`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, suggestTask1234, suggestTask5678], allTasks);
+                shouldStartWithSuggestionsEqualling(
+                    line,
+                    [suggestTaskxy, suggestTask1234, suggestTask5678, defaultSuggestion],
+                    allTasks,
+                );
             });
 
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -379,6 +379,19 @@ describe.each([
                 );
             });
 
+            it('should find non-exact matches for multi-word search strings', () => {
+                const feedBaby = taskBuilder.description('Feed the baby').id('bby').build();
+                const feedCat = taskBuilder.description('Feed the cat').id('ct').build();
+
+                const line = `- [ ] some task ${dependsOnSymbol} xy,1234,5678,feed baby`;
+                // Search string 'feed baby' should match only 'Feed the baby':
+                shouldStartWithSuggestionsEqualling(
+                    line,
+                    ['Feed the baby - From: file-name.md', defaultSuggestion],
+                    [feedBaby, feedCat, ...allTasks],
+                );
+            });
+
             it('should not offer any tasks if there is not a comma after existing depends IDs', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,5678`;
                 const suggestions = buildSuggestionsForEndOfLine(line, allTasks);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -370,17 +370,11 @@ describe.each([
 
             it('should use equality to check for existing IDs, not containment', () => {
                 const taskWithId123 = taskBuilder.description('3').id('123').build();
-                const suggestTask123 = suggestionLabel(taskWithId123);
-
                 const line = `- [ ] some task ${dependsOnSymbol} xy,1234,5678,`;
 
                 // 123 is only a substring of one of the ID 1234 which is already depended on, not an exat match.
                 // So it should not count as already matched.
-                shouldStartWithSuggestionsEqualling(
-                    line,
-                    [suggestTask123, defaultSuggestion],
-                    [taskWithId123, ...allTasks],
-                );
+                shouldStartWithSuggestedTasks(line, [taskWithId123], [taskWithId123, ...allTasks]);
                 expect(allTasks.length).toBe(3);
             });
 
@@ -390,27 +384,18 @@ describe.each([
 
                 const line = `- [ ] some task ${dependsOnSymbol} xy,1234,5678,feed baby`;
                 // Search string 'feed baby' should match only 'Feed the baby':
-                shouldStartWithSuggestionsEqualling(
-                    line,
-                    [suggestionLabel(feedBaby), defaultSuggestion],
-                    [feedBaby, feedCat, ...allTasks],
-                );
+                shouldStartWithSuggestedTasks(line, [feedBaby], [feedBaby, feedCat, ...allTasks]);
                 expect(allTasks.length).toBe(3);
             });
 
             it.failing('should allow punctuation in search strings', () => {
                 const peace1 = taskBuilder.description('World peace!').id('peace1').build();
-                const peace1Match = suggestionLabel(peace1);
 
                 // Don't match a task that has peace present, but without the exclamation mark
                 const peace2 = taskBuilder.description('Peacefulness').id('peace2').build();
 
                 const line = `- [ ] some task ${dependsOnSymbol} xy,1234,5678,peace!`;
-                shouldStartWithSuggestionsEqualling(
-                    line,
-                    [peace1Match, defaultSuggestion],
-                    [peace1, peace2, ...allTasks],
-                );
+                shouldStartWithSuggestedTasks(line, [peace1], [peace1, peace2, ...allTasks]);
                 expect(allTasks.length).toBe(3);
             });
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -304,6 +304,11 @@ describe.each([
                 return task;
             }
 
+            function shouldStartWithSuggestedTasks(line: string, selectedTasks: Task[], allTasks: Task[]) {
+                const selectedTaskLabels = selectedTasks.map((task) => suggestionLabel(task));
+                shouldStartWithSuggestionsEqualling(line, [...selectedTaskLabels, defaultSuggestion], allTasks);
+            }
+
             // Create tasks and add them to allTasks
             const taskxy = createAndAddTask('x_y', 'xy');
             const task1234 = createAndAddTask('1', '1234');
@@ -363,8 +368,7 @@ describe.each([
             it('should offer tasks when first existing dependency id has hyphen and underscore', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1_2-3,`;
                 const selectedTasks = [taskxy, task1234, task5678];
-                const selectedTaskLabels = selectedTasks.map((task) => suggestionLabel(task));
-                shouldStartWithSuggestionsEqualling(line, [...selectedTaskLabels, defaultSuggestion], allTasks);
+                shouldStartWithSuggestedTasks(line, selectedTasks, allTasks);
             });
 
             it('should only offer tasks not already depended upon - and allows spaces around commas', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -258,6 +258,12 @@ describe.each([
             const line = `- [ ] some task ${idSymbol}`;
             shouldStartWithSuggestionsEqualling(line, ['Auto Generate Unique ID']);
         });
+
+        it('should offer to generate unique id if the id symbol is already present', () => {
+            const line = `- [ ] some task ${idSymbol} 1234`;
+            const suggestions = buildSuggestionsForEndOfLine(line);
+            shouldOnlyOfferDefaultSuggestions(suggestions);
+        });
     });
 
     describe('suggestions for dependency field ', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -367,8 +367,7 @@ describe.each([
 
             it('should offer tasks when first existing dependency id has hyphen and underscore', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1_2-3,`;
-                const selectedTasks = [taskxy, task1234, task5678];
-                shouldStartWithSuggestedTasks(line, selectedTasks, allTasks);
+                shouldStartWithSuggestedTasks(line, [taskxy, task1234, task5678], allTasks);
             });
 
             it('should only offer tasks not already depended upon - and allows spaces around commas', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -248,7 +248,7 @@ describe.each([
         expect(suggestions[0].displayText).not.toContain('created today');
     });
 
-    describe('suggestions for dependency fields', () => {
+    describe('suggestions for dependency field ID', () => {
         it('should offer "id" then "depends on" if user typed "id"', () => {
             const line = '- [ ] some task id';
             shouldStartWithSuggestionsEqualling(line, [`${idSymbol} Task ID`, `${dependsOnSymbol} Task depends on ID`]);
@@ -258,7 +258,9 @@ describe.each([
             const line = `- [ ] some task ${idSymbol}`;
             shouldStartWithSuggestionsEqualling(line, ['Auto Generate Unique ID']);
         });
+    });
 
+    describe('suggestions for dependency field ', () => {
         it('should offer to depend on only task in vault, and include its filename in suggestion if user typed "id"', () => {
             const line = `- [ ] some task ${dependsOnSymbol} `;
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -273,18 +273,26 @@ describe.each([
 
         describe('suggesting additional dependencies', () => {
             const taskBuilder = new TaskBuilder().path('root/dir 1/dir 2/file-name.md');
+            // If adding new task lines here, add them before the end of the list,
+            // to ensure that existing shouldStartWithSuggestions...()-based tests really
+            // do exercise the new task line.
+            // If they are added at the end of the list, all existing tests will just
+            // silently pass.
             const allTasks = [
                 // force line break
+                taskBuilder.description('x_y').id('xy').build(),
                 taskBuilder.description('1').id('1234').build(),
                 taskBuilder.description('2').id('5678').build(),
             ];
 
+            // Variable names based on ID, not description:
+            const suggestTaskxy = 'x_y - From: file-name.md';
             const suggestTask1234 = '1 - From: file-name.md';
             const suggestTask5678 = '2 - From: file-name.md';
 
             it('should suggest all tasks when there is no existing ID after dependsOn', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} `;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask1234, suggestTask5678], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, suggestTask1234, suggestTask5678], allTasks);
             });
 
             it('should offer tasks containing the search string, if given a partial ID', () => {
@@ -295,16 +303,16 @@ describe.each([
 
             it('should only offer tasks not already depended upon - with 1 existing dependency', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask5678], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, suggestTask5678], allTasks);
             });
 
             it('should offer tasks when first existing dependency id has hyphen and underscore', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1_2-3,`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask1234, suggestTask5678], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, suggestTask1234, suggestTask5678], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {
-                const line = `- [ ] some task ${dependsOnSymbol} 1234,5678,`;
+                const line = `- [ ] some task ${dependsOnSymbol} xy,1234,5678,`;
                 const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
                 shouldOnlyOfferDefaultSuggestions(suggestions);
             });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -321,44 +321,36 @@ describe.each([
 
             it('should suggest all tasks when there is no existing ID after dependsOn', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} `;
-                shouldStartWithSuggestionsEqualling(
-                    line,
-                    [suggestionLabel(taskxy), suggestionLabel(task1234), suggestionLabel(task5678), defaultSuggestion],
-                    allTasks,
-                );
+                shouldStartWithSuggestedTasks(line, [taskxy, task1234, task5678], allTasks);
             });
 
             it('should offer tasks containing the search string, if given a partial ID', () => {
                 // 1 does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol} 1`;
-                shouldStartWithSuggestionsEqualling(line, [suggestionLabel(task1234), defaultSuggestion], allTasks);
+                shouldStartWithSuggestedTasks(line, [task1234], allTasks);
             });
 
             it('should offer tasks containing the search string, if given a partial ID even when no space between symbol and ID', () => {
                 // 1 does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol}1`;
-                shouldStartWithSuggestionsEqualling(line, [suggestionLabel(task1234), defaultSuggestion], allTasks);
+                shouldStartWithSuggestedTasks(line, [task1234], allTasks);
             });
 
             it('should offer tasks containing underscore in description, if given as partial ID', () => {
                 // x_ does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol} x_`;
-                shouldStartWithSuggestionsEqualling(line, [suggestionLabel(taskxy), defaultSuggestion], allTasks);
+                shouldStartWithSuggestedTasks(line, [taskxy], allTasks);
             });
 
             it('should offer tasks containing underscore in description, if given as second partial ID', () => {
                 // x_ does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,x_`;
-                shouldStartWithSuggestionsEqualling(line, [suggestionLabel(taskxy), defaultSuggestion], allTasks);
+                shouldStartWithSuggestedTasks(line, [taskxy], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with 1 existing dependency', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,`;
-                shouldStartWithSuggestionsEqualling(
-                    line,
-                    [suggestionLabel(taskxy), suggestionLabel(task5678), defaultSuggestion],
-                    allTasks,
-                );
+                shouldStartWithSuggestedTasks(line, [taskxy, task5678], allTasks);
             });
 
             it('should offer tasks when first existing dependency id has hyphen and underscore', () => {
@@ -368,7 +360,7 @@ describe.each([
 
             it('should only offer tasks not already depended upon - and allows spaces around commas', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} xy , 5678 , `;
-                shouldStartWithSuggestionsEqualling(line, [suggestionLabel(task1234), defaultSuggestion], allTasks);
+                shouldStartWithSuggestedTasks(line, [task1234], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -370,7 +370,7 @@ describe.each([
 
             it('should use equality to check for existing IDs, not containment', () => {
                 const taskWithId123 = taskBuilder.description('3').id('123').build();
-                const suggestTask123 = '3 - From: file-name.md';
+                const suggestTask123 = suggestionLabel(taskWithId123);
 
                 const line = `- [ ] some task ${dependsOnSymbol} xy,1234,5678,`;
 
@@ -381,6 +381,7 @@ describe.each([
                     [suggestTask123, defaultSuggestion],
                     [taskWithId123, ...allTasks],
                 );
+                expect(allTasks.length).toBe(3);
             });
 
             it('should find non-exact matches for multi-word search strings', () => {
@@ -391,14 +392,15 @@ describe.each([
                 // Search string 'feed baby' should match only 'Feed the baby':
                 shouldStartWithSuggestionsEqualling(
                     line,
-                    ['Feed the baby - From: file-name.md', defaultSuggestion],
+                    [suggestionLabel(feedBaby), defaultSuggestion],
                     [feedBaby, feedCat, ...allTasks],
                 );
+                expect(allTasks.length).toBe(3);
             });
 
             it.failing('should allow punctuation in search strings', () => {
                 const peace1 = taskBuilder.description('World peace!').id('peace1').build();
-                const peace1Match = 'World peace! - From: file-name.md';
+                const peace1Match = suggestionLabel(peace1);
 
                 // Don't match a task that has peace present, but without the exclamation mark
                 const peace2 = taskBuilder.description('Peacefulness').id('peace2').build();
@@ -409,6 +411,7 @@ describe.each([
                     [peace1Match, defaultSuggestion],
                     [peace1, peace2, ...allTasks],
                 );
+                expect(allTasks.length).toBe(3);
             });
 
             it('should not offer any tasks if there is not a comma after existing depends IDs', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -310,14 +310,10 @@ describe.each([
             }
 
             // Create tasks and add them to allTasks
+            // Variable names based on ID, not description:
             const taskxy = createAndAddTask('x_y', 'xy');
             const task1234 = createAndAddTask('1', '1234');
             const task5678 = createAndAddTask('2', '5678');
-
-            // Variable names based on ID, not description:
-            const suggestTaskxy = suggestionLabel(taskxy);
-            const suggestTask1234 = suggestionLabel(task1234);
-            const suggestTask5678 = suggestionLabel(task5678);
 
             // Make tests more thorough by allowing tests to ensure that there are no more dependency suggestions
             // after the ones we supply to shouldStartWithSuggestionsEqualling():
@@ -327,7 +323,7 @@ describe.each([
                 const line = `- [ ] some task ${dependsOnSymbol} `;
                 shouldStartWithSuggestionsEqualling(
                     line,
-                    [suggestTaskxy, suggestTask1234, suggestTask5678, defaultSuggestion],
+                    [suggestionLabel(taskxy), suggestionLabel(task1234), suggestionLabel(task5678), defaultSuggestion],
                     allTasks,
                 );
             });
@@ -335,32 +331,32 @@ describe.each([
             it('should offer tasks containing the search string, if given a partial ID', () => {
                 // 1 does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol} 1`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask1234, defaultSuggestion], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestionLabel(task1234), defaultSuggestion], allTasks);
             });
 
             it('should offer tasks containing the search string, if given a partial ID even when no space between symbol and ID', () => {
                 // 1 does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol}1`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask1234, defaultSuggestion], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestionLabel(task1234), defaultSuggestion], allTasks);
             });
 
             it('should offer tasks containing underscore in description, if given as partial ID', () => {
                 // x_ does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol} x_`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, defaultSuggestion], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestionLabel(taskxy), defaultSuggestion], allTasks);
             });
 
             it('should offer tasks containing underscore in description, if given as second partial ID', () => {
                 // x_ does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,x_`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, defaultSuggestion], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestionLabel(taskxy), defaultSuggestion], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with 1 existing dependency', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,`;
                 shouldStartWithSuggestionsEqualling(
                     line,
-                    [suggestTaskxy, suggestTask5678, defaultSuggestion],
+                    [suggestionLabel(taskxy), suggestionLabel(task5678), defaultSuggestion],
                     allTasks,
                 );
             });
@@ -372,7 +368,7 @@ describe.each([
 
             it('should only offer tasks not already depended upon - and allows spaces around commas', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} xy , 5678 , `;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask1234, defaultSuggestion], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestionLabel(task1234), defaultSuggestion], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -171,6 +171,11 @@ describe.each([
         }
     }
 
+    function shouldOnlyOfferDefaultSuggestionsForEndOfLine(line: string) {
+        const suggestions = buildSuggestionsForEndOfLine(line);
+        shouldOnlyOfferDefaultSuggestions(suggestions);
+    }
+
     const {
         dueDateSymbol,
         scheduledDateSymbol,
@@ -261,8 +266,7 @@ describe.each([
 
         it('should offer to generate unique id if the id symbol is already present', () => {
             const line = `- [ ] some task ${idSymbol} 1234`;
-            const suggestions = buildSuggestionsForEndOfLine(line);
-            shouldOnlyOfferDefaultSuggestions(suggestions);
+            shouldOnlyOfferDefaultSuggestionsForEndOfLine(line);
         });
     });
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -274,7 +274,7 @@ describe.each([
         it('should offer to depend on only task in vault, and include its filename in suggestion if user typed "id"', () => {
             const line = `- [ ] some task ${dependsOnSymbol} `;
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
-            shouldStartWithSuggestionsEqualling(line, ['Do exercises - From: fileName.md'], [taskToDependOn]);
+            shouldStartWithSuggestionsEqualling(line, [suggestionLabel(taskToDependOn)], [taskToDependOn]);
         });
 
         // TODO should not offer to depend on self
@@ -284,7 +284,7 @@ describe.each([
         // TODO confirm it does not unnecessarily rewrite tasks that already have an ID
 
         function suggestionLabel(taskxy: Task) {
-            return `${taskxy.description} - From: ${taskxy.file.filename}`;
+            return `${taskxy.descriptionWithoutTags} - From: ${taskxy.file.filename}`;
         }
 
         describe('suggesting additional dependencies', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -294,11 +294,8 @@ describe.each([
             // do exercise the new task line.
             // If they are added at the end of the list, all existing tests will just
             // silently pass.
-            const allTasks = [
-                // force line break
-                taskBuilder.description('x_y').id('xy').build(),
-                taskBuilder.description('1').id('1234').build(),
-            ];
+
+            const allTasks: Task[] = [];
 
             // Function to create a task and append it to the allTasks array
             function createAndAddTask(description: string, id: string): Task {
@@ -307,8 +304,9 @@ describe.each([
                 return task;
             }
 
-            const taskxy = allTasks[0];
-            const task1234 = allTasks[1];
+            // Create tasks and add them to allTasks
+            const taskxy = createAndAddTask('x_y', 'xy');
+            const task1234 = createAndAddTask('1', '1234');
             const task5678 = createAndAddTask('2', '5678');
 
             // Variable names based on ID, not description:

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -362,11 +362,8 @@ describe.each([
 
             it('should offer tasks when first existing dependency id has hyphen and underscore', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1_2-3,`;
-                const selectedTaskLabels = [
-                    suggestionLabel(taskxy),
-                    suggestionLabel(task1234),
-                    suggestionLabel(task5678),
-                ];
+                const selectedTasks = [taskxy, task1234, task5678];
+                const selectedTaskLabels = selectedTasks.map((task) => suggestionLabel(task));
                 shouldStartWithSuggestionsEqualling(line, [...selectedTaskLabels, defaultSuggestion], allTasks);
             });
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -364,7 +364,7 @@ describe.each([
                 shouldOnlyOfferDefaultSuggestions(suggestions);
             });
 
-            it.failing('should use equality to check for existing IDs, not containment', () => {
+            it('should use equality to check for existing IDs, not containment', () => {
                 const taskWithId123 = taskBuilder.description('3').id('123').build();
                 const suggestTask123 = '3 - From: file-name.md';
 
@@ -372,7 +372,6 @@ describe.each([
 
                 // 123 is only a substring of one of the ID 1234 which is already depended on, not an exat match.
                 // So it should not count as already matched.
-                // TODO Stop 123 being treated as already depended on, if ID 1234 is already depended on.
                 shouldStartWithSuggestionsEqualling(
                     line,
                     [suggestTask123, defaultSuggestion],

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -362,11 +362,8 @@ describe.each([
 
             it('should offer tasks when first existing dependency id has hyphen and underscore', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1_2-3,`;
-                shouldStartWithSuggestionsEqualling(
-                    line,
-                    [suggestTaskxy, suggestTask1234, suggestTask5678, defaultSuggestion],
-                    allTasks,
-                );
+                const selectedTaskLabels = [suggestTaskxy, suggestTask1234, suggestTask5678];
+                shouldStartWithSuggestionsEqualling(line, [...selectedTaskLabels, defaultSuggestion], allTasks);
             });
 
             it('should only offer tasks not already depended upon - and allows spaces around commas', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -279,28 +279,28 @@ describe.each([
                 taskBuilder.description('2').id('5678').build(),
             ];
 
-            const suggestTask1 = '1 - From: file-name.md';
-            const suggestTask2 = '2 - From: file-name.md';
+            const suggestTask1234 = '1 - From: file-name.md';
+            const suggestTask5678 = '2 - From: file-name.md';
 
             it('should suggest all tasks when there is no existing ID after dependsOn', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} `;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask1, suggestTask2], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTask1234, suggestTask5678], allTasks);
             });
 
             it('should offer tasks containing the search string, if given a partial ID', () => {
                 // 1 does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol} 1`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask1], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTask1234], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with 1 existing dependency', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask2], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTask5678], allTasks);
             });
 
             it('should offer tasks when first existing dependency id has hyphen and underscore', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1_2-3,`;
-                shouldStartWithSuggestionsEqualling(line, [suggestTask1, suggestTask2], allTasks);
+                shouldStartWithSuggestionsEqualling(line, [suggestTask1234, suggestTask5678], allTasks);
             });
 
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -329,9 +329,9 @@ describe.each([
                 shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, defaultSuggestion], allTasks);
             });
 
-            it.failing('should offer tasks containing underscore in description, if given as second partial ID', () => {
+            it('should offer tasks containing underscore in description, if given as second partial ID', () => {
                 // x_ does not match any of the existing IDs, so is presumed to be a substring to search for.
-                const line = `- [ ] some task ${dependsOnSymbol} 1234,x_,`;
+                const line = `- [ ] some task ${dependsOnSymbol} 1234,x_`;
                 shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, defaultSuggestion], allTasks);
             });
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -171,8 +171,8 @@ describe.each([
         }
     }
 
-    function shouldOnlyOfferDefaultSuggestionsForEndOfLine(line: string) {
-        const suggestions = buildSuggestionsForEndOfLine(line);
+    function shouldOnlyOfferDefaultSuggestionsForEndOfLine(line: string, allTasks: Task[] = []) {
+        const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
         shouldOnlyOfferDefaultSuggestions(suggestions);
     }
 
@@ -364,8 +364,7 @@ describe.each([
 
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} xy,1234,5678,`;
-                const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
-                shouldOnlyOfferDefaultSuggestions(suggestions);
+                shouldOnlyOfferDefaultSuggestionsForEndOfLine(line, allTasks);
             });
 
             it('should use equality to check for existing IDs, not containment', () => {
@@ -413,14 +412,12 @@ describe.each([
 
             it('should not offer any tasks if there is not a comma after existing depends IDs', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,5678`;
-                const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
-                shouldOnlyOfferDefaultSuggestions(suggestions);
+                shouldOnlyOfferDefaultSuggestionsForEndOfLine(line, allTasks);
             });
 
             it('should not offer tasks if "IDs" are separated by spaces', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234 5678`;
-                const suggestions = buildSuggestionsForEndOfLine(line, allTasks);
-                shouldOnlyOfferDefaultSuggestions(suggestions);
+                shouldOnlyOfferDefaultSuggestionsForEndOfLine(line, allTasks);
             });
         });
     });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -317,6 +317,12 @@ describe.each([
                 shouldStartWithSuggestionsEqualling(line, [suggestTask1234, defaultSuggestion], allTasks);
             });
 
+            it('should offer tasks containing the search string, if given a partial ID even when no space between symbol and ID', () => {
+                // 1 does not match any of the existing IDs, so is presumed to be a substring to search for.
+                const line = `- [ ] some task ${dependsOnSymbol}1`;
+                shouldStartWithSuggestionsEqualling(line, [suggestTask1234, defaultSuggestion], allTasks);
+            });
+
             it('should offer tasks containing underscore in description, if given as partial ID', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} x_`;
                 shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, defaultSuggestion], allTasks);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -309,6 +309,16 @@ describe.each([
                 shouldStartWithSuggestionsEqualling(line, [suggestTask1234, defaultSuggestion], allTasks);
             });
 
+            it('should offer tasks containing underscore in description, if given as partial ID', () => {
+                const line = `- [ ] some task ${dependsOnSymbol} x_`;
+                shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, defaultSuggestion], allTasks);
+            });
+
+            it.failing('should offer tasks containing underscore in description, if given as second partial ID', () => {
+                const line = `- [ ] some task ${dependsOnSymbol} 1234,x_,`;
+                shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, defaultSuggestion], allTasks);
+            });
+
             it('should only offer tasks not already depended upon - with 1 existing dependency', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,`;
                 shouldStartWithSuggestionsEqualling(

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -298,12 +298,18 @@ describe.each([
                 // force line break
                 taskBuilder.description('x_y').id('xy').build(),
                 taskBuilder.description('1').id('1234').build(),
-                taskBuilder.description('2').id('5678').build(),
             ];
+
+            // Function to create a task and append it to the allTasks array
+            function createAndAddTask(description: string, id: string): Task {
+                const task = taskBuilder.description(description).id(id).build();
+                allTasks.push(task);
+                return task;
+            }
 
             const taskxy = allTasks[0];
             const task1234 = allTasks[1];
-            const task5678 = allTasks[2];
+            const task5678 = createAndAddTask('2', '5678');
 
             // Variable names based on ID, not description:
             const suggestTaskxy = suggestionLabel(taskxy);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -357,6 +357,22 @@ describe.each([
                 shouldOnlyOfferDefaultSuggestions(suggestions);
             });
 
+            it.failing('should use equality to check for existing IDs, not containment', () => {
+                const taskWithId123 = taskBuilder.description('3').id('123').build();
+                const suggestTask123 = '3 - From: file-name.md';
+
+                const line = `- [ ] some task ${dependsOnSymbol} xy,1234,5678,`;
+
+                // 123 is only a substring of one of the ID 1234 which is already depended on, not an exat match.
+                // So it should not count as already matched.
+                // TODO Stop 123 being treated as already depended on, if ID 1234 is already depended on.
+                shouldStartWithSuggestionsEqualling(
+                    line,
+                    [suggestTask123, defaultSuggestion],
+                    [taskWithId123, ...allTasks],
+                );
+            });
+
             it('should not offer any tasks if there is not a comma after existing depends IDs', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,5678`;
                 const suggestions = buildSuggestionsForEndOfLine(line, allTasks);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -324,11 +324,13 @@ describe.each([
             });
 
             it('should offer tasks containing underscore in description, if given as partial ID', () => {
+                // x_ does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol} x_`;
                 shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, defaultSuggestion], allTasks);
             });
 
             it.failing('should offer tasks containing underscore in description, if given as second partial ID', () => {
+                // x_ does not match any of the existing IDs, so is presumed to be a substring to search for.
                 const line = `- [ ] some task ${dependsOnSymbol} 1234,x_,`;
                 shouldStartWithSuggestionsEqualling(line, [suggestTaskxy, defaultSuggestion], allTasks);
             });

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -302,11 +302,13 @@ describe.each([
             ];
 
             const taskxy = allTasks[0];
+            const task1234 = allTasks[1];
+            const task5678 = allTasks[2];
 
             // Variable names based on ID, not description:
             const suggestTaskxy = suggestionLabel(taskxy);
-            const suggestTask1234 = '1 - From: file-name.md';
-            const suggestTask5678 = '2 - From: file-name.md';
+            const suggestTask1234 = suggestionLabel(task1234);
+            const suggestTask5678 = suggestionLabel(task5678);
 
             // Make tests more thorough by allowing tests to ensure that there are no more dependency suggestions
             // after the ones we supply to shouldStartWithSuggestionsEqualling():

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -280,6 +280,10 @@ describe.each([
             shouldStartWithSuggestionsEqualling(line, [...selectedTaskLabels, defaultSuggestion], allTasks);
         }
 
+        function suggestionLabel(taskxy: Task) {
+            return `${taskxy.descriptionWithoutTags} - From: ${taskxy.file.filename}`;
+        }
+
         it('should offer to depend on only task in vault, and include its filename in suggestion if user typed "id"', () => {
             const line = `- [ ] some task ${dependsOnSymbol} `;
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
@@ -291,10 +295,6 @@ describe.each([
         // TODO should not offer id or dependsOn if cursor is in the middle of the line
         // TODO test that it uses the same regex for Task IDs as the rest of the code
         // TODO confirm it does not unnecessarily rewrite tasks that already have an ID
-
-        function suggestionLabel(taskxy: Task) {
-            return `${taskxy.descriptionWithoutTags} - From: ${taskxy.file.filename}`;
-        }
 
         describe('suggesting additional dependencies', () => {
             const taskBuilder = new TaskBuilder().path('root/dir 1/dir 2/file-name.md');

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -362,7 +362,11 @@ describe.each([
 
             it('should offer tasks when first existing dependency id has hyphen and underscore', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} 1_2-3,`;
-                const selectedTaskLabels = [suggestTaskxy, suggestTask1234, suggestTask5678];
+                const selectedTaskLabels = [
+                    suggestionLabel(taskxy),
+                    suggestionLabel(task1234),
+                    suggestionLabel(task5678),
+                ];
                 shouldStartWithSuggestionsEqualling(line, [...selectedTaskLabels, defaultSuggestion], allTasks);
             });
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -289,11 +289,6 @@ describe.each([
 
         describe('suggesting additional dependencies', () => {
             const taskBuilder = new TaskBuilder().path('root/dir 1/dir 2/file-name.md');
-            // If adding new task lines here, add them before the end of the list,
-            // to ensure that existing shouldStartWithSuggestions...()-based tests really
-            // do exercise the new task line.
-            // If they are added at the end of the list, all existing tests will just
-            // silently pass.
 
             const allTasks: Task[] = [];
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -353,6 +353,11 @@ describe.each([
                 );
             });
 
+            it('should only offer tasks not already depended upon - and allows spaces around commas', () => {
+                const line = `- [ ] some task ${dependsOnSymbol} xy , 5678 , `;
+                shouldStartWithSuggestionsEqualling(line, [suggestTask1234, defaultSuggestion], allTasks);
+            });
+
             it('should only offer tasks not already depended upon - with all tasks already depended on', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} xy,1234,5678,`;
                 const suggestions = buildSuggestionsForEndOfLine(line, allTasks);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -271,6 +271,15 @@ describe.each([
     });
 
     describe('suggestions for dependency field ', () => {
+        // Make tests more thorough by allowing tests to ensure that there are no more dependency suggestions
+        // after the ones we supply to shouldStartWithSuggestionsEqualling():
+        const defaultSuggestion = `${dueDateSymbol} due date`;
+
+        function shouldStartWithSuggestedTasks(line: string, selectedTasks: Task[], allTasks: Task[]) {
+            const selectedTaskLabels = selectedTasks.map((task) => suggestionLabel(task));
+            shouldStartWithSuggestionsEqualling(line, [...selectedTaskLabels, defaultSuggestion], allTasks);
+        }
+
         it('should offer to depend on only task in vault, and include its filename in suggestion if user typed "id"', () => {
             const line = `- [ ] some task ${dependsOnSymbol} `;
             const taskToDependOn = TaskBuilder.createFullyPopulatedTask();
@@ -289,7 +298,6 @@ describe.each([
 
         describe('suggesting additional dependencies', () => {
             const taskBuilder = new TaskBuilder().path('root/dir 1/dir 2/file-name.md');
-
             const allTasks: Task[] = [];
 
             // Function to create a task and append it to the allTasks array
@@ -299,20 +307,11 @@ describe.each([
                 return task;
             }
 
-            function shouldStartWithSuggestedTasks(line: string, selectedTasks: Task[], allTasks: Task[]) {
-                const selectedTaskLabels = selectedTasks.map((task) => suggestionLabel(task));
-                shouldStartWithSuggestionsEqualling(line, [...selectedTaskLabels, defaultSuggestion], allTasks);
-            }
-
             // Create tasks and add them to allTasks
             // Variable names based on ID, not description:
             const taskxy = createAndAddTask('x_y', 'xy');
             const task1234 = createAndAddTask('1', '1234');
             const task5678 = createAndAddTask('2', '5678');
-
-            // Make tests more thorough by allowing tests to ensure that there are no more dependency suggestions
-            // after the ones we supply to shouldStartWithSuggestionsEqualling():
-            const defaultSuggestion = `${dueDateSymbol} due date`;
 
             it('should suggest all tasks when there is no existing ID after dependsOn', () => {
                 const line = `- [ ] some task ${dependsOnSymbol} `;

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -283,6 +283,10 @@ describe.each([
         // TODO test that it uses the same regex for Task IDs as the rest of the code
         // TODO confirm it does not unnecessarily rewrite tasks that already have an ID
 
+        function suggestionLabel(taskxy: Task) {
+            return `${taskxy.description} - From: ${taskxy.file.filename}`;
+        }
+
         describe('suggesting additional dependencies', () => {
             const taskBuilder = new TaskBuilder().path('root/dir 1/dir 2/file-name.md');
             // If adding new task lines here, add them before the end of the list,
@@ -300,7 +304,7 @@ describe.each([
             const taskxy = allTasks[0];
 
             // Variable names based on ID, not description:
-            const suggestTaskxy = `${taskxy.description} - From: ${taskxy.file.filename}`;
+            const suggestTaskxy = suggestionLabel(taskxy);
             const suggestTask1234 = '1 - From: file-name.md';
             const suggestTask5678 = '2 - From: file-name.md';
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -297,8 +297,10 @@ describe.each([
                 taskBuilder.description('2').id('5678').build(),
             ];
 
+            const taskxy = allTasks[0];
+
             // Variable names based on ID, not description:
-            const suggestTaskxy = 'x_y - From: file-name.md';
+            const suggestTaskxy = `${taskxy.description} - From: ${taskxy.file.filename}`;
             const suggestTask1234 = '1 - From: file-name.md';
             const suggestTask5678 = '2 - From: file-name.md';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

I'm using the new auto-suggest for ID and dependsOn in my own vault, and it's incredibly valuable.

Before release, I wanted to add tests to make sure I understand the code.

Along the way, I improved a couple of behaviours:

- 99129ea218f5b4771259aa5e3b66663fa18cf6ee - allow additional dependencies after ids with hyphen and underscore
- bcee94a9e5eaa32a3dd2068de56824bb2878c3d2 - correct the search for blocking tasks to use exact id match, not substring

## Motivation and Context

Getting this facility ready for release

## How has this been tested?

- Adding new tests
- Manual exploratory testing

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
