### PR TITLE
refactor: move `TasksFile` object to `TaskLocation`

### DIFF
--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -47,10 +47,10 @@ export class GlobalQuery {
 
     /**
      * Returns {@link Query} object with the Global Query
-     * @param path
+     * @param tasksFile
      */
-    public query(path: OptionalTasksFile = undefined): Query {
-        return new Query(this._source, path);
+    public query(tasksFile: OptionalTasksFile = undefined): Query {
+        return new Query(this._source, tasksFile);
     }
 
     /**

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -1,5 +1,5 @@
 import { Query } from '../Query/Query';
-import type { OptionalFilePath } from '../Scripting/TasksFile';
+import type { OptionalTasksFile } from '../Scripting/TasksFile';
 
 /**
  * Global Query set in the {@link SettingsTab} and associated services.
@@ -49,7 +49,7 @@ export class GlobalQuery {
      * Returns {@link Query} object with the Global Query
      * @param path
      */
-    public query(path: OptionalFilePath = undefined): Query {
+    public query(path: OptionalTasksFile = undefined): Query {
         return new Query(this._source, path);
     }
 

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -1,4 +1,5 @@
 import { Query } from '../Query/Query';
+import type { OptionalFilePath } from '../Scripting/TasksFile';
 
 /**
  * Global Query set in the {@link SettingsTab} and associated services.
@@ -48,7 +49,7 @@ export class GlobalQuery {
      * Returns {@link Query} object with the Global Query
      * @param path
      */
-    public query(path: string | undefined = undefined): Query {
+    public query(path: OptionalFilePath = undefined): Query {
         return new Query(this._source, path);
     }
 

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -7,7 +7,7 @@ import { logging } from '../lib/logging';
 import { expandPlaceholders } from '../Scripting/ExpandPlaceholders';
 import { makeQueryContext } from '../Scripting/QueryContext';
 import type { Task } from '../Task/Task';
-import type { OptionalFilePath } from '../Scripting/TasksFile';
+import type { OptionalTasksFile } from '../Scripting/TasksFile';
 import { Explainer } from './Explain/Explainer';
 import type { Filter } from './Filter/Filter';
 import * as FilterParser from './FilterParser';
@@ -23,7 +23,7 @@ import { Statement } from './Statement';
 export class Query implements IQuery {
     /** Note: source is the raw source, before expanding any placeholders */
     public readonly source: string;
-    public readonly filePath: OptionalFilePath;
+    public readonly filePath: OptionalTasksFile;
 
     private _limit: number | undefined = undefined;
     private _taskGroupLimit: number | undefined = undefined;
@@ -50,7 +50,7 @@ export class Query implements IQuery {
 
     private readonly commentRegexp = /^#.*/;
 
-    constructor(source: string, path: OptionalFilePath = undefined) {
+    constructor(source: string, path: OptionalTasksFile = undefined) {
         this._queryId = this.generateQueryId(10);
 
         this.source = source;
@@ -123,7 +123,7 @@ export class Query implements IQuery {
         return `[${this.source.split('\n').join(' ; ')}]`;
     }
 
-    private expandPlaceholders(statement: Statement, path: OptionalFilePath) {
+    private expandPlaceholders(statement: Statement, path: OptionalTasksFile) {
         const source = statement.anyContinuationLinesRemoved;
         if (source.includes('{{') && source.includes('}}')) {
             if (this.filePath === undefined) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -7,6 +7,7 @@ import { logging } from '../lib/logging';
 import { expandPlaceholders } from '../Scripting/ExpandPlaceholders';
 import { makeQueryContext } from '../Scripting/QueryContext';
 import type { Task } from '../Task/Task';
+import type { OptionalFilePath } from '../Scripting/TasksFile';
 import { Explainer } from './Explain/Explainer';
 import type { Filter } from './Filter/Filter';
 import * as FilterParser from './FilterParser';
@@ -22,7 +23,7 @@ import { Statement } from './Statement';
 export class Query implements IQuery {
     /** Note: source is the raw source, before expanding any placeholders */
     public readonly source: string;
-    public readonly filePath: string | undefined;
+    public readonly filePath: OptionalFilePath;
 
     private _limit: number | undefined = undefined;
     private _taskGroupLimit: number | undefined = undefined;
@@ -49,7 +50,7 @@ export class Query implements IQuery {
 
     private readonly commentRegexp = /^#.*/;
 
-    constructor(source: string, path: string | undefined = undefined) {
+    constructor(source: string, path: OptionalFilePath = undefined) {
         this._queryId = this.generateQueryId(10);
 
         this.source = source;
@@ -122,7 +123,7 @@ export class Query implements IQuery {
         return `[${this.source.split('\n').join(' ; ')}]`;
     }
 
-    private expandPlaceholders(statement: Statement, path: string | undefined) {
+    private expandPlaceholders(statement: Statement, path: OptionalFilePath) {
         const source = statement.anyContinuationLinesRemoved;
         if (source.includes('{{') && source.includes('}}')) {
             if (this.filePath === undefined) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -81,6 +81,10 @@ export class Query implements IQuery {
         });
     }
 
+    public get filePath(): string | undefined {
+        return this.tasksFile?.path ?? undefined;
+    }
+
     public get queryId(): string {
         return this._queryId;
     }
@@ -420,6 +424,6 @@ ${statement.explainStatement('    ')}
     }
 
     public debug(message: string, objects?: any): void {
-        this.logger.debugWithId(this._queryId, `"${this.tasksFile}": ${message}`, objects);
+        this.logger.debugWithId(this._queryId, `"${this.filePath}": ${message}`, objects);
     }
 }

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -50,16 +50,16 @@ export class Query implements IQuery {
 
     private readonly commentRegexp = /^#.*/;
 
-    constructor(source: string, path: OptionalTasksFile = undefined) {
+    constructor(source: string, tasksFile: OptionalTasksFile = undefined) {
         this._queryId = this.generateQueryId(10);
 
         this.source = source;
-        this.filePath = path;
+        this.filePath = tasksFile;
 
         this.debug(`Creating query: ${this.formatQueryForLogging()}`);
 
         continueLines(source).forEach((statement: Statement) => {
-            const line = this.expandPlaceholders(statement, path);
+            const line = this.expandPlaceholders(statement, tasksFile);
             if (this.error !== undefined) {
                 // There was an error expanding placeholders.
                 return;
@@ -123,7 +123,7 @@ export class Query implements IQuery {
         return `[${this.source.split('\n').join(' ; ')}]`;
     }
 
-    private expandPlaceholders(statement: Statement, path: OptionalTasksFile) {
+    private expandPlaceholders(statement: Statement, tasksFile: OptionalTasksFile) {
         const source = statement.anyContinuationLinesRemoved;
         if (source.includes('{{') && source.includes('}}')) {
             if (this.filePath === undefined) {
@@ -139,8 +139,8 @@ ${source}`;
         // TODO Show the original and expanded text in explanations
         // TODO Give user error info if they try and put a string in a regex search
         let expandedSource: string = source;
-        if (path) {
-            const queryContext = makeQueryContext(path);
+        if (tasksFile) {
+            const queryContext = makeQueryContext(tasksFile);
             try {
                 expandedSource = expandPlaceholders(source, queryContext);
             } catch (error) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -23,7 +23,7 @@ import { Statement } from './Statement';
 export class Query implements IQuery {
     /** Note: source is the raw source, before expanding any placeholders */
     public readonly source: string;
-    public readonly filePath: OptionalTasksFile;
+    public readonly tasksFile: OptionalTasksFile;
 
     private _limit: number | undefined = undefined;
     private _taskGroupLimit: number | undefined = undefined;
@@ -54,7 +54,7 @@ export class Query implements IQuery {
         this._queryId = this.generateQueryId(10);
 
         this.source = source;
-        this.filePath = tasksFile;
+        this.tasksFile = tasksFile;
 
         this.debug(`Creating query: ${this.formatQueryForLogging()}`);
 
@@ -126,7 +126,7 @@ export class Query implements IQuery {
     private expandPlaceholders(statement: Statement, tasksFile: OptionalTasksFile) {
         const source = statement.anyContinuationLinesRemoved;
         if (source.includes('{{') && source.includes('}}')) {
-            if (this.filePath === undefined) {
+            if (this.tasksFile === undefined) {
                 this._error = `The query looks like it contains a placeholder, with "{{" and "}}"
 but no file path has been supplied, so cannot expand placeholder values.
 The query is:
@@ -181,7 +181,7 @@ ${source}`;
     public append(q2: Query): Query {
         if (this.source === '') return q2;
         if (q2.source === '') return this;
-        return new Query(`${this.source}\n${q2.source}`, this.filePath);
+        return new Query(`${this.source}\n${q2.source}`, this.tasksFile);
     }
 
     /**
@@ -260,7 +260,7 @@ ${statement.explainStatement('    ')}
     public applyQueryToTasks(tasks: Task[]): QueryResult {
         this.debug(`Executing query: ${this.formatQueryForLogging()}`);
 
-        const searchInfo = new SearchInfo(this.filePath, tasks);
+        const searchInfo = new SearchInfo(this.tasksFile, tasks);
         try {
             this.filters.forEach((filter) => {
                 tasks = tasks.filter((task) => filter.filterFunction(task, searchInfo));
@@ -420,6 +420,6 @@ ${statement.explainStatement('    ')}
     }
 
     public debug(message: string, objects?: any): void {
-        this.logger.debugWithId(this._queryId, `"${this.filePath}": ${message}`, objects);
+        this.logger.debugWithId(this._queryId, `"${this.tasksFile}": ${message}`, objects);
     }
 }

--- a/src/Query/SearchInfo.ts
+++ b/src/Query/SearchInfo.ts
@@ -1,6 +1,6 @@
 import type { Task } from '../Task/Task';
 import { type QueryContext, makeQueryContextWithTasks } from '../Scripting/QueryContext';
-import type { OptionalFilePath } from '../Scripting/TasksFile';
+import type { OptionalTasksFile } from '../Scripting/TasksFile';
 
 /**
  * SearchInfo contains selected data passed in from the {@link Query} being executed.
@@ -13,9 +13,9 @@ export class SearchInfo {
     /** The list of tasks being searched.
      */
     public readonly allTasks: Readonly<Task[]>;
-    public readonly queryPath: OptionalFilePath;
+    public readonly queryPath: OptionalTasksFile;
 
-    public constructor(queryPath: OptionalFilePath, allTasks: Task[]) {
+    public constructor(queryPath: OptionalTasksFile, allTasks: Task[]) {
         this.queryPath = queryPath;
         this.allTasks = [...allTasks];
     }

--- a/src/Query/SearchInfo.ts
+++ b/src/Query/SearchInfo.ts
@@ -1,5 +1,6 @@
 import type { Task } from '../Task/Task';
 import { type QueryContext, makeQueryContextWithTasks } from '../Scripting/QueryContext';
+import type { OptionalFilePath } from '../Scripting/TasksFile';
 
 /**
  * SearchInfo contains selected data passed in from the {@link Query} being executed.
@@ -12,9 +13,9 @@ export class SearchInfo {
     /** The list of tasks being searched.
      */
     public readonly allTasks: Readonly<Task[]>;
-    public readonly queryPath: string | undefined;
+    public readonly queryPath: OptionalFilePath;
 
-    public constructor(queryPath: string | undefined, allTasks: Task[]) {
+    public constructor(queryPath: OptionalFilePath, allTasks: Task[]) {
         this.queryPath = queryPath;
         this.allTasks = [...allTasks];
     }

--- a/src/Query/SearchInfo.ts
+++ b/src/Query/SearchInfo.ts
@@ -13,10 +13,10 @@ export class SearchInfo {
     /** The list of tasks being searched.
      */
     public readonly allTasks: Readonly<Task[]>;
-    public readonly queryPath: OptionalTasksFile;
+    public readonly tasksFile: OptionalTasksFile;
 
     public constructor(queryPath: OptionalTasksFile, allTasks: Task[]) {
-        this.queryPath = queryPath;
+        this.tasksFile = queryPath;
         this.allTasks = [...allTasks];
     }
 
@@ -31,6 +31,6 @@ export class SearchInfo {
      * @return A QueryContext, or undefined if the path to the query file is unknown.
      */
     public queryContext(): QueryContext | undefined {
-        return this.queryPath ? makeQueryContextWithTasks(this.queryPath, this.allTasks) : undefined;
+        return this.tasksFile ? makeQueryContextWithTasks(this.tasksFile, this.allTasks) : undefined;
     }
 }

--- a/src/Query/SearchInfo.ts
+++ b/src/Query/SearchInfo.ts
@@ -15,8 +15,8 @@ export class SearchInfo {
     public readonly allTasks: Readonly<Task[]>;
     public readonly tasksFile: OptionalTasksFile;
 
-    public constructor(queryPath: OptionalTasksFile, allTasks: Task[]) {
-        this.tasksFile = queryPath;
+    public constructor(tasksFile: OptionalTasksFile, allTasks: Task[]) {
+        this.tasksFile = tasksFile;
         this.allTasks = [...allTasks];
     }
 

--- a/src/Query/SearchInfo.ts
+++ b/src/Query/SearchInfo.ts
@@ -24,6 +24,10 @@ export class SearchInfo {
         return new SearchInfo(undefined, tasks);
     }
 
+    public get queryPath(): string | undefined {
+        return this.tasksFile?.path ?? undefined;
+    }
+
     /**
      * Construct a {@link QueryContext} from this, for use in the placeholder
      * facility and scripting code.

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -45,7 +45,7 @@ export class QueryRenderer {
             events: this.events,
             container: element,
             source,
-            filePath: new TasksFile(context.sourcePath),
+            tasksFile: new TasksFile(context.sourcePath),
         });
         context.addChild(queryRenderChild);
         queryRenderChild.load();
@@ -70,7 +70,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     private readonly source: string;
 
     /// The path of the file that contains the instruction block.
-    private readonly filePath: TasksFile;
+    private readonly tasksFile: TasksFile;
 
     private query: IQuery;
     // @ts-expect-error: TS6133: 'queryType' is declared but its value is never read
@@ -85,14 +85,14 @@ class QueryRenderChild extends MarkdownRenderChild {
         events,
         container,
         source,
-        filePath,
+        tasksFile,
     }: {
         app: App;
         plugin: TasksPlugin;
         events: TasksEvents;
         container: HTMLElement;
         source: string;
-        filePath: TasksFile;
+        tasksFile: TasksFile;
     }) {
         super(container);
 
@@ -100,19 +100,19 @@ class QueryRenderChild extends MarkdownRenderChild {
         this.plugin = plugin;
         this.events = events;
         this.source = source;
-        this.filePath = filePath;
+        this.tasksFile = tasksFile;
 
         // The engine is chosen on the basis of the code block language. Currently,
         // there is only the main engine for the plugin, this allows others to be
         // added later.
         switch (this.containerEl.className) {
             case 'block-language-tasks':
-                this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.filePath);
+                this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
                 this.queryType = 'tasks';
                 break;
 
             default:
-                this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.filePath);
+                this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
                 this.queryType = 'tasks';
                 break;
         }
@@ -153,7 +153,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         const millisecondsToMidnight = midnight.getTime() - now.getTime();
 
         this.queryReloadTimeout = setTimeout(() => {
-            this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.filePath);
+            this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
             // Process the current cache state:
             this.events.triggerRequestCacheUpdate(this.render.bind(this));
             this.reloadQueryAtMidnight();
@@ -190,7 +190,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private explainAndPerformSearch(state: State.Warm, tasks: Task[], content: HTMLDivElement) {
-        const measureSearch = new PerformanceTracker(`Search: ${this.query.queryId} - ${this.filePath}`);
+        const measureSearch = new PerformanceTracker(`Search: ${this.query.queryId} - ${this.tasksFile}`);
         measureSearch.start();
 
         this.query.debug(`[render] Render called: plugin state: ${state}; searching ${tasks.length} tasks`);
@@ -206,7 +206,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private async renderSearchResults(queryResult: QueryResult, content: HTMLDivElement) {
-        const measureRender = new PerformanceTracker(`Render: ${this.query.queryId} - ${this.filePath}`);
+        const measureRender = new PerformanceTracker(`Render: ${this.query.queryId} - ${this.tasksFile}`);
         measureRender.start();
 
         await this.addAllTaskGroups(queryResult.taskGroups, content);
@@ -233,7 +233,7 @@ class QueryRenderChild extends MarkdownRenderChild {
             this.source,
             GlobalFilter.getInstance(),
             GlobalQuery.getInstance(),
-            this.filePath,
+            this.tasksFile,
         );
 
         const explanationsBlock = createAndAppendElement('pre', content);
@@ -371,7 +371,7 @@ class QueryRenderChild extends MarkdownRenderChild {
 
         const headerEl = createAndAppendElement(header, content);
         headerEl.addClass('tasks-group-heading');
-        await MarkdownRenderer.renderMarkdown(group.displayName, headerEl, this.filePath.path, this);
+        await MarkdownRenderer.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this);
     }
 
     private addBacklinks(listItem: HTMLElement, task: Task, shortMode: boolean, isFilenameUnique: boolean | undefined) {

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -20,7 +20,7 @@ import type { TasksEvents } from '../Obsidian/TasksEvents';
 import { getTaskLineAndFile, replaceTaskWithTasks } from '../Obsidian/File';
 import { State } from '../Obsidian/Cache';
 import { PerformanceTracker } from '../lib/PerformanceTracker';
-import type { FilePath } from '../Scripting/TasksFile';
+import { type FilePath, TasksFile } from '../Scripting/TasksFile';
 import { TaskLineRenderer, createAndAppendElement } from './TaskLineRenderer';
 
 export class QueryRenderer {
@@ -45,7 +45,7 @@ export class QueryRenderer {
             events: this.events,
             container: element,
             source,
-            filePath: context.sourcePath,
+            filePath: new TasksFile(context.sourcePath),
         });
         context.addChild(queryRenderChild);
         queryRenderChild.load();
@@ -371,7 +371,7 @@ class QueryRenderChild extends MarkdownRenderChild {
 
         const headerEl = createAndAppendElement(header, content);
         headerEl.addClass('tasks-group-heading');
-        await MarkdownRenderer.renderMarkdown(group.displayName, headerEl, this.filePath, this);
+        await MarkdownRenderer.renderMarkdown(group.displayName, headerEl, this.filePath.path, this);
     }
 
     private addBacklinks(listItem: HTMLElement, task: Task, shortMode: boolean, isFilenameUnique: boolean | undefined) {

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -20,6 +20,7 @@ import type { TasksEvents } from '../Obsidian/TasksEvents';
 import { getTaskLineAndFile, replaceTaskWithTasks } from '../Obsidian/File';
 import { State } from '../Obsidian/Cache';
 import { PerformanceTracker } from '../lib/PerformanceTracker';
+import type { FilePath } from '../Scripting/TasksFile';
 import { TaskLineRenderer, createAndAppendElement } from './TaskLineRenderer';
 
 export class QueryRenderer {
@@ -69,7 +70,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     private readonly source: string;
 
     /// The path of the file that contains the instruction block.
-    private readonly filePath: string;
+    private readonly filePath: FilePath;
 
     private query: IQuery;
     // @ts-expect-error: TS6133: 'queryType' is declared but its value is never read
@@ -91,7 +92,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         events: TasksEvents;
         container: HTMLElement;
         source: string;
-        filePath: string;
+        filePath: FilePath;
     }) {
         super(container);
 

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -137,6 +137,10 @@ class QueryRenderChild extends MarkdownRenderChild {
         }
     }
 
+    public get filePath(): string | undefined {
+        return this.tasksFile?.path ?? undefined;
+    }
+
     /**
      * Reloads the query after midnight to update results from relative date queries.
      *
@@ -190,7 +194,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private explainAndPerformSearch(state: State.Warm, tasks: Task[], content: HTMLDivElement) {
-        const measureSearch = new PerformanceTracker(`Search: ${this.query.queryId} - ${this.tasksFile}`);
+        const measureSearch = new PerformanceTracker(`Search: ${this.query.queryId} - ${this.filePath}`);
         measureSearch.start();
 
         this.query.debug(`[render] Render called: plugin state: ${state}; searching ${tasks.length} tasks`);
@@ -206,7 +210,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private async renderSearchResults(queryResult: QueryResult, content: HTMLDivElement) {
-        const measureRender = new PerformanceTracker(`Render: ${this.query.queryId} - ${this.tasksFile}`);
+        const measureRender = new PerformanceTracker(`Render: ${this.query.queryId} - ${this.filePath}`);
         measureRender.start();
 
         await this.addAllTaskGroups(queryResult.taskGroups, content);

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -69,7 +69,7 @@ class QueryRenderChild extends MarkdownRenderChild {
      */
     private readonly source: string;
 
-    /// The path of the file that contains the instruction block.
+    // The path of the file that contains the instruction block, and cached data from that file.
     private readonly tasksFile: TasksFile;
 
     private query: IQuery;

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -20,7 +20,7 @@ import type { TasksEvents } from '../Obsidian/TasksEvents';
 import { getTaskLineAndFile, replaceTaskWithTasks } from '../Obsidian/File';
 import { State } from '../Obsidian/Cache';
 import { PerformanceTracker } from '../lib/PerformanceTracker';
-import { type FilePath, TasksFile } from '../Scripting/TasksFile';
+import { TasksFile } from '../Scripting/TasksFile';
 import { TaskLineRenderer, createAndAppendElement } from './TaskLineRenderer';
 
 export class QueryRenderer {
@@ -70,7 +70,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     private readonly source: string;
 
     /// The path of the file that contains the instruction block.
-    private readonly filePath: FilePath;
+    private readonly filePath: TasksFile;
 
     private query: IQuery;
     // @ts-expect-error: TS6133: 'queryType' is declared but its value is never read
@@ -92,7 +92,7 @@ class QueryRenderChild extends MarkdownRenderChild {
         events: TasksEvents;
         container: HTMLElement;
         source: string;
-        filePath: FilePath;
+        filePath: TasksFile;
     }) {
         super(container);
 

--- a/src/Scripting/QueryContext.ts
+++ b/src/Scripting/QueryContext.ts
@@ -24,7 +24,7 @@ export interface QueryContext {
 }
 
 /**
- * Create a {@link QueryContext} to represent a query in note at the give path.
+ * Create a {@link QueryContext} to represent a query in note at the given path in the {@link TasksFile}.
  * @param tasksFile
  *
  * @see SearchInfo.queryContext

--- a/src/Scripting/QueryContext.ts
+++ b/src/Scripting/QueryContext.ts
@@ -1,5 +1,5 @@
 import type { Task } from '../Task/Task';
-import type { FilePath, TasksFile } from './TasksFile';
+import type { TasksFile } from './TasksFile';
 
 /**
  * This interface is part of the implementation of placeholders and scripting.
@@ -30,11 +30,11 @@ export interface QueryContext {
  * @see SearchInfo.queryContext
  * @see makeQueryContextWithTasks
  */
-export function makeQueryContext(path: FilePath): QueryContext {
+export function makeQueryContext(path: TasksFile): QueryContext {
     return makeQueryContextWithTasks(path, []);
 }
 
-export function makeQueryContextWithTasks(tasksFile: FilePath, allTasks: Readonly<Task[]>): QueryContext {
+export function makeQueryContextWithTasks(tasksFile: TasksFile, allTasks: Readonly<Task[]>): QueryContext {
     return {
         query: {
             file: tasksFile,

--- a/src/Scripting/QueryContext.ts
+++ b/src/Scripting/QueryContext.ts
@@ -1,5 +1,5 @@
 import type { Task } from '../Task/Task';
-import { type FilePath, TasksFile } from './TasksFile';
+import type { FilePath, TasksFile } from './TasksFile';
 
 /**
  * This interface is part of the implementation of placeholders and scripting.
@@ -34,8 +34,7 @@ export function makeQueryContext(path: FilePath): QueryContext {
     return makeQueryContextWithTasks(path, []);
 }
 
-export function makeQueryContextWithTasks(path: FilePath, allTasks: Readonly<Task[]>): QueryContext {
-    const tasksFile = new TasksFile(path);
+export function makeQueryContextWithTasks(tasksFile: FilePath, allTasks: Readonly<Task[]>): QueryContext {
     return {
         query: {
             file: tasksFile,

--- a/src/Scripting/QueryContext.ts
+++ b/src/Scripting/QueryContext.ts
@@ -25,13 +25,13 @@ export interface QueryContext {
 
 /**
  * Create a {@link QueryContext} to represent a query in note at the give path.
- * @param path
+ * @param tasksFile
  *
  * @see SearchInfo.queryContext
  * @see makeQueryContextWithTasks
  */
-export function makeQueryContext(path: TasksFile): QueryContext {
-    return makeQueryContextWithTasks(path, []);
+export function makeQueryContext(tasksFile: TasksFile): QueryContext {
+    return makeQueryContextWithTasks(tasksFile, []);
 }
 
 export function makeQueryContextWithTasks(tasksFile: TasksFile, allTasks: Readonly<Task[]>): QueryContext {

--- a/src/Scripting/QueryContext.ts
+++ b/src/Scripting/QueryContext.ts
@@ -1,5 +1,5 @@
 import type { Task } from '../Task/Task';
-import { TasksFile } from './TasksFile';
+import { type FilePath, TasksFile } from './TasksFile';
 
 /**
  * This interface is part of the implementation of placeholders and scripting.
@@ -30,11 +30,11 @@ export interface QueryContext {
  * @see SearchInfo.queryContext
  * @see makeQueryContextWithTasks
  */
-export function makeQueryContext(path: string): QueryContext {
+export function makeQueryContext(path: FilePath): QueryContext {
     return makeQueryContextWithTasks(path, []);
 }
 
-export function makeQueryContextWithTasks(path: string, allTasks: Readonly<Task[]>): QueryContext {
+export function makeQueryContextWithTasks(path: FilePath, allTasks: Readonly<Task[]>): QueryContext {
     const tasksFile = new TasksFile(path);
     return {
         query: {

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -1,9 +1,6 @@
 import { type CachedMetadata, type FrontMatterCache, getAllTags, parseFrontMatterTags } from 'obsidian';
 
-/** Potentially temporary alias, from preparing to migrate more path storage to use {@link TasksFile} instead */
-export type FilePath = TasksFile;
-
-export type OptionalFilePath = FilePath | undefined;
+export type OptionalFilePath = TasksFile | undefined;
 
 /**
  * A simple class to provide access to file information via 'task.file' in scripting code.

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -1,5 +1,10 @@
 import { type CachedMetadata, type FrontMatterCache, getAllTags, parseFrontMatterTags } from 'obsidian';
 
+/** Potentially temporary alias, preparing to migrate more path storage to use {@link TasksFile} instead */
+export type FilePath = string;
+
+export type OptionalFilePath = string | undefined;
+
 /**
  * A simple class to provide access to file information via 'task.file' in scripting code.
  */

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -3,7 +3,7 @@ import { type CachedMetadata, type FrontMatterCache, getAllTags, parseFrontMatte
 /** Potentially temporary alias, preparing to migrate more path storage to use {@link TasksFile} instead */
 export type FilePath = string;
 
-export type OptionalFilePath = string | undefined;
+export type OptionalFilePath = FilePath | undefined;
 
 /**
  * A simple class to provide access to file information via 'task.file' in scripting code.

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -1,7 +1,7 @@
 import { type CachedMetadata, type FrontMatterCache, getAllTags, parseFrontMatterTags } from 'obsidian';
 
-/** Potentially temporary alias, preparing to migrate more path storage to use {@link TasksFile} instead */
-export type FilePath = string;
+/** Potentially temporary alias, from preparing to migrate more path storage to use {@link TasksFile} instead */
+export type FilePath = TasksFile;
 
 export type OptionalFilePath = FilePath | undefined;
 

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -1,6 +1,6 @@
 import { type CachedMetadata, type FrontMatterCache, getAllTags, parseFrontMatterTags } from 'obsidian';
 
-export type OptionalFilePath = TasksFile | undefined;
+export type OptionalTasksFile = TasksFile | undefined;
 
 /**
  * A simple class to provide access to file information via 'task.file' in scripting code.

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -2,6 +2,7 @@ import type { GlobalFilter } from '../Config/GlobalFilter';
 import type { GlobalQuery } from '../Config/GlobalQuery';
 import { Query } from '../Query/Query';
 import { Explainer } from '../Query/Explain/Explainer';
+import type { OptionalFilePath } from '../Scripting/TasksFile';
 
 /**
  * @summary
@@ -22,14 +23,14 @@ import { Explainer } from '../Query/Explain/Explainer';
  * @param {string} source The source of the task block to explain
  * @param {GlobalFilter} globalFilter The global filter. In `src/`, generally pass in {@link GlobalFilter.getInstance}
  * @param {GlobalQuery} globalQuery The global query. In `src/`, generally pass in {@link GlobalQuery.getInstance}
- * @param {string} path The location of the task block, if known
+ * @param {OptionalFilePath} path The location of the task block, if known
  * @returns {string}
  */
 export function explainResults(
     source: string,
     globalFilter: GlobalFilter,
     globalQuery: GlobalQuery,
-    path: string | undefined = undefined,
+    path: OptionalFilePath = undefined,
 ): string {
     let result = '';
 
@@ -59,10 +60,10 @@ export function explainResults(
  *
  * @param {string} source The query source from the task block
  * @param globalQuery
- * @param {string | undefined} path The path to the file containing the query, if available.
+ * @param {OptionalFilePath} path The path to the file containing the query, if available.
  * @returns {Query} The query to execute
  */
-export function getQueryForQueryRenderer(source: string, globalQuery: GlobalQuery, path: string | undefined): Query {
+export function getQueryForQueryRenderer(source: string, globalQuery: GlobalQuery, path: OptionalFilePath): Query {
     const tasksBlockQuery = new Query(source, path);
 
     if (tasksBlockQuery.ignoreGlobalQuery) {

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -23,14 +23,14 @@ import type { OptionalTasksFile } from '../Scripting/TasksFile';
  * @param {string} source The source of the task block to explain
  * @param {GlobalFilter} globalFilter The global filter. In `src/`, generally pass in {@link GlobalFilter.getInstance}
  * @param {GlobalQuery} globalQuery The global query. In `src/`, generally pass in {@link GlobalQuery.getInstance}
- * @param {OptionalTasksFile} path The location of the task block, if known
+ * @param {OptionalTasksFile} tasksFile The location of the task block, if known
  * @returns {string}
  */
 export function explainResults(
     source: string,
     globalFilter: GlobalFilter,
     globalQuery: GlobalQuery,
-    path: OptionalTasksFile = undefined,
+    tasksFile: OptionalTasksFile = undefined,
 ): string {
     let result = '';
 
@@ -39,11 +39,11 @@ export function explainResults(
     }
 
     const explainer = new Explainer('  ');
-    const tasksBlockQuery = new Query(source, path);
+    const tasksBlockQuery = new Query(source, tasksFile);
 
     if (!tasksBlockQuery.ignoreGlobalQuery) {
         if (globalQuery.hasInstructions()) {
-            const globalQueryQuery = globalQuery.query(path);
+            const globalQueryQuery = globalQuery.query(tasksFile);
             result += `Explanation of the global query:\n\n${explainer.explainQuery(globalQueryQuery)}\n`;
         }
     }
@@ -60,15 +60,19 @@ export function explainResults(
  *
  * @param {string} source The query source from the task block
  * @param globalQuery
- * @param {OptionalTasksFile} path The path to the file containing the query, if available.
+ * @param {OptionalTasksFile} tasksFile The path to the file containing the query, if available.
  * @returns {Query} The query to execute
  */
-export function getQueryForQueryRenderer(source: string, globalQuery: GlobalQuery, path: OptionalTasksFile): Query {
-    const tasksBlockQuery = new Query(source, path);
+export function getQueryForQueryRenderer(
+    source: string,
+    globalQuery: GlobalQuery,
+    tasksFile: OptionalTasksFile,
+): Query {
+    const tasksBlockQuery = new Query(source, tasksFile);
 
     if (tasksBlockQuery.ignoreGlobalQuery) {
         return tasksBlockQuery;
     }
 
-    return globalQuery.query(path).append(tasksBlockQuery);
+    return globalQuery.query(tasksFile).append(tasksBlockQuery);
 }

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -2,7 +2,7 @@ import type { GlobalFilter } from '../Config/GlobalFilter';
 import type { GlobalQuery } from '../Config/GlobalQuery';
 import { Query } from '../Query/Query';
 import { Explainer } from '../Query/Explain/Explainer';
-import type { OptionalFilePath } from '../Scripting/TasksFile';
+import type { OptionalTasksFile } from '../Scripting/TasksFile';
 
 /**
  * @summary
@@ -23,14 +23,14 @@ import type { OptionalFilePath } from '../Scripting/TasksFile';
  * @param {string} source The source of the task block to explain
  * @param {GlobalFilter} globalFilter The global filter. In `src/`, generally pass in {@link GlobalFilter.getInstance}
  * @param {GlobalQuery} globalQuery The global query. In `src/`, generally pass in {@link GlobalQuery.getInstance}
- * @param {OptionalFilePath} path The location of the task block, if known
+ * @param {OptionalTasksFile} path The location of the task block, if known
  * @returns {string}
  */
 export function explainResults(
     source: string,
     globalFilter: GlobalFilter,
     globalQuery: GlobalQuery,
-    path: OptionalFilePath = undefined,
+    path: OptionalTasksFile = undefined,
 ): string {
     let result = '';
 
@@ -60,10 +60,10 @@ export function explainResults(
  *
  * @param {string} source The query source from the task block
  * @param globalQuery
- * @param {OptionalFilePath} path The path to the file containing the query, if available.
+ * @param {OptionalTasksFile} path The path to the file containing the query, if available.
  * @returns {Query} The query to execute
  */
-export function getQueryForQueryRenderer(source: string, globalQuery: GlobalQuery, path: OptionalFilePath): Query {
+export function getQueryForQueryRenderer(source: string, globalQuery: GlobalQuery, path: OptionalTasksFile): Query {
     const tasksBlockQuery = new Query(source, path);
 
     if (tasksBlockQuery.ignoreGlobalQuery) {

--- a/tests/CustomMatchers/CustomMatchersForSorting.ts
+++ b/tests/CustomMatchers/CustomMatchersForSorting.ts
@@ -4,6 +4,7 @@ import type { Sorter } from '../../src/Query/Sort/Sorter';
 import type { Task } from '../../src/Task/Task';
 import { compareByDate } from '../../src/lib/DateTools';
 import { SearchInfo } from '../../src/Query/SearchInfo';
+import { TasksFile } from '../../src/Scripting/TasksFile';
 
 declare global {
     namespace jest {
@@ -39,7 +40,7 @@ expect.extend({
         expect(tasks.length).toEqual(2);
         const taskA = tasks[0];
         const taskB = tasks[1];
-        const actual = sorting.comparator(taskA, taskB, new SearchInfo('dummy path.md', tasks));
+        const actual = sorting.comparator(taskA, taskB, new SearchInfo(new TasksFile('dummy path.md'), tasks));
 
         let pass;
         let expectedDesription: string;

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -9,6 +9,7 @@ import { Query } from '../../../src/Query/Query';
 import { Explainer } from '../../../src/Query/Explain/Explainer';
 import { resetSettings, updateSettings } from '../../../src/Config/Settings';
 import { DebugSettings } from '../../../src/Config/DebugSettings';
+import { TasksFile } from '../../../src/Scripting/TasksFile';
 
 window.moment = moment;
 
@@ -18,7 +19,7 @@ window.moment = moment;
  */
 function makeQueryFromContinuationLines(lines: string[]) {
     const source = lines.join('\\\n');
-    const query = new Query(source, 'sample.md');
+    const query = new Query(source, new TasksFile('sample.md'));
     expect(query.error).toBeUndefined();
     return query;
 }

--- a/tests/Query/Filter/BooleanField.test.ts
+++ b/tests/Query/Filter/BooleanField.test.ts
@@ -284,8 +284,8 @@ describe('boolean query - explain', () => {
 
     function explainFilters(indentationLevel: number, source: string) {
         const indentation = ' '.repeat(indentationLevel);
-        const path = new TasksFile('some/sample/note.md');
-        const query1 = new Query(source, path);
+        const tasksFile = new TasksFile('some/sample/note.md');
+        const query1 = new Query(source, tasksFile);
         return new Explainer(indentation).explainFilters(query1);
     }
 

--- a/tests/Query/Filter/BooleanField.test.ts
+++ b/tests/Query/Filter/BooleanField.test.ts
@@ -9,6 +9,7 @@ import { testFilter } from '../../TestingTools/FilterTestHelpers';
 import { Query } from '../../../src/Query/Query';
 import { Explainer } from '../../../src/Query/Explain/Explainer';
 import { BooleanPreprocessor } from '../../../src/Query/Filter/BooleanPreprocessor';
+import { TasksFile } from '../../../src/Scripting/TasksFile';
 import { verifyBooleanExpressionExplanation, verifyBooleanExpressionPreprocessing } from './BooleanFieldVerify';
 
 window.moment = moment;
@@ -283,7 +284,7 @@ describe('boolean query - explain', () => {
 
     function explainFilters(indentationLevel: number, source: string) {
         const indentation = ' '.repeat(indentationLevel);
-        const path = 'some/sample/note.md';
+        const path = new TasksFile('some/sample/note.md');
         const query1 = new Query(source, path);
         return new Explainer(indentation).explainFilters(query1);
     }

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -22,6 +22,7 @@ import { fromLine } from '../../TestingTools/TestHelpers';
 import { Query } from '../../../src/Query/Query';
 import { TasksDate } from '../../../src/Scripting/TasksDate';
 import { Priority } from '../../../src/Task/Priority';
+import { TasksFile } from '../../../src/Scripting/TasksFile';
 
 window.moment = moment;
 
@@ -59,9 +60,9 @@ describe('FunctionField - filtering', () => {
             'filter by function task.file.path === query.file.path',
         );
         expect(tasksInSameFileAsQuery).toBeValid();
-        const queryFilePath = '/a/b/query.md';
+        const queryFilePath = new TasksFile('/a/b/query.md');
 
-        const taskInQueryFile: Task = new TaskBuilder().path(queryFilePath).build();
+        const taskInQueryFile: Task = new TaskBuilder().path(queryFilePath.path).build();
         const taskNotInQueryFile: Task = new TaskBuilder().path('some other path.md').build();
         const searchInfo = new SearchInfo(queryFilePath, [taskInQueryFile, taskNotInQueryFile]);
 
@@ -617,6 +618,8 @@ describe('FunctionField - grouping - example functions', () => {
         const line = 'group by function query.file.filename';
         const grouper = createGrouper(line);
         const task = new TaskBuilder().build();
-        toGroupTaskUsingSearchInfo(grouper, task, new SearchInfo('queries/query file.md', [task]), ['query file.md']);
+        toGroupTaskUsingSearchInfo(grouper, task, new SearchInfo(new TasksFile('queries/query file.md'), [task]), [
+            'query file.md',
+        ]);
     });
 });

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -60,11 +60,11 @@ describe('FunctionField - filtering', () => {
             'filter by function task.file.path === query.file.path',
         );
         expect(tasksInSameFileAsQuery).toBeValid();
-        const queryFilePath = new TasksFile('/a/b/query.md');
+        const queryTasksFile = new TasksFile('/a/b/query.md');
 
-        const taskInQueryFile: Task = new TaskBuilder().path(queryFilePath.path).build();
+        const taskInQueryFile: Task = new TaskBuilder().path(queryTasksFile.path).build();
         const taskNotInQueryFile: Task = new TaskBuilder().path('some other path.md').build();
-        const searchInfo = new SearchInfo(queryFilePath, [taskInQueryFile, taskNotInQueryFile]);
+        const searchInfo = new SearchInfo(queryTasksFile, [taskInQueryFile, taskNotInQueryFile]);
 
         expect(tasksInSameFileAsQuery.filterFunction!(taskInQueryFile, searchInfo)).toEqual(true);
         expect(tasksInSameFileAsQuery.filterFunction!(taskNotInQueryFile, searchInfo)).toEqual(false);

--- a/tests/Query/Group/TaskGroups.test.ts
+++ b/tests/Query/Group/TaskGroups.test.ts
@@ -104,7 +104,7 @@ describe('Grouping tasks', () => {
     it('should provide access to SearchInfo', () => {
         // Arrange
         const groupByQueryPath: GrouperFunction = (_task: Task, searchInfo: SearchInfo) => {
-            return [searchInfo.queryPath ? searchInfo.queryPath.path : 'No SearchInfo'];
+            return [searchInfo.tasksFile ? searchInfo.tasksFile.path : 'No SearchInfo'];
         };
         const grouper: Grouper = new Grouper('group by test', 'test', groupByQueryPath, false);
 

--- a/tests/Query/Group/TaskGroups.test.ts
+++ b/tests/Query/Group/TaskGroups.test.ts
@@ -15,6 +15,7 @@ import { DueDateField } from '../../../src/Query/Filter/DueDateField';
 import { SearchInfo } from '../../../src/Query/SearchInfo';
 import { fromLine } from '../../TestingTools/TestHelpers';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
+import { TasksFile } from '../../../src/Scripting/TasksFile';
 
 window.moment = moment;
 
@@ -103,11 +104,11 @@ describe('Grouping tasks', () => {
     it('should provide access to SearchInfo', () => {
         // Arrange
         const groupByQueryPath: GrouperFunction = (_task: Task, searchInfo: SearchInfo) => {
-            return [searchInfo.queryPath ? searchInfo.queryPath : 'No SearchInfo'];
+            return [searchInfo.queryPath ? searchInfo.queryPath.path : 'No SearchInfo'];
         };
         const grouper: Grouper = new Grouper('group by test', 'test', groupByQueryPath, false);
 
-        const filename = 'somewhere/anything.md';
+        const filename = new TasksFile('somewhere/anything.md');
         const tasks = [new TaskBuilder().build()];
         const searchInfo = new SearchInfo(filename, tasks);
 
@@ -116,7 +117,7 @@ describe('Grouping tasks', () => {
 
         // Assert
         expect(groups.groups.length).toEqual(1);
-        expect(groups.groups[0].groups).toEqual([filename]);
+        expect(groups.groups[0].groups).toEqual([filename.path]);
     });
 
     it('sorts group names correctly', () => {

--- a/tests/Query/Group/TaskGroups.test.ts
+++ b/tests/Query/Group/TaskGroups.test.ts
@@ -108,16 +108,16 @@ describe('Grouping tasks', () => {
         };
         const grouper: Grouper = new Grouper('group by test', 'test', groupByQueryPath, false);
 
-        const filename = new TasksFile('somewhere/anything.md');
+        const tasksFile = new TasksFile('somewhere/anything.md');
         const tasks = [new TaskBuilder().build()];
-        const searchInfo = new SearchInfo(filename, tasks);
+        const searchInfo = new SearchInfo(tasksFile, tasks);
 
         // Act
         const groups = new TaskGroups([grouper], tasks, searchInfo);
 
         // Assert
         expect(groups.groups.length).toEqual(1);
-        expect(groups.groups[0].groups).toEqual([filename.path]);
+        expect(groups.groups[0].groups).toEqual([tasksFile.path]);
     });
 
     it('sorts group names correctly', () => {

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -535,7 +535,7 @@ describe('Query parsing', () => {
 
     describe('should include instruction in parsing error messages', () => {
         function getQueryError(source: string) {
-            return new Query(source, 'Example Path.md').error;
+            return new Query(source, new TasksFile('Example Path.md')).error;
         }
 
         it('for invalid regular expression filter', () => {
@@ -682,7 +682,7 @@ Problem statement:
         it('should expand placeholder values in filters, but not source', () => {
             // Arrange
             const rawQuery = 'path includes {{query.file.path}}';
-            const path = 'a/b/path with space.md';
+            const path = new TasksFile('a/b/path with space.md');
 
             // Act
             const query = new Query(rawQuery, path);
@@ -714,7 +714,7 @@ Problem statement:
         it('should report error if non-existent placeholder used', () => {
             // Arrange
             const source = 'path includes {{query.file.noSuchProperty}}';
-            const path = 'a/b/path with space.md';
+            const path = new TasksFile('a/b/path with space.md');
 
             // Act
             const query = new Query(source, path);
@@ -1251,7 +1251,7 @@ describe('Query', () => {
 
         it('should pass the query path through to filter functions', () => {
             // Arrange
-            const queryPath = 'this/was/passed/in/correctly.md';
+            const queryPath = new TasksFile('this/was/passed/in/correctly.md');
             const query = new Query('', queryPath);
 
             const matchesIfSearchInfoHasCorrectPath = (_task: Task, searchInfo: SearchInfo) => {
@@ -1351,7 +1351,7 @@ describe('Query', () => {
             const source = 'group by function query.file.path';
             const sourceUpper = 'GROUP BY FUNCTION query.file.path';
 
-            const path = 'hello.md';
+            const path = new TasksFile('hello.md');
             const query = new Query(source, path);
             const queryUpper = new Query(sourceUpper, path);
 
@@ -1366,8 +1366,8 @@ describe('Query', () => {
             expect(groups.groups.length).toEqual(1);
             expect(groupsUpper.groups.length).toEqual(1);
 
-            expect(groups.groups[0].groups).toEqual([path]);
-            expect(groupsUpper.groups[0].groups).toEqual([path]);
+            expect(groups.groups[0].groups).toEqual([path.path]);
+            expect(groupsUpper.groups[0].groups).toEqual([path.path]);
         });
 
         it('should log meaningful error for supported group type', () => {
@@ -1534,7 +1534,7 @@ describe('Query', () => {
         it('should save the source correctly in a Statement object', () => {
             const source = String.raw`(path includes A) OR \
                 (path includes {{query.file.path}})`;
-            const query = new Query(source, 'Test.md');
+            const query = new Query(source, new TasksFile('Test.md'));
 
             expect(query.error).toBeUndefined();
             const filter = query.filters[0];

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -1264,7 +1264,7 @@ describe('Query', () => {
             const query = new Query('', queryPath);
 
             const matchesIfSearchInfoHasCorrectPath = (_task: Task, searchInfo: SearchInfo) => {
-                return searchInfo.queryPath === queryPath;
+                return searchInfo.tasksFile === queryPath;
             };
             query.addFilter(
                 new Filter('instruction', matchesIfSearchInfoHasCorrectPath, new Explanation('explanation')),

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -1227,6 +1227,15 @@ describe('Query', () => {
         });
     });
 
+    describe('query path and metadata', function () {
+        it('should provide access to the path of the query', () => {
+            const path = 'query location.md';
+            const query = new Query('not done', new TasksFile(path));
+
+            expect(query.filePath).toEqual(path);
+        });
+    });
+
     describe('SearchInfo', () => {
         it('should pass SearchInfo through to filter functions', () => {
             // Arrange

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -682,10 +682,10 @@ Problem statement:
         it('should expand placeholder values in filters, but not source', () => {
             // Arrange
             const rawQuery = 'path includes {{query.file.path}}';
-            const path = new TasksFile('a/b/path with space.md');
+            const tasksFile = new TasksFile('a/b/path with space.md');
 
             // Act
-            const query = new Query(rawQuery, path);
+            const query = new Query(rawQuery, tasksFile);
 
             // Assert
             expect(query.source).toEqual(rawQuery); // Interesting that query.source still has the placeholder text
@@ -714,10 +714,10 @@ Problem statement:
         it('should report error if non-existent placeholder used', () => {
             // Arrange
             const source = 'path includes {{query.file.noSuchProperty}}';
-            const path = new TasksFile('a/b/path with space.md');
+            const tasksFile = new TasksFile('a/b/path with space.md');
 
             // Act
-            const query = new Query(source, path);
+            const query = new Query(source, tasksFile);
 
             // Assert
             expect(query).not.toBeValid();
@@ -1265,11 +1265,11 @@ describe('Query', () => {
 
         it('should pass the query path through to filter functions', () => {
             // Arrange
-            const queryPath = new TasksFile('this/was/passed/in/correctly.md');
-            const query = new Query('', queryPath);
+            const queryTasksFile = new TasksFile('this/was/passed/in/correctly.md');
+            const query = new Query('', queryTasksFile);
 
             const matchesIfSearchInfoHasCorrectPath = (_task: Task, searchInfo: SearchInfo) => {
-                return searchInfo.tasksFile === queryPath;
+                return searchInfo.tasksFile === queryTasksFile;
             };
             query.addFilter(
                 new Filter('instruction', matchesIfSearchInfoHasCorrectPath, new Explanation('explanation')),
@@ -1365,9 +1365,9 @@ describe('Query', () => {
             const source = 'group by function query.file.path';
             const sourceUpper = 'GROUP BY FUNCTION query.file.path';
 
-            const path = new TasksFile('hello.md');
-            const query = new Query(source, path);
-            const queryUpper = new Query(sourceUpper, path);
+            const tasksFile = new TasksFile('hello.md');
+            const query = new Query(source, tasksFile);
+            const queryUpper = new Query(sourceUpper, tasksFile);
 
             // Act
             const results = query.applyQueryToTasks([new TaskBuilder().build()]);
@@ -1380,8 +1380,8 @@ describe('Query', () => {
             expect(groups.groups.length).toEqual(1);
             expect(groupsUpper.groups.length).toEqual(1);
 
-            expect(groups.groups[0].groups).toEqual([path.path]);
-            expect(groupsUpper.groups[0].groups).toEqual([path.path]);
+            expect(groups.groups[0].groups).toEqual([tasksFile.path]);
+            expect(groupsUpper.groups[0].groups).toEqual([tasksFile.path]);
         });
 
         it('should log meaningful error for supported group type', () => {

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -1234,6 +1234,11 @@ describe('Query', () => {
 
             expect(query.filePath).toEqual(path);
         });
+
+        it('should give filePath unknown if no path provided to query', () => {
+            const query = new Query('not done');
+            expect(query.filePath).toEqual(undefined);
+        });
     });
 
     describe('SearchInfo', () => {

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -1351,8 +1351,9 @@ describe('Query', () => {
             const source = 'group by function query.file.path';
             const sourceUpper = 'GROUP BY FUNCTION query.file.path';
 
-            const query = new Query(source, 'hello.md');
-            const queryUpper = new Query(sourceUpper, 'hello.md');
+            const path = 'hello.md';
+            const query = new Query(source, path);
+            const queryUpper = new Query(sourceUpper, path);
 
             // Act
             const results = query.applyQueryToTasks([new TaskBuilder().build()]);
@@ -1365,8 +1366,8 @@ describe('Query', () => {
             expect(groups.groups.length).toEqual(1);
             expect(groupsUpper.groups.length).toEqual(1);
 
-            expect(groups.groups[0].groups).toEqual(['hello.md']);
-            expect(groupsUpper.groups[0].groups).toEqual(['hello.md']);
+            expect(groups.groups[0].groups).toEqual([path]);
+            expect(groupsUpper.groups[0].groups).toEqual([path]);
         });
 
         it('should log meaningful error for supported group type', () => {

--- a/tests/Query/SearchInfo.test.ts
+++ b/tests/Query/SearchInfo.test.ts
@@ -25,10 +25,12 @@ describe('SearchInfo', () => {
     });
 
     it('should provide access to query search path', () => {
-        const path = new TasksFile('a/b/c.md');
-        const searchInfo = new SearchInfo(path, []);
+        const path = 'a/b/c.md';
+        const tasksFile = new TasksFile(path);
+        const searchInfo = new SearchInfo(tasksFile, []);
 
-        expect(searchInfo.tasksFile).toEqual(path);
+        expect(searchInfo.tasksFile).toEqual(tasksFile);
+        expect(searchInfo.tasksFile?.path).toEqual(path);
     });
 
     it('should create a QueryContext from a known path', () => {

--- a/tests/Query/SearchInfo.test.ts
+++ b/tests/Query/SearchInfo.test.ts
@@ -28,7 +28,7 @@ describe('SearchInfo', () => {
         const path = new TasksFile('a/b/c.md');
         const searchInfo = new SearchInfo(path, []);
 
-        expect(searchInfo.queryPath).toEqual(path);
+        expect(searchInfo.tasksFile).toEqual(path);
     });
 
     it('should create a QueryContext from a known path', () => {

--- a/tests/Query/SearchInfo.test.ts
+++ b/tests/Query/SearchInfo.test.ts
@@ -34,13 +34,13 @@ describe('SearchInfo', () => {
     });
 
     it('should create a QueryContext from a known path', () => {
-        const path = new TasksFile('a/b/c.md');
-        const searchInfo = new SearchInfo(path, []);
+        const tasksFile = new TasksFile('a/b/c.md');
+        const searchInfo = new SearchInfo(tasksFile, []);
 
         const queryContext = searchInfo.queryContext();
 
         expect(queryContext).not.toBeUndefined();
-        expect(queryContext!.query.file.path).toEqual(path.path);
+        expect(queryContext!.query.file.path).toEqual(tasksFile.path);
     });
 
     it('should not create a QueryContext from unknown path', () => {

--- a/tests/Query/SearchInfo.test.ts
+++ b/tests/Query/SearchInfo.test.ts
@@ -1,5 +1,6 @@
 import { SearchInfo } from '../../src/Query/SearchInfo';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { TasksFile } from '../../src/Scripting/TasksFile';
 
 describe('SearchInfo', () => {
     it('should not be able to modify SearchInfo.allTasks directly', () => {
@@ -24,20 +25,20 @@ describe('SearchInfo', () => {
     });
 
     it('should provide access to query search path', () => {
-        const path = 'a/b/c.md';
+        const path = new TasksFile('a/b/c.md');
         const searchInfo = new SearchInfo(path, []);
 
         expect(searchInfo.queryPath).toEqual(path);
     });
 
     it('should create a QueryContext from a known path', () => {
-        const path = 'a/b/c.md';
+        const path = new TasksFile('a/b/c.md');
         const searchInfo = new SearchInfo(path, []);
 
         const queryContext = searchInfo.queryContext();
 
         expect(queryContext).not.toBeUndefined();
-        expect(queryContext!.query.file.path).toEqual(path);
+        expect(queryContext!.query.file.path).toEqual(path.path);
     });
 
     it('should not create a QueryContext from unknown path', () => {

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -3,7 +3,7 @@ import { makeQueryContext } from '../../src/Scripting/QueryContext';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 
 describe('ExpandTemplate', () => {
-    const path = new TasksFile('a/b/path with space.md');
+    const tasksFile = new TasksFile('a/b/path with space.md');
 
     it('hard-coded call', () => {
         const view = {
@@ -19,7 +19,7 @@ describe('ExpandTemplate', () => {
         const rawString = `path includes {{query.file.path}}
 filename includes {{query.file.filename}}`;
 
-        const queryContext = makeQueryContext(path);
+        const queryContext = makeQueryContext(tasksFile);
         expect(expandPlaceholders(rawString, queryContext)).toMatchInlineSnapshot(`
             "path includes a/b/path with space.md
             filename includes path with space.md"
@@ -27,7 +27,7 @@ filename includes {{query.file.filename}}`;
     });
 
     it('should return the input string if no {{ in line', function () {
-        const queryContext = makeQueryContext(path);
+        const queryContext = makeQueryContext(tasksFile);
         const line = 'no braces here';
 
         const result = expandPlaceholders(line, queryContext);

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -1,8 +1,9 @@
 import { expandPlaceholders } from '../../src/Scripting/ExpandPlaceholders';
 import { makeQueryContext } from '../../src/Scripting/QueryContext';
+import { TasksFile } from '../../src/Scripting/TasksFile';
 
 describe('ExpandTemplate', () => {
-    const path = 'a/b/path with space.md';
+    const path = new TasksFile('a/b/path with space.md');
 
     it('hard-coded call', () => {
         const view = {
@@ -51,7 +52,7 @@ The problem is in:
     });
 
     it('should throw an error if unknown template nested field used', () => {
-        const queryContext = makeQueryContext('stuff.md');
+        const queryContext = makeQueryContext(new TasksFile('stuff.md'));
         const source = '{{ query.file.nonsense }}';
 
         expect(() => expandPlaceholders(source, queryContext)).toThrow(

--- a/tests/Scripting/Expression.test.ts
+++ b/tests/Scripting/Expression.test.ts
@@ -9,6 +9,7 @@ import { verifyMarkdownForDocs } from '../TestingTools/VerifyMarkdown';
 import { continueLinesFlattened } from '../../src/Query/Scanner';
 import { constructArguments, parseAndEvaluateExpression } from '../../src/Scripting/TaskExpression';
 import { makeQueryContext } from '../../src/Scripting/QueryContext';
+import { TasksFile } from '../../src/Scripting/TasksFile';
 import { formatToRepresentType } from './ScriptingTestHelpers';
 
 window.moment = moment;
@@ -54,7 +55,7 @@ describe('Expression', () => {
     });
 
     const task = TaskBuilder.createFullyPopulatedTask();
-    const queryContext = makeQueryContext('temp.md');
+    const queryContext = makeQueryContext(new TasksFile('temp.md'));
 
     describe('detect errors at parse stage', () => {
         it('should report meaningful error message for parentheses too few parentheses', () => {

--- a/tests/Scripting/QueryContext.test.ts
+++ b/tests/Scripting/QueryContext.test.ts
@@ -8,9 +8,9 @@ import { FunctionField } from '../../src/Query/Filter/FunctionField';
 import { SearchInfo } from '../../src/Query/SearchInfo';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 
-const path = new TasksFile('a/b/c.md');
-const task = new TaskBuilder().path(path.path).build();
-const queryContext = makeQueryContext(path);
+const tasksFile = new TasksFile('a/b/c.md');
+const task = new TaskBuilder().path(tasksFile.path).build();
+const queryContext = makeQueryContext(tasksFile);
 
 describe('QueryContext', () => {
     describe('values should all match their corresponding filters', () => {
@@ -47,7 +47,7 @@ describe('QueryContext', () => {
             const instruction = 'group by function query.allTasks.length';
             const grouper = new FunctionField().createGrouperFromLine(instruction);
             expect(grouper).not.toBeNull();
-            const searchInfo = new SearchInfo(path, [task]);
+            const searchInfo = new SearchInfo(tasksFile, [task]);
 
             // Act
             const group: string[] = grouper!.grouper(task, searchInfo);

--- a/tests/Scripting/QueryContext.test.ts
+++ b/tests/Scripting/QueryContext.test.ts
@@ -6,9 +6,10 @@ import { RootField } from '../../src/Query/Filter/RootField';
 import { makeQueryContext } from '../../src/Scripting/QueryContext';
 import { FunctionField } from '../../src/Query/Filter/FunctionField';
 import { SearchInfo } from '../../src/Query/SearchInfo';
+import { TasksFile } from '../../src/Scripting/TasksFile';
 
-const path = 'a/b/c.md';
-const task = new TaskBuilder().path(path).build();
+const path = new TasksFile('a/b/c.md');
+const task = new TaskBuilder().path(path.path).build();
 const queryContext = makeQueryContext(path);
 
 describe('QueryContext', () => {

--- a/tests/Scripting/QueryProperties.test.ts
+++ b/tests/Scripting/QueryProperties.test.ts
@@ -4,12 +4,13 @@ import { verifyMarkdownForDocs } from '../TestingTools/VerifyMarkdown';
 import { MarkdownTable } from '../../src/lib/MarkdownTable';
 import { parseAndEvaluateExpression } from '../../src/Scripting/TaskExpression';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { TasksFile } from '../../src/Scripting/TasksFile';
 import { addBackticks, determineExpressionType, formatToRepresentType } from './ScriptingTestHelpers';
 
 describe('query', () => {
     function verifyFieldDataForReferenceDocs(fields: string[]) {
         const markdownTable = new MarkdownTable(['Field', 'Type', 'Example']);
-        const path = 'root/sub-folder/file containing query.md';
+        const path = new TasksFile('root/sub-folder/file containing query.md');
         const task = new TaskBuilder()
             .description('... an array with all the Tasks-tracked tasks in the vault ...')
             .build();

--- a/tests/Scripting/QueryProperties.test.ts
+++ b/tests/Scripting/QueryProperties.test.ts
@@ -10,11 +10,11 @@ import { addBackticks, determineExpressionType, formatToRepresentType } from './
 describe('query', () => {
     function verifyFieldDataForReferenceDocs(fields: string[]) {
         const markdownTable = new MarkdownTable(['Field', 'Type', 'Example']);
-        const path = new TasksFile('root/sub-folder/file containing query.md');
+        const tasksFile = new TasksFile('root/sub-folder/file containing query.md');
         const task = new TaskBuilder()
             .description('... an array with all the Tasks-tracked tasks in the vault ...')
             .build();
-        const queryContext = makeQueryContextWithTasks(path, [task]);
+        const queryContext = makeQueryContextWithTasks(tasksFile, [task]);
         for (const field of fields) {
             const value1 = parseAndEvaluateExpression(task, field, queryContext);
             const cells = [

--- a/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
+++ b/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
@@ -9,6 +9,7 @@ import { scan } from '../../../src/Query/Scanner';
 import { SearchInfo } from '../../../src/Query/SearchInfo';
 import { Sort } from '../../../src/Query/Sort/Sort';
 import { toLines } from '../../TestingTools/TestHelpers';
+import type { FilePath } from '../../../src/Scripting/TasksFile';
 
 /** For example, 'task.due' */
 type TaskPropertyName = string;
@@ -19,7 +20,7 @@ export type CustomPropertyDocsTestData = [TaskPropertyName, QueryInstructionLine
 // Helper functions
 // -----------------------------------------------------------------------------------------------------------------
 
-function preprocessSingleInstruction(instruction: string, path: string) {
+function preprocessSingleInstruction(instruction: string, path: FilePath) {
     const instructions = scan(instruction);
     expect(instructions.length).toEqual(1);
     return expandPlaceholders(instructions[0], makeQueryContext(path));

--- a/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
+++ b/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
@@ -9,7 +9,7 @@ import { scan } from '../../../src/Query/Scanner';
 import { SearchInfo } from '../../../src/Query/SearchInfo';
 import { Sort } from '../../../src/Query/Sort/Sort';
 import { toLines } from '../../TestingTools/TestHelpers';
-import { type FilePath, TasksFile } from '../../../src/Scripting/TasksFile';
+import { TasksFile } from '../../../src/Scripting/TasksFile';
 
 /** For example, 'task.due' */
 type TaskPropertyName = string;
@@ -20,7 +20,7 @@ export type CustomPropertyDocsTestData = [TaskPropertyName, QueryInstructionLine
 // Helper functions
 // -----------------------------------------------------------------------------------------------------------------
 
-function preprocessSingleInstruction(instruction: string, path: FilePath) {
+function preprocessSingleInstruction(instruction: string, path: TasksFile) {
     const instructions = scan(instruction);
     expect(instructions.length).toEqual(1);
     return expandPlaceholders(instructions[0], makeQueryContext(path));

--- a/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
+++ b/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
@@ -9,7 +9,7 @@ import { scan } from '../../../src/Query/Scanner';
 import { SearchInfo } from '../../../src/Query/SearchInfo';
 import { Sort } from '../../../src/Query/Sort/Sort';
 import { toLines } from '../../TestingTools/TestHelpers';
-import type { FilePath } from '../../../src/Scripting/TasksFile';
+import { type FilePath, TasksFile } from '../../../src/Scripting/TasksFile';
 
 /** For example, 'task.due' */
 type TaskPropertyName = string;
@@ -88,7 +88,7 @@ export function verifyFunctionFieldFilterSamplesOnTasks(filters: QueryInstructio
         const instruction = filter[0];
         const comment = filter.slice(1);
 
-        const path = 'a/b.md';
+        const path = new TasksFile('a/b.md');
         const expandedInstruction = preprocessSingleInstruction(instruction, path);
         const filterOrErrorMessage = new FunctionField().createFilterOrErrorMessage(expandedInstruction);
         expect(filterOrErrorMessage).toBeValid();
@@ -126,7 +126,7 @@ export function verifyFunctionFieldSortSamplesOnTasks(
         const instruction = filter[0];
         const comment = filter.slice(1);
 
-        const path = 'a/b.md';
+        const path = new TasksFile('a/b.md');
         const expandedInstruction = preprocessSingleInstruction(instruction, path);
         const sorter = new FunctionField().createSorterFromLine(expandedInstruction);
         expect(sorter).not.toBeNull();
@@ -158,7 +158,7 @@ export function verifyFunctionFieldGrouperSamplesOnTasks(
         const instruction = group[0];
         const comment = group.slice(1);
 
-        const path = 'a/b.md';
+        const path = new TasksFile('a/b.md');
         const expandedInstruction = preprocessSingleInstruction(instruction, path);
         const grouper = new FunctionField().createGrouperFromLine(expandedInstruction);
         expect(grouper).not.toBeNull();

--- a/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
+++ b/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
@@ -20,10 +20,10 @@ export type CustomPropertyDocsTestData = [TaskPropertyName, QueryInstructionLine
 // Helper functions
 // -----------------------------------------------------------------------------------------------------------------
 
-function preprocessSingleInstruction(instruction: string, path: TasksFile) {
+function preprocessSingleInstruction(instruction: string, tasksFile: TasksFile) {
     const instructions = scan(instruction);
     expect(instructions.length).toEqual(1);
-    return expandPlaceholders(instructions[0], makeQueryContext(path));
+    return expandPlaceholders(instructions[0], makeQueryContext(tasksFile));
 }
 
 function punctuateComments(comments: string[]) {
@@ -88,14 +88,14 @@ export function verifyFunctionFieldFilterSamplesOnTasks(filters: QueryInstructio
         const instruction = filter[0];
         const comment = filter.slice(1);
 
-        const path = new TasksFile('a/b.md');
-        const expandedInstruction = preprocessSingleInstruction(instruction, path);
+        const tasksFile = new TasksFile('a/b.md');
+        const expandedInstruction = preprocessSingleInstruction(instruction, tasksFile);
         const filterOrErrorMessage = new FunctionField().createFilterOrErrorMessage(expandedInstruction);
         expect(filterOrErrorMessage).toBeValid();
 
         const filterFunction = filterOrErrorMessage.filterFunction!;
         const matchingTasks: string[] = [];
-        const searchInfo = new SearchInfo(path, tasks);
+        const searchInfo = new SearchInfo(tasksFile, tasks);
         for (const task of tasks) {
             const matches = filterFunction(task, searchInfo);
             if (matches) {
@@ -126,12 +126,12 @@ export function verifyFunctionFieldSortSamplesOnTasks(
         const instruction = filter[0];
         const comment = filter.slice(1);
 
-        const path = new TasksFile('a/b.md');
-        const expandedInstruction = preprocessSingleInstruction(instruction, path);
+        const tasksFile = new TasksFile('a/b.md');
+        const expandedInstruction = preprocessSingleInstruction(instruction, tasksFile);
         const sorter = new FunctionField().createSorterFromLine(expandedInstruction);
         expect(sorter).not.toBeNull();
 
-        const tasksSorted = Sort.by([sorter!], tasks, new SearchInfo(path, tasks));
+        const tasksSorted = Sort.by([sorter!], tasks, new SearchInfo(tasksFile, tasks));
         return formatQueryAndResultsForApproving(instruction, comment, toLines(tasksSorted));
     });
 }
@@ -158,12 +158,12 @@ export function verifyFunctionFieldGrouperSamplesOnTasks(
         const instruction = group[0];
         const comment = group.slice(1);
 
-        const path = new TasksFile('a/b.md');
-        const expandedInstruction = preprocessSingleInstruction(instruction, path);
+        const tasksFile = new TasksFile('a/b.md');
+        const expandedInstruction = preprocessSingleInstruction(instruction, tasksFile);
         const grouper = new FunctionField().createGrouperFromLine(expandedInstruction);
         expect(grouper).not.toBeNull();
 
-        const headings = groupHeadingsForTask(grouper!, tasks, new SearchInfo(path, tasks));
+        const headings = groupHeadingsForTask(grouper!, tasks, new SearchInfo(tasksFile, tasks));
         return formatQueryAndResultsForApproving(instruction, comment, headings);
     });
 }

--- a/tests/Scripting/TaskExpression.test.ts
+++ b/tests/Scripting/TaskExpression.test.ts
@@ -1,17 +1,18 @@
 import { TaskExpression, constructArguments, parseAndEvaluateExpression } from '../../src/Scripting/TaskExpression';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { makeQueryContext } from '../../src/Scripting/QueryContext';
+import { TasksFile } from '../../src/Scripting/TasksFile';
 
 describe('TaskExpression', () => {
     describe('low level functions', () => {
         it('should allow passing QueryContext or null to constructArguments()', () => {
             const task = new TaskBuilder().build();
             constructArguments(task, null);
-            constructArguments(task, makeQueryContext('dummy.md'));
+            constructArguments(task, makeQueryContext(new TasksFile('dummy.md')));
         });
 
         it('should calculate an expression value from a QueryContext', () => {
-            const queryContext = makeQueryContext('test.md');
+            const queryContext = makeQueryContext(new TasksFile('test.md'));
             const task = new TaskBuilder().build();
             const result = parseAndEvaluateExpression(task, 'query.file.path', queryContext);
             expect(result).toEqual('test.md');
@@ -69,7 +70,7 @@ describe('TaskExpression', () => {
     });
 
     describe('evaluating', () => {
-        const queryContext = makeQueryContext('dummy.md');
+        const queryContext = makeQueryContext(new TasksFile('dummy.md'));
         it('should evaluate a valid task property and give correct result', () => {
             // Arrange
             const taskExpression = new TaskExpression('task.description');

--- a/tests/Scripting/TaskProperties.test.ts
+++ b/tests/Scripting/TaskProperties.test.ts
@@ -10,6 +10,7 @@ import { verifyMarkdownForDocs } from '../TestingTools/VerifyMarkdown';
 import { parseAndEvaluateExpression } from '../../src/Scripting/TaskExpression';
 import { MarkdownTable } from '../../src/lib/MarkdownTable';
 import { makeQueryContextWithTasks } from '../../src/Scripting/QueryContext';
+import { TasksFile } from '../../src/Scripting/TasksFile';
 import { addBackticks, determineExpressionType, formatToRepresentType } from './ScriptingTestHelpers';
 
 window.moment = moment;
@@ -21,7 +22,7 @@ describe('task', () => {
         const markdownTable = new MarkdownTable(['Field', 'Type 1', 'Example 1', 'Type 2', 'Example 2']);
         const task1 = TaskBuilder.createFullyPopulatedTask();
         const task2 = new TaskBuilder().description('minimal task').status(Status.makeInProgress()).build();
-        const queryContext = makeQueryContextWithTasks(task1.path, [task1, task2]);
+        const queryContext = makeQueryContextWithTasks(new TasksFile(task1.path), [task1, task2]);
         for (const field of fields) {
             const value1 = parseAndEvaluateExpression(task1, field, queryContext);
             const value2 = parseAndEvaluateExpression(task2, field, queryContext);

--- a/tests/TestingTools/ApprovalTestHelpers.ts
+++ b/tests/TestingTools/ApprovalTestHelpers.ts
@@ -5,6 +5,7 @@ import type { GlobalQuery } from '../../src/Config/GlobalQuery';
 import { Query } from '../../src/Query/Query';
 import { explainResults } from '../../src/lib/QueryRendererHelper';
 import type { Task } from '../../src/Task/Task';
+import { TasksFile } from '../../src/Scripting/TasksFile';
 import { verifyMarkdown } from './VerifyMarkdown';
 
 export function printIteration<T1>(func: <T1>(t1: T1) => any, params1: T1[]): string {
@@ -93,7 +94,12 @@ export function verifyTaskBlockExplanation(
     globalQuery: GlobalQuery,
     options?: Options,
 ): void {
-    const explanation = explainResults(instructions, globalFilter, globalQuery, 'some/sample/file path.md');
+    const explanation = explainResults(
+        instructions,
+        globalFilter,
+        globalQuery,
+        new TasksFile('some/sample/file path.md'),
+    );
 
     verifyWithFileExtension(explanation, 'explanation.text', options);
 }

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -128,31 +128,31 @@ describe('query used for QueryRenderer', () => {
         // Arrange
         const querySource = 'description includes world';
         const globalQuerySource = 'description includes hello';
-        const filePath = new TasksFile('a/b/c.md');
+        const tasksFile = new TasksFile('a/b/c.md');
 
         // Act
         const globalQuery = new GlobalQuery(globalQuerySource);
-        const query = getQueryForQueryRenderer(querySource, globalQuery, filePath);
+        const query = getQueryForQueryRenderer(querySource, globalQuery, tasksFile);
 
         // Assert
         expect(query.source).toEqual(`${globalQuerySource}\n${querySource}`);
-        expect(query.tasksFile).toEqual(filePath);
+        expect(query.tasksFile).toEqual(tasksFile);
     });
 
     it('should ignore the global query if "ignore global query" is set', () => {
         // Arrange
         const globalQuery = new GlobalQuery('path includes from_global_query');
-        const filePath = new TasksFile('a/b/c.md');
+        const tasksFile = new TasksFile('a/b/c.md');
 
         // Act
         const query = getQueryForQueryRenderer(
             'description includes from_block_query\nignore global query',
             globalQuery,
-            filePath,
+            tasksFile,
         );
 
         // Assert
         expect(query.source).toEqual('description includes from_block_query\nignore global query');
-        expect(query.tasksFile).toEqual(filePath);
+        expect(query.tasksFile).toEqual(tasksFile);
     });
 });

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -136,7 +136,7 @@ describe('query used for QueryRenderer', () => {
 
         // Assert
         expect(query.source).toEqual(`${globalQuerySource}\n${querySource}`);
-        expect(query.tasksFile).toEqual(tasksFile);
+        expect(query.tasksFile).toBe(tasksFile);
     });
 
     it('should ignore the global query if "ignore global query" is set', () => {
@@ -153,6 +153,6 @@ describe('query used for QueryRenderer', () => {
 
         // Assert
         expect(query.source).toEqual('description includes from_block_query\nignore global query');
-        expect(query.tasksFile).toEqual(tasksFile);
+        expect(query.tasksFile).toBe(tasksFile);
     });
 });

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -6,6 +6,7 @@ import { Query } from '../../src/Query/Query';
 import { explainResults, getQueryForQueryRenderer } from '../../src/lib/QueryRendererHelper';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { GlobalQuery } from '../../src/Config/GlobalQuery';
+import { TasksFile } from '../../src/Scripting/TasksFile';
 
 window.moment = moment;
 
@@ -127,7 +128,7 @@ describe('query used for QueryRenderer', () => {
         // Arrange
         const querySource = 'description includes world';
         const globalQuerySource = 'description includes hello';
-        const filePath = 'a/b/c.md';
+        const filePath = new TasksFile('a/b/c.md');
 
         // Act
         const globalQuery = new GlobalQuery(globalQuerySource);
@@ -141,7 +142,7 @@ describe('query used for QueryRenderer', () => {
     it('should ignore the global query if "ignore global query" is set', () => {
         // Arrange
         const globalQuery = new GlobalQuery('path includes from_global_query');
-        const filePath = 'a/b/c.md';
+        const filePath = new TasksFile('a/b/c.md');
 
         // Act
         const query = getQueryForQueryRenderer(

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -136,7 +136,7 @@ describe('query used for QueryRenderer', () => {
 
         // Assert
         expect(query.source).toEqual(`${globalQuerySource}\n${querySource}`);
-        expect(query.filePath).toEqual(filePath);
+        expect(query.tasksFile).toEqual(filePath);
     });
 
     it('should ignore the global query if "ignore global query" is set', () => {
@@ -153,6 +153,6 @@ describe('query used for QueryRenderer', () => {
 
         // Assert
         expect(query.source).toEqual('description includes from_block_query\nignore global query');
-        expect(query.filePath).toEqual(filePath);
+        expect(query.tasksFile).toEqual(filePath);
     });
 });


### PR DESCRIPTION


# Types of changes



Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description


This is preparation for enabling `query.file` to access the frontmatter, for https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2480

It is the `Query` equivalent of:

- <https://github.com/obsidian-tasks-group/obsidian-tasks/pull/2752>

Details:

- The key commit is:
    - [refactor: - Use TasksPath instead of string, for file locations in Query and QueryRenderer](https://github.com/obsidian-tasks-group/obsidian-tasks/commit/ef2c47c0acc4d83081a02a83115791c0182656ed)

A summary of the final changes is:

1. Add a new type alias `OptionalTasksFile`

```ts
export type OptionalTasksFile = TasksFile | undefined;
```

2. Change many path `string` values to `TasksFile`:
    - `path: string`
        - becomes
    - `tasksFile: TasksFile`

3. Change `path: string | undefined` to `OptionalTasksFile`:
    - `path: string | undefined = undefined`
        - becomes
    - `tasksFile: OptionalTasksFile = undefined`



## Motivation and Context

More preparation for [Filter Tasks by Properties Frontmatter · Issue #2480 · obsidian-tasks-group/obsidian-tasks · GitHub](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2480).


## How has this been tested?



- Running the tests
- Doing some exploratory testing
- Checking the updated console output, to make sure there is no new `"[object Object]"` console output
    - turning on all Tasks [debug output](https://publish.obsidian.md/tasks-contributing/Debugging/Console+logging+facilities+in+Tasks) and [query timing](https://publish.obsidian.md/tasks-contributing/Debugging/Console+timing+facilities+in+Tasks),
    - running a build of the new code
    - exercising all areas of Tasks
    - searching the console output for `object` (case-insensitive)


## Checklist



- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms



- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
