### PR TITLE
feat: Increase Default Max Auto Suggestion Number to 20

### DIFF
--- a/docs/Editing/Auto-Suggest.md
+++ b/docs/Editing/Auto-Suggest.md
@@ -184,9 +184,6 @@ Our second task looks like this. Note that the due date is shown in the Descript
 
 ### How do I see fewer or more suggestions?
 
-In the Obsidian Settings, Navigate too Community Plugins.
-There find the Tasks Plugin, and go too Options via the Cog.
-
 Increase the 'Maximum number of auto-suggestions to show' Settings Slider too the Value you want (and re-start Obsidian).
 
 Now the Auto Suggest should only Suggest, as much at once as you have Specified.

--- a/docs/Editing/Auto-Suggest.md
+++ b/docs/Editing/Auto-Suggest.md
@@ -184,7 +184,7 @@ Our second task looks like this. Note that the due date is shown in the Descript
 
 ### How do I see fewer or more suggestions?
 
-Increase the 'Maximum number of auto-suggestions to show' Settings Slider too the Value you want (and re-start Obsidian).
+Change the 'Maximum number of auto-suggestions to show' Settings Slider too the Value you want (and re-start Obsidian).
 
 Now the Auto Suggest should only Suggest, as much at once as you have Specified.
 

--- a/docs/Editing/Auto-Suggest.md
+++ b/docs/Editing/Auto-Suggest.md
@@ -182,7 +182,7 @@ Our second task looks like this. Note that the due date is shown in the Descript
 
 ![auto-suggest-edit-incorrect-task](../images/auto-suggest-edit-incorrect-task.png)
 
-### How do I see less/more suggestions?
+### How do I see fewer or more suggestions?
 
 In the Obsidian Settings, Navigate too Community Plugins.
 There find the Tasks Plugin, and go too Options via the Cog.

--- a/docs/Editing/Auto-Suggest.md
+++ b/docs/Editing/Auto-Suggest.md
@@ -184,12 +184,12 @@ Our second task looks like this. Note that the due date is shown in the Descript
 
 ### How do I see fewer or more suggestions?
 
-Change the 'Maximum number of auto-suggestions to show' Settings Slider too the Value you want (and re-start Obsidian).
+Change the 'Maximum number of auto-suggestions to show' settings slider to the value you want (and re-start Obsidian).
 
-Now the Auto Suggest should only Suggest, as much at once as you have Specified.
+Now the auto-suggest should only suggest, as much at once as you have specified.
 
-If there are suggestions Hidden by the Value in the popup menu that where there before, they are not gone.
-Only the best Matches are Shown, the rest is Cutoff at the Value. As you type more characters, the suggestions shown will be more specific to what you typed.
+If there are suggestions hidden by the value in the popup menu that where there before, they are not gone.
+Only the best matches are shown, the rest is cutoff at the value. As you type more characters, the suggestions shown will be more specific to what you typed.
 
 ### How do I make the menu pop up less?
 

--- a/docs/Editing/Auto-Suggest.md
+++ b/docs/Editing/Auto-Suggest.md
@@ -184,12 +184,13 @@ Our second task looks like this. Note that the due date is shown in the Descript
 
 ### How do I see fewer or more suggestions?
 
-Change the 'Maximum number of auto-suggestions to show' settings slider to the value you want (and re-start Obsidian).
+In the Tasks settings, change the 'Maximum number of auto-suggestions to show' slider to the value you want (and re-start Obsidian).
 
-Now the auto-suggest should only suggest, as much at once as you have specified.
+Now the auto-suggest menu will show at most the number of options that you have specified.
 
-If there are suggestions hidden by the value in the popup menu that where there before, they are not gone.
-Only the best matches are shown, the rest is cutoff at the value. As you type more characters, the suggestions shown will be more specific to what you typed.
+Any other options are just hidden and not removed. As you type more characters, the suggestions shown will be filtered to show only suggestions containing the text you typed.
+
+For more on filtering, and some examples, see [[#What keywords may I type to make auto-suggest write the emoji for me?]] below.
 
 ### How do I make the menu pop up less?
 

--- a/docs/Editing/Auto-Suggest.md
+++ b/docs/Editing/Auto-Suggest.md
@@ -182,11 +182,17 @@ Our second task looks like this. Note that the due date is shown in the Descript
 
 ![auto-suggest-edit-incorrect-task](../images/auto-suggest-edit-incorrect-task.png)
 
-### How do I see more suggestions?
+### How do I see less/more suggestions?
 
-Increase the 'Maximum number of auto-suggestions to show' value in settings (and re-start Obsidian) so that the menu will contain more options.
+In the Obsidian Settings, Navigate too Community Plugins.
+There find the Tasks Plugin, and go too Options via the Cog.
 
-There are many more suggestions available than are first shown in the popup menu. As you type more characters, the suggestions shown will be more specific to what you typed.
+Increase the 'Maximum number of auto-suggestions to show' Settings Slider too the Value you want (and re-start Obsidian).
+
+Now the Auto Suggest should only Suggest, as much at once as you have Specified.
+
+If there are suggestions Hidden by the Value in the popup menu that where there before, they are not gone.
+Only the best Matches are Shown, the rest is Cutoff at the Value. As you type more characters, the suggestions shown will be more specific to what you typed.
 
 ### How do I make the menu pop up less?
 

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -102,7 +102,7 @@ const defaultSettings: Settings = {
     setCancelledDate: true,
     autoSuggestInEditor: true,
     autoSuggestMinMatch: 0,
-    autoSuggestMaxItems: 6,
+    autoSuggestMaxItems: 20,
     provideAccessKeys: true,
     useFilenameAsScheduledDate: false,
     filenameAsDateFolders: [],

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -315,7 +315,7 @@ export class SettingsTab extends PluginSettingTab {
             .addSlider((slider) => {
                 const settings = getSettings();
                 slider
-                    .setLimits(3, 12, 1)
+                    .setLimits(3, 20, 1)
                     .setValue(settings.autoSuggestMaxItems)
                     .setDynamicTooltip()
                     .onChange(async (value) => {

--- a/tests/Suggestor/Suggestor.test.auto-complete_with__dataview__symbols_offers_basic_completion_options_for_an_empty_task.approved.json
+++ b/tests/Suggestor/Suggestor.test.auto-complete_with__dataview__symbols_offers_basic_completion_options_for_an_empty_task.approved.json
@@ -23,5 +23,35 @@
     "displayText": "priority:: high priority",
     "appendText": "priority:: high] ",
     "insertSkip": 0
+  },
+  {
+    "displayText": "priority:: medium priority",
+    "appendText": "priority:: medium] ",
+    "insertSkip": 0
+  },
+  {
+    "displayText": "priority:: low priority",
+    "appendText": "priority:: low] ",
+    "insertSkip": 0
+  },
+  {
+    "displayText": "priority:: highest priority",
+    "appendText": "priority:: highest] ",
+    "insertSkip": 0
+  },
+  {
+    "displayText": "priority:: lowest priority",
+    "appendText": "priority:: lowest] ",
+    "insertSkip": 0
+  },
+  {
+    "displayText": "repeat:: recurring (repeat)",
+    "appendText": "repeat:: "
+  },
+  {
+    "textToMatch": "created:: created",
+    "displayText": "created:: created today (2022-07-11)",
+    "appendText": "created:: 2022-07-11] ",
+    "insertSkip": 0
   }
 ]

--- a/tests/Suggestor/Suggestor.test.auto-complete_with__emoji__symbols_offers_basic_completion_options_for_an_empty_task.approved.json
+++ b/tests/Suggestor/Suggestor.test.auto-complete_with__emoji__symbols_offers_basic_completion_options_for_an_empty_task.approved.json
@@ -23,5 +23,34 @@
   {
     "displayText": "⛔ depends on id",
     "appendText": "⛔"
+  },
+  {
+    "displayText": "⏫ high priority",
+    "appendText": "⏫ "
+  },
+  {
+    "displayText": "🔼 medium priority",
+    "appendText": "🔼 "
+  },
+  {
+    "displayText": "🔽 low priority",
+    "appendText": "🔽 "
+  },
+  {
+    "displayText": "🔺 highest priority",
+    "appendText": "🔺 "
+  },
+  {
+    "displayText": "⏬ lowest priority",
+    "appendText": "⏬ "
+  },
+  {
+    "displayText": "🔁 recurring (repeat)",
+    "appendText": "🔁 "
+  },
+  {
+    "textToMatch": "➕ created",
+    "displayText": "➕ created today (2022-07-11)",
+    "appendText": "➕ 2022-07-11 "
   }
 ]

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -206,8 +206,7 @@ describe.each([
     it('offers generic due date completions', () => {
         // Arrange
         const line = `- [ ] some task ${dueDateSymbol}`;
-        const suggestions = shouldStartWithSuggestionsContaining(line, ['today', 'tomorrow']);
-        expect(suggestions.length).toEqual(6);
+        shouldStartWithSuggestionsContaining(line, ['today', 'tomorrow']);
     });
 
     it('offers specific due date completions', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -5,7 +5,7 @@ import { verifyAsJson } from 'approvals/lib/Providers/Jest/JestApprovals';
 import moment from 'moment';
 import * as chrono from 'chrono-node';
 import type { Task } from 'Task/Task';
-import { getSettings } from '../../src/Config/Settings';
+import { getSettings, resetSettings } from '../../src/Config/Settings';
 import type { SuggestInfo, SuggestionBuilder } from '../../src/Suggestor';
 import {
     canSuggestForLine,
@@ -67,6 +67,16 @@ function maskIDSuggestionForTesting(idSymbol: string, suggestions: SuggestInfo[]
 }
 
 const MAX_GENERIC_SUGGESTIONS_FOR_TESTS = 50;
+
+describe('default auto-complete settings', () => {
+    it('should offer correct default values', () => {
+        resetSettings();
+        const settings = getSettings();
+        expect(settings.autoSuggestInEditor).toEqual(true);
+        expect(settings.autoSuggestMinMatch).toEqual(0);
+        expect(settings.autoSuggestMaxItems).toEqual(20);
+    });
+});
 
 // NEW_TASK_FIELD_EDIT_REQUIRED
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: Agreed by @claremacrae in https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2885#issuecomment-2156029598
  - **WARNING: If the link is absent, the PR may be closed without review**, due to the workload that such reviews usually require.
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->
The Default Value of the Settings Option "Maximum Number of auto-suggestion to show" was increased.
Increased the default value for better visibility. (At least for the Default Task Attributes)
This adjustment will provide new users with a comprehensive overview, thereby preventing confusion on what options exists in the Future.

Additionally, the settings upper limit was increased to 20, as the Max Number of Normal Task Property Suggestions is 13, which didn't fit the Previous Max (12).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As Discussed here: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2885

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested it in the Existing Vault.
The Default Setting doesn't Overwrite the existing setting. When rebuilding.
When the Contents of the Plugin Folder is deleted and Refreshed with the Output of a Fresh Build, the Value is then set to the new Default for new Users.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
