### PR TITLE
refactor: extract `nextOccurrence()` method and reuse it

### DIFF
--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -146,8 +146,6 @@ export class Recurrence {
             };
         }
 
-        // Keep the relative difference between the reference date and
-        // start/scheduled/due.
         return {
             startDate: this.appleSauce(next, this.startDate),
             scheduledDate: this.appleSauce(next, this.scheduledDate),
@@ -155,6 +153,14 @@ export class Recurrence {
         };
     }
 
+    /**
+     * Gets next occurrence (start/scheduled/due date) keeping the relative distance
+     * with the reference date
+     *
+     * @param nextReferenceDate
+     * @param currentOccurrence start/scheduled/due date
+     * @private
+     */
     private appleSauce(nextReferenceDate: Date, currentOccurrence: Moment | null) {
         if (currentOccurrence === null) {
             return null;

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -136,12 +136,6 @@ export class Recurrence {
             return null;
         }
 
-        // Keep the relative difference between the reference date and
-        // start/scheduled/due.
-        let startDate: Moment | null = null;
-        let scheduledDate: Moment | null = null;
-        let dueDate: Moment | null = null;
-
         // Only if a reference date is given. A reference date will exist if at
         // least one of the other dates is set.
         if (this.referenceDate === null) {
@@ -151,6 +145,12 @@ export class Recurrence {
                 dueDate: null,
             };
         }
+
+        // Keep the relative difference between the reference date and
+        // start/scheduled/due.
+        let startDate: Moment | null = null;
+        let scheduledDate: Moment | null = null;
+        let dueDate: Moment | null = null;
 
         if (this.startDate) {
             const originalDifference = window.moment.duration(this.startDate.diff(this.referenceDate));

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -147,9 +147,9 @@ export class Recurrence {
         }
 
         return {
-            startDate: this.appleSauce(next, this.startDate),
-            scheduledDate: this.appleSauce(next, this.scheduledDate),
-            dueDate: this.appleSauce(next, this.dueDate),
+            startDate: this.nextOccurrence(next, this.startDate),
+            scheduledDate: this.nextOccurrence(next, this.scheduledDate),
+            dueDate: this.nextOccurrence(next, this.dueDate),
         };
     }
 
@@ -161,7 +161,7 @@ export class Recurrence {
      * @param currentOccurrence start/scheduled/due date
      * @private
      */
-    private appleSauce(nextReferenceDate: Date, currentOccurrence: Moment | null) {
+    private nextOccurrence(nextReferenceDate: Date, currentOccurrence: Moment | null) {
         if (currentOccurrence === null) {
             return null;
         }

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -179,7 +179,9 @@ export class Recurrence {
 
     private appleSauce(nextReferenceDate: Date, currentOccurrence: Moment | null) {
         let nextOccurrence: Moment | null = null;
-        if (currentOccurrence) {
+        if (currentOccurrence === null) {
+            return null;
+        } else {
             const originalDifference = window.moment.duration(currentOccurrence.diff(this.referenceDate));
 
             // Cloning so that original won't be manipulated:

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -148,15 +148,7 @@ export class Recurrence {
 
         // Keep the relative difference between the reference date and
         // start/scheduled/due.
-        let startDate: Moment | null = null;
-        if (this.startDate) {
-            const originalDifference = window.moment.duration(this.startDate.diff(this.referenceDate));
-
-            // Cloning so that original won't be manipulated:
-            startDate = window.moment(next);
-            // Rounding days to handle cross daylight-savings-time recurrences.
-            startDate.add(Math.round(originalDifference.asDays()), 'days');
-        }
+        const startDate = this.appleSauce(next);
 
         let scheduledDate: Moment | null = null;
         if (this.scheduledDate) {
@@ -183,6 +175,19 @@ export class Recurrence {
             scheduledDate,
             dueDate,
         };
+    }
+
+    private appleSauce(nextReferenceDate: Date) {
+        let startDate: Moment | null = null;
+        if (this.startDate) {
+            const originalDifference = window.moment.duration(this.startDate.diff(this.referenceDate));
+
+            // Cloning so that original won't be manipulated:
+            startDate = window.moment(nextReferenceDate);
+            // Rounding days to handle cross daylight-savings-time recurrences.
+            startDate.add(Math.round(originalDifference.asDays()), 'days');
+        }
+        return startDate;
     }
 
     public identicalTo(other: Recurrence) {

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -149,9 +149,6 @@ export class Recurrence {
         // Keep the relative difference between the reference date and
         // start/scheduled/due.
         let startDate: Moment | null = null;
-        let scheduledDate: Moment | null = null;
-        let dueDate: Moment | null = null;
-
         if (this.startDate) {
             const originalDifference = window.moment.duration(this.startDate.diff(this.referenceDate));
 
@@ -160,6 +157,8 @@ export class Recurrence {
             // Rounding days to handle cross daylight-savings-time recurrences.
             startDate.add(Math.round(originalDifference.asDays()), 'days');
         }
+
+        let scheduledDate: Moment | null = null;
         if (this.scheduledDate) {
             const originalDifference = window.moment.duration(this.scheduledDate.diff(this.referenceDate));
 
@@ -168,6 +167,8 @@ export class Recurrence {
             // Rounding days to handle cross daylight-savings-time recurrences.
             scheduledDate.add(Math.round(originalDifference.asDays()), 'days');
         }
+
+        let dueDate: Moment | null = null;
         if (this.dueDate) {
             const originalDifference = window.moment.duration(this.dueDate.diff(this.referenceDate));
 

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -181,14 +181,14 @@ export class Recurrence {
         let nextOccurrence: Moment | null = null;
         if (currentOccurrence === null) {
             return null;
-        } else {
-            const originalDifference = window.moment.duration(currentOccurrence.diff(this.referenceDate));
-
-            // Cloning so that original won't be manipulated:
-            nextOccurrence = window.moment(nextReferenceDate);
-            // Rounding days to handle cross daylight-savings-time recurrences.
-            nextOccurrence.add(Math.round(originalDifference.asDays()), 'days');
         }
+
+        const originalDifference = window.moment.duration(currentOccurrence.diff(this.referenceDate));
+
+        // Cloning so that original won't be manipulated:
+        nextOccurrence = window.moment(nextReferenceDate);
+        // Rounding days to handle cross daylight-savings-time recurrences.
+        nextOccurrence.add(Math.round(originalDifference.asDays()), 'days');
         return nextOccurrence;
     }
 

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -178,16 +178,16 @@ export class Recurrence {
     }
 
     private appleSauce(nextReferenceDate: Date, currentOccurrence: Moment | null) {
-        let startDate: Moment | null = null;
+        let nextOccurrence: Moment | null = null;
         if (currentOccurrence) {
             const originalDifference = window.moment.duration(currentOccurrence.diff(this.referenceDate));
 
             // Cloning so that original won't be manipulated:
-            startDate = window.moment(nextReferenceDate);
+            nextOccurrence = window.moment(nextReferenceDate);
             // Rounding days to handle cross daylight-savings-time recurrences.
-            startDate.add(Math.round(originalDifference.asDays()), 'days');
+            nextOccurrence.add(Math.round(originalDifference.asDays()), 'days');
         }
-        return startDate;
+        return nextOccurrence;
     }
 
     public identicalTo(other: Recurrence) {

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -161,7 +161,7 @@ export class Recurrence {
      * @param currentOccurrence start/scheduled/due date
      * @private
      */
-    private nextOccurrence(nextReferenceDate: Date, currentOccurrence: Moment | null) {
+    private nextOccurrence(nextReferenceDate: Date, currentOccurrence: Moment | null): Moment | null {
         if (currentOccurrence === null) {
             return null;
         }

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -148,7 +148,7 @@ export class Recurrence {
 
         // Keep the relative difference between the reference date and
         // start/scheduled/due.
-        const startDate = this.appleSauce(next);
+        const startDate = this.appleSauce(next, this.startDate);
 
         let scheduledDate: Moment | null = null;
         if (this.scheduledDate) {
@@ -177,10 +177,10 @@ export class Recurrence {
         };
     }
 
-    private appleSauce(nextReferenceDate: Date) {
+    private appleSauce(nextReferenceDate: Date, currentOccurrence: Moment | null) {
         let startDate: Moment | null = null;
-        if (this.startDate) {
-            const originalDifference = window.moment.duration(this.startDate.diff(this.referenceDate));
+        if (currentOccurrence) {
+            const originalDifference = window.moment.duration(currentOccurrence.diff(this.referenceDate));
 
             // Cloning so that original won't be manipulated:
             startDate = window.moment(nextReferenceDate);

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -178,7 +178,6 @@ export class Recurrence {
     }
 
     private appleSauce(nextReferenceDate: Date, currentOccurrence: Moment | null) {
-        let nextOccurrence: Moment | null = null;
         if (currentOccurrence === null) {
             return null;
         }
@@ -186,7 +185,7 @@ export class Recurrence {
         const originalDifference = window.moment.duration(currentOccurrence.diff(this.referenceDate));
 
         // Cloning so that original won't be manipulated:
-        nextOccurrence = window.moment(nextReferenceDate);
+        const nextOccurrence = window.moment(nextReferenceDate);
         // Rounding days to handle cross daylight-savings-time recurrences.
         nextOccurrence.add(Math.round(originalDifference.asDays()), 'days');
         return nextOccurrence;

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -148,14 +148,10 @@ export class Recurrence {
 
         // Keep the relative difference between the reference date and
         // start/scheduled/due.
-        const startDate = this.appleSauce(next, this.startDate);
-        const scheduledDate = this.appleSauce(next, this.scheduledDate);
-        const dueDate = this.appleSauce(next, this.dueDate);
-
         return {
-            startDate,
-            scheduledDate,
-            dueDate,
+            startDate: this.appleSauce(next, this.startDate),
+            scheduledDate: this.appleSauce(next, this.scheduledDate),
+            dueDate: this.appleSauce(next, this.dueDate),
         };
     }
 

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -149,26 +149,8 @@ export class Recurrence {
         // Keep the relative difference between the reference date and
         // start/scheduled/due.
         const startDate = this.appleSauce(next, this.startDate);
-
-        let scheduledDate: Moment | null = null;
-        if (this.scheduledDate) {
-            const originalDifference = window.moment.duration(this.scheduledDate.diff(this.referenceDate));
-
-            // Cloning so that original won't be manipulated:
-            scheduledDate = window.moment(next);
-            // Rounding days to handle cross daylight-savings-time recurrences.
-            scheduledDate.add(Math.round(originalDifference.asDays()), 'days');
-        }
-
-        let dueDate: Moment | null = null;
-        if (this.dueDate) {
-            const originalDifference = window.moment.duration(this.dueDate.diff(this.referenceDate));
-
-            // Cloning so that original won't be manipulated:
-            dueDate = window.moment(next);
-            // Rounding days to handle cross daylight-savings-time recurrences.
-            dueDate.add(Math.round(originalDifference.asDays()), 'days');
-        }
+        const scheduledDate = this.appleSauce(next, this.scheduledDate);
+        const dueDate = this.appleSauce(next, this.dueDate);
 
         return {
             startDate,


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

- extract `nextOccurrence()` method and reuse it
- contrary to what you mentioned in the previous PR, I had to extract a wider method since there will be a check whether `this.scheduledDate`/`this.dueDate`/`this.startDate` is `null` and the `if {}` will be in the caller and in the body of the method

## Motivation and Context

- better code

## How has this been tested?

- unit tests

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
