### PR TITLE
fix: Auto-suggest can search many more characters for `dependsOn` field

### DIFF
--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -470,6 +470,16 @@ function addDependsOnSuggestions(
 ) {
     const results: SuggestInfo[] = [];
 
+    // When working out what the user wants to depend on, we wish to allow all sorts of punctuation,
+    // accented characters and so on.
+    // Bit it's possible that the new dependsOn field is followed by other fields later in the line,
+    // and we do not want those fields to be included in our task search, and that detection depends on
+    // the current task format.
+    // In dataview format:
+    //    - Our dependOn field will be finished with ] or ) - and the next field will begin [ or (.
+    // In Tasks format:
+    //    - Any following field will begin with an emoji.
+    // See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2827
     const charactersExcludedFromDescriptionSearch = dataviewMode ? escapeRegExp('()[]') : allTaskPluginEmojis();
     const dependsOnRegex = new RegExp(
         `(${dependsOnSymbol})([0-9a-zA-Z-_ ^,]*,)*([^,${charactersExcludedFromDescriptionSearch}]*)`,

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -13,6 +13,7 @@ import { generateUniqueId } from '../Task/TaskDependency';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { TaskRegularExpressions } from '../Task/TaskRegularExpressions';
 import { searchForCandidateTasksForDependency } from '../ui/DependencyHelpers';
+import { escapeRegExp } from '../lib/RegExpTools';
 import type { SuggestInfo, SuggestionBuilder } from '.';
 
 /**
@@ -469,7 +470,7 @@ function addDependsOnSuggestions(
 ) {
     const results: SuggestInfo[] = [];
 
-    const charactersExcludedFromDescriptionSearch = dataviewMode ? '\\(\\)\\[\\]' : allTaskPluginEmojis();
+    const charactersExcludedFromDescriptionSearch = dataviewMode ? escapeRegExp('()[]') : allTaskPluginEmojis();
     const dependsOnRegex = new RegExp(
         `(${dependsOnSymbol})([0-9a-zA-Z-_ ^,]*,)*([^,${charactersExcludedFromDescriptionSearch}]*)`,
         'ug',

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -3,7 +3,11 @@ import type { Settings } from '../Config/Settings';
 import { DateParser } from '../Query/DateParser';
 import { doAutocomplete } from '../lib/DateAbbreviations';
 import { Recurrence } from '../Task/Recurrence';
-import { type DefaultTaskSerializerSymbols, taskIdRegex } from '../TaskSerializer/DefaultTaskSerializer';
+import {
+    type DefaultTaskSerializerSymbols,
+    allTaskPluginEmojis,
+    taskIdRegex,
+} from '../TaskSerializer/DefaultTaskSerializer';
 import { Task } from '../Task/Task';
 import { generateUniqueId } from '../Task/TaskDependency';
 import { GlobalFilter } from '../Config/GlobalFilter';
@@ -61,7 +65,15 @@ export function makeDefaultSuggestionBuilder(
 
             // add dependecy suggestions
             suggestions = suggestions.concat(
-                addDependsOnSuggestions(line, cursorPos, settings, symbols.dependsOnSymbol, allTasks, taskToSuggestFor),
+                addDependsOnSuggestions(
+                    line,
+                    cursorPos,
+                    settings,
+                    symbols.dependsOnSymbol,
+                    allTasks,
+                    dataviewMode,
+                    taskToSuggestFor,
+                ),
             );
         }
 
@@ -452,11 +464,16 @@ function addDependsOnSuggestions(
     settings: Settings,
     dependsOnSymbol: string,
     allTasks: Task[],
+    dataviewMode: boolean,
     taskToSuggestFor?: Task,
 ) {
     const results: SuggestInfo[] = [];
 
-    const dependsOnRegex = new RegExp(`(${dependsOnSymbol})([0-9a-zA-Z-_ ^,]*,)*([0-9a-zA-Z ^,]*)`, 'ug');
+    const charactersExcludedFromDescriptionSearch = dataviewMode ? '\\(\\)\\[\\]' : allTaskPluginEmojis();
+    const dependsOnRegex = new RegExp(
+        `(${dependsOnSymbol})([0-9a-zA-Z-_ ^,]*,)*([^,${charactersExcludedFromDescriptionSearch}]*)`,
+        'ug',
+    );
     const dependsOnMatch = matchIfCursorInRegex(line, dependsOnRegex, cursorPos);
     if (dependsOnMatch && dependsOnMatch.length >= 1) {
         // dependsOnMatch[1] = Depends On Symbol

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -390,7 +390,7 @@ describe.each([
                 shouldStartWithSuggestedTasks(line, [feedBaby], [feedBaby, feedCat, ...allTasks]);
             });
 
-            it.failing('should allow punctuation in search strings', () => {
+            it('should allow punctuation in search strings', () => {
                 const peace1 = taskBuilder.description('World peace!').id('peace1').build();
 
                 // Don't match a task that has peace present, but without the exclamation mark


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2827

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


This fixes https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2827

It allows auto-suggest to add dependencies on tasks containing punctuation, accented characters and all emojis except those used by Tasks.

For vaults in dataview format, any character except `[]()` can be used to search task descriptions, to add dependencies.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Lots of exploratory testing.

I tried adding tests via `EditorSuggestorPopup.ts` but it was too much effort for the time available.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
