### PR TITLE
contrib: add documentation on testing code that uses Obsidian API

### DIFF
--- a/contributing/Testing/About Testing.md
+++ b/contributing/Testing/About Testing.md
@@ -24,6 +24,10 @@ Testing dates and times:
 - [[How do I use Moment in tests]] - how to test date and time values
 - [[Simulating Dates and Times]] - examples of how to use fixed dates and times in tests
 
+Testing code that uses Obsidian API:
+
+- [[Using Obsidian API in tests]]
+
 More advanced features:
 
 - [[Snapshot Tests]] - easy testing of complex string values

--- a/contributing/Testing/Using Obsidian API in tests.md
+++ b/contributing/Testing/Using Obsidian API in tests.md
@@ -1,0 +1,24 @@
+---
+publish: true
+---
+
+# Using Obsidian API in tests
+
+<span class="related-pages">#testing/automated-testing</span>
+
+## Test data creation sequence
+  
+If using this on an Obsidian version newer than the one in saved `tests/Obsidian/__test_data__/*.ts`, go to Settings → Files and links → Advanced → Rebuild vault cache.
+  
+- Create a sample markdown file in Tasks demo vault (root/Test Data/) with the simplest content to represent your test case. Choose a meaningful file name in snake case. See example in `Test Data/one_task.md`.
+  - There is a Templater template that may help with creating a new file, for single-tasks cases: `resources/sample_vaults/Tasks-Demo/_meta/templates/Test Data file.md`.
+- Open any other note in the vault, just so that Templater will run.
+  - The Templater plugin requires a note to be open. The script won't edit the file, so it doesn't matter which file you have open.
+- Run the command `Templater: Insert _meta/templates/convert_test_data_markdown_to_js.md`.
+  - Or type the short-cut `Ctrl + Cmd + Alt + T` / `Ctrl + Ctrl + Alt + T`.
+- This will convert all the files `root/Test Data/*.md` to test functions in `tests/Obsidian/__test_data__/*.ts`.
+- Run `yarn lint:test-data` to standardise the formatting in the generated TypeScript files.
+- Use the data in the test with `readTasksFromSimulatedFile()`, the argument is the constant you created in the previous step.
+- Remember to commit the markdown file in the demo vault and the file with the simulated data.
+
+> TODO: Make the order of values in the generated code stable.

--- a/contributing/Testing/Using Obsidian API in tests.md
+++ b/contributing/Testing/Using Obsidian API in tests.md
@@ -6,6 +6,16 @@ publish: true
 
 <span class="related-pages">#testing/automated-testing</span>
 
+## Overview
+
+The Tasks plugin uses data created by the Obsidian API. The Obsidian API does not run in any test framework.
+
+So we need a way to access Obsidian-generated data in our tests. This page tries to describe this mechanism.
+
+1. [resources/sample_vaults/Tasks-Demo/Test Data](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo/Test%20Data) contains representative samples Markdown files for different scenarios.
+2. The process described in [[#Test data creation sequence]] converts these files to matching TypeScript files in [tests/Obsidian/\_\_test_data\_\_](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/tests/Obsidian/__test_data__).
+3. So far the files that use this mechanism are [tests/Obsidian/Cache.test.ts](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/tests/Obsidian/Cache.test.ts) and [tests/Scripting/TasksFile.test.ts](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/tests/Scripting/TasksFile.test.ts). Refer to these files for examples.
+
 ## Test data creation sequence
   
 If using this on an Obsidian version newer than the one in saved `tests/Obsidian/__test_data__/*.ts`, go to Settings → Files and links → Advanced → Rebuild vault cache.

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -39,43 +39,18 @@ function errorReporter() {
     return;
 }
 
-/* Test creation sequence:
-
-If using this on an Obsidian version newer than the one in saved tests/Obsidian/__test_data__/*.ts
-go to Settings → Files and links → Advanced → Rebuild vault cache.
-
-- Create a sample markdown file in Tasks demo vault (root/Test Data/) with the simplest content
-to represent your test case. Choose a meaningful file name in snake case. See example in 'Test Data/one_task.md'.
-
-    - There is a Templater template that may help with creating a new file, for single-tasks cases:
-      `resources/sample_vaults/Tasks-Demo/_meta/templates/Test Data file.md`
-
-- Open any other note in the vault, just so that Templater will run.
-
-    - The Templater plugin requires a note to be open. The script won't edit the file, so it
-      doesn't matter which file you have open.
-
-- Run the command 'Templater: Insert _meta/templates/convert_test_data_markdown_to_js.md'
-    - Or type the short-cut 'Ctrl + Cmd + Alt + T' / 'Ctrl + Ctrl + Alt + T'
-
-- This will convert all the files 'root/Test Data/*.md' to test functions in 'tests/Obsidian/__test_data__/*.ts'
-
-- Run 'yarn lint:test-data' to standardise the formatting in the generated TypeScript files.
-
-- Use the data in the test with `readTasksFromSimulatedFile()`, the argument is the constant you
-created in the previous step.
-
-- Remember to commit the markdown file in the demo vault and the file with the simulated data.
-
-TODO: Make the order of values in the generated code stable.
- */
-
 interface SimulatedFile {
     cachedMetadata: CachedMetadata;
     filePath: string;
     fileContents: string;
 }
 
+/**
+ For explanations on how to test code that is using Obsidian API
+ refer to https://publish.obsidian.md/tasks-contributing/Testing/Using+Obsidian+API+in+tests
+
+ TODO: Make the order of values in the generated code stable.
+ */
 function readTasksFromSimulatedFile(testData: SimulatedFile) {
     const logger = logging.getLogger('testCache');
     setCurrentCacheFile(testData);


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

## Description

Done by pairing with @claremacrae 

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
