### PR TITLE
refactor: encapsulate adding children in `ListItem` constructor

### DIFF
--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -102,8 +102,6 @@ export function getTasksFromFileContent2(
                             ...task,
                             parent: parentTask,
                         });
-
-                        parentTask.children.push(task);
                     }
 
                     line2Task.set(lineNumber, task);

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -6,12 +6,11 @@ export class ListItem {
     public readonly originalMarkdown: string;
 
     public readonly parent: ListItem | null = null;
-    public readonly children: ListItem[];
+    public readonly children: ListItem[] = [];
 
-    constructor(originalMarkdown: string, parent: ListItem | null, children: ListItem[]) {
+    constructor(originalMarkdown: string, parent: ListItem | null) {
         this.originalMarkdown = originalMarkdown;
         this.parent = parent;
-        this.children = children;
 
         if (parent !== null) {
             parent.children.push(this);

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -12,5 +12,9 @@ export class ListItem {
         this.originalMarkdown = originalMarkdown;
         this.parent = parent;
         this.children = children;
+
+        if (parent !== null) {
+            parent.children.push(this);
+        }
     }
 }

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -116,7 +116,7 @@ export class Task extends ListItem {
         scheduledDateIsInferred: boolean;
         parent?: ListItem | null;
     }) {
-        super(originalMarkdown, parent, []);
+        super(originalMarkdown, parent);
         // NEW_TASK_FIELD_EDIT_REQUIRED
         this.status = status;
         this.description = description;

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -149,6 +149,11 @@ export class Task extends ListItem {
      * Takes the given line from an Obsidian note and returns a Task object.
      * Will check if Global Filter is present in the line.
      *
+     * If you want to specify a parent ListItem or Task after a fromLine call,
+     * you have to do the following:
+     * @example
+     *  const finalTask = new Task({ ...firstReadTask!, parent: parentListItem });
+     *
      * @static
      * @param {string} line - The full line in the note to parse.
      * @param {TaskLocation} taskLocation - The location of the task line

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -3,16 +3,16 @@ import { ListItem } from '../../src/Task/ListItem';
 
 describe('list item tests', () => {
     it('should create list item with empty children and absent parent', () => {
-        const listItem = new ListItem('', null, []);
+        const listItem = new ListItem('', null);
         expect(listItem).toBeDefined();
         expect(listItem.children).toEqual([]);
         expect(listItem.parent).toEqual(null);
     });
 
     it('should create list item with a child', () => {
-        const listItem = new ListItem('', null, []);
-        const childItem1 = new ListItem('', listItem, []);
-        const childItem2 = new ListItem('', listItem, []);
+        const listItem = new ListItem('', null);
+        const childItem1 = new ListItem('', listItem);
+        const childItem2 = new ListItem('', listItem);
         expect(listItem).toBeDefined();
         expect(childItem1.parent).toEqual(listItem);
         expect(childItem2.parent).toEqual(listItem);
@@ -20,8 +20,8 @@ describe('list item tests', () => {
     });
 
     it('should create list item with a parent', () => {
-        const parentItem = new ListItem('', null, []);
-        const listItem = new ListItem('', parentItem, []);
+        const parentItem = new ListItem('', null);
+        const listItem = new ListItem('', parentItem);
         expect(listItem).toBeDefined();
         expect(listItem.parent).toEqual(parentItem);
         expect(parentItem.children).toEqual([listItem]);

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -49,4 +49,16 @@ describe('list item tests', () => {
         expect(finalTask.parent).toBe(parentListItem);
         expect(parentListItem.children).toEqual([finalTask]);
     });
+
+    it('should create a list item child for a task parent', () => {
+        const parentTask = Task.fromLine({
+            line: '    - [ ] parent task',
+            taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
+            fallbackDate: null,
+        });
+        const childListItem = new ListItem('', parentTask);
+
+        expect(parentTask!.children).toEqual([childListItem]);
+        expect(childListItem.parent).toBe(parentTask);
+    });
 });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -1,3 +1,4 @@
+import { expect } from '@jest/globals';
 import { ListItem } from '../../src/Task/ListItem';
 
 describe('list item tests', () => {
@@ -9,10 +10,12 @@ describe('list item tests', () => {
     });
 
     it('should create list item with a child', () => {
-        const childItem1 = new ListItem('', null, []);
-        const childItem2 = new ListItem('', null, []);
-        const listItem = new ListItem('', null, [childItem1, childItem2]);
+        const listItem = new ListItem('', null, []);
+        const childItem1 = new ListItem('', listItem, []);
+        const childItem2 = new ListItem('', listItem, []);
         expect(listItem).toBeDefined();
+        expect(childItem1.parent).toEqual(listItem);
+        expect(childItem2.parent).toEqual(listItem);
         expect(listItem.children).toEqual([childItem1, childItem2]);
     });
 
@@ -21,5 +24,6 @@ describe('list item tests', () => {
         const listItem = new ListItem('', parentItem, []);
         expect(listItem).toBeDefined();
         expect(listItem.parent).toEqual(parentItem);
+        expect(parentItem.children).toEqual([listItem]);
     });
 });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -17,7 +17,7 @@ describe('list item tests', () => {
         expect(listItem.parent).toEqual(null);
     });
 
-    it('should create list item with a child', () => {
+    it('should create a list item with 2 children', () => {
         const listItem = new ListItem('', null);
         const childItem1 = new ListItem('', listItem);
         const childItem2 = new ListItem('', listItem);
@@ -27,7 +27,7 @@ describe('list item tests', () => {
         expect(listItem.children).toEqual([childItem1, childItem2]);
     });
 
-    it('should create list item with a parent', () => {
+    it('should create a list item with a parent', () => {
         const parentItem = new ListItem('', null);
         const listItem = new ListItem('', parentItem);
         expect(listItem).toBeDefined();

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -36,7 +36,7 @@ describe('list item tests', () => {
     });
 
     it('should create a task child for a list item parent', () => {
-        const parentListItem = new ListItem('', null);
+        const parentListItem = new ListItem('- parent item', null);
         const firstReadTask = Task.fromLine({
             line: '    - [ ] child task',
             taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
@@ -46,17 +46,17 @@ describe('list item tests', () => {
         // ListItem.parent is immutable, so we have to create a new task
         const finalTask = new Task({ ...firstReadTask!, parent: parentListItem });
 
-        expect(finalTask.parent).toBe(parentListItem);
         expect(parentListItem.children).toEqual([finalTask]);
+        expect(finalTask.parent).toBe(parentListItem);
     });
 
     it('should create a list item child for a task parent', () => {
         const parentTask = Task.fromLine({
-            line: '    - [ ] parent task',
+            line: '- [ ] parent task',
             taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
             fallbackDate: null,
         });
-        const childListItem = new ListItem('', parentTask);
+        const childListItem = new ListItem('    - child item', parentTask);
 
         expect(parentTask!.children).toEqual([childListItem]);
         expect(childListItem.parent).toBe(parentTask);

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -1,5 +1,13 @@
-import { expect } from '@jest/globals';
+/**
+ * @jest-environment jsdom
+ */
+import moment from 'moment/moment';
+import { TasksFile } from '../../src/Scripting/TasksFile';
+import { Task } from '../../src/Task/Task';
+import { TaskLocation } from '../../src/Task/TaskLocation';
 import { ListItem } from '../../src/Task/ListItem';
+
+window.moment = moment;
 
 describe('list item tests', () => {
     it('should create list item with empty children and absent parent', () => {
@@ -25,5 +33,20 @@ describe('list item tests', () => {
         expect(listItem).toBeDefined();
         expect(listItem.parent).toEqual(parentItem);
         expect(parentItem.children).toEqual([listItem]);
+    });
+
+    it('should create a task child for a list item parent', () => {
+        const parentListItem = new ListItem('', null);
+        const firstReadTask = Task.fromLine({
+            line: '    - [ ] child task',
+            taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
+            fallbackDate: null,
+        });
+
+        // ListItem.parent is immutable, so we have to create a new task
+        const finalTask = new Task({ ...firstReadTask!, parent: parentListItem });
+
+        expect(finalTask.parent).toBe(parentListItem);
+        expect(parentListItem.children).toEqual([finalTask]);
     });
 });


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Done by pairing with @claremacrae 

- Remove `children` parameter from `ListItem.constructor`
- Assign `children` inside the constructor
- Add tests and jsdocs showing the creation of `Task` & `ListItem` parent-child hierarchies

## Motivation and Context

- Improve usage of parent-child relationship code

## How has this been tested?

- unit tests

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
