### PR TITLE
chore: run `update-docs-markdown.yml` on ubuntu

### DIFF
--- a/.github/workflows/update-docs-markdown.yml
+++ b/.github/workflows/update-docs-markdown.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   docs:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# Description

- change the OS in the `update-docs-markdown.yml` from win to ubuntu

I tried exploring the root cause of the failure but had no success. However I just trying changing the OS and the action was running well =)

I run the workflow on a branch where the workflow was successfully run before and see it fail now (Just go to your fork and try running the action in question on any branch where a run was successful, for example something done in April this year)

Previously (May 15) good result from workflow 
https://github.com/ilandikov/obsidian-tasks/actions/runs/9094786277/attempts/1

Today's bad result from the workflow on the same state
https://github.com/ilandikov/obsidian-tasks/actions/runs/9094786277/attempts/2

Today's good result of the workflow in my fork on this branch
https://github.com/ilandikov/obsidian-tasks/actions/runs/9150144571

## Motivation and Context

Fixes https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2834

- fix the action and have the md snippets generated =)

## How has this been tested?

- pushed commit to my fork, verified that the action was ok


## Types of changes

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
