### PR TITLE
test: ensure dates reset

### DIFF
--- a/tests/Api/executeToggleTaskDoneCommand.test.ts
+++ b/tests/Api/executeToggleTaskDoneCommand.test.ts
@@ -15,8 +15,16 @@ jest.mock('obsidian', () => ({
 window.moment = moment;
 
 describe('APIv1 - executeToggleTaskDoneCommand', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2022-09-04'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
     const api = tasksApiV1({} as App);
-    const todaySpy = jest.spyOn(Date, 'now').mockReturnValue(moment('2022-09-04').valueOf());
 
     // This is a simple smoke test to make sure executeToggleTaskDoneCommand is working. Its core
     // functionality is covered by other tests
@@ -24,6 +32,4 @@ describe('APIv1 - executeToggleTaskDoneCommand', () => {
         expect(api.executeToggleTaskDoneCommand('- [ ] ', 'x.md')).toBe('- [x]  ✅ 2022-09-04');
         expect(api.executeToggleTaskDoneCommand('- [x] ✅ 2022-09-04', 'x.md')).toBe('- [ ] ');
     });
-
-    todaySpy.mockClear();
 });

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -77,11 +77,15 @@ function testToggleLineForOutOfRangeCursorPositions(
 }
 
 describe('ToggleDone', () => {
-    afterEach(() => {
-        GlobalFilter.getInstance().reset();
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2022-09-04'));
     });
 
-    const todaySpy = jest.spyOn(Date, 'now').mockReturnValue(moment('2022-09-04').valueOf());
+    afterEach(() => {
+        jest.useRealTimers();
+        GlobalFilter.getInstance().reset();
+    });
 
     // The | (pipe) indicates the calculated position where the cursor should be displayed.
     // Note that prior to the #1103 fix, this position was sometimes ignored.
@@ -260,6 +264,4 @@ describe('ToggleDone', () => {
             );
         });
     });
-
-    todaySpy.mockClear();
 });

--- a/tests/Task/Urgency.test.ts
+++ b/tests/Task/Urgency.test.ts
@@ -23,12 +23,9 @@ function testUrgency(builder: TaskBuilder, expectedScore: number) {
  * @param expectedScore
  */
 function testUrgencyOnDate(today: string, builder: TaskBuilder, expectedScore: number) {
-    // TODO Remove this duplication from Task.test.ts
-    const todaySpy = jest.spyOn(Date, 'now').mockReturnValue(moment(today).valueOf());
+    jest.setSystemTime(new Date(today));
 
     testUrgency(builder, expectedScore);
-
-    todaySpy.mockClear();
 }
 
 /**
@@ -99,6 +96,14 @@ function testUrgencyForDueDate(daysToDate: number, expectedScore: number) {
 
     testUrgencyOnDate(today, lowPriorityBuilder().dueDate(dueAsString), expectedScore);
 }
+
+beforeEach(() => {
+    jest.useFakeTimers();
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
 
 describe('urgency - due date component', () => {
     it('More than 7 days overdue: 12.0', () => {


### PR DESCRIPTION
# Types of changes


Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

## Motivation and Context

- Increase test robustness by resetting dates even after failing tests

## How has this been tested?

- unit tests

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
