### PR TITLE
fix: recurrence with 'when done' could give wrong 'done' date

### DIFF
--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -200,7 +200,7 @@ export class Recurrence {
     private nextReferenceDate(today: Moment): Date {
         if (this.baseOnToday) {
             // The next occurrence should happen based off the current date.
-            return this.nextReferenceDateFromToday(today).toDate();
+            return this.nextReferenceDateFromToday(today.clone()).toDate();
         } else {
             return this.nextReferenceDateFromOriginalReferenceDate().toDate();
         }

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -1099,12 +1099,14 @@ describe('toggle done', () => {
             scheduled: '1999-01-23',
             today: '2021-08-31',
             nextScheduled: '2021-09-30',
+            expectedDone: '2021-08-30', // TODO Wrong - see #2867
         },
         {
             interval: 'every 2 years when done',
             start: '1999-01-23',
             today: '2020-02-29', // is a leap year
             nextStart: '2022-02-28',
+            expectedDone: '2020-02-28', // TODO Wrong - see #2867
         },
         // ==================================
         // Test toggling with custom statuses.
@@ -1185,12 +1187,19 @@ describe('toggle done', () => {
         const nextTask: Task = tasks[0];
 
         expect(doneTask.status.symbol).toEqual(doneSymbol ?? 'x');
-        if (expectedDone) {
+
+        function checkDoneDone(doneTask: Task, expectedDone: string) {
             expect({
                 doneDate: doneTask.doneDate?.format('YYYY-MM-DD'),
             }).toMatchObject({
                 doneDate: expectedDone,
             });
+        }
+
+        if (expectedDone) {
+            checkDoneDone(doneTask, expectedDone);
+        } else if (today) {
+            checkDoneDone(doneTask, today);
         }
 
         expect(nextTask.status.symbol).toEqual(nextSymbol ?? ' ');

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -842,6 +842,7 @@ describe('toggle done', () => {
         start?: string;
         today?: string;
         // results:
+        expectedDone?: string; // TODO Remove this and use today as expected done date, when #2867 is fixed
         doneSymbol?: string; // the symbol of the completed task
         nextSymbol?: string; // the symbol of the recurrence
         nextDue?: string;
@@ -1141,6 +1142,7 @@ describe('toggle done', () => {
             start,
             today,
             // results:
+            expectedDone,
             doneSymbol,
             nextSymbol,
             nextDue,
@@ -1183,6 +1185,14 @@ describe('toggle done', () => {
         const nextTask: Task = tasks[0];
 
         expect(doneTask.status.symbol).toEqual(doneSymbol ?? 'x');
+        if (expectedDone) {
+            expect({
+                doneDate: doneTask.doneDate?.format('YYYY-MM-DD'),
+            }).toMatchObject({
+                doneDate: expectedDone,
+            });
+        }
+
         expect(nextTask.status.symbol).toEqual(nextSymbol ?? ' ');
         expect({
             nextDue: nextTask.dueDate?.format('YYYY-MM-DD'),
@@ -1266,6 +1276,28 @@ describe('toggle done', () => {
                 "- [ ] should remove *id* and *dependsOn* in next recurrence 🔁 every day 📅 2024-02-14
                 - [x] should remove *id* and *dependsOn* in next recurrence 🆔 id2 ⛔ id1 🔁 every day 📅 2024-02-13"
             `);
+        });
+    });
+
+    it('should apply the correct done date - without "when done"', () => {
+        const today = '2024-05-31';
+        testRecurrenceCase({
+            today: today,
+            scheduled: today,
+            interval: 'every 6 months',
+            nextScheduled: '2024-11-30',
+            expectedDone: today,
+        });
+    });
+
+    it.failing('should apply the correct done date - with "when done"', () => {
+        const today = '2024-05-31';
+        testRecurrenceCase({
+            today: today,
+            scheduled: today,
+            interval: 'every 6 months when done',
+            nextScheduled: '2024-11-30',
+            expectedDone: today, // fails - gives '2024-05-30'
         });
     });
 });

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -1099,14 +1099,14 @@ describe('toggle done', () => {
             scheduled: '1999-01-23',
             today: '2021-08-31',
             nextScheduled: '2021-09-30',
-            expectedDone: '2021-08-30', // TODO Wrong - see #2867
+            expectedDone: '2021-08-31',
         },
         {
             interval: 'every 2 years when done',
             start: '1999-01-23',
             today: '2020-02-29', // is a leap year
             nextStart: '2022-02-28',
-            expectedDone: '2020-02-28', // TODO Wrong - see #2867
+            expectedDone: '2020-02-29',
         },
         // ==================================
         // Test toggling with custom statuses.
@@ -1299,7 +1299,7 @@ describe('toggle done', () => {
         });
     });
 
-    it.failing('should apply the correct done date - with "when done"', () => {
+    it('should apply the correct done date - with "when done"', () => {
         const today = '2024-05-31';
         testRecurrenceCase({
             today: today,

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -1185,17 +1185,12 @@ describe('toggle done', () => {
         const nextTask: Task = tasks[0];
 
         expect(doneTask.status.symbol).toEqual(doneSymbol ?? 'x');
-
-        function checkDoneDone(doneTask: Task, expectedDone: string) {
+        if (today) {
             expect({
                 doneDate: doneTask.doneDate?.format('YYYY-MM-DD'),
             }).toMatchObject({
-                doneDate: expectedDone,
+                doneDate: today,
             });
-        }
-
-        if (today) {
-            checkDoneDone(doneTask, today);
         }
 
         expect(nextTask.status.symbol).toEqual(nextSymbol ?? ' ');

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -842,7 +842,6 @@ describe('toggle done', () => {
         start?: string;
         today?: string;
         // results:
-        expectedDone?: string; // TODO Remove this and use today as expected done date, when #2867 is fixed
         doneSymbol?: string; // the symbol of the completed task
         nextSymbol?: string; // the symbol of the recurrence
         nextDue?: string;
@@ -1095,18 +1094,18 @@ describe('toggle done', () => {
 
         // Testing 'when done' does not skip when next occurrence is a non-existent date
         {
+            // This also showed the existence of #2867 - which caused the done date to be '2021-08-30'
             interval: 'every month when done',
             scheduled: '1999-01-23',
             today: '2021-08-31',
             nextScheduled: '2021-09-30',
-            expectedDone: '2021-08-31',
         },
         {
+            // This also showed the existence of #2867 - which caused the done date to be '2020-02-28'
             interval: 'every 2 years when done',
             start: '1999-01-23',
             today: '2020-02-29', // is a leap year
             nextStart: '2022-02-28',
-            expectedDone: '2020-02-29',
         },
         // ==================================
         // Test toggling with custom statuses.
@@ -1144,7 +1143,6 @@ describe('toggle done', () => {
             start,
             today,
             // results:
-            expectedDone,
             doneSymbol,
             nextSymbol,
             nextDue,
@@ -1196,9 +1194,7 @@ describe('toggle done', () => {
             });
         }
 
-        if (expectedDone) {
-            checkDoneDone(doneTask, expectedDone);
-        } else if (today) {
+        if (today) {
             checkDoneDone(doneTask, today);
         }
 
@@ -1295,7 +1291,6 @@ describe('toggle done', () => {
             scheduled: today,
             interval: 'every 6 months',
             nextScheduled: '2024-11-30',
-            expectedDone: today,
         });
     });
 
@@ -1306,7 +1301,6 @@ describe('toggle done', () => {
             scheduled: today,
             interval: 'every 6 months when done',
             nextScheduled: '2024-11-30',
-            expectedDone: today, // fails - gives '2024-05-30'
         });
     });
 });

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -1283,26 +1283,6 @@ describe('toggle done', () => {
             `);
         });
     });
-
-    it('should apply the correct done date - without "when done"', () => {
-        const today = '2024-05-31';
-        testRecurrenceCase({
-            today: today,
-            scheduled: today,
-            interval: 'every 6 months',
-            nextScheduled: '2024-11-30',
-        });
-    });
-
-    it('should apply the correct done date - with "when done"', () => {
-        const today = '2024-05-31';
-        testRecurrenceCase({
-            today: today,
-            scheduled: today,
-            interval: 'every 6 months when done',
-            nextScheduled: '2024-11-30',
-        });
-    });
 });
 
 describe('handle new status', () => {


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #2867

## Description

Prevent unintended mutation of 'today' that broke the saved done date.

The underlying cause of this us that `today.startOf('day')` was being called in `nextReferenceDateFromToday()` - which was adjust the reference date passed in, in the case that the next recurrence was a non-existent date and so needed to be adjusted.

## Motivation and Context

Fixes #2867

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

- Adding some tests - and then later removing them, when I discovered that the problem could be found with existing test cases
- Repeating the 'steps to reproduce' in #2867, to confirm it really is fixed.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
