### PR TITLE
fix: remove background under the dependency delete button

### DIFF
--- a/src/ui/Dependency.scss
+++ b/src/ui/Dependency.scss
@@ -10,7 +10,7 @@
     background-color: var(--interactive-normal);
     box-shadow: var(--input-shadow);
     border-radius: 28px;
-    padding: 4px 8px;
+    padding: 4px 4px 4px 8px;
 }
 
 .task-dependency-name {
@@ -26,7 +26,7 @@
     cursor: pointer;
     height: inherit;
     box-shadow: none !important;
-    background-color: inherit !important;
+    border-radius: 50%;
 }
 
 .task-dependency-dropdown {

--- a/src/ui/Dependency.scss
+++ b/src/ui/Dependency.scss
@@ -26,7 +26,7 @@
     cursor: pointer;
     height: inherit;
     box-shadow: none !important;
-    background-color: var(--background-primary) !important;
+    background-color: inherit !important;
 }
 
 .task-dependency-dropdown {


### PR DESCRIPTION
# Description

The change is seen only on the dark theme.

Before

<img width="206" alt="Снимок экрана 2024-05-18 в 17 36 02" src="https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/6f9b979a-cf1e-4227-b9f4-fda7da45d57f">

After (Note the background under the "x" is gone)

<img width="202" alt="Снимок экрана 2024-05-18 в 17 46 52" src="https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/43f75a08-d400-4f44-a01f-85c61c1a37e4">

On the clear theme the is no change in color, only the shape slightly changed. After:

<img width="206" alt="Снимок экрана 2024-05-18 в 17 37 57" src="https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/02f9a525-846e-407c-9c92-8f687371be89">


## Motivation and Context

- have a prettier task modal =)

## How has this been tested?

- manual test in demo valuet
## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

(I don't consider this a big enough change to update the modal screenshot)

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
