### PR TITLE
fix: Prevent task.frontmatter.tags being null if no frontmatter

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/How To/Access properties in frontmatter.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Access properties in frontmatter.md
@@ -14,5 +14,5 @@ group by function task.file.frontmatter.custom_number_prop ?? 'not set'
 
 ```tasks
 folder includes Test Data
-group by function task.file.frontmatter.tags ?? ''
+group by function task.file.frontmatter.tags
 ```

--- a/resources/sample_vaults/Tasks-Demo/How To/Access properties in frontmatter.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Access properties in frontmatter.md
@@ -1,8 +1,5 @@
 # Access properties in frontmatter
 
-> [!warning]
-> Tasks does not currently sanitise tags from frontmatter, such as adding a  `#` prefix.
->
 ## Accessing a custom property
 
 ```tasks

--- a/resources/sample_vaults/Tasks-Demo/How To/Find tasks in notes with particular tag.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Find tasks in notes with particular tag.md
@@ -36,7 +36,7 @@ Credit: jonlemon in [this Obsidian Forum thread](https://forum.obsidian.md/t/how
 #### Presence of tag - in frontmatter
 
 ```tasks
-filter by function task.file.frontmatter.tags?.includes('#examples') ?? false
+filter by function task.file.frontmatter.tags.includes('#examples')
 ```
 
 ### Tasks in files that have a Tag anywhere - in frontmatter or body

--- a/resources/sample_vaults/Tasks-Demo/How To/Find tasks in notes with particular tag.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Find tasks in notes with particular tag.md
@@ -54,3 +54,24 @@ filter by function ! task.file.tags.includes('#examples')
 
 limit 20
 ```
+
+#### Group by tags - in frontmatter or body
+
+```tasks
+group by function task.file.tags
+folder does not include Test Data
+
+limit groups 3
+limit 100
+```
+
+#### Group by tags - in frontmatter or body, ignoring the global filter
+
+```tasks
+# TODO Provide task.file.tagsWithoutGlobalFilter
+group by function task.file.tags.filter( (t) => t !== '#task' )
+folder does not include Test Data
+
+limit groups 3
+limit 100
+```

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -54,7 +54,10 @@ async function writeListOfAllTestFunctions(files) {
         functions += `        ${filename},\n`;
     }
 
-    let content = `${imports}
+    let content = `// DO NOT EDIT!
+// This file is machine-generated in the test vault, by convert_test_data_markdown_to_js.js.
+
+${imports}
 export function allCacheSampleData() {
     return [
 ${functions}    ];

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -31,8 +31,7 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
         return '';
     }
 
-    const outputFile = '__test_data__/' + filename + '.ts';
-    const testSourceFile = getOutputFilePath(outputFile);
+    const testSourceFile = getOutputFilePath('__test_data__/' + filename + '.ts');
 
     const options = { depth: null, compact: false };
     const dataAsJSSource = util.inspect(data, options);

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -65,10 +65,11 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
 async function writeListOfAllTestFunctions(files) {
     const basenames = files.map((file) => getBasename(file));
 
-    let imports = '';
+    const imports = basenames
+        .map((filename) => `import { ${filename} } from './__test_data__/${filename}';\n`)
+        .join('');
     let functions = '';
     for (const filename of basenames) {
-        imports += `import { ${filename} } from './__test_data__/${filename}';\n`;
         functions += `        ${filename},\n`;
     }
 

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -25,8 +25,9 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
         return '';
     }
 
+    const outputFile = '__test_data__/' + filename + '.ts';
     const rootOfVault = app.vault.adapter.getBasePath();
-    const testSourceFile = rootOfVault + '/../../../tests/Obsidian/' + '__test_data__/' + filename + '.ts';
+    const testSourceFile = rootOfVault + '/../../../tests/Obsidian/' + outputFile;
 
     const options = { depth: null, compact: false };
     const dataAsJSSource = util.inspect(data, options);

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -43,14 +43,12 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
     const filename = getBasename(filePath);
     if (filename.includes(' ')) {
         // The file name is used to create a TypeScript variable, so disallow spaces:
-        const message = `ERROR - spaces not allowed in filenames: "${filename}"`;
-        showNotice(message);
+        showNotice(`ERROR - spaces not allowed in filenames: "${filename}"`);
         return '';
     }
 
     if (!fileContents.endsWith('\n')) {
-        const message = `ERROR - missing newline character at end of: "${filename}"`;
-        showNotice(message);
+        showNotice(`ERROR - missing newline character at end of: "${filename}"`);
         return '';
     }
 
@@ -94,8 +92,7 @@ async function export_files(tp) {
 
     await writeListOfAllTestFunctions(markdownFiles);
 
-    const message = 'Success - now run "yarn lint:test-data" to format the generated files.';
-    showNotice(message);
+    showNotice('Success - now run "yarn lint:test-data" to format the generated files.');
     return '';
 }
 

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -3,8 +3,7 @@ const util = require('util');
 
 function getOutputFilePath(outputFile) {
     const rootOfVault = app.vault.adapter.getBasePath();
-    const testSourceFile = rootOfVault + '/../../../tests/Obsidian/' + outputFile;
-    return testSourceFile;
+    return rootOfVault + '/../../../tests/Obsidian/' + outputFile;
 }
 
 function writeFile(testSourceFile, content) {

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -63,11 +63,7 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
 }
 
 async function writeListOfAllTestFunctions(files) {
-    const basenames = [];
-    for (const file of files) {
-        const filename = getBasename(file);
-        basenames.push(filename);
-    }
+    const basenames = files.map((file) => getBasename(file));
 
     let imports = '';
     let functions = '';

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -51,8 +51,7 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
 async function writeListOfAllTestFunctions(files) {
     let imports = '';
     let functions = '';
-    for (let i = 0; i < files.length; i++) {
-        const file = files[i];
+    for (const file of files) {
         if (!file.endsWith('.md')) {
             continue;
         }
@@ -78,8 +77,7 @@ ${functions}    ];
 async function export_files(tp) {
     // Get all files from Test Data/ directory
     const { files } = await app.vault.adapter.list('Test Data/');
-    for (let i = 0; i < files.length; i++) {
-        const file = files[i];
+    for (const file of files) {
         if (!file.endsWith('.md')) {
             continue;
         }

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -63,10 +63,15 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
 }
 
 async function writeListOfAllTestFunctions(files) {
-    let imports = '';
-    let functions = '';
+    const basenames = [];
     for (const file of files) {
         const filename = getBasename(file);
+        basenames.push(filename);
+    }
+
+    let imports = '';
+    let functions = '';
+    for (const filename of basenames) {
         imports += `import { ${filename} } from './__test_data__/${filename}';\n`;
         functions += `        ${filename},\n`;
     }

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -1,9 +1,11 @@
 const fs = require('node:fs');
 const util = require('util');
 
+const vault = app.vault;
+
 async function getMarkdownFiles() {
     // Get all files from Test Data/ directory
-    const { files } = await app.vault.adapter.list('Test Data/');
+    const { files } = await vault.adapter.list('Test Data/');
     return files.filter((file) => file.endsWith('.md'));
 }
 
@@ -12,7 +14,7 @@ function getBasename(filePath) {
 }
 
 function getOutputFilePath(outputFile) {
-    const rootOfVault = app.vault.adapter.getBasePath();
+    const rootOfVault = vault.adapter.getBasePath();
     return rootOfVault + '/../../../tests/Obsidian/' + outputFile;
 }
 
@@ -31,9 +33,9 @@ function showNotice(message) {
 }
 
 async function convertMarkdownFileToTestFunction(filePath, tp) {
-    const tFile = app.vault.getAbstractFileByPath(filePath);
+    const tFile = vault.getAbstractFileByPath(filePath);
 
-    const fileContents = await app.vault.read(tFile);
+    const fileContents = await vault.read(tFile);
     const cachedMetadata = app.metadataCache.getFileCache(tFile);
     const obsidianApiVersion = tp.obsidian.apiVersion;
     const getAllTags = tp.obsidian.getAllTags(cachedMetadata);

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs');
 const util = require('util');
 
-async function getMarkdownFile() {
+async function getMarkdownFiles() {
     // Get all files from Test Data/ directory
     const markdownFiles = [];
     const { files } = await app.vault.adapter.list('Test Data/');
@@ -89,7 +89,7 @@ ${functions}    ];
 }
 
 async function export_files(tp) {
-    const markdownFiles = await getMarkdownFile();
+    const markdownFiles = await getMarkdownFiles();
 
     for (const file of markdownFiles) {
         await convertMarkdownFileToTestFunction(file, tp);

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -68,7 +68,7 @@ async function writeListOfAllTestFunctions(files) {
     const imports = basenames.map((filename) => `import { ${filename} } from './__test_data__/${filename}';`);
     const functions = basenames.map((filename) => `        ${filename},`);
 
-    let content = `// DO NOT EDIT!
+    const content = `// DO NOT EDIT!
 // This file is machine-generated in the test vault, by convert_test_data_markdown_to_js.js.
 
 ${imports.join('\n')}

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -76,11 +76,16 @@ ${functions}    ];
 
 async function export_files(tp) {
     // Get all files from Test Data/ directory
+    const markdownFiles = [];
     const { files } = await app.vault.adapter.list('Test Data/');
     for (const file of files) {
         if (!file.endsWith('.md')) {
             continue;
         }
+        markdownFiles.push(file);
+    }
+
+    for (const file of markdownFiles) {
         await convertMarkdownFileToTestFunction(file, tp);
     }
 

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -1,6 +1,12 @@
 const fs = require('node:fs');
 const util = require('util');
 
+function getOutputFilePath(outputFile) {
+    const rootOfVault = app.vault.adapter.getBasePath();
+    const testSourceFile = rootOfVault + '/../../../tests/Obsidian/' + outputFile;
+    return testSourceFile;
+}
+
 async function convertMarkdownFileToTestFunction(filePath, tp) {
     const tFile = app.vault.getAbstractFileByPath(filePath);
 
@@ -26,8 +32,7 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
     }
 
     const outputFile = '__test_data__/' + filename + '.ts';
-    const rootOfVault = app.vault.adapter.getBasePath();
-    const testSourceFile = rootOfVault + '/../../../tests/Obsidian/' + outputFile;
+    const testSourceFile = getOutputFilePath(outputFile);
 
     const options = { depth: null, compact: false };
     const dataAsJSSource = util.inspect(data, options);

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -52,9 +52,6 @@ async function writeListOfAllTestFunctions(files) {
     let imports = '';
     let functions = '';
     for (const file of files) {
-        if (!file.endsWith('.md')) {
-            continue;
-        }
         const filename = file.split('/')[1].replace('.md', '');
         imports += `import { ${filename} } from './__test_data__/${filename}';\n`;
         functions += `        ${filename},\n`;
@@ -89,7 +86,7 @@ async function export_files(tp) {
         await convertMarkdownFileToTestFunction(file, tp);
     }
 
-    await writeListOfAllTestFunctions(files);
+    await writeListOfAllTestFunctions(markdownFiles);
 
     const message = 'Success - now run "yarn lint:test-data" to format the generated files.';
     new Notice(message);

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -26,7 +26,7 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
     }
 
     const rootOfVault = app.vault.adapter.getBasePath();
-    const testSourceFile = rootOfVault + '/../../../tests/Obsidian/__test_data__/' + filename + '.ts';
+    const testSourceFile = rootOfVault + '/../../../tests/Obsidian/' + '__test_data__/' + filename + '.ts';
 
     const options = { depth: null, compact: false };
     const dataAsJSSource = util.inspect(data, options);

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -14,6 +14,10 @@ async function getMarkdownFile() {
     return markdownFiles;
 }
 
+function getBasename(filePath) {
+    return filePath.split('/')[1].replace('.md', '');
+}
+
 function getOutputFilePath(outputFile) {
     const rootOfVault = app.vault.adapter.getBasePath();
     return rootOfVault + '/../../../tests/Obsidian/' + outputFile;
@@ -39,7 +43,7 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
     const parseFrontMatterTags = tp.obsidian.parseFrontMatterTags(cachedMetadata.frontmatter);
     const data = { filePath, fileContents, cachedMetadata, obsidianApiVersion, getAllTags, parseFrontMatterTags };
 
-    const filename = filePath.split('/')[1].replace('.md', '');
+    const filename = getBasename(filePath);
     if (filename.includes(' ')) {
         // The file name is used to create a TypeScript variable, so disallow spaces:
         const message = `ERROR - spaces not allowed in filenames: "${filename}"`;
@@ -65,7 +69,7 @@ async function writeListOfAllTestFunctions(files) {
     let imports = '';
     let functions = '';
     for (const file of files) {
-        const filename = file.split('/')[1].replace('.md', '');
+        const filename = getBasename(file);
         imports += `import { ${filename} } from './__test_data__/${filename}';\n`;
         functions += `        ${filename},\n`;
     }

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -3,15 +3,8 @@ const util = require('util');
 
 async function getMarkdownFiles() {
     // Get all files from Test Data/ directory
-    const markdownFiles = [];
     const { files } = await app.vault.adapter.list('Test Data/');
-    for (const file of files) {
-        if (!file.endsWith('.md')) {
-            continue;
-        }
-        markdownFiles.push(file);
-    }
-    return markdownFiles;
+    return files.filter((file) => file.endsWith('.md'));
 }
 
 function getBasename(filePath) {

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -68,10 +68,7 @@ async function writeListOfAllTestFunctions(files) {
     const imports = basenames
         .map((filename) => `import { ${filename} } from './__test_data__/${filename}';\n`)
         .join('');
-    let functions = '';
-    for (const filename of basenames) {
-        functions += `        ${filename},\n`;
-    }
+    const functions = basenames.map((filename) => `        ${filename},\n`).join('');
 
     let content = `// DO NOT EDIT!
 // This file is machine-generated in the test vault, by convert_test_data_markdown_to_js.js.

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -65,18 +65,18 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
 async function writeListOfAllTestFunctions(files) {
     const basenames = files.map((file) => getBasename(file));
 
-    const imports = basenames
-        .map((filename) => `import { ${filename} } from './__test_data__/${filename}';\n`)
-        .join('');
-    const functions = basenames.map((filename) => `        ${filename},\n`).join('');
+    const imports = basenames.map((filename) => `import { ${filename} } from './__test_data__/${filename}';`);
+    const functions = basenames.map((filename) => `        ${filename},`);
 
     let content = `// DO NOT EDIT!
 // This file is machine-generated in the test vault, by convert_test_data_markdown_to_js.js.
 
-${imports}
+${imports.join('\n')}
+
 export function allCacheSampleData() {
     return [
-${functions}    ];
+${functions.join('\n')}
+    ];
 }
 `;
 

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -7,6 +7,16 @@ function getOutputFilePath(outputFile) {
     return testSourceFile;
 }
 
+function writeFile(testSourceFile, content) {
+    fs.writeFile(testSourceFile, content, (err) => {
+        if (err) {
+            console.error(err);
+        } else {
+            // file written successfully
+        }
+    });
+}
+
 async function convertMarkdownFileToTestFunction(filePath, tp) {
     const tFile = app.vault.getAbstractFileByPath(filePath);
 
@@ -36,14 +46,7 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
     const options = { depth: null, compact: false };
     const dataAsJSSource = util.inspect(data, options);
     const content = `export const ${filename} = ${dataAsJSSource};`;
-
-    fs.writeFile(testSourceFile, content, (err) => {
-        if (err) {
-            console.error(err);
-        } else {
-            // file written successfully
-        }
-    });
+    writeFile(testSourceFile, content);
 }
 
 async function writeListOfAllTestFunctions(files) {

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -26,6 +26,10 @@ function writeFile(testSourceFile, content) {
     });
 }
 
+function showNotice(message) {
+    new Notice(message);
+}
+
 async function convertMarkdownFileToTestFunction(filePath, tp) {
     const tFile = app.vault.getAbstractFileByPath(filePath);
 
@@ -40,13 +44,13 @@ async function convertMarkdownFileToTestFunction(filePath, tp) {
     if (filename.includes(' ')) {
         // The file name is used to create a TypeScript variable, so disallow spaces:
         const message = `ERROR - spaces not allowed in filenames: "${filename}"`;
-        new Notice(message);
+        showNotice(message);
         return '';
     }
 
     if (!fileContents.endsWith('\n')) {
         const message = `ERROR - missing newline character at end of: "${filename}"`;
-        new Notice(message);
+        showNotice(message);
         return '';
     }
 
@@ -91,7 +95,7 @@ async function export_files(tp) {
     await writeListOfAllTestFunctions(markdownFiles);
 
     const message = 'Success - now run "yarn lint:test-data" to format the generated files.';
-    new Notice(message);
+    showNotice(message);
     return '';
 }
 

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -73,13 +73,7 @@ ${functions}    ];
 `;
 
     const testSourceFile = getOutputFilePath('AllCacheSampleData.ts');
-    fs.writeFile(testSourceFile, content, (err) => {
-        if (err) {
-            console.error(err);
-        } else {
-            // file written successfully
-        }
-    });
+    writeFile(testSourceFile, content);
 }
 
 async function export_files(tp) {

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -1,6 +1,19 @@
 const fs = require('node:fs');
 const util = require('util');
 
+async function getMarkdownFile() {
+    // Get all files from Test Data/ directory
+    const markdownFiles = [];
+    const { files } = await app.vault.adapter.list('Test Data/');
+    for (const file of files) {
+        if (!file.endsWith('.md')) {
+            continue;
+        }
+        markdownFiles.push(file);
+    }
+    return markdownFiles;
+}
+
 function getOutputFilePath(outputFile) {
     const rootOfVault = app.vault.adapter.getBasePath();
     return rootOfVault + '/../../../tests/Obsidian/' + outputFile;
@@ -72,15 +85,7 @@ ${functions}    ];
 }
 
 async function export_files(tp) {
-    // Get all files from Test Data/ directory
-    const markdownFiles = [];
-    const { files } = await app.vault.adapter.list('Test Data/');
-    for (const file of files) {
-        if (!file.endsWith('.md')) {
-            continue;
-        }
-        markdownFiles.push(file);
-    }
+    const markdownFiles = await getMarkdownFile();
 
     for (const file of markdownFiles) {
         await convertMarkdownFileToTestFunction(file, tp);

--- a/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
+++ b/resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js
@@ -69,8 +69,7 @@ ${functions}    ];
 }
 `;
 
-    const rootOfVault = app.vault.adapter.getBasePath();
-    const testSourceFile = rootOfVault + '/../../../tests/Obsidian/AllCacheSampleData.ts';
+    const testSourceFile = getOutputFilePath('AllCacheSampleData.ts');
     fs.writeFile(testSourceFile, content, (err) => {
         if (err) {
             console.error(err);

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -18,6 +18,9 @@ export class TasksFile {
         if (rawFrontmatter !== undefined) {
             this._frontmatter = JSON.parse(JSON.stringify(rawFrontmatter));
             this._frontmatter.tags = parseFrontMatterTags(rawFrontmatter) ?? [];
+        } else {
+            // Always make TasksFile.frontmatter.tags exist and be empty, even if no frontmatter present.
+            this._frontmatter.tags = [];
         }
     }
 

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -8,7 +8,8 @@ export type OptionalTasksFile = TasksFile | undefined;
 export class TasksFile {
     private readonly _path: string;
     private readonly _cachedMetadata: CachedMetadata;
-    private readonly _frontmatter: FrontMatterCache = {} as FrontMatterCache;
+    // Always make TasksFile.frontmatter.tags exist and be empty, even if no frontmatter present:
+    private readonly _frontmatter = { tags: [] } as any;
 
     constructor(path: string, cachedMetadata: CachedMetadata = {}) {
         this._path = path;
@@ -18,9 +19,6 @@ export class TasksFile {
         if (rawFrontmatter !== undefined) {
             this._frontmatter = JSON.parse(JSON.stringify(rawFrontmatter));
             this._frontmatter.tags = parseFrontMatterTags(rawFrontmatter) ?? [];
-        } else {
-            // Always make TasksFile.frontmatter.tags exist and be empty, even if no frontmatter present.
-            this._frontmatter.tags = [];
         }
     }
 

--- a/tests/Obsidian/AllCacheSampleData.ts
+++ b/tests/Obsidian/AllCacheSampleData.ts
@@ -1,3 +1,6 @@
+// DO NOT EDIT!
+// This file is machine-generated in the test vault, by convert_test_data_markdown_to_js.js.
+
 import { blockquote } from './__test_data__/blockquote';
 import { callout } from './__test_data__/callout';
 import { callout_custom } from './__test_data__/callout_custom';

--- a/tests/Obsidian/AllCacheSampleData.ts
+++ b/tests/Obsidian/AllCacheSampleData.ts
@@ -1,0 +1,111 @@
+import { blockquote } from './__test_data__/blockquote';
+import { callout } from './__test_data__/callout';
+import { callout_custom } from './__test_data__/callout_custom';
+import { callout_labelled } from './__test_data__/callout_labelled';
+import { callouts_nested_issue_2890_labelled } from './__test_data__/callouts_nested_issue_2890_labelled';
+import { callouts_nested_issue_2890_unlabelled } from './__test_data__/callouts_nested_issue_2890_unlabelled';
+import { comments_html_style } from './__test_data__/comments_html_style';
+import { comments_markdown_style } from './__test_data__/comments_markdown_style';
+import { empty_yaml } from './__test_data__/empty_yaml';
+import { example_kanban } from './__test_data__/example_kanban';
+import { inheritance_1parent1child } from './__test_data__/inheritance_1parent1child';
+import { inheritance_1parent1child1newroot_after_header } from './__test_data__/inheritance_1parent1child1newroot_after_header';
+import { inheritance_1parent1child1sibling_emptystring } from './__test_data__/inheritance_1parent1child1sibling_emptystring';
+import { inheritance_1parent2children } from './__test_data__/inheritance_1parent2children';
+import { inheritance_1parent2children1grandchild } from './__test_data__/inheritance_1parent2children1grandchild';
+import { inheritance_1parent2children1sibling } from './__test_data__/inheritance_1parent2children1sibling';
+import { inheritance_1parent2children2grandchildren } from './__test_data__/inheritance_1parent2children2grandchildren';
+import { inheritance_1parent2children2grandchildren1sibling } from './__test_data__/inheritance_1parent2children2grandchildren1sibling';
+import { inheritance_1parent2children2grandchildren1sibling_start_with_heading } from './__test_data__/inheritance_1parent2children2grandchildren1sibling_start_with_heading';
+import { inheritance_2siblings } from './__test_data__/inheritance_2siblings';
+import { inheritance_listitem_task } from './__test_data__/inheritance_listitem_task';
+import { inheritance_listitem_task_siblings } from './__test_data__/inheritance_listitem_task_siblings';
+import { inheritance_task_2listitem_3task } from './__test_data__/inheritance_task_2listitem_3task';
+import { inheritance_task_listitem } from './__test_data__/inheritance_task_listitem';
+import { inheritance_task_listitem_mixed_grandchildren } from './__test_data__/inheritance_task_listitem_mixed_grandchildren';
+import { inheritance_task_listitem_task } from './__test_data__/inheritance_task_listitem_task';
+import { inheritance_task_mixed_children } from './__test_data__/inheritance_task_mixed_children';
+import { link_in_file_body } from './__test_data__/link_in_file_body';
+import { link_in_file_body_with_custom_display_text } from './__test_data__/link_in_file_body_with_custom_display_text';
+import { link_in_heading } from './__test_data__/link_in_heading';
+import { link_in_yaml } from './__test_data__/link_in_yaml';
+import { link_is_broken } from './__test_data__/link_is_broken';
+import { list_statuses } from './__test_data__/list_statuses';
+import { list_styles } from './__test_data__/list_styles';
+import { multi_line_task_and_list_item } from './__test_data__/multi_line_task_and_list_item';
+import { multiple_headings } from './__test_data__/multiple_headings';
+import { no_heading } from './__test_data__/no_heading';
+import { no_yaml } from './__test_data__/no_yaml';
+import { one_task } from './__test_data__/one_task';
+import { yaml_1_alias } from './__test_data__/yaml_1_alias';
+import { yaml_2_aliases } from './__test_data__/yaml_2_aliases';
+import { yaml_complex_example } from './__test_data__/yaml_complex_example';
+import { yaml_complex_example_standardised } from './__test_data__/yaml_complex_example_standardised';
+import { yaml_custom_number_property } from './__test_data__/yaml_custom_number_property';
+import { yaml_tags_field_added_by_obsidian_but_not_populated } from './__test_data__/yaml_tags_field_added_by_obsidian_but_not_populated';
+import { yaml_tags_had_value_then_was_emptied_by_obsidian } from './__test_data__/yaml_tags_had_value_then_was_emptied_by_obsidian';
+import { yaml_tags_has_multiple_values } from './__test_data__/yaml_tags_has_multiple_values';
+import { yaml_tags_is_empty } from './__test_data__/yaml_tags_is_empty';
+import { yaml_tags_is_empty_list } from './__test_data__/yaml_tags_is_empty_list';
+import { yaml_tags_with_one_value_on_new_line } from './__test_data__/yaml_tags_with_one_value_on_new_line';
+import { yaml_tags_with_one_value_on_single_line } from './__test_data__/yaml_tags_with_one_value_on_single_line';
+import { yaml_tags_with_two_values_on_one_line } from './__test_data__/yaml_tags_with_two_values_on_one_line';
+import { yaml_tags_with_two_values_on_two_lines } from './__test_data__/yaml_tags_with_two_values_on_two_lines';
+
+export function allCacheSampleData() {
+    return [
+        blockquote,
+        callout,
+        callout_custom,
+        callout_labelled,
+        callouts_nested_issue_2890_labelled,
+        callouts_nested_issue_2890_unlabelled,
+        comments_html_style,
+        comments_markdown_style,
+        empty_yaml,
+        example_kanban,
+        inheritance_1parent1child,
+        inheritance_1parent1child1newroot_after_header,
+        inheritance_1parent1child1sibling_emptystring,
+        inheritance_1parent2children,
+        inheritance_1parent2children1grandchild,
+        inheritance_1parent2children1sibling,
+        inheritance_1parent2children2grandchildren,
+        inheritance_1parent2children2grandchildren1sibling,
+        inheritance_1parent2children2grandchildren1sibling_start_with_heading,
+        inheritance_2siblings,
+        inheritance_listitem_task,
+        inheritance_listitem_task_siblings,
+        inheritance_task_2listitem_3task,
+        inheritance_task_listitem,
+        inheritance_task_listitem_mixed_grandchildren,
+        inheritance_task_listitem_task,
+        inheritance_task_mixed_children,
+        link_in_file_body,
+        link_in_file_body_with_custom_display_text,
+        link_in_heading,
+        link_in_yaml,
+        link_is_broken,
+        list_statuses,
+        list_styles,
+        multi_line_task_and_list_item,
+        multiple_headings,
+        no_heading,
+        no_yaml,
+        one_task,
+        yaml_1_alias,
+        yaml_2_aliases,
+        yaml_complex_example,
+        yaml_complex_example_standardised,
+        yaml_custom_number_property,
+        yaml_tags_field_added_by_obsidian_but_not_populated,
+        yaml_tags_had_value_then_was_emptied_by_obsidian,
+        yaml_tags_has_multiple_values,
+        yaml_tags_is_empty,
+        yaml_tags_is_empty_list,
+        yaml_tags_with_one_value_on_new_line,
+        yaml_tags_with_one_value_on_single_line,
+        yaml_tags_with_two_values_on_one_line,
+        yaml_tags_with_two_values_on_two_lines,
+    ];
+}

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -31,36 +31,7 @@ import { callout } from './__test_data__/callout';
 import { callout_labelled } from './__test_data__/callout_labelled';
 import { callout_custom } from './__test_data__/callout_custom';
 import { callouts_nested_issue_2890_unlabelled } from './__test_data__/callouts_nested_issue_2890_unlabelled';
-import { blockquote } from './__test_data__/blockquote';
-import { comments_html_style } from './__test_data__/comments_html_style';
-import { link_in_file_body } from './__test_data__/link_in_file_body';
-import { comments_markdown_style } from './__test_data__/comments_markdown_style';
-import { empty_yaml } from './__test_data__/empty_yaml';
-import { example_kanban } from './__test_data__/example_kanban';
-import { link_in_file_body_with_custom_display_text } from './__test_data__/link_in_file_body_with_custom_display_text';
-import { link_in_heading } from './__test_data__/link_in_heading';
-import { link_in_yaml } from './__test_data__/link_in_yaml';
-import { link_is_broken } from './__test_data__/link_is_broken';
-import { list_statuses } from './__test_data__/list_statuses';
-import { list_styles } from './__test_data__/list_styles';
-import { multi_line_task_and_list_item } from './__test_data__/multi_line_task_and_list_item';
-import { multiple_headings } from './__test_data__/multiple_headings';
-import { no_heading } from './__test_data__/no_heading';
-import { no_yaml } from './__test_data__/no_yaml';
-import { yaml_1_alias } from './__test_data__/yaml_1_alias';
-import { yaml_2_aliases } from './__test_data__/yaml_2_aliases';
-import { yaml_complex_example } from './__test_data__/yaml_complex_example';
-import { yaml_complex_example_standardised } from './__test_data__/yaml_complex_example_standardised';
-import { yaml_custom_number_property } from './__test_data__/yaml_custom_number_property';
-import { yaml_tags_field_added_by_obsidian_but_not_populated } from './__test_data__/yaml_tags_field_added_by_obsidian_but_not_populated';
-import { yaml_tags_had_value_then_was_emptied_by_obsidian } from './__test_data__/yaml_tags_had_value_then_was_emptied_by_obsidian';
-import { yaml_tags_has_multiple_values } from './__test_data__/yaml_tags_has_multiple_values';
-import { yaml_tags_is_empty } from './__test_data__/yaml_tags_is_empty';
-import { yaml_tags_is_empty_list } from './__test_data__/yaml_tags_is_empty_list';
-import { yaml_tags_with_one_value_on_new_line } from './__test_data__/yaml_tags_with_one_value_on_new_line';
-import { yaml_tags_with_one_value_on_single_line } from './__test_data__/yaml_tags_with_one_value_on_single_line';
-import { yaml_tags_with_two_values_on_one_line } from './__test_data__/yaml_tags_with_two_values_on_one_line';
-import { yaml_tags_with_two_values_on_two_lines } from './__test_data__/yaml_tags_with_two_values_on_two_lines';
+import { allCacheSampleData } from './AllCacheSampleData';
 
 window.moment = moment;
 
@@ -637,64 +608,6 @@ describe('cache', () => {
         expect(tasks.length).toEqual(4);
     });
 });
-
-function allCacheSampleData() {
-    return [
-        blockquote,
-        callout,
-        callout_custom,
-        callout_labelled,
-        callouts_nested_issue_2890_labelled,
-        callouts_nested_issue_2890_unlabelled,
-        comments_html_style,
-        comments_markdown_style,
-        empty_yaml,
-        example_kanban,
-        inheritance_1parent1child,
-        inheritance_1parent1child1newroot_after_header,
-        inheritance_1parent1child1sibling_emptystring,
-        inheritance_1parent2children,
-        inheritance_1parent2children1grandchild,
-        inheritance_1parent2children1sibling,
-        inheritance_1parent2children2grandchildren,
-        inheritance_1parent2children2grandchildren1sibling,
-        inheritance_1parent2children2grandchildren1sibling_start_with_heading,
-        inheritance_2siblings,
-        inheritance_listitem_task,
-        inheritance_listitem_task_siblings,
-        inheritance_task_2listitem_3task,
-        inheritance_task_listitem,
-        inheritance_task_listitem_mixed_grandchildren,
-        inheritance_task_listitem_task,
-        inheritance_task_mixed_children,
-        link_in_file_body,
-        link_in_file_body_with_custom_display_text,
-        link_in_heading,
-        link_in_yaml,
-        link_is_broken,
-        list_statuses,
-        list_styles,
-        multi_line_task_and_list_item,
-        multiple_headings,
-        no_heading,
-        no_yaml,
-        one_task,
-        yaml_1_alias,
-        yaml_2_aliases,
-        yaml_complex_example,
-        yaml_complex_example_standardised,
-        yaml_custom_number_property,
-        yaml_tags_field_added_by_obsidian_but_not_populated,
-        yaml_tags_had_value_then_was_emptied_by_obsidian,
-        yaml_tags_has_multiple_values,
-        yaml_tags_is_empty,
-        yaml_tags_is_empty_list,
-        yaml_tags_with_one_value_on_new_line,
-        yaml_tags_with_one_value_on_single_line,
-        yaml_tags_with_two_values_on_one_line,
-        yaml_tags_with_two_values_on_two_lines,
-    ];
-}
 
 describe('all mock files', () => {
     const files: any = allCacheSampleData();

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -620,6 +620,16 @@ describe('all mock files', () => {
             const frontmatter = tasksFile.frontmatter;
             expect(frontmatter).not.toBeUndefined();
             expect(frontmatter).not.toBeNull();
+
+            if (tasksFile.cachedMetadata.frontmatter === undefined) {
+                // No frontmatter in the file, so processed frontmatter will be empty object (so without a tags value)
+                expect(frontmatter).toEqual({});
+            } else {
+                expect(frontmatter.tags).not.toBeUndefined();
+                expect(frontmatter.tags).not.toBeNull();
+                expect(frontmatter.tags).not.toContain(null);
+                expect(frontmatter.tags).not.toContain(undefined);
+            }
         },
     );
 

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -78,6 +78,7 @@ interface SimulatedFile {
 
 function readTasksFromSimulatedFile(testData: SimulatedFile) {
     const logger = logging.getLogger('testCache');
+    setCurrentCacheFile(testData);
     return getTasksFromFileContent2(
         testData.filePath,
         testData.fileContents,
@@ -633,7 +634,6 @@ describe('all mock files', () => {
     it.each(listPathAndData(files))(
         'should be able to read tasks from all mock files: "%s"',
         (_path: string, file: any) => {
-            setCurrentCacheFile(file);
             const tasks = readTasksFromSimulatedFile(file);
             expect(tasks.length).toBeGreaterThan(0);
         },

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -6,6 +6,8 @@ import type { CachedMetadata } from 'obsidian';
 import { logging } from '../../src/lib/logging';
 import { getTasksFromFileContent2 } from '../../src/Obsidian/Cache';
 import type { ListItem } from '../../src/Task/ListItem';
+import { setCurrentCacheFile } from '../__mocks__/obsidian';
+import { getTasksFileFromMockData, listPathAndData } from '../TestingTools/MockDataHelpers';
 import { inheritance_1parent1child } from './__test_data__/inheritance_1parent1child';
 import { inheritance_1parent1child1newroot_after_header } from './__test_data__/inheritance_1parent1child1newroot_after_header';
 import { inheritance_1parent1child1sibling_emptystring } from './__test_data__/inheritance_1parent1child1sibling_emptystring';
@@ -29,6 +31,36 @@ import { callout } from './__test_data__/callout';
 import { callout_labelled } from './__test_data__/callout_labelled';
 import { callout_custom } from './__test_data__/callout_custom';
 import { callouts_nested_issue_2890_unlabelled } from './__test_data__/callouts_nested_issue_2890_unlabelled';
+import { blockquote } from './__test_data__/blockquote';
+import { comments_html_style } from './__test_data__/comments_html_style';
+import { link_in_file_body } from './__test_data__/link_in_file_body';
+import { comments_markdown_style } from './__test_data__/comments_markdown_style';
+import { empty_yaml } from './__test_data__/empty_yaml';
+import { example_kanban } from './__test_data__/example_kanban';
+import { link_in_file_body_with_custom_display_text } from './__test_data__/link_in_file_body_with_custom_display_text';
+import { link_in_heading } from './__test_data__/link_in_heading';
+import { link_in_yaml } from './__test_data__/link_in_yaml';
+import { link_is_broken } from './__test_data__/link_is_broken';
+import { list_statuses } from './__test_data__/list_statuses';
+import { list_styles } from './__test_data__/list_styles';
+import { multi_line_task_and_list_item } from './__test_data__/multi_line_task_and_list_item';
+import { multiple_headings } from './__test_data__/multiple_headings';
+import { no_heading } from './__test_data__/no_heading';
+import { no_yaml } from './__test_data__/no_yaml';
+import { yaml_1_alias } from './__test_data__/yaml_1_alias';
+import { yaml_2_aliases } from './__test_data__/yaml_2_aliases';
+import { yaml_complex_example } from './__test_data__/yaml_complex_example';
+import { yaml_complex_example_standardised } from './__test_data__/yaml_complex_example_standardised';
+import { yaml_custom_number_property } from './__test_data__/yaml_custom_number_property';
+import { yaml_tags_field_added_by_obsidian_but_not_populated } from './__test_data__/yaml_tags_field_added_by_obsidian_but_not_populated';
+import { yaml_tags_had_value_then_was_emptied_by_obsidian } from './__test_data__/yaml_tags_had_value_then_was_emptied_by_obsidian';
+import { yaml_tags_has_multiple_values } from './__test_data__/yaml_tags_has_multiple_values';
+import { yaml_tags_is_empty } from './__test_data__/yaml_tags_is_empty';
+import { yaml_tags_is_empty_list } from './__test_data__/yaml_tags_is_empty_list';
+import { yaml_tags_with_one_value_on_new_line } from './__test_data__/yaml_tags_with_one_value_on_new_line';
+import { yaml_tags_with_one_value_on_single_line } from './__test_data__/yaml_tags_with_one_value_on_single_line';
+import { yaml_tags_with_two_values_on_one_line } from './__test_data__/yaml_tags_with_two_values_on_one_line';
+import { yaml_tags_with_two_values_on_two_lines } from './__test_data__/yaml_tags_with_two_values_on_two_lines';
 
 window.moment = moment;
 
@@ -604,4 +636,82 @@ describe('cache', () => {
         `);
         expect(tasks.length).toEqual(4);
     });
+});
+
+describe('all mock files', () => {
+    const files: any = [
+        blockquote,
+        callout,
+        callout_custom,
+        callout_labelled,
+        callouts_nested_issue_2890_labelled,
+        callouts_nested_issue_2890_unlabelled,
+        comments_html_style,
+        comments_markdown_style,
+        empty_yaml,
+        example_kanban,
+        inheritance_1parent1child,
+        inheritance_1parent1child1newroot_after_header,
+        inheritance_1parent1child1sibling_emptystring,
+        inheritance_1parent2children,
+        inheritance_1parent2children1grandchild,
+        inheritance_1parent2children1sibling,
+        inheritance_1parent2children2grandchildren,
+        inheritance_1parent2children2grandchildren1sibling,
+        inheritance_1parent2children2grandchildren1sibling_start_with_heading,
+        inheritance_2siblings,
+        inheritance_listitem_task,
+        inheritance_listitem_task_siblings,
+        inheritance_task_2listitem_3task,
+        inheritance_task_listitem,
+        inheritance_task_listitem_mixed_grandchildren,
+        inheritance_task_listitem_task,
+        inheritance_task_mixed_children,
+        link_in_file_body,
+        link_in_file_body_with_custom_display_text,
+        link_in_heading,
+        link_in_yaml,
+        link_is_broken,
+        list_statuses,
+        list_styles,
+        multi_line_task_and_list_item,
+        multiple_headings,
+        no_heading,
+        no_yaml,
+        one_task,
+        yaml_1_alias,
+        yaml_2_aliases,
+        yaml_complex_example,
+        yaml_complex_example_standardised,
+        yaml_custom_number_property,
+        yaml_tags_field_added_by_obsidian_but_not_populated,
+        yaml_tags_had_value_then_was_emptied_by_obsidian,
+        yaml_tags_has_multiple_values,
+        yaml_tags_is_empty,
+        yaml_tags_is_empty_list,
+        yaml_tags_with_one_value_on_new_line,
+        yaml_tags_with_one_value_on_single_line,
+        yaml_tags_with_two_values_on_one_line,
+        yaml_tags_with_two_values_on_two_lines,
+    ];
+
+    it.each(listPathAndData(files))(
+        'should create valid TasksFile for all mock files: "%s"',
+        (_path: string, file: any) => {
+            const tasksFile = getTasksFileFromMockData(file);
+
+            const frontmatter = tasksFile.frontmatter;
+            expect(frontmatter).not.toBeUndefined();
+            expect(frontmatter).not.toBeNull();
+        },
+    );
+
+    it.each(listPathAndData(files))(
+        'should be able to read tasks from all mock files: "%s"',
+        (_path: string, file: any) => {
+            setCurrentCacheFile(file);
+            const tasks = readTasksFromSimulatedFile(file);
+            expect(tasks.length).toBeGreaterThan(0);
+        },
+    );
 });

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -638,8 +638,8 @@ describe('cache', () => {
     });
 });
 
-describe('all mock files', () => {
-    const files: any = [
+function allCacheSampleData() {
+    return [
         blockquote,
         callout,
         callout_custom,
@@ -694,6 +694,10 @@ describe('all mock files', () => {
         yaml_tags_with_two_values_on_one_line,
         yaml_tags_with_two_values_on_two_lines,
     ];
+}
+
+describe('all mock files', () => {
+    const files: any = allCacheSampleData();
 
     it.each(listPathAndData(files))(
         'should create valid TasksFile for all mock files: "%s"',

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -621,15 +621,12 @@ describe('all mock files', () => {
             expect(frontmatter).not.toBeUndefined();
             expect(frontmatter).not.toBeNull();
 
-            if (tasksFile.cachedMetadata.frontmatter === undefined) {
-                // No frontmatter in the file, so processed frontmatter will be empty object (so without a tags value)
-                expect(frontmatter).toEqual({});
-            } else {
-                expect(frontmatter.tags).not.toBeUndefined();
-                expect(frontmatter.tags).not.toBeNull();
-                expect(frontmatter.tags).not.toContain(null);
-                expect(frontmatter.tags).not.toContain(undefined);
-            }
+            // We always define frontmatter.tags, even if there was no frontmatter,
+            // to simplify a common user operation in custom filters.
+            expect(frontmatter.tags).not.toBeUndefined();
+            expect(frontmatter.tags).not.toBeNull();
+            expect(frontmatter.tags).not.toContain(null);
+            expect(frontmatter.tags).not.toContain(undefined);
         },
     );
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -1,6 +1,4 @@
-import type { CachedMetadata } from 'obsidian';
 import { TasksFile } from '../../src/Scripting/TasksFile';
-import { setCurrentCacheFile } from '../__mocks__/obsidian';
 import { callouts_nested_issue_2890_unlabelled } from '../Obsidian/__test_data__/callouts_nested_issue_2890_unlabelled';
 import { no_yaml } from '../Obsidian/__test_data__/no_yaml';
 import { empty_yaml } from '../Obsidian/__test_data__/empty_yaml';
@@ -12,6 +10,7 @@ import { yaml_tags_had_value_then_was_emptied_by_obsidian } from '../Obsidian/__
 import { yaml_tags_is_empty_list } from '../Obsidian/__test_data__/yaml_tags_is_empty_list';
 import { yaml_tags_is_empty } from '../Obsidian/__test_data__/yaml_tags_is_empty';
 import { example_kanban } from '../Obsidian/__test_data__/example_kanban';
+import { getTasksFileFromMockData, listPathAndData } from '../TestingTools/MockDataHelpers';
 
 describe('TasksFile', () => {
     it('should provide access to path', () => {
@@ -59,17 +58,6 @@ describe('TasksFile', () => {
         expect(new TasksFile('1.md.only-replace.2,md').filenameWithoutExtension).toEqual('1.md.only-replace.2,md');
     });
 });
-
-function getTasksFileFromMockData(data: any) {
-    setCurrentCacheFile(data);
-    const cachedMetadata = data.cachedMetadata as any as CachedMetadata;
-    return new TasksFile(data.filePath, cachedMetadata);
-}
-
-function listPathAndData(inputs: any[]) {
-    // We use map() to extract the path, to use it as a test name in it.each()
-    return inputs.map((data) => [data.filePath, data]);
-}
 
 describe('TasksFile - reading frontmatter', () => {
     it('should read file if not given CachedMetadata', () => {

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -64,21 +64,21 @@ describe('TasksFile - reading frontmatter', () => {
         const tasksFile = new TasksFile('some path.md', {});
 
         expect(tasksFile.cachedMetadata.frontmatter).toBeUndefined();
-        expect(tasksFile.frontmatter).toEqual({});
+        expect(tasksFile.frontmatter).toEqual({ tags: [] });
     });
 
     it('should read file with no yaml metadata', () => {
         const tasksFile = getTasksFileFromMockData(no_yaml);
         expect(tasksFile.cachedMetadata.frontmatter).toBeUndefined();
-        expect(tasksFile.frontmatter).toEqual({});
-        expect(tasksFile.frontmatter.tags).toEqual(undefined); // TODO This will be inconvenient for users - should be []?
+        expect(tasksFile.frontmatter).toEqual({ tags: [] });
+        expect(tasksFile.frontmatter.tags).toEqual([]);
     });
 
     it('should read file with empty yaml metadata', () => {
         const tasksFile = getTasksFileFromMockData(empty_yaml);
         expect(tasksFile.cachedMetadata.frontmatter).toBeUndefined();
-        expect(tasksFile.frontmatter).toEqual({});
-        expect(tasksFile.frontmatter.tags).toEqual(undefined); // TODO This will be inconvenient for users - should be []?
+        expect(tasksFile.frontmatter).toEqual({ tags: [] });
+        expect(tasksFile.frontmatter.tags).toEqual([]);
     });
 
     it('should provide an independent copy of frontmatter', () => {

--- a/tests/TestingTools/MockDataHelpers.ts
+++ b/tests/TestingTools/MockDataHelpers.ts
@@ -6,7 +6,7 @@ import { TasksFile } from '../../src/Scripting/TasksFile';
 
 export function getTasksFileFromMockData(data: any) {
     setCurrentCacheFile(data);
-    const cachedMetadata = data.cachedMetadata as any as CachedMetadata;
+    const cachedMetadata = data.cachedMetadata as CachedMetadata;
     return new TasksFile(data.filePath, cachedMetadata);
 }
 

--- a/tests/TestingTools/MockDataHelpers.ts
+++ b/tests/TestingTools/MockDataHelpers.ts
@@ -1,0 +1,16 @@
+import type { CachedMetadata } from 'obsidian';
+import { setCurrentCacheFile } from '../__mocks__/obsidian';
+import { TasksFile } from '../../src/Scripting/TasksFile';
+
+// For explanation of the mock data, see Cache.test.ts.
+
+export function getTasksFileFromMockData(data: any) {
+    setCurrentCacheFile(data);
+    const cachedMetadata = data.cachedMetadata as any as CachedMetadata;
+    return new TasksFile(data.filePath, cachedMetadata);
+}
+
+export function listPathAndData(inputs: any[]) {
+    // We use map() to extract the path, to use it as a test name in it.each()
+    return inputs.map((data) => [data.filePath, data]);
+}

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -195,7 +195,9 @@ describe('EditableTask tests', () => {
                 "_sectionStart": 5,
                 "_tasksFile": TasksFile {
                   "_cachedMetadata": {},
-                  "_frontmatter": {},
+                  "_frontmatter": {
+                    "tags": [],
+                  },
                   "_path": "some/folder/fileName.md",
                 },
               },


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Fix:

- `TasksFile` now ensures that `task.frontmatter.tags` always exists, so 'no frontmatter' behaves the same as 'has frontmatter but no tags'

Tests:

- Make it easy to write tests of the behaviour with all the sample CachedMetadata saved data:
    - Add new file `tests/Obsidian/AllCacheSampleData.ts`, which exports a function `allCacheSampleData()`
    - Then make `resources/sample_vaults/Tasks-Demo/_meta/templater_scripts/convert_test_data_markdown_to_js.js` to also update the above file when new sample files are added
- Add systematic tests to `tests/Obsidian/Cache.test.ts`, showing the invariants of the code reading CachedMetadata, including the frontmatter
    - This will be useful when writing documentation
    - I am not super happy with the test names

Test vault:

- Update some searches to show simplified code
- Show how to group tasks by all tags, but ignore the global filter

## Motivation and Context

More progress on #2480

## How has this been tested?

- Adding new tests
- Exploratory testing in demo vault

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
