### PR TITLE
fix: Tasks search results now render correctly in Tabs plugin

### DIFF
--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -38,16 +38,16 @@ export class QueryRenderer {
     public addQueryRenderChild = this._addQueryRenderChild.bind(this);
 
     private async _addQueryRenderChild(source: string, element: HTMLElement, context: MarkdownPostProcessorContext) {
-        context.addChild(
-            new QueryRenderChild({
-                app: this.app,
-                plugin: this.plugin,
-                events: this.events,
-                container: element,
-                source,
-                filePath: context.sourcePath,
-            }),
-        );
+        const queryRenderChild = new QueryRenderChild({
+            app: this.app,
+            plugin: this.plugin,
+            events: this.events,
+            container: element,
+            source,
+            filePath: context.sourcePath,
+        });
+        context.addChild(queryRenderChild);
+        queryRenderChild.load();
     }
 }
 


### PR DESCRIPTION
Fixes #2941

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2941

## Description

Add missing call to `QueryRenderChild.load()` - see [Component.load()](https://docs.obsidian.md/Reference/TypeScript+API/Component/load) in the Obsidian developer docs.

## Motivation and Context

Fixes https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2941

## How has this been tested?

- In the test vault supplied in https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2941
- By running all the Tasks smoke tests and confirming they pass

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
