### PR TITLE
chore: Add Ilyas Landikov as co-author of Tasks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Martin Schenck and Clare Macrae
+Copyright (c) 2021 Clare Macrae, Ilyas Landikov and Martin Schenck
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -14,7 +14,7 @@ if you want to view the source visit the plugins github repository
 License obsidian-tasks:
 MIT License
 
-Copyright (c) 2021 Martin Schenck and Clare Macrae
+Copyright (c) 2021 Clare Macrae, Ilyas Landikov and Martin Schenck
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "minAppVersion": "1.1.1",
   "description": "Track tasks across your vault. Supports due dates, recurring tasks, done dates, sub-set of checklist items, and filtering.",
   "helpUrl": "https://publish.obsidian.md/tasks/",
-  "author": "Martin Schenck and Clare Macrae",
+  "author": "Clare Macrae and Ilyas Landikov (created by Martin Schenck)",
   "authorUrl": "https://github.com/obsidian-tasks-group",
   "fundingUrl": "https://github.com/sponsors/claremacrae",
   "isDesktopOnly": false

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "task-manager",
     "task-management"
   ],
-  "author": "Martin Schenck and Clare Macrae",
+  "author": "Clare Macrae and Ilyas Landikov (created by Martin Schenck)",
   "license": "MIT",
   "devDependencies": {
     "@codemirror/view": "^6.2.0",


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

Ilyas (@ilandikov) has been contributing a lot to Tasks for well over a year now.

This adds him as the second author, by agreement with @schemar, the original author.

It updates the Copyright names too.

See also:

- https://github.com/obsidianmd/obsidian-releases/pull/3914.

## Motivation and Context

See above.

## How has this been tested?

Untested.

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
