### PR TITLE
fix: make creating a task with both Cancelled and Done not possible with the Edit Task modal

### DIFF
--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount } from 'svelte';
     import { TASK_FORMATS, getSettings } from '../Config/Settings';
+    import { parseTypedDateForDisplayUsingFutureDate } from '../lib/DateTools';
     import type { Status } from '../Statuses/Status';
     import type { Task } from '../Task/Task';
     import DateEditor from './DateEditor.svelte';
@@ -105,6 +106,20 @@
         if (cancelledAndDoneDateAreSet) {
             isCancelledDateValid = false;
             isDoneDateValid = false;
+        } else {
+            const cancelledParsedDate = parseTypedDateForDisplayUsingFutureDate(
+                'cancelled',
+                editableTask.cancelledDate,
+                editableTask.forwardOnly,
+            );
+            isCancelledDateValid = !cancelledParsedDate.includes('invalid');
+
+            const doneParsedDate = parseTypedDateForDisplayUsingFutureDate(
+                'done',
+                editableTask.doneDate,
+                editableTask.forwardOnly,
+            );
+            isDoneDateValid = !doneParsedDate.includes('invalid');
         }
     }
 

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -99,6 +99,15 @@
     ];
 
     $: accesskey = (key: string) => (withAccessKeys ? key : null);
+
+    $: {
+        const cancelledAndDoneDateAreSet = editableTask.cancelledDate.length > 0 && editableTask.doneDate.length > 0;
+        if (cancelledAndDoneDateAreSet) {
+            isCancelledDateValid = false;
+            isDoneDateValid = false;
+        }
+    }
+
     $: formIsValid =
         isDueDateValid &&
         isRecurrenceValid &&


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - fixes #2986 

## Description

- when validating edit modal input, check whether done and cancelled date have been input. If yes, invalidate the form and show error on cancelled and done date inputs for user to take action.

## Motivation and Context

- make editing with modal consistent and logical (a task cannot have cancelled and done date at the same time).

## How has this been tested?

- manual test in demo vault build on the commit with the fix

## Screenshots

![Снимок экрана 2024-07-24 в 13 00 29](https://github.com/user-attachments/assets/4ab4c86e-5a40-4c7b-a11f-acb39655e643)


## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - this is not testable, developing tests here requires quite an effort, the fix is small and manually testable

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
