### PR TITLE
refactor: Improve encapsulation of behaviour in `EditableTask` class

### DIFF
--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -29,7 +29,7 @@
 
     let descriptionInput: HTMLTextAreaElement;
 
-    let { editableTask, originalBlocking } = EditableTask.fromTask(task, allTasks);
+    let { editableTask } = EditableTask.fromTask(task, allTasks);
 
     let isDescriptionValid: boolean = true;
 
@@ -142,7 +142,7 @@
     };
 
     const _onSubmit = async () => {
-        const newTasks = await editableTask.applyEdits(task, originalBlocking, allTasks);
+        const newTasks = await editableTask.applyEdits(task, allTasks);
         onSubmit(newTasks);
     };
 </script>

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -29,7 +29,7 @@
 
     let descriptionInput: HTMLTextAreaElement;
 
-    let { editableTask } = EditableTask.fromTask(task, allTasks);
+    let editableTask = EditableTask.fromTask(task, allTasks);
 
     let isDescriptionValid: boolean = true;
 

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -29,7 +29,7 @@
 
     let descriptionInput: HTMLTextAreaElement;
 
-    let { editableTask, addGlobalFilterOnSave, originalBlocking } = EditableTask.fromTask(task, allTasks);
+    let { editableTask, originalBlocking } = EditableTask.fromTask(task, allTasks);
 
     let isDescriptionValid: boolean = true;
 
@@ -142,7 +142,7 @@
     };
 
     const _onSubmit = async () => {
-        const newTasks = await editableTask.applyEdits(task, originalBlocking, addGlobalFilterOnSave, allTasks);
+        const newTasks = await editableTask.applyEdits(task, originalBlocking, allTasks);
         onSubmit(newTasks);
     };
 </script>

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -142,15 +142,9 @@ export class EditableTask {
      *
      * @param task
      * @param originalBlocking
-     * @param _addGlobalFilterOnSave
      * @param allTasks
      */
-    public async applyEdits(
-        task: Task,
-        originalBlocking: Task[],
-        _addGlobalFilterOnSave: boolean,
-        allTasks: Task[],
-    ): Promise<Task[]> {
+    public async applyEdits(task: Task, originalBlocking: Task[], allTasks: Task[]): Promise<Task[]> {
         // NEW_TASK_FIELD_EDIT_REQUIRED
         let description = this.description.trim();
         if (this.addGlobalFilterOnSave) {

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -142,10 +142,9 @@ export class EditableTask {
      * There are cases where the output of the edits is more than one task, for example, completing a {@link Task} with {@link Recurrence}.
      *
      * @param task
-     * @param _originalBlocking
      * @param allTasks
      */
-    public async applyEdits(task: Task, _originalBlocking: Task[], allTasks: Task[]): Promise<Task[]> {
+    public async applyEdits(task: Task, allTasks: Task[]): Promise<Task[]> {
         // NEW_TASK_FIELD_EDIT_REQUIRED
         let description = this.description.trim();
         if (this.addGlobalFilterOnSave) {

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -78,7 +78,6 @@ export class EditableTask {
         task: Task,
         allTasks: Task[],
     ): {
-        originalBlocking: Task[];
         editableTask: EditableTask;
     } {
         const description = GlobalFilter.getInstance().removeAsWordFrom(task.description);
@@ -132,7 +131,6 @@ export class EditableTask {
                 addGlobalFilterOnSave,
                 originalBlocking,
             }),
-            originalBlocking,
         };
     }
 

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -82,10 +82,9 @@ export class EditableTask {
         // If we're displaying to the user the description without the global filter (i.e. it was removed in the method
         // above), or if the description did not include a global filter in the first place, we'll add the global filter
         // when saving the task.
-        let addGlobalFilterOnSave = false;
-        if (description != task.description || !GlobalFilter.getInstance().includedIn(task.description)) {
-            addGlobalFilterOnSave = true;
-        }
+        const addGlobalFilterOnSave =
+            description != task.description || !GlobalFilter.getInstance().includedIn(task.description);
+
         let priority: EditableTaskPriority = 'none';
         if (task.priority === Priority.Lowest) {
             priority = 'lowest';

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -15,6 +15,8 @@ type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'hig
  *
  */
 export class EditableTask {
+    private readonly addGlobalFilterOnSave: boolean;
+
     // NEW_TASK_FIELD_EDIT_REQUIRED
     description: string;
     status: Status;
@@ -45,6 +47,7 @@ export class EditableTask {
         forwardOnly: boolean;
         blockedBy: Task[];
         blocking: Task[];
+        addGlobalFilterOnSave: boolean;
     }) {
         this.description = editableTask.description;
         this.status = editableTask.status;
@@ -59,6 +62,7 @@ export class EditableTask {
         this.forwardOnly = editableTask.forwardOnly;
         this.blockedBy = editableTask.blockedBy;
         this.blocking = editableTask.blocking;
+        this.addGlobalFilterOnSave = editableTask.addGlobalFilterOnSave;
     }
 
     /**
@@ -124,6 +128,7 @@ export class EditableTask {
                 forwardOnly: true,
                 blockedBy: blockedBy,
                 blocking: originalBlocking,
+                addGlobalFilterOnSave,
             }),
             addGlobalFilterOnSave,
             originalBlocking,
@@ -137,18 +142,18 @@ export class EditableTask {
      *
      * @param task
      * @param originalBlocking
-     * @param addGlobalFilterOnSave
+     * @param _addGlobalFilterOnSave
      * @param allTasks
      */
     public async applyEdits(
         task: Task,
         originalBlocking: Task[],
-        addGlobalFilterOnSave: boolean,
+        _addGlobalFilterOnSave: boolean,
         allTasks: Task[],
     ): Promise<Task[]> {
         // NEW_TASK_FIELD_EDIT_REQUIRED
         let description = this.description.trim();
-        if (addGlobalFilterOnSave) {
+        if (this.addGlobalFilterOnSave) {
             description = GlobalFilter.getInstance().prependTo(description);
         }
 

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -75,7 +75,6 @@ export class EditableTask {
         task: Task,
         allTasks: Task[],
     ): {
-        addGlobalFilterOnSave: boolean;
         originalBlocking: Task[];
         editableTask: EditableTask;
     } {
@@ -130,7 +129,6 @@ export class EditableTask {
                 blocking: originalBlocking,
                 addGlobalFilterOnSave,
             }),
-            addGlobalFilterOnSave,
             originalBlocking,
         };
     }

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -16,6 +16,7 @@ type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'hig
  */
 export class EditableTask {
     private readonly addGlobalFilterOnSave: boolean;
+    private readonly originalBlocking: Task[];
 
     // NEW_TASK_FIELD_EDIT_REQUIRED
     description: string;
@@ -48,6 +49,7 @@ export class EditableTask {
         blockedBy: Task[];
         blocking: Task[];
         addGlobalFilterOnSave: boolean;
+        originalBlocking: Task[];
     }) {
         this.description = editableTask.description;
         this.status = editableTask.status;
@@ -63,6 +65,7 @@ export class EditableTask {
         this.blockedBy = editableTask.blockedBy;
         this.blocking = editableTask.blocking;
         this.addGlobalFilterOnSave = editableTask.addGlobalFilterOnSave;
+        this.originalBlocking = editableTask.originalBlocking;
     }
 
     /**
@@ -127,6 +130,7 @@ export class EditableTask {
                 blockedBy: blockedBy,
                 blocking: originalBlocking,
                 addGlobalFilterOnSave,
+                originalBlocking,
             }),
             originalBlocking,
         };
@@ -138,10 +142,10 @@ export class EditableTask {
      * There are cases where the output of the edits is more than one task, for example, completing a {@link Task} with {@link Recurrence}.
      *
      * @param task
-     * @param originalBlocking
+     * @param _originalBlocking
      * @param allTasks
      */
-    public async applyEdits(task: Task, originalBlocking: Task[], allTasks: Task[]): Promise<Task[]> {
+    public async applyEdits(task: Task, _originalBlocking: Task[], allTasks: Task[]): Promise<Task[]> {
         // NEW_TASK_FIELD_EDIT_REQUIRED
         let description = this.description.trim();
         if (this.addGlobalFilterOnSave) {
@@ -198,14 +202,14 @@ export class EditableTask {
         let removedBlocking: Task[] = [];
         let addedBlocking: Task[] = [];
 
-        if (this.blocking.toString() !== originalBlocking.toString() || this.blocking.length !== 0) {
+        if (this.blocking.toString() !== this.originalBlocking.toString() || this.blocking.length !== 0) {
             if (task.id === '') {
                 id = generateUniqueId(allTasks.filter((task) => task.id !== '').map((task) => task.id));
             }
 
-            removedBlocking = originalBlocking.filter((task) => !this.blocking.includes(task));
+            removedBlocking = this.originalBlocking.filter((task) => !this.blocking.includes(task));
 
-            addedBlocking = this.blocking.filter((task) => !originalBlocking.includes(task));
+            addedBlocking = this.blocking.filter((task) => !this.originalBlocking.includes(task));
         }
 
         // First create an updated task, with all edits except Status:

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -34,6 +34,9 @@ export class EditableTask {
     blocking: Task[];
 
     private constructor(editableTask: {
+        addGlobalFilterOnSave: boolean;
+        originalBlocking: Task[];
+
         // NEW_TASK_FIELD_EDIT_REQUIRED
         description: string;
         status: Status;
@@ -48,9 +51,10 @@ export class EditableTask {
         forwardOnly: boolean;
         blockedBy: Task[];
         blocking: Task[];
-        addGlobalFilterOnSave: boolean;
-        originalBlocking: Task[];
     }) {
+        this.addGlobalFilterOnSave = editableTask.addGlobalFilterOnSave;
+        this.originalBlocking = editableTask.originalBlocking;
+
         this.description = editableTask.description;
         this.status = editableTask.status;
         this.priority = editableTask.priority;
@@ -64,8 +68,6 @@ export class EditableTask {
         this.forwardOnly = editableTask.forwardOnly;
         this.blockedBy = editableTask.blockedBy;
         this.blocking = editableTask.blocking;
-        this.addGlobalFilterOnSave = editableTask.addGlobalFilterOnSave;
-        this.originalBlocking = editableTask.originalBlocking;
     }
 
     /**
@@ -108,6 +110,9 @@ export class EditableTask {
         const originalBlocking = allTasks.filter((cacheTask) => cacheTask.dependsOn.includes(task.id));
 
         return new EditableTask({
+            addGlobalFilterOnSave,
+            originalBlocking,
+
             // NEW_TASK_FIELD_EDIT_REQUIRED
             description,
             status: task.status,
@@ -122,8 +127,6 @@ export class EditableTask {
             forwardOnly: true,
             blockedBy: blockedBy,
             blocking: originalBlocking,
-            addGlobalFilterOnSave,
-            originalBlocking,
         });
     }
 

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -74,12 +74,7 @@ export class EditableTask {
      * @param task
      * @param allTasks
      */
-    public static fromTask(
-        task: Task,
-        allTasks: Task[],
-    ): {
-        editableTask: EditableTask;
-    } {
+    public static fromTask(task: Task, allTasks: Task[]): EditableTask {
         const description = GlobalFilter.getInstance().removeAsWordFrom(task.description);
         // If we're displaying to the user the description without the global filter (i.e. it was removed in the method
         // above), or if the description did not include a global filter in the first place, we'll add the global filter
@@ -112,26 +107,24 @@ export class EditableTask {
 
         const originalBlocking = allTasks.filter((cacheTask) => cacheTask.dependsOn.includes(task.id));
 
-        return {
-            editableTask: new EditableTask({
-                // NEW_TASK_FIELD_EDIT_REQUIRED
-                description,
-                status: task.status,
-                priority,
-                recurrenceRule: task.recurrence ? task.recurrence.toText() : '',
-                createdDate: task.created.formatAsDate(),
-                startDate: task.start.formatAsDate(),
-                scheduledDate: task.scheduled.formatAsDate(),
-                dueDate: task.due.formatAsDate(),
-                doneDate: task.done.formatAsDate(),
-                cancelledDate: task.cancelled.formatAsDate(),
-                forwardOnly: true,
-                blockedBy: blockedBy,
-                blocking: originalBlocking,
-                addGlobalFilterOnSave,
-                originalBlocking,
-            }),
-        };
+        return new EditableTask({
+            // NEW_TASK_FIELD_EDIT_REQUIRED
+            description,
+            status: task.status,
+            priority,
+            recurrenceRule: task.recurrence ? task.recurrence.toText() : '',
+            createdDate: task.created.formatAsDate(),
+            startDate: task.start.formatAsDate(),
+            scheduledDate: task.scheduled.formatAsDate(),
+            dueDate: task.due.formatAsDate(),
+            doneDate: task.done.formatAsDate(),
+            cancelledDate: task.cancelled.formatAsDate(),
+            forwardOnly: true,
+            blockedBy: blockedBy,
+            blocking: originalBlocking,
+            addGlobalFilterOnSave,
+            originalBlocking,
+        });
     }
 
     /**

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -50,7 +50,7 @@ describe('labelContentWithAccessKey() tests', () => {
 
 describe('parseAndValidateRecurrence() tests', () => {
     const emptyTask = new TaskBuilder().description('').build();
-    const { editableTask } = EditableTask.fromTask(emptyTask, [emptyTask]);
+    const editableTask = EditableTask.fromTask(emptyTask, [emptyTask]);
 
     const noRecurrenceRule = (editableTask: EditableTask) => {
         editableTask.recurrenceRule = '';

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -50,6 +50,7 @@ describe('EditableTask tests', () => {
 
         expect(editableTask).toMatchInlineSnapshot(`
             EditableTask {
+              "addGlobalFilterOnSave": false,
               "blockedBy": [],
               "blocking": [],
               "cancelledDate": "2023-07-06",

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -22,7 +22,7 @@ function testEditableTaskDescriptionAndGlobalFilterOnSave({
     GlobalFilter.getInstance().set(globalFilter);
     const taskWithoutGlobalFilter = new TaskBuilder().description(taskDescription).build();
 
-    const { editableTask } = EditableTask.fromTask(taskWithoutGlobalFilter, [taskWithoutGlobalFilter]);
+    const editableTask = EditableTask.fromTask(taskWithoutGlobalFilter, [taskWithoutGlobalFilter]);
 
     expect(editableTask.description).toEqual(expectedEditableTaskDescription);
 }
@@ -41,7 +41,7 @@ describe('EditableTask tests', () => {
     it('should create an editable task without dependencies', () => {
         const taskToEdit = TaskBuilder.createFullyPopulatedTask();
 
-        const { editableTask } = EditableTask.fromTask(taskToEdit, [taskToEdit]);
+        const editableTask = EditableTask.fromTask(taskToEdit, [taskToEdit]);
 
         expect(editableTask).toMatchInlineSnapshot(`
             EditableTask {
@@ -81,7 +81,7 @@ describe('EditableTask tests', () => {
             .build();
         const allTasks = [taskToEdit, blockingTask, blockedTask];
 
-        const { editableTask } = EditableTask.fromTask(taskToEdit, allTasks);
+        const editableTask = EditableTask.fromTask(taskToEdit, allTasks);
 
         expect(editableTask.blocking).toEqual([blockedTask]);
         expect(editableTask.blockedBy).toEqual([blockingTask]);
@@ -115,7 +115,7 @@ describe('EditableTask tests', () => {
         const task = new TaskBuilder().build();
         const allTasks = [task];
 
-        const { editableTask } = EditableTask.fromTask(task, allTasks);
+        const editableTask = EditableTask.fromTask(task, allTasks);
         const appliedEdits = await editableTask.applyEdits(task, [task]);
 
         expect(appliedEdits).toEqual([task]);
@@ -125,7 +125,7 @@ describe('EditableTask tests', () => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const allTasks = [task];
 
-        const { editableTask } = EditableTask.fromTask(task, allTasks);
+        const editableTask = EditableTask.fromTask(task, allTasks);
         const appliedEdits = await editableTask.applyEdits(task, [task]);
 
         expect(appliedEdits).toEqual([task]);
@@ -135,7 +135,7 @@ describe('EditableTask tests', () => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const allTasks = [task];
 
-        const { editableTask } = EditableTask.fromTask(task, allTasks);
+        const editableTask = EditableTask.fromTask(task, allTasks);
 
         editableTask.description = '';
         editableTask.status = Status.TODO;
@@ -204,7 +204,7 @@ describe('EditableTask tests', () => {
     it('should set a date in YYYY-MM-DD format', async () => {
         const task = new TaskBuilder().build();
         const allTasks: Task[] = [];
-        const { editableTask } = EditableTask.fromTask(task, allTasks);
+        const editableTask = EditableTask.fromTask(task, allTasks);
 
         editableTask.dueDate = '2024-07-13';
 
@@ -222,7 +222,7 @@ describe('EditableTask tests', () => {
     it('should honour the forwardOnly value', async () => {
         const task = new TaskBuilder().build();
         const allTasks: Task[] = [];
-        const { editableTask } = EditableTask.fromTask(task, allTasks);
+        const editableTask = EditableTask.fromTask(task, allTasks);
 
         jest.setSystemTime(new Date('2024-05-22')); // Wednesday 22nd May
 

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -124,8 +124,8 @@ describe('EditableTask tests', () => {
         const task = new TaskBuilder().build();
         const allTasks = [task];
 
-        const { editableTask, originalBlocking, addGlobalFilterOnSave } = EditableTask.fromTask(task, allTasks);
-        const appliedEdits = await editableTask.applyEdits(task, originalBlocking, addGlobalFilterOnSave, [task]);
+        const { editableTask, originalBlocking } = EditableTask.fromTask(task, allTasks);
+        const appliedEdits = await editableTask.applyEdits(task, originalBlocking, [task]);
 
         expect(appliedEdits).toEqual([task]);
     });
@@ -134,8 +134,8 @@ describe('EditableTask tests', () => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const allTasks = [task];
 
-        const { editableTask, originalBlocking, addGlobalFilterOnSave } = EditableTask.fromTask(task, allTasks);
-        const appliedEdits = await editableTask.applyEdits(task, originalBlocking, addGlobalFilterOnSave, [task]);
+        const { editableTask, originalBlocking } = EditableTask.fromTask(task, allTasks);
+        const appliedEdits = await editableTask.applyEdits(task, originalBlocking, [task]);
 
         expect(appliedEdits).toEqual([task]);
     });
@@ -144,7 +144,7 @@ describe('EditableTask tests', () => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const allTasks = [task];
 
-        const { editableTask, originalBlocking, addGlobalFilterOnSave } = EditableTask.fromTask(task, allTasks);
+        const { editableTask, originalBlocking } = EditableTask.fromTask(task, allTasks);
 
         editableTask.description = '';
         editableTask.status = Status.TODO;
@@ -160,7 +160,7 @@ describe('EditableTask tests', () => {
         editableTask.blockedBy = [];
         editableTask.blocking = [];
 
-        const appliedEdits = await editableTask.applyEdits(task, originalBlocking, addGlobalFilterOnSave, allTasks);
+        const appliedEdits = await editableTask.applyEdits(task, originalBlocking, allTasks);
 
         expect(appliedEdits.length).toEqual(1);
         expect(appliedEdits[0]).toMatchInlineSnapshot(`

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -54,6 +54,7 @@ describe('EditableTask tests', () => {
               "doneDate": "2023-07-05",
               "dueDate": "2023-07-04",
               "forwardOnly": true,
+              "originalBlocking": [],
               "priority": "medium",
               "recurrenceRule": "every day when done",
               "scheduledDate": "2023-07-03",

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -41,7 +41,7 @@ describe('EditableTask tests', () => {
     it('should create an editable task without dependencies', () => {
         const taskToEdit = TaskBuilder.createFullyPopulatedTask();
 
-        const { editableTask, originalBlocking } = EditableTask.fromTask(taskToEdit, [taskToEdit]);
+        const { editableTask } = EditableTask.fromTask(taskToEdit, [taskToEdit]);
 
         expect(editableTask).toMatchInlineSnapshot(`
             EditableTask {
@@ -70,7 +70,6 @@ describe('EditableTask tests', () => {
               },
             }
         `);
-        expect(originalBlocking).toEqual([]);
     });
 
     it('should create an editable task with dependencies', () => {
@@ -82,11 +81,10 @@ describe('EditableTask tests', () => {
             .build();
         const allTasks = [taskToEdit, blockingTask, blockedTask];
 
-        const { editableTask, originalBlocking } = EditableTask.fromTask(taskToEdit, allTasks);
+        const { editableTask } = EditableTask.fromTask(taskToEdit, allTasks);
 
         expect(editableTask.blocking).toEqual([blockedTask]);
         expect(editableTask.blockedBy).toEqual([blockingTask]);
-        expect(originalBlocking).toEqual([blockedTask]);
     });
 
     it('should remember to add global filter when it is absent in task description', () => {
@@ -206,11 +204,11 @@ describe('EditableTask tests', () => {
     it('should set a date in YYYY-MM-DD format', async () => {
         const task = new TaskBuilder().build();
         const allTasks: Task[] = [];
-        const { editableTask, originalBlocking, addGlobalFilterOnSave } = EditableTask.fromTask(task, allTasks);
+        const { editableTask } = EditableTask.fromTask(task, allTasks);
 
         editableTask.dueDate = '2024-07-13';
 
-        const editedTasks = await editableTask.applyEdits(task, originalBlocking, addGlobalFilterOnSave, allTasks);
+        const editedTasks = await editableTask.applyEdits(task, allTasks);
         // TODO Why does this have the time 12:00?
         //      When I edit a task in the plugin, in the modal, and then group by the following, the time is midnight,
         //      so where is the time dropped in production code?
@@ -224,7 +222,7 @@ describe('EditableTask tests', () => {
     it('should honour the forwardOnly value', async () => {
         const task = new TaskBuilder().build();
         const allTasks: Task[] = [];
-        const { editableTask, originalBlocking, addGlobalFilterOnSave } = EditableTask.fromTask(task, allTasks);
+        const { editableTask } = EditableTask.fromTask(task, allTasks);
 
         jest.setSystemTime(new Date('2024-05-22')); // Wednesday 22nd May
 
@@ -233,11 +231,11 @@ describe('EditableTask tests', () => {
         const tuesdayAfter = moment('2024-05-21T12:00:00.000Z');
 
         editableTask.forwardOnly = true;
-        const tasksFutureDay = await editableTask.applyEdits(task, originalBlocking, addGlobalFilterOnSave, allTasks);
+        const tasksFutureDay = await editableTask.applyEdits(task, allTasks);
         expect(tasksFutureDay[0].dueDate).toEqualMoment(tuesdayBefore);
 
         editableTask.forwardOnly = false;
-        const tasksClosestDay = await editableTask.applyEdits(task, originalBlocking, addGlobalFilterOnSave, allTasks);
+        const tasksClosestDay = await editableTask.applyEdits(task, allTasks);
         expect(tasksClosestDay[0].dueDate).toEqualMoment(tuesdayAfter);
     });
 });

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -117,8 +117,8 @@ describe('EditableTask tests', () => {
         const task = new TaskBuilder().build();
         const allTasks = [task];
 
-        const { editableTask, originalBlocking } = EditableTask.fromTask(task, allTasks);
-        const appliedEdits = await editableTask.applyEdits(task, originalBlocking, [task]);
+        const { editableTask } = EditableTask.fromTask(task, allTasks);
+        const appliedEdits = await editableTask.applyEdits(task, [task]);
 
         expect(appliedEdits).toEqual([task]);
     });
@@ -127,8 +127,8 @@ describe('EditableTask tests', () => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const allTasks = [task];
 
-        const { editableTask, originalBlocking } = EditableTask.fromTask(task, allTasks);
-        const appliedEdits = await editableTask.applyEdits(task, originalBlocking, [task]);
+        const { editableTask } = EditableTask.fromTask(task, allTasks);
+        const appliedEdits = await editableTask.applyEdits(task, [task]);
 
         expect(appliedEdits).toEqual([task]);
     });
@@ -137,7 +137,7 @@ describe('EditableTask tests', () => {
         const task = TaskBuilder.createFullyPopulatedTask();
         const allTasks = [task];
 
-        const { editableTask, originalBlocking } = EditableTask.fromTask(task, allTasks);
+        const { editableTask } = EditableTask.fromTask(task, allTasks);
 
         editableTask.description = '';
         editableTask.status = Status.TODO;
@@ -153,7 +153,7 @@ describe('EditableTask tests', () => {
         editableTask.blockedBy = [];
         editableTask.blocking = [];
 
-        const appliedEdits = await editableTask.applyEdits(task, originalBlocking, allTasks);
+        const appliedEdits = await editableTask.applyEdits(task, allTasks);
 
         expect(appliedEdits.length).toEqual(1);
         expect(appliedEdits[0]).toMatchInlineSnapshot(`

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -14,22 +14,17 @@ function testEditableTaskDescriptionAndGlobalFilterOnSave({
     globalFilter,
     taskDescription,
     expectedEditableTaskDescription,
-    expectedAddGlobalFilterOnSave,
 }: {
     globalFilter: string;
     taskDescription: string;
     expectedEditableTaskDescription: string;
-    expectedAddGlobalFilterOnSave: boolean;
 }) {
     GlobalFilter.getInstance().set(globalFilter);
     const taskWithoutGlobalFilter = new TaskBuilder().description(taskDescription).build();
 
-    const { editableTask, addGlobalFilterOnSave } = EditableTask.fromTask(taskWithoutGlobalFilter, [
-        taskWithoutGlobalFilter,
-    ]);
+    const { editableTask } = EditableTask.fromTask(taskWithoutGlobalFilter, [taskWithoutGlobalFilter]);
 
     expect(editableTask.description).toEqual(expectedEditableTaskDescription);
-    expect(addGlobalFilterOnSave).toEqual(expectedAddGlobalFilterOnSave);
 }
 
 describe('EditableTask tests', () => {
@@ -98,7 +93,6 @@ describe('EditableTask tests', () => {
             globalFilter: '#todo',
             taskDescription: 'global filter is absent',
             expectedEditableTaskDescription: 'global filter is absent',
-            expectedAddGlobalFilterOnSave: true,
         });
     });
 
@@ -107,7 +101,6 @@ describe('EditableTask tests', () => {
             globalFilter: '#important',
             taskDescription: '#important is the global filter',
             expectedEditableTaskDescription: 'is the global filter',
-            expectedAddGlobalFilterOnSave: true,
         });
     });
 
@@ -116,7 +109,6 @@ describe('EditableTask tests', () => {
             globalFilter: GlobalFilter.empty,
             taskDescription: 'global filter has not been set',
             expectedEditableTaskDescription: 'global filter has not been set',
-            expectedAddGlobalFilterOnSave: false,
         });
     });
 


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- remove `addGlobalFilterOnSave` and `originalBlocking` from `EditableTask` methods' input and output
- move them to `private readonly` fields of `EditableTask` class

## Motivation and Context

- encapsulate behaviour that does not need to be exposed

## How has this been tested?

- Unit tests

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
