### PR TITLE
refactor:  make `EditableTask` constructor private

### DIFF
--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -30,7 +30,7 @@ export class EditableTask {
     blockedBy: Task[];
     blocking: Task[];
 
-    constructor(editableTask: {
+    private constructor(editableTask: {
         // NEW_TASK_FIELD_EDIT_REQUIRED
         description: string;
         status: Status;

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -64,16 +64,22 @@ describe('parseAndValidateRecurrence() tests', () => {
         blockedBy: [],
         blocking: [],
     });
-    const noRecurrenceRule: Partial<EditableTask> = emptyTask;
-    const invalidRecurrenceRule: Partial<EditableTask> = {
-        recurrenceRule: 'thisIsWrong',
+    const noRecurrenceRule = (editableTask: EditableTask) => {
+        editableTask.recurrenceRule = '';
+        return editableTask;
     };
-    const withRecurrenceRuleButNoHappensDate: Partial<EditableTask> = {
-        recurrenceRule: 'every day',
+    const invalidRecurrenceRule = (editableTask: EditableTask) => {
+        editableTask.recurrenceRule = 'thisIsWrong';
+        return editableTask;
     };
-    const withRecurrenceRuleAndHappensDate: Partial<EditableTask> = {
-        recurrenceRule: 'every 1 months when done', // confirm that recurrence text is standardised
-        startDate: '2024-05-20',
+    const withRecurrenceRuleButNoHappensDate = (editableTask: EditableTask) => {
+        editableTask.recurrenceRule = 'every day';
+        return editableTask;
+    };
+    const withRecurrenceRuleAndHappensDate = (editableTask: EditableTask) => {
+        editableTask.recurrenceRule = 'every 1 months when done'; // confirm that recurrence text is standardised
+        editableTask.startDate = '2024-05-20';
+        return editableTask;
     };
 
     it.each([
@@ -85,11 +91,11 @@ describe('parseAndValidateRecurrence() tests', () => {
     ])(
         "editable task with '%s' fields should have '%s' parsed recurrence and its validity is %s",
         (
-            editableTaskFields: Partial<EditableTask>,
+            editableTaskFields: (editableTask: EditableTask) => EditableTask,
             expectedParsedRecurrence: string,
             expectedRecurrenceValidity: boolean,
         ) => {
-            const editableTask = new EditableTask({ ...emptyTask, ...editableTaskFields });
+            const editableTask = editableTaskFields(emptyTask);
 
             const { parsedRecurrence, isRecurrenceValid } = parseAndValidateRecurrence(editableTask);
             expect(parsedRecurrence).toEqual(expectedParsedRecurrence);

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -49,10 +49,8 @@ describe('labelContentWithAccessKey() tests', () => {
 });
 
 describe('parseAndValidateRecurrence() tests', () => {
-    const taskWithoutRecurrence = new TaskBuilder().build();
-    const { editableTask: editableTaskWithoutRecurrence } = EditableTask.fromTask(taskWithoutRecurrence, [
-        taskWithoutRecurrence,
-    ]);
+    const emptyTask = new TaskBuilder().build();
+    const { editableTask } = EditableTask.fromTask(emptyTask, [emptyTask]);
 
     const noRecurrenceRule = (editableTask: EditableTask) => {
         editableTask.recurrenceRule = '';
@@ -85,7 +83,7 @@ describe('parseAndValidateRecurrence() tests', () => {
             expectedParsedRecurrence: string,
             expectedRecurrenceValidity: boolean,
         ) => {
-            const editedTask = taskEditor(editableTaskWithoutRecurrence);
+            const editedTask = taskEditor(editableTask);
 
             const { parsedRecurrence, isRecurrenceValid } = parseAndValidateRecurrence(editedTask);
             expect(parsedRecurrence).toEqual(expectedParsedRecurrence);

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -83,9 +83,9 @@ describe('parseAndValidateRecurrence() tests', () => {
             expectedParsedRecurrence: string,
             expectedRecurrenceValidity: boolean,
         ) => {
-            const editableTask = editableTaskFields(emptyTask);
+            const editedTask = editableTaskFields(emptyTask);
 
-            const { parsedRecurrence, isRecurrenceValid } = parseAndValidateRecurrence(editableTask);
+            const { parsedRecurrence, isRecurrenceValid } = parseAndValidateRecurrence(editedTask);
             expect(parsedRecurrence).toEqual(expectedParsedRecurrence);
             expect(isRecurrenceValid).toEqual(expectedRecurrenceValidity);
         },

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -49,8 +49,10 @@ describe('labelContentWithAccessKey() tests', () => {
 });
 
 describe('parseAndValidateRecurrence() tests', () => {
-    const emptyTask = new TaskBuilder().build();
-    const { editableTask } = EditableTask.fromTask(emptyTask, [emptyTask]);
+    const taskWithoutRecurrence = new TaskBuilder().build();
+    const { editableTask: editableTaskWithoutRecurrence } = EditableTask.fromTask(taskWithoutRecurrence, [
+        taskWithoutRecurrence,
+    ]);
 
     const noRecurrenceRule = (editableTask: EditableTask) => {
         editableTask.recurrenceRule = '';
@@ -83,7 +85,7 @@ describe('parseAndValidateRecurrence() tests', () => {
             expectedParsedRecurrence: string,
             expectedRecurrenceValidity: boolean,
         ) => {
-            const editedTask = taskEditor(editableTask);
+            const editedTask = taskEditor(editableTaskWithoutRecurrence);
 
             const { parsedRecurrence, isRecurrenceValid } = parseAndValidateRecurrence(editedTask);
             expect(parsedRecurrence).toEqual(expectedParsedRecurrence);

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -50,7 +50,7 @@ describe('labelContentWithAccessKey() tests', () => {
 
 describe('parseAndValidateRecurrence() tests', () => {
     const emptyTask1 = new TaskBuilder().build();
-    const { editableTask: emptyTask } = EditableTask.fromTask(emptyTask1, [emptyTask1]);
+    const { editableTask } = EditableTask.fromTask(emptyTask1, [emptyTask1]);
 
     const noRecurrenceRule = (editableTask: EditableTask) => {
         editableTask.recurrenceRule = '';
@@ -83,7 +83,7 @@ describe('parseAndValidateRecurrence() tests', () => {
             expectedParsedRecurrence: string,
             expectedRecurrenceValidity: boolean,
         ) => {
-            const editedTask = editableTaskFields(emptyTask);
+            const editedTask = editableTaskFields(editableTask);
 
             const { parsedRecurrence, isRecurrenceValid } = parseAndValidateRecurrence(editedTask);
             expect(parsedRecurrence).toEqual(expectedParsedRecurrence);

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -79,11 +79,11 @@ describe('parseAndValidateRecurrence() tests', () => {
     ])(
         "editable task with '%s' fields should have '%s' parsed recurrence and its validity is %s",
         (
-            editableTaskFields: (editableTask: EditableTask) => EditableTask,
+            taskEditor: (editableTask: EditableTask) => EditableTask,
             expectedParsedRecurrence: string,
             expectedRecurrenceValidity: boolean,
         ) => {
-            const editedTask = editableTaskFields(editableTask);
+            const editedTask = taskEditor(editableTask);
 
             const { parsedRecurrence, isRecurrenceValid } = parseAndValidateRecurrence(editedTask);
             expect(parsedRecurrence).toEqual(expectedParsedRecurrence);

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -49,8 +49,8 @@ describe('labelContentWithAccessKey() tests', () => {
 });
 
 describe('parseAndValidateRecurrence() tests', () => {
-    const emptyTask1 = new TaskBuilder().build();
-    const { editableTask } = EditableTask.fromTask(emptyTask1, [emptyTask1]);
+    const emptyTask = new TaskBuilder().build();
+    const { editableTask } = EditableTask.fromTask(emptyTask, [emptyTask]);
 
     const noRecurrenceRule = (editableTask: EditableTask) => {
         editableTask.recurrenceRule = '';

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -49,7 +49,7 @@ describe('labelContentWithAccessKey() tests', () => {
 });
 
 describe('parseAndValidateRecurrence() tests', () => {
-    const emptyTask = new TaskBuilder().build();
+    const emptyTask = new TaskBuilder().description('').build();
     const { editableTask } = EditableTask.fromTask(emptyTask, [emptyTask]);
 
     const noRecurrenceRule = (editableTask: EditableTask) => {

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -3,9 +3,9 @@
  */
 
 import moment from 'moment/moment';
-import { Status } from '../../src/Statuses/Status';
 import { EditableTask } from '../../src/ui/EditableTask';
 import { labelContentWithAccessKey, parseAndValidateRecurrence } from '../../src/ui/EditTaskHelpers';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
 
 window.moment = moment;
 
@@ -49,21 +49,9 @@ describe('labelContentWithAccessKey() tests', () => {
 });
 
 describe('parseAndValidateRecurrence() tests', () => {
-    const emptyTask = new EditableTask({
-        description: '',
-        status: Status.TODO,
-        priority: 'none',
-        recurrenceRule: '',
-        createdDate: '',
-        startDate: '',
-        scheduledDate: '',
-        dueDate: '',
-        doneDate: '',
-        cancelledDate: '',
-        forwardOnly: true,
-        blockedBy: [],
-        blocking: [],
-    });
+    const emptyTask1 = new TaskBuilder().build();
+    const { editableTask: emptyTask } = EditableTask.fromTask(emptyTask1, [emptyTask1]);
+
     const noRecurrenceRule = (editableTask: EditableTask) => {
         editableTask.recurrenceRule = '';
         return editableTask;


### PR DESCRIPTION
# Types of changes

Changes visible to users:

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- Make `EditableTask.constructor()` private
- Rewrite tests using `EditableTask.fromTask()` factory

(There is also possibility is to make the constructor accept the `(task: Task, allTasks: Task[])` parameters, in other words, make the factory be the constructor. But I don't know if there is a value in that so I propose to leave that story here for now =))

## Motivation and Context

Creation of `EditableTask` is done in the code from a `Task` object, so a constructor with every field being open shall not be exposed, which is the case in the tests, what makes them farer from the real use-case.

This is actually simpler for tests since the `TaskBuilder` is leveraged.

## How has this been tested?

- unit tests

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
