### PR TITLE
fix: Correctly align 'Before ...' & 'After ...' in Edit Task modal

### DIFF
--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -99,7 +99,6 @@
 
     .status-editor-status-selector {
         grid-column: 2;
-        width: 15em;
     }
 }
 
@@ -183,7 +182,6 @@
     .tasks-modal-dates-section {
         .status-editor-status-selector {
             grid-column: 1;
-            width: auto;
         }
 
         > .tasks-modal-parsed-date {

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -30,7 +30,6 @@
 .tasks-modal-priority-section {
     display: grid;
     grid-template-columns: 6em auto auto auto;
-    grid-column-gap: 0.5em;
     grid-row-gap: 0.15em;
 
     > label {
@@ -69,7 +68,6 @@
 .tasks-modal-dates-section {
     display: grid;
     grid-template-columns: 6.0em auto;
-    grid-auto-columns: 1fr;
     column-gap: .5em;
     row-gap: 5px;
     align-items: center;
@@ -105,7 +103,7 @@
 .tasks-modal-dependencies-section {
     display: grid;
     grid-template-columns: 6.0em auto;
-    grid-auto-columns: 1fr;
+    column-gap: 0.5em;
     row-gap: 5px;
     align-items: center;
 


### PR DESCRIPTION
# Types of changes

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Description

- align the view of date editors, dependency editors and the status editor

## Motivation and Context

Better looking Edit Task modal =)

## How has this been tested?

Smoke test in demo vault

## Screenshots (if appropriate)

| Before | After |
|-------|-----|
|  <img width="613" alt="Снимок экрана 2024-05-30 в 14 02 58" src="https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/c998fd0e-6ef1-41b6-a9c7-ec7a01243aab">| <img width="614" alt="Снимок экрана 2024-05-30 в 14 03 55" src="https://github.com/obsidian-tasks-group/obsidian-tasks/assets/93825870/d6721c35-73e0-4eb1-966a-c34cd2b732b7"> |

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - CSS code not covered

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
