### PR TITLE
fix: Disable auto-suggest for dependencies to allow 7.2.0 release

### DIFF
--- a/docs/Editing/Auto-Suggest.md
+++ b/docs/Editing/Auto-Suggest.md
@@ -288,3 +288,7 @@ at least the specified number of characters to find a match.
 How many suggestions should be shown when an auto-suggest menu pops up (including the "⏎" option).
 
 The default is 6, and you can select any value from 3 to 12.
+
+## Current Limitations
+
+- The Auto-Suggest mechanism does not yet support [[task dependencies]]. We are tracking this in [issue #2681](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2681).

--- a/docs/Editing/Auto-Suggest.md
+++ b/docs/Editing/Auto-Suggest.md
@@ -188,8 +188,17 @@ Similarly, you can type some fraction of the word `start` (of whatever length is
 <!-- include: Suggestor.test.auto-complete_with__emoji__symbols_show_all_suggested_text.approved.md -->
 | Searchable Text | Text that is added |
 | ----- | ----- |
-| 🆔 Task ID | 🆔 |
-| ⛔ Task depends on ID | ⛔ |
+| ⏎ | &lt;new line> |
+| 📅 due date | 📅  |
+| 🛫 start date | 🛫  |
+| ⏳ scheduled date | ⏳  |
+| ⏫ high priority | ⏫  |
+| 🔼 medium priority | 🔼  |
+| 🔽 low priority | 🔽  |
+| 🔺 highest priority | 🔺  |
+| ⏬ lowest priority | ⏬  |
+| 🔁 recurring (repeat) | 🔁  |
+| ➕ created today (2022-07-11) | ➕ 2022-07-11  |
 | every | 🔁 every  |
 | every day | 🔁 every day  |
 | every week | 🔁 every week  |
@@ -203,15 +212,6 @@ Similarly, you can type some fraction of the word `start` (of whatever length is
 | every week on Thursday | 🔁 every week on Thursday  |
 | every week on Friday | 🔁 every week on Friday  |
 | every week on Saturday | 🔁 every week on Saturday  |
-| 📅 due date | 📅  |
-| 🛫 start date | 🛫  |
-| ⏳ scheduled date | ⏳  |
-| ⏫ high priority | ⏫  |
-| 🔼 medium priority | 🔼  |
-| 🔽 low priority | 🔽  |
-| 🔺 highest priority | 🔺  |
-| ⏬ lowest priority | ⏬  |
-| ➕ created today (2022-07-11) | ➕ 2022-07-11  |
 | today (2022-07-11) | 📅 2022-07-11  |
 | tomorrow (2022-07-12) | 📅 2022-07-12  |
 | Sunday (2022-07-17) | 📅 2022-07-17  |
@@ -224,7 +224,6 @@ Similarly, you can type some fraction of the word `start` (of whatever length is
 | next week (2022-07-18) | 📅 2022-07-18  |
 | next month (2022-08-11) | 📅 2022-08-11  |
 | next year (2023-07-11) | 📅 2023-07-11  |
-| 🔁 recurring (repeat) | 🔁  |
 | today (2022-07-11) | ⏳ 2022-07-11  |
 | tomorrow (2022-07-12) | ⏳ 2022-07-12  |
 | Sunday (2022-07-17) | ⏳ 2022-07-17  |
@@ -249,8 +248,6 @@ Similarly, you can type some fraction of the word `start` (of whatever length is
 | next week (2022-07-18) | 🛫 2022-07-18  |
 | next month (2022-08-11) | 🛫 2022-08-11  |
 | next year (2023-07-11) | 🛫 2023-07-11  |
-| Auto Generate Unique ID | 🆔 ****** |
-| ⏎ | &lt;new line> |
 <!-- endInclude -->
 
 ### How can I use auto-suggest features from other plugins together with the Tasks auto-suggest?

--- a/docs/Getting Started/Task Dependencies.md
+++ b/docs/Getting Started/Task Dependencies.md
@@ -130,6 +130,7 @@ In this scenario, testing with users can only occur after the initial draft is c
 ![Making the 'Test with users' task depend on the 'Build a first draft'](../images/task-dependencies-blocked-by-example.png)
 <span class="caption">Making the **'Test with users'** task depend on the **'Build a first draft'** task.</span>
 
+<!--
 **Via the Auto Suggest Feature:**
 
 1. (Optional) On the 'Build a frist draft' You can select the ID symbol via the Automatic suggestion dialog box. An ID can be generated automatically via Auto Suggestions. Or you can Specify your own.
@@ -144,6 +145,7 @@ In this scenario, testing with users can only occur after the initial draft is c
 > - it only searche/shows descriptions of not-done tasks.
 > - It initially filters to show tasks in the same file ('closer' to the Task), but if you type more text, it will search all non-done tasks in the vault.
 > - Circular Dependecy, should not be created
+-->
 
 By implementing either of these methods, the task list is updated to reflect the dependency relationship:
 

--- a/docs/Support and Help/Known Limitations.md
+++ b/docs/Support and Help/Known Limitations.md
@@ -55,6 +55,10 @@ This page gathers together all the documentation on known limitations of the plu
 
 ![[Create or edit Task#Known limitations]]
 
+## Editing Tasks: Auto-Suggest
+
+![[Auto-Suggest#Current Limitations]]
+
 ## Editing Tasks: Postponing
 
 ![[Postponing#Current Limitations]]

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -23,7 +23,8 @@ declare global {
 }
 
 // Set default value for production to off, temporarily. It will be turned on in tests.
-globalThis.SHOW_DEPENDENCY_SUGGESTIONS = false;
+export const showDependencySuggestionsDefault = false;
+globalThis.SHOW_DEPENDENCY_SUGGESTIONS = showDependencySuggestionsDefault;
 
 export function makeDefaultSuggestionBuilder(
     symbols: DefaultTaskSerializerSymbols,

--- a/tests/Suggestor/Suggestor.test.auto-complete_with__dataview__symbols_show_all_suggested_text.approved.md
+++ b/tests/Suggestor/Suggestor.test.auto-complete_with__dataview__symbols_show_all_suggested_text.approved.md
@@ -1,7 +1,15 @@
 | Searchable Text | Text that is added |
 | ----- | ----- |
-| id:: Task ID | id:: |
-| dependsOn:: Task depends on ID | dependsOn:: |
+| due:: due date | due::  |
+| start:: start date | start::  |
+| scheduled:: scheduled date | scheduled::  |
+| priority:: high priority | priority:: high]  |
+| priority:: medium priority | priority:: medium]  |
+| priority:: low priority | priority:: low]  |
+| priority:: highest priority | priority:: highest]  |
+| priority:: lowest priority | priority:: lowest]  |
+| repeat:: recurring (repeat) | repeat::  |
+| created:: created today (2022-07-11) | created:: 2022-07-11]  |
 | every | repeat:: every  |
 | every day | repeat:: every day  |
 | every week | repeat:: every week  |
@@ -15,15 +23,6 @@
 | every week on Thursday | repeat:: every week on Thursday  |
 | every week on Friday | repeat:: every week on Friday  |
 | every week on Saturday | repeat:: every week on Saturday  |
-| due:: due date | due::  |
-| start:: start date | start::  |
-| scheduled:: scheduled date | scheduled::  |
-| priority:: high priority | priority:: high]  |
-| priority:: medium priority | priority:: medium]  |
-| priority:: low priority | priority:: low]  |
-| priority:: highest priority | priority:: highest]  |
-| priority:: lowest priority | priority:: lowest]  |
-| created:: created today (2022-07-11) | created:: 2022-07-11]  |
 | today (2022-07-11) | due:: 2022-07-11]  |
 | tomorrow (2022-07-12) | due:: 2022-07-12]  |
 | Sunday (2022-07-17) | due:: 2022-07-17]  |
@@ -36,7 +35,6 @@
 | next week (2022-07-18) | due:: 2022-07-18]  |
 | next month (2022-08-11) | due:: 2022-08-11]  |
 | next year (2023-07-11) | due:: 2023-07-11]  |
-| repeat:: recurring (repeat) | repeat::  |
 | today (2022-07-11) | scheduled:: 2022-07-11]  |
 | tomorrow (2022-07-12) | scheduled:: 2022-07-12]  |
 | Sunday (2022-07-17) | scheduled:: 2022-07-17]  |
@@ -61,4 +59,3 @@
 | next week (2022-07-18) | start:: 2022-07-18]  |
 | next month (2022-08-11) | start:: 2022-08-11]  |
 | next year (2023-07-11) | start:: 2023-07-11]  |
-| Auto Generate Unique ID | id:: ****** |

--- a/tests/Suggestor/Suggestor.test.auto-complete_with__emoji__symbols_show_all_suggested_text.approved.md
+++ b/tests/Suggestor/Suggestor.test.auto-complete_with__emoji__symbols_show_all_suggested_text.approved.md
@@ -1,7 +1,16 @@
 | Searchable Text | Text that is added |
 | ----- | ----- |
-| 🆔 Task ID | 🆔 |
-| ⛔ Task depends on ID | ⛔ |
+| ⏎ | &lt;new line> |
+| 📅 due date | 📅  |
+| 🛫 start date | 🛫  |
+| ⏳ scheduled date | ⏳  |
+| ⏫ high priority | ⏫  |
+| 🔼 medium priority | 🔼  |
+| 🔽 low priority | 🔽  |
+| 🔺 highest priority | 🔺  |
+| ⏬ lowest priority | ⏬  |
+| 🔁 recurring (repeat) | 🔁  |
+| ➕ created today (2022-07-11) | ➕ 2022-07-11  |
 | every | 🔁 every  |
 | every day | 🔁 every day  |
 | every week | 🔁 every week  |
@@ -15,15 +24,6 @@
 | every week on Thursday | 🔁 every week on Thursday  |
 | every week on Friday | 🔁 every week on Friday  |
 | every week on Saturday | 🔁 every week on Saturday  |
-| 📅 due date | 📅  |
-| 🛫 start date | 🛫  |
-| ⏳ scheduled date | ⏳  |
-| ⏫ high priority | ⏫  |
-| 🔼 medium priority | 🔼  |
-| 🔽 low priority | 🔽  |
-| 🔺 highest priority | 🔺  |
-| ⏬ lowest priority | ⏬  |
-| ➕ created today (2022-07-11) | ➕ 2022-07-11  |
 | today (2022-07-11) | 📅 2022-07-11  |
 | tomorrow (2022-07-12) | 📅 2022-07-12  |
 | Sunday (2022-07-17) | 📅 2022-07-17  |
@@ -36,7 +36,6 @@
 | next week (2022-07-18) | 📅 2022-07-18  |
 | next month (2022-08-11) | 📅 2022-08-11  |
 | next year (2023-07-11) | 📅 2023-07-11  |
-| 🔁 recurring (repeat) | 🔁  |
 | today (2022-07-11) | ⏳ 2022-07-11  |
 | tomorrow (2022-07-12) | ⏳ 2022-07-12  |
 | Sunday (2022-07-17) | ⏳ 2022-07-17  |
@@ -61,5 +60,3 @@
 | next week (2022-07-18) | 🛫 2022-07-18  |
 | next month (2022-08-11) | 🛫 2022-08-11  |
 | next year (2023-07-11) | 🛫 2023-07-11  |
-| Auto Generate Unique ID | 🆔 ****** |
-| ⏎ | &lt;new line> |

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -412,6 +412,11 @@ describe.each([
     });
 
     it('show all suggested text', () => {
+        // TODO Turn off dependency suggestions for now, as per default value,
+        // as the outputs of this test are embedded in the documentation,
+        // and I wish to hide ID and dependsOn there.
+        global.SHOW_DEPENDENCY_SUGGESTIONS = true;
+
         const originalSettings = getSettings();
         originalSettings.autoSuggestMaxItems = 200;
 
@@ -421,9 +426,11 @@ describe.each([
             `- [ ] some task ${dueDateSymbol} `,
             `- [ ] some task ${scheduledDateSymbol} `,
             `- [ ] some task ${startDateSymbol} `,
-            `- [ ] some task ${idSymbol} `,
-            `- [ ] some task ${dependsOnSymbol} `,
         ];
+        if (global.SHOW_DEPENDENCY_SUGGESTIONS) {
+            lines.push(`- [ ] some task ${idSymbol} `);
+            lines.push(`- [ ] some task ${dependsOnSymbol} `);
+        }
         const markdownTable = new MarkdownTable(['Searchable Text', 'Text that is added']);
         for (const line of lines) {
             let suggestions = buildSuggestions(line, line.length - 1, originalSettings, []);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -78,6 +78,15 @@ describe.each([
         MAX_GENERIC_SUGGESTIONS_FOR_TESTS,
         name === 'dataview',
     );
+    beforeEach(() => {
+        // Note: Dependency suggestions are temporarily turned off in the released plugin,
+        //       but turned on in tests so that we continue to check the behaviour.
+        global.SHOW_DEPENDENCY_SUGGESTIONS = true;
+    });
+
+    afterEach(() => {
+        global.SHOW_DEPENDENCY_SUGGESTIONS = false;
+    });
 
     /** Build suggestions for the simple case where the cursor is at the very end of the line.
      */

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -12,6 +12,7 @@ import {
     lastOpenBracket,
     makeDefaultSuggestionBuilder,
     onlySuggestIfBracketOpen,
+    showDependencySuggestionsDefault,
 } from '../../src/Suggestor/Suggestor';
 import { DEFAULT_SYMBOLS } from '../../src/TaskSerializer/DefaultTaskSerializer';
 import { DATAVIEW_SYMBOLS } from '../../src/TaskSerializer/DataviewTaskSerializer';
@@ -412,10 +413,10 @@ describe.each([
     });
 
     it('show all suggested text', () => {
-        // TODO Turn off dependency suggestions for now, as per default value,
+        // Turn off dependency suggestions for now, as per default value,
         // as the outputs of this test are embedded in the documentation,
         // and I wish to hide ID and dependsOn there.
-        global.SHOW_DEPENDENCY_SUGGESTIONS = true;
+        global.SHOW_DEPENDENCY_SUGGESTIONS = showDependencySuggestionsDefault;
 
         const originalSettings = getSettings();
         originalSettings.autoSuggestMaxItems = 200;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This temporarily disables the auto-suggestion of `id` and `dependsOn` fields that was added in #2771.

I'm keen to release the new features for the Kanban plugin, and auto-suggestion of `id` and `dependsOn` needs a bit more time to get it ready for release, so I am temporarily disabling it...

I had first thought that I might just release it as-is, with notes in the docs about limitations,  but it [sometimes break existing IDs for users with Obsidian Sync](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2823) was sadly a show-stopper for me.

## Motivation and Context

I've been testing that code in my own fork on my main vault, and the facility is going to be really, really useful.

When adding tests for it, I found and fixed a couple of small issues - see:

- https://github.com/obsidian-tasks-group/obsidian-tasks/pull/2806
- https://github.com/obsidian-tasks-group/obsidian-tasks/pull/2826

However, further real-world use has shown that it needs a bit more polish before it's ready for general release:

- https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2823
- https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2825
- https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2827

## How has this been tested?

- Updating existing tests.
- Manual exploratory testing.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
