### PR TITLE
refactor: move `parseAndValidateRecurrence()` to `EditableTask`

### DIFF
--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -39,7 +39,7 @@ export function labelContentWithAccessKey(labelText: string, accessKey: string |
     return labelContent;
 }
 
-export function parseAndValidateRecurrence(editableTask: EditableTask) {
+function appleSauce(editableTask: EditableTask) {
     // NEW_TASK_FIELD_EDIT_REQUIRED
     if (!editableTask.recurrenceRule) {
         return { parsedRecurrence: '<i>not recurring</>', isRecurrenceValid: true };
@@ -62,4 +62,8 @@ export function parseAndValidateRecurrence(editableTask: EditableTask) {
     }
 
     return { parsedRecurrence: '<i>due, scheduled or start date required</i>', isRecurrenceValid: false };
+}
+
+export function parseAndValidateRecurrence(editableTask: EditableTask) {
+    return appleSauce(editableTask);
 }

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -1,5 +1,4 @@
 import { capitalizeFirstLetter } from '../lib/StringHelpers';
-import { Recurrence } from '../Task/Recurrence';
 import type { EditableTask } from './EditableTask';
 
 /**
@@ -37,31 +36,6 @@ export function labelContentWithAccessKey(labelText: string, accessKey: string |
     labelContent += labelText.substring(accessKeyIndex + 1);
     labelContent = capitalizeFirstLetter(labelContent);
     return labelContent;
-}
-
-export function appleSauce(editableTask: EditableTask) {
-    // NEW_TASK_FIELD_EDIT_REQUIRED
-    if (!editableTask.recurrenceRule) {
-        return { parsedRecurrence: '<i>not recurring</>', isRecurrenceValid: true };
-    }
-
-    const recurrenceFromText = Recurrence.fromText({
-        recurrenceRuleText: editableTask.recurrenceRule,
-        // Only for representation in the modal, no dates required.
-        startDate: null,
-        scheduledDate: null,
-        dueDate: null,
-    })?.toText();
-
-    if (!recurrenceFromText) {
-        return { parsedRecurrence: '<i>invalid recurrence rule</i>', isRecurrenceValid: false };
-    }
-
-    if (editableTask.startDate || editableTask.scheduledDate || editableTask.dueDate) {
-        return { parsedRecurrence: recurrenceFromText, isRecurrenceValid: true };
-    }
-
-    return { parsedRecurrence: '<i>due, scheduled or start date required</i>', isRecurrenceValid: false };
 }
 
 export function parseAndValidateRecurrence(editableTask: EditableTask) {

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -1,5 +1,4 @@
 import { capitalizeFirstLetter } from '../lib/StringHelpers';
-import type { EditableTask } from './EditableTask';
 
 /**
  * Returns contents for a `<label>` HTML element.
@@ -36,8 +35,4 @@ export function labelContentWithAccessKey(labelText: string, accessKey: string |
     labelContent += labelText.substring(accessKeyIndex + 1);
     labelContent = capitalizeFirstLetter(labelContent);
     return labelContent;
-}
-
-export function parseAndValidateRecurrence(editableTask: EditableTask) {
-    return editableTask.parseAndValidateRecurrence();
 }

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -39,7 +39,7 @@ export function labelContentWithAccessKey(labelText: string, accessKey: string |
     return labelContent;
 }
 
-function appleSauce(editableTask: EditableTask) {
+export function appleSauce(editableTask: EditableTask) {
     // NEW_TASK_FIELD_EDIT_REQUIRED
     if (!editableTask.recurrenceRule) {
         return { parsedRecurrence: '<i>not recurring</>', isRecurrenceValid: true };
@@ -65,5 +65,5 @@ function appleSauce(editableTask: EditableTask) {
 }
 
 export function parseAndValidateRecurrence(editableTask: EditableTask) {
-    return appleSauce(editableTask);
+    return editableTask.parseAndValidateRecurrence();
 }

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -6,6 +6,7 @@ import { Priority } from '../Task/Priority';
 import { Recurrence } from '../Task/Recurrence';
 import { Task } from '../Task/Task';
 import { addDependencyToParent, ensureTaskHasId, generateUniqueId, removeDependency } from '../Task/TaskDependency';
+import { appleSauce } from './EditTaskHelpers';
 
 type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
 
@@ -239,6 +240,10 @@ export class EditableTask {
         // Otherwise, use the current date.
         const today = doneDate ? doneDate : window.moment();
         return updatedTask.handleNewStatusWithRecurrenceInUsersOrder(this.status, today);
+    }
+
+    parseAndValidateRecurrence() {
+        return appleSauce(this);
     }
 }
 

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -6,7 +6,6 @@ import { Priority } from '../Task/Priority';
 import { Recurrence } from '../Task/Recurrence';
 import { Task } from '../Task/Task';
 import { addDependencyToParent, ensureTaskHasId, generateUniqueId, removeDependency } from '../Task/TaskDependency';
-import { appleSauce } from './EditTaskHelpers';
 
 type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
 
@@ -243,7 +242,28 @@ export class EditableTask {
     }
 
     parseAndValidateRecurrence() {
-        return appleSauce(this);
+        // NEW_TASK_FIELD_EDIT_REQUIRED
+        if (!this.recurrenceRule) {
+            return { parsedRecurrence: '<i>not recurring</>', isRecurrenceValid: true };
+        }
+
+        const recurrenceFromText = Recurrence.fromText({
+            recurrenceRuleText: this.recurrenceRule,
+            // Only for representation in the modal, no dates required.
+            startDate: null,
+            scheduledDate: null,
+            dueDate: null,
+        })?.toText();
+
+        if (!recurrenceFromText) {
+            return { parsedRecurrence: '<i>invalid recurrence rule</i>', isRecurrenceValid: false };
+        }
+
+        if (this.startDate || this.scheduledDate || this.dueDate) {
+            return { parsedRecurrence: recurrenceFromText, isRecurrenceValid: true };
+        }
+
+        return { parsedRecurrence: '<i>due, scheduled or start date required</i>', isRecurrenceValid: false };
     }
 }
 

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -241,7 +241,7 @@ export class EditableTask {
         return updatedTask.handleNewStatusWithRecurrenceInUsersOrder(this.status, today);
     }
 
-    parseAndValidateRecurrence() {
+    public parseAndValidateRecurrence() {
         // NEW_TASK_FIELD_EDIT_REQUIRED
         if (!this.recurrenceRule) {
             return { parsedRecurrence: '<i>not recurring</>', isRecurrenceValid: true };

--- a/src/ui/RecurrenceEditor.svelte
+++ b/src/ui/RecurrenceEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { TASK_FORMATS } from '../Config/Settings';
     import type { EditableTask } from './EditableTask';
-    import { labelContentWithAccessKey, parseAndValidateRecurrence } from './EditTaskHelpers';
+    import { labelContentWithAccessKey } from './EditTaskHelpers';
 
     export let editableTask: EditableTask;
     export let isRecurrenceValid: boolean;
@@ -9,7 +9,7 @@
 
     let parsedRecurrence: string;
 
-    $: ({ parsedRecurrence, isRecurrenceValid } = parseAndValidateRecurrence(editableTask));
+    $: ({ parsedRecurrence, isRecurrenceValid } = editableTask.parseAndValidateRecurrence());
 
     const { recurrenceSymbol } = TASK_FORMATS.tasksPluginEmoji.taskSerializer.symbols;
 </script>

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -4,7 +4,7 @@
 
 import moment from 'moment/moment';
 import { EditableTask } from '../../src/ui/EditableTask';
-import { labelContentWithAccessKey, parseAndValidateRecurrence } from '../../src/ui/EditTaskHelpers';
+import { labelContentWithAccessKey } from '../../src/ui/EditTaskHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 
 window.moment = moment;
@@ -85,7 +85,7 @@ describe('parseAndValidateRecurrence() tests', () => {
         ) => {
             const editedTask = taskEditor(editableTask);
 
-            const { parsedRecurrence, isRecurrenceValid } = parseAndValidateRecurrence(editedTask);
+            const { parsedRecurrence, isRecurrenceValid } = editedTask.parseAndValidateRecurrence();
             expect(parsedRecurrence).toEqual(expectedParsedRecurrence);
             expect(isRecurrenceValid).toEqual(expectedRecurrenceValidity);
         },

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -1,13 +1,4 @@
-/**
- * @jest-environment jsdom
- */
-
-import moment from 'moment/moment';
-import { EditableTask } from '../../src/ui/EditableTask';
 import { labelContentWithAccessKey } from '../../src/ui/EditTaskHelpers';
-import { TaskBuilder } from '../TestingTools/TaskBuilder';
-
-window.moment = moment;
 
 describe('labelContentWithAccessKey() tests', () => {
     it.each([
@@ -46,48 +37,4 @@ describe('labelContentWithAccessKey() tests', () => {
     ])("label text '%s' with access key '%s' should have label content '%s'", (labelText, accessKey, labelContent) => {
         expect(labelContentWithAccessKey(labelText, accessKey)).toEqual(labelContent);
     });
-});
-
-describe('parseAndValidateRecurrence() tests', () => {
-    const emptyTask = new TaskBuilder().description('').build();
-    const editableTask = EditableTask.fromTask(emptyTask, [emptyTask]);
-
-    const noRecurrenceRule = (editableTask: EditableTask) => {
-        editableTask.recurrenceRule = '';
-        return editableTask;
-    };
-    const invalidRecurrenceRule = (editableTask: EditableTask) => {
-        editableTask.recurrenceRule = 'thisIsWrong';
-        return editableTask;
-    };
-    const withRecurrenceRuleButNoHappensDate = (editableTask: EditableTask) => {
-        editableTask.recurrenceRule = 'every day';
-        return editableTask;
-    };
-    const withRecurrenceRuleAndHappensDate = (editableTask: EditableTask) => {
-        editableTask.recurrenceRule = 'every 1 months when done'; // confirm that recurrence text is standardised
-        editableTask.startDate = '2024-05-20';
-        return editableTask;
-    };
-
-    it.each([
-        // editable task, expected parsed recurrence, expected recurrence validity
-        [noRecurrenceRule, '<i>not recurring</>', true],
-        [invalidRecurrenceRule, '<i>invalid recurrence rule</i>', false],
-        [withRecurrenceRuleButNoHappensDate, '<i>due, scheduled or start date required</i>', false],
-        [withRecurrenceRuleAndHappensDate, 'every month when done', true],
-    ])(
-        "editable task with '%s' fields should have '%s' parsed recurrence and its validity is %s",
-        (
-            taskEditor: (editableTask: EditableTask) => EditableTask,
-            expectedParsedRecurrence: string,
-            expectedRecurrenceValidity: boolean,
-        ) => {
-            const editedTask = taskEditor(editableTask);
-
-            const { parsedRecurrence, isRecurrenceValid } = editedTask.parseAndValidateRecurrence();
-            expect(parsedRecurrence).toEqual(expectedParsedRecurrence);
-            expect(isRecurrenceValid).toEqual(expectedRecurrenceValidity);
-        },
-    );
 });

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -239,3 +239,47 @@ describe('EditableTask tests', () => {
         expect(tasksClosestDay[0].dueDate).toEqualMoment(tuesdayAfter);
     });
 });
+
+describe('parseAndValidateRecurrence() tests', () => {
+    const emptyTask = new TaskBuilder().description('').build();
+    const editableTask = EditableTask.fromTask(emptyTask, [emptyTask]);
+
+    const noRecurrenceRule = (editableTask: EditableTask) => {
+        editableTask.recurrenceRule = '';
+        return editableTask;
+    };
+    const invalidRecurrenceRule = (editableTask: EditableTask) => {
+        editableTask.recurrenceRule = 'thisIsWrong';
+        return editableTask;
+    };
+    const withRecurrenceRuleButNoHappensDate = (editableTask: EditableTask) => {
+        editableTask.recurrenceRule = 'every day';
+        return editableTask;
+    };
+    const withRecurrenceRuleAndHappensDate = (editableTask: EditableTask) => {
+        editableTask.recurrenceRule = 'every 1 months when done'; // confirm that recurrence text is standardised
+        editableTask.startDate = '2024-05-20';
+        return editableTask;
+    };
+
+    it.each([
+        // editable task, expected parsed recurrence, expected recurrence validity
+        [noRecurrenceRule, '<i>not recurring</>', true],
+        [invalidRecurrenceRule, '<i>invalid recurrence rule</i>', false],
+        [withRecurrenceRuleButNoHappensDate, '<i>due, scheduled or start date required</i>', false],
+        [withRecurrenceRuleAndHappensDate, 'every month when done', true],
+    ])(
+        "editable task with '%s' fields should have '%s' parsed recurrence and its validity is %s",
+        (
+            taskEditor: (editableTask: EditableTask) => EditableTask,
+            expectedParsedRecurrence: string,
+            expectedRecurrenceValidity: boolean,
+        ) => {
+            const editedTask = taskEditor(editableTask);
+
+            const { parsedRecurrence, isRecurrenceValid } = editedTask.parseAndValidateRecurrence();
+            expect(parsedRecurrence).toEqual(expectedParsedRecurrence);
+            expect(isRecurrenceValid).toEqual(expectedRecurrenceValidity);
+        },
+    );
+});

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -242,7 +242,6 @@ describe('EditableTask tests', () => {
 
 describe('parseAndValidateRecurrence() tests', () => {
     const emptyTask = new TaskBuilder().description('').build();
-    const editableTask = EditableTask.fromTask(emptyTask, [emptyTask]);
 
     const noRecurrenceRule = (editableTask: EditableTask) => {
         editableTask.recurrenceRule = '';
@@ -275,6 +274,7 @@ describe('parseAndValidateRecurrence() tests', () => {
             expectedParsedRecurrence: string,
             expectedRecurrenceValidity: boolean,
         ) => {
+            const editableTask = EditableTask.fromTask(emptyTask, [emptyTask]);
             const editedTask = taskEditor(editableTask);
 
             const { parsedRecurrence, isRecurrenceValid } = editedTask.parseAndValidateRecurrence();


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- move `parseAndValidateRecurrence()` free function to `EditableTask` class method
- improve this method tests (create `EditableTask` instance at every test, see last commit)

This is the last PR in `EditableTask`-related refactorings, I think this is better than 'good enough` so we can live with this for a while =)

## Motivation and Context

- group behaviour in the class

## How has this been tested?

- unit tests

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
