### PR TITLE
test: Make a test spurious - will Sonar Cloud spot it?

### DIFF
--- a/tests/lib/DateAbbreviations.test.ts
+++ b/tests/lib/DateAbbreviations.test.ts
@@ -18,6 +18,6 @@ describe('DateAbbreviations', () => {
     });
 
     it('should not expand other words', () => {
-        expect(doAutocomplete('sunshine ')).toEqual('sunshine ');
+        expect(doAutocomplete('sunshine '));
     });
 });


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

Will the Sonar Cloud bot spot the dodgy test?