### PR TITLE
refactor: remove _onPriorityKeyup()

### DIFF
--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -208,15 +208,6 @@
         }, 10);
     });
 
-    const _onPriorityKeyup = (event: KeyboardEvent) => {
-        if (event.key && !event.altKey && !event.ctrlKey) {
-            const priorityOption = priorityOptions.find((option) => option.label.charAt(0).toLowerCase() == event.key);
-            if (priorityOption) {
-                editableTask.priority = priorityOption.value;
-            }
-        }
-    };
-
     const _onClose = () => {
         onSubmit([]);
     };
@@ -398,7 +389,7 @@ Availability of access keys:
     <!-- --------------------------------------------------------------------------- -->
     <!--  Priority  -->
     <!-- --------------------------------------------------------------------------- -->
-    <section class="tasks-modal-priority-section" on:keyup={_onPriorityKeyup}>
+    <section class="tasks-modal-priority-section">
         <label for="priority-{editableTask.priority}">Priority</label>
         {#each priorityOptions as { value, label, symbol, accessKey, accessKeyIndex }}
             <div class="task-modal-priority-option-container">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- remove `_onPriorityKeyup()` (Dead code)

## Motivation and Context

- remove dead code

## How has this been tested?

- manual test in demo vault - try setting priority with mouse and access keys

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
