### PR TITLE
refactor: move `referenceDate` field to `Occurrence` class

### DIFF
--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -109,7 +109,7 @@ export class Recurrence {
 
             const options = RRule.parseText(isolatedRuleText);
             if (options !== null) {
-                const referenceDate = occurrence.getReferenceDate();
+                const referenceDate = occurrence.referenceDate;
 
                 if (!baseOnToday && referenceDate !== null) {
                     options.dtstart = window.moment(referenceDate).startOf('day').utc(true).toDate();

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -75,16 +75,7 @@ export class Recurrence {
     private readonly baseOnToday: boolean;
     readonly occurrence: Occurrence;
 
-    constructor({
-        rrule,
-        baseOnToday,
-        occurrence,
-    }: {
-        rrule: RRule;
-        baseOnToday: boolean;
-        referenceDate: Moment | null;
-        occurrence: Occurrence;
-    }) {
+    constructor({ rrule, baseOnToday, occurrence }: { rrule: RRule; baseOnToday: boolean; occurrence: Occurrence }) {
         this.rrule = rrule;
         this.baseOnToday = baseOnToday;
         this.occurrence = occurrence;
@@ -120,7 +111,6 @@ export class Recurrence {
                 return new Recurrence({
                     rrule,
                     baseOnToday,
-                    referenceDate,
                     occurrence,
                 });
             }

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -52,12 +52,6 @@ export class Occurrence {
 
         return true;
     }
-}
-
-export class Recurrence {
-    private readonly rrule: RRule;
-    private readonly baseOnToday: boolean;
-    readonly occurrence: Occurrence;
 
     /**
      * The reference date is used to calculate future occurrences.
@@ -72,12 +66,19 @@ export class Recurrence {
      * same relative distance to the due date as the original task. For example
      * "starts one week before it is due".
      */
-    private readonly referenceDate: Moment | null;
+    public get referenceDate(): Moment | null {
+        return this.getReferenceDate();
+    }
+}
+
+export class Recurrence {
+    private readonly rrule: RRule;
+    private readonly baseOnToday: boolean;
+    readonly occurrence: Occurrence;
 
     constructor({
         rrule,
         baseOnToday,
-        referenceDate,
         occurrence,
     }: {
         rrule: RRule;
@@ -87,7 +88,6 @@ export class Recurrence {
     }) {
         this.rrule = rrule;
         this.baseOnToday = baseOnToday;
-        this.referenceDate = referenceDate;
         this.occurrence = occurrence;
     }
 
@@ -163,7 +163,7 @@ export class Recurrence {
 
         // Only if a reference date is given. A reference date will exist if at
         // least one of the other dates is set.
-        if (this.referenceDate === null) {
+        if (this.occurrence.referenceDate === null) {
             return {
                 startDate: null,
                 scheduledDate: null,
@@ -191,7 +191,7 @@ export class Recurrence {
             return null;
         }
 
-        const originalDifference = window.moment.duration(currentOccurrence.diff(this.referenceDate));
+        const originalDifference = window.moment.duration(currentOccurrence.diff(this.occurrence.referenceDate));
 
         // Cloning so that original won't be manipulated:
         const nextOccurrence = window.moment(nextReferenceDate);
@@ -237,7 +237,7 @@ export class Recurrence {
         const after = window
             // Reference date can be `undefined` to mean "today".
             // Moment only accepts `undefined`, not `null`.
-            .moment(this.referenceDate ?? undefined)
+            .moment(this.occurrence.referenceDate ?? undefined)
             .endOf('day');
 
         return this.nextAfter(after, this.rrule);

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -8,6 +8,7 @@ export class Occurrence {
     readonly startDate: Moment | null;
     readonly scheduledDate: Moment | null;
     readonly dueDate: Moment | null;
+    readonly _referenceDate: Moment | null;
 
     constructor({
         startDate,
@@ -21,6 +22,7 @@ export class Occurrence {
         this.startDate = startDate;
         this.scheduledDate = scheduledDate;
         this.dueDate = dueDate;
+        this._referenceDate = this.getReferenceDate();
     }
 
     public getReferenceDate(): Moment | null {
@@ -67,7 +69,7 @@ export class Occurrence {
      * "starts one week before it is due".
      */
     public get referenceDate(): Moment | null {
-        return this.getReferenceDate();
+        return this._referenceDate;
     }
 }
 

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -8,7 +8,21 @@ export class Occurrence {
     readonly startDate: Moment | null;
     readonly scheduledDate: Moment | null;
     readonly dueDate: Moment | null;
-    readonly _referenceDate: Moment | null;
+
+    /**
+     * The reference date is used to calculate future occurrences.
+     *
+     * Future occurrences will recur based on the reference date.
+     * The reference date is the due date, if it is given.
+     * Otherwise the scheduled date, if it is given. And so on.
+     *
+     * Recurrence of all dates will be kept relative to the reference date.
+     * For example: if the due date and the start date are given, the due date
+     * is the reference date. Future occurrences will have a start date with the
+     * same relative distance to the due date as the original task. For example
+     * "starts one week before it is due".
+     */
+    readonly referenceDate: Moment | null;
 
     constructor({
         startDate,
@@ -22,7 +36,7 @@ export class Occurrence {
         this.startDate = startDate;
         this.scheduledDate = scheduledDate;
         this.dueDate = dueDate;
-        this._referenceDate = this.getReferenceDate();
+        this.referenceDate = this.getReferenceDate();
     }
 
     public getReferenceDate(): Moment | null {
@@ -53,23 +67,6 @@ export class Occurrence {
         }
 
         return true;
-    }
-
-    /**
-     * The reference date is used to calculate future occurrences.
-     *
-     * Future occurrences will recur based on the reference date.
-     * The reference date is the due date, if it is given.
-     * Otherwise the scheduled date, if it is given. And so on.
-     *
-     * Recurrence of all dates will be kept relative to the reference date.
-     * For example: if the due date and the start date are given, the due date
-     * is the reference date. Future occurrences will have a start date with the
-     * same relative distance to the due date as the original task. For example
-     * "starts one week before it is due".
-     */
-    public get referenceDate(): Moment | null {
-        return this._referenceDate;
     }
 }
 


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

- move `referenceDate` field from `Recurrence` to `Occurrence` class

## Motivation and Context

- separate concerns (Reference date is related to `Occurrence`)


## How has this been tested?

- unit tests

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
