### PR TITLE
fix: Editing properties/frontmatter now updates Query results

### DIFF
--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -94,8 +94,8 @@ export class TasksFile {
      * @param other
      */
     public rawFrontMatterIdenticalTo(other: TasksFile): boolean {
-        const thisFrontmatter = this.cachedMetadata.frontmatter;
-        const thatFrontmatter = other.cachedMetadata.frontmatter;
+        const thisFrontmatter: FrontMatterCache | undefined = this.cachedMetadata.frontmatter;
+        const thatFrontmatter: FrontMatterCache | undefined = other.cachedMetadata.frontmatter;
         if (thisFrontmatter === thatFrontmatter) {
             // The same object or both undefined
             return true;

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -94,8 +94,8 @@ export class TasksFile {
      * @param other
      */
     public rawFrontMatterIdenticalTo(other: TasksFile): boolean {
-        const thisFrontmatter = this.cachedMetadata.frontmatter ?? undefined;
-        const thatFrontmatter = other.cachedMetadata.frontmatter ?? undefined;
+        const thisFrontmatter = this.cachedMetadata.frontmatter;
+        const thatFrontmatter = other.cachedMetadata.frontmatter;
         if (thisFrontmatter === thatFrontmatter) {
             // The same object or both undefined
             return true;

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -91,10 +91,15 @@ export class TasksFile {
      * This can be used to detect whether Task objects need to be updated,
      * or (later) whether queries need to be updated, due to user edits.
      *
-     * @param _noYaml
+     * @param other
      */
-    public rawFrontMatterIdenticalTo(_noYaml: TasksFile): boolean {
-        return true;
+    public rawFrontMatterIdenticalTo(other: TasksFile): boolean {
+        const thisFrontmatter = this.cachedMetadata.frontmatter ?? undefined;
+        const thatFrontmatter = other.cachedMetadata.frontmatter ?? undefined;
+        if (thisFrontmatter === thatFrontmatter) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -85,6 +85,19 @@ export class TasksFile {
     }
 
     /**
+     * Does the data content of another TasksFile's raw frontmatter
+     * match this one.
+     *
+     * This can be used to detect whether Task objects need to be updated,
+     * or (later) whether queries need to be updated, due to user edits.
+     *
+     * @param _noYaml
+     */
+    public rawFrontMatterIdenticalTo(_noYaml: TasksFile): boolean {
+        return true;
+    }
+
+    /**
      * Return the path to the file, with the filename extension removed.
      */
     get pathWithoutExtension(): string {

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -93,7 +93,7 @@ export class TasksFile {
      *
      * @param other
      */
-    public rawFrontMatterIdenticalTo(other: TasksFile): boolean {
+    public rawFrontmatterIdenticalTo(other: TasksFile): boolean {
         const thisFrontmatter: FrontMatterCache | undefined = this.cachedMetadata.frontmatter;
         const thatFrontmatter: FrontMatterCache | undefined = other.cachedMetadata.frontmatter;
         if (thisFrontmatter === thatFrontmatter) {

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -97,9 +97,14 @@ export class TasksFile {
         const thisFrontmatter = this.cachedMetadata.frontmatter ?? undefined;
         const thatFrontmatter = other.cachedMetadata.frontmatter ?? undefined;
         if (thisFrontmatter === thatFrontmatter) {
+            // The same object
             return true;
         }
-        return false;
+        // Check if the same content.
+        // This is fairly simplistic.
+        // For example, it treats values that are the same but in a different order as being different,
+        // although their information content is the same.
+        return JSON.stringify(thisFrontmatter) === JSON.stringify(thatFrontmatter);
     }
 
     /**

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -97,9 +97,14 @@ export class TasksFile {
         const thisFrontmatter = this.cachedMetadata.frontmatter ?? undefined;
         const thatFrontmatter = other.cachedMetadata.frontmatter ?? undefined;
         if (thisFrontmatter === thatFrontmatter) {
-            // The same object
+            // The same object or both undefined
             return true;
         }
+
+        if (!thisFrontmatter || !thatFrontmatter) {
+            return false; // One is undefined and the other is not
+        }
+
         // Check if the same content.
         // This is fairly simplistic.
         // For example, it treats values that are the same but in a different order as being different,

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -875,6 +875,10 @@ export class Task extends ListItem {
             return false;
         }
 
+        if (!this.file.rawFrontMatterIdenticalTo(other.file)) {
+            return false;
+        }
+
         return true;
     }
 

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -875,7 +875,7 @@ export class Task extends ListItem {
             return false;
         }
 
-        if (!this.file.rawFrontMatterIdenticalTo(other.file)) {
+        if (!this.file.rawFrontmatterIdenticalTo(other.file)) {
             return false;
         }
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -18,6 +18,8 @@ import { yaml_complex_example } from '../Obsidian/__test_data__/yaml_complex_exa
 import { yaml_complex_example_standardised } from '../Obsidian/__test_data__/yaml_complex_example_standardised';
 import { yaml_all_property_types_empty } from '../Obsidian/__test_data__/yaml_all_property_types_empty';
 import { yaml_all_property_types_populated } from '../Obsidian/__test_data__/yaml_all_property_types_populated';
+import { yaml_1_alias } from '../Obsidian/__test_data__/yaml_1_alias';
+import { yaml_2_aliases } from '../Obsidian/__test_data__/yaml_2_aliases';
 import { determineExpressionType, formatToRepresentType } from './ScriptingTestHelpers';
 
 describe('TasksFile', () => {
@@ -71,6 +73,18 @@ describe('TasksFile - raw frontmatter - identicalTo', () => {
     it('should treat self as identical', () => {
         const noYaml = getTasksFileFromMockData(no_yaml);
         expect(noYaml.rawFrontMatterIdenticalTo(noYaml)).toEqual(true);
+    });
+
+    it('should treat empty frontmatter same as no frontmatter', () => {
+        const file1 = getTasksFileFromMockData(no_yaml);
+        const file2 = getTasksFileFromMockData(empty_yaml);
+        expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(true);
+    });
+
+    it('should detect different alias values as different', () => {
+        const file1 = getTasksFileFromMockData(yaml_1_alias);
+        const file2 = getTasksFileFromMockData(yaml_2_aliases);
+        expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(false);
     });
 });
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -81,6 +81,12 @@ describe('TasksFile - raw frontmatter - identicalTo', () => {
         expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(true);
     });
 
+    it('should recognise identical frontmatter', () => {
+        const file1 = getTasksFileFromMockData(yaml_tags_is_empty_list);
+        const file2 = getTasksFileFromMockData(yaml_tags_had_value_then_was_emptied_by_obsidian);
+        expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(true);
+    });
+
     it('should detect different alias values as different', () => {
         const file1 = getTasksFileFromMockData(yaml_1_alias);
         const file2 = getTasksFileFromMockData(yaml_2_aliases);

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -67,6 +67,13 @@ describe('TasksFile', () => {
     });
 });
 
+describe('TasksFile - raw frontmatter - identicalTo', () => {
+    it('should treat self as identical', () => {
+        const noYaml = getTasksFileFromMockData(no_yaml);
+        expect(noYaml.rawFrontMatterIdenticalTo(noYaml)).toEqual(true);
+    });
+});
+
 describe('TasksFile - reading frontmatter', () => {
     it('should read file if not given CachedMetadata', () => {
         const tasksFile = new TasksFile('some path.md', {});

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -81,7 +81,7 @@ describe('TasksFile - raw frontmatter - identicalTo', () => {
         expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(true);
     });
 
-    it('should recognise identical frontmatter', () => {
+    it('should recognise identical frontmatter - simple empty tags list', () => {
         const file1 = getTasksFileFromMockData(yaml_tags_is_empty_list);
         const file2 = getTasksFileFromMockData(yaml_tags_had_value_then_was_emptied_by_obsidian);
         expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(true);
@@ -90,6 +90,12 @@ describe('TasksFile - raw frontmatter - identicalTo', () => {
     it('should detect different alias values as different', () => {
         const file1 = getTasksFileFromMockData(yaml_1_alias);
         const file2 = getTasksFileFromMockData(yaml_2_aliases);
+        expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(false);
+    });
+
+    it('should treat missing and populated frontmatter as different', () => {
+        const file1 = getTasksFileFromMockData(no_yaml);
+        const file2 = getTasksFileFromMockData(yaml_complex_example);
         expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(false);
     });
 });

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -74,6 +74,7 @@ describe('TasksFile - raw frontmatter - identicalTo', () => {
         const file1 = getTasksFileFromMockData(case1);
         const file2 = getTasksFileFromMockData(case2);
         expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(expectedToBeIdentical);
+        expect(file2.rawFrontMatterIdenticalTo(file1)).toEqual(expectedToBeIdentical);
     }
 
     it('should treat self as identical', () => {

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -77,33 +77,27 @@ describe('TasksFile - raw frontmatter - identicalTo', () => {
     }
 
     it('should treat self as identical', () => {
-        const noYaml = getTasksFileFromMockData(no_yaml);
-        expect(noYaml.rawFrontMatterIdenticalTo(noYaml)).toEqual(true);
+        expectRawFrontmatterToBeIdentical(no_yaml, no_yaml, true);
     });
 
     it('should treat empty frontmatter same as no frontmatter', () => {
-        const case1 = no_yaml;
-        const case2 = empty_yaml;
-        const expectedToBeIdentical = true;
-        expectRawFrontmatterToBeIdentical(case1, case2, expectedToBeIdentical);
+        expectRawFrontmatterToBeIdentical(no_yaml, empty_yaml, true);
     });
 
     it('should recognise identical frontmatter - simple empty tags list', () => {
-        const file1 = getTasksFileFromMockData(yaml_tags_is_empty_list);
-        const file2 = getTasksFileFromMockData(yaml_tags_had_value_then_was_emptied_by_obsidian);
-        expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(true);
+        expectRawFrontmatterToBeIdentical(
+            yaml_tags_is_empty_list,
+            yaml_tags_had_value_then_was_emptied_by_obsidian,
+            true,
+        );
     });
 
     it('should detect different alias values as different', () => {
-        const file1 = getTasksFileFromMockData(yaml_1_alias);
-        const file2 = getTasksFileFromMockData(yaml_2_aliases);
-        expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(false);
+        expectRawFrontmatterToBeIdentical(yaml_1_alias, yaml_2_aliases, false);
     });
 
     it('should treat missing and populated frontmatter as different', () => {
-        const file1 = getTasksFileFromMockData(no_yaml);
-        const file2 = getTasksFileFromMockData(yaml_complex_example);
-        expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(false);
+        expectRawFrontmatterToBeIdentical(no_yaml, yaml_complex_example, false);
     });
 });
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -70,15 +70,22 @@ describe('TasksFile', () => {
 });
 
 describe('TasksFile - raw frontmatter - identicalTo', () => {
+    function expectRawFrontmatterToBeIdentical(case1: any, case2: any, expectedToBeIdentical: boolean) {
+        const file1 = getTasksFileFromMockData(case1);
+        const file2 = getTasksFileFromMockData(case2);
+        expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(expectedToBeIdentical);
+    }
+
     it('should treat self as identical', () => {
         const noYaml = getTasksFileFromMockData(no_yaml);
         expect(noYaml.rawFrontMatterIdenticalTo(noYaml)).toEqual(true);
     });
 
     it('should treat empty frontmatter same as no frontmatter', () => {
-        const file1 = getTasksFileFromMockData(no_yaml);
-        const file2 = getTasksFileFromMockData(empty_yaml);
-        expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(true);
+        const case1 = no_yaml;
+        const case2 = empty_yaml;
+        const expectedToBeIdentical = true;
+        expectRawFrontmatterToBeIdentical(case1, case2, expectedToBeIdentical);
     });
 
     it('should recognise identical frontmatter - simple empty tags list', () => {

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -73,8 +73,8 @@ describe('TasksFile - raw frontmatter - identicalTo', () => {
     function expectRawFrontmatterToBeIdentical(case1: any, case2: any, expectedToBeIdentical: boolean) {
         const file1 = getTasksFileFromMockData(case1);
         const file2 = getTasksFileFromMockData(case2);
-        expect(file1.rawFrontMatterIdenticalTo(file2)).toEqual(expectedToBeIdentical);
-        expect(file2.rawFrontMatterIdenticalTo(file1)).toEqual(expectedToBeIdentical);
+        expect(file1.rawFrontmatterIdenticalTo(file2)).toEqual(expectedToBeIdentical);
+        expect(file2.rawFrontmatterIdenticalTo(file1)).toEqual(expectedToBeIdentical);
     }
 
     it('should treat self as identical', () => {

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -19,6 +19,8 @@ import { Priority } from '../../src/Task/Priority';
 import { SampleTasks } from '../TestingTools/SampleTasks';
 import { booleanToEmoji } from '../TestingTools/FilterTestHelpers';
 import type { TasksDate } from '../../src/Scripting/TasksDate';
+import { example_kanban } from '../Obsidian/__test_data__/example_kanban';
+import { jason_properties } from '../Obsidian/__test_data__/jason_properties';
 
 window.moment = moment;
 
@@ -1567,6 +1569,14 @@ describe('identicalTo', () => {
         // Check it is case-sensitive
         expect(lhs).not.toBeIdenticalTo(new TaskBuilder().path('Same Test File.md'));
         expect(lhs).not.toBeIdenticalTo(new TaskBuilder().path('different text.md'));
+    });
+
+    it('should check frontmatter/properties', () => {
+        const lhs = new TaskBuilder().mockData(example_kanban);
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().mockData(example_kanban));
+
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().mockData({}));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().mockData(jason_properties));
     });
 
     it('should check indentation', () => {

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -4,7 +4,9 @@
 
 import moment from 'moment';
 import type { Task } from '../../src/Task/Task';
+import { example_kanban } from '../Obsidian/__test_data__/example_kanban';
 import { TaskBuilder } from './TaskBuilder';
+import { getTasksFileFromMockData } from './MockDataHelpers';
 
 export {};
 
@@ -21,6 +23,13 @@ describe('TaskBuilder', () => {
         const builder = new TaskBuilder();
         const task = builder.description('hello').build();
         expect(task.originalMarkdown).toEqual('- [ ] hello');
+    });
+
+    it('should populate CachedMetadata', () => {
+        const cachedMetadata = getTasksFileFromMockData(example_kanban).cachedMetadata;
+        const builder = new TaskBuilder().cachedMetadata(cachedMetadata);
+        const task = builder.build();
+        expect(task.file.cachedMetadata).toBe(cachedMetadata);
     });
 
     function hasValue<Type>(value: Type[keyof Type]): boolean {

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -5,6 +5,7 @@
 import moment from 'moment';
 import type { Task } from '../../src/Task/Task';
 import { example_kanban } from '../Obsidian/__test_data__/example_kanban';
+import { jason_properties } from '../Obsidian/__test_data__/jason_properties';
 import { TaskBuilder } from './TaskBuilder';
 import { getTasksFileFromMockData } from './MockDataHelpers';
 
@@ -30,6 +31,15 @@ describe('TaskBuilder', () => {
         const builder = new TaskBuilder().cachedMetadata(cachedMetadata);
         const task = builder.build();
         expect(task.file.cachedMetadata).toBe(cachedMetadata);
+    });
+
+    it('should populate CachedMetadata in two different TaskBuilder objects simultaneously', () => {
+        const builder1 = new TaskBuilder().mockData(example_kanban);
+        const builder2 = new TaskBuilder().mockData(jason_properties);
+        const task1 = builder1.build();
+        const task2 = builder2.build();
+        expect(task1.file.property('kanban-plugin')).toEqual('basic');
+        expect(task2.file.property('publish')).toEqual(false);
     });
 
     function hasValue<Type>(value: Type[keyof Type]): boolean {

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -7,7 +7,6 @@ import type { Task } from '../../src/Task/Task';
 import { example_kanban } from '../Obsidian/__test_data__/example_kanban';
 import { jason_properties } from '../Obsidian/__test_data__/jason_properties';
 import { TaskBuilder } from './TaskBuilder';
-import { getTasksFileFromMockData } from './MockDataHelpers';
 
 export {};
 
@@ -27,10 +26,9 @@ describe('TaskBuilder', () => {
     });
 
     it('should populate CachedMetadata', () => {
-        const cachedMetadata = getTasksFileFromMockData(example_kanban).cachedMetadata;
-        const builder = new TaskBuilder().cachedMetadata(cachedMetadata);
+        const builder = new TaskBuilder().mockData(example_kanban);
         const task = builder.build();
-        expect(task.file.cachedMetadata).toBe(cachedMetadata);
+        expect(task.file.cachedMetadata).toBe(example_kanban.cachedMetadata);
     });
 
     it('should populate CachedMetadata in two different TaskBuilder objects simultaneously', () => {

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -1,6 +1,5 @@
 // Builder
 import type { Moment } from 'moment';
-import type { CachedMetadata } from 'obsidian';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Status } from '../../src/Statuses/Status';
 import { Occurrence } from '../../src/Task/Occurrence';
@@ -53,7 +52,6 @@ export class TaskBuilder {
     private _scheduledDateIsInferred: boolean = false;
     private _id: string = '';
     private _dependsOn: string[] = [];
-    private _cachedMetadata: CachedMetadata = {};
     private _mockData: any = undefined;
 
     /**
@@ -76,12 +74,13 @@ export class TaskBuilder {
         if (this._mockData !== undefined) {
             setCurrentCacheFile(this._mockData);
         }
+        const cachedMetadata = this._mockData?.cachedMetadata ?? {};
         const task = new Task({
             // NEW_TASK_FIELD_EDIT_REQUIRED
             status: this._status,
             description: description,
             taskLocation: new TaskLocation(
-                new TasksFile(this._path, this._cachedMetadata),
+                new TasksFile(this._path, cachedMetadata),
                 this._lineNumber,
                 this._sectionStart,
                 this._sectionIndex,
@@ -199,20 +198,6 @@ export class TaskBuilder {
     }
 
     /**
-     * See {@link example_kanban} and other files in the same directory, for available sample test data.
-     * See {@link getTasksFileFromMockData} for obtaining CachedMetadata objects from sample test data.
-     *
-     * @example
-     *      const cachedMetadata = getTasksFileFromMockData(example_kanban).cachedMetadata;
-     *      const builder = new TaskBuilder().cachedMetadata(cachedMetadata);
-     * @param cachedMetadata
-     */
-    public cachedMetadata(cachedMetadata: CachedMetadata) {
-        this._cachedMetadata = cachedMetadata;
-        return this;
-    }
-
-    /**
      * See {@link example_kanban} and other files in the same directory, for available sample mock data.
      *
      * @example
@@ -221,7 +206,6 @@ export class TaskBuilder {
      */
     public mockData(mockData: any) {
         this._mockData = mockData;
-        this._cachedMetadata = mockData.cachedMetadata;
         return this;
     }
 

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -1,5 +1,6 @@
 // Builder
 import type { Moment } from 'moment';
+import type { CachedMetadata } from 'obsidian';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Status } from '../../src/Statuses/Status';
 import { Occurrence } from '../../src/Task/Occurrence';
@@ -51,6 +52,7 @@ export class TaskBuilder {
     private _scheduledDateIsInferred: boolean = false;
     private _id: string = '';
     private _dependsOn: string[] = [];
+    private _cachedMetadata: CachedMetadata = {};
 
     /**
      * Build a Task
@@ -74,7 +76,7 @@ export class TaskBuilder {
             status: this._status,
             description: description,
             taskLocation: new TaskLocation(
-                new TasksFile(this._path),
+                new TasksFile(this._path, this._cachedMetadata),
                 this._lineNumber,
                 this._sectionStart,
                 this._sectionIndex,
@@ -188,6 +190,20 @@ export class TaskBuilder {
      */
     public path(path: string): TaskBuilder {
         this._path = path;
+        return this;
+    }
+
+    /**
+     * See {@link example_kanban} and other files in the same directory, for available sample test data.
+     * See {@link getTasksFileFromMockData} for obtaining CachedMetadata objects from sample test data.
+     *
+     * @example
+     *      const cachedMetadata = getTasksFileFromMockData(example_kanban).cachedMetadata;
+     *      const builder = new TaskBuilder().cachedMetadata(cachedMetadata);
+     * @param cachedMetadata
+     */
+    public cachedMetadata(cachedMetadata: CachedMetadata) {
+        this._cachedMetadata = cachedMetadata;
         return this;
     }
 

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -10,6 +10,7 @@ import { DateParser } from '../../src/Query/DateParser';
 import { StatusConfiguration, StatusType } from '../../src/Statuses/StatusConfiguration';
 import { TaskLocation } from '../../src/Task/TaskLocation';
 import { Priority } from '../../src/Task/Priority';
+import { setCurrentCacheFile } from '../__mocks__/obsidian';
 
 /**
  * A fluent class for creating tasks for tests.
@@ -53,6 +54,7 @@ export class TaskBuilder {
     private _id: string = '';
     private _dependsOn: string[] = [];
     private _cachedMetadata: CachedMetadata = {};
+    private _mockData: any = undefined;
 
     /**
      * Build a Task
@@ -70,6 +72,9 @@ export class TaskBuilder {
         let description = this._description;
         if (this._tags.length > 0) {
             description += ' ' + this._tags.join(' ');
+        }
+        if (this._mockData !== undefined) {
+            setCurrentCacheFile(this._mockData);
         }
         const task = new Task({
             // NEW_TASK_FIELD_EDIT_REQUIRED
@@ -204,6 +209,19 @@ export class TaskBuilder {
      */
     public cachedMetadata(cachedMetadata: CachedMetadata) {
         this._cachedMetadata = cachedMetadata;
+        return this;
+    }
+
+    /**
+     * See {@link example_kanban} and other files in the same directory, for available sample mock data.
+     *
+     * @example
+     *      const builder = new TaskBuilder().mockData(example_kanban);
+     * @param mockData
+     */
+    public mockData(mockData: any) {
+        this._mockData = mockData;
+        this._cachedMetadata = mockData.cachedMetadata;
         return this;
     }
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

`Task` objects are now updated if the frontmatter in the file containing them is edited.

## Motivation and Context

This fixes an unreleased bug, that editing properties/frontmatter did not update Tasks query results. This matters now that  properties/frontmatter can be used in Tasks queries.

The steps to reproduce the bug are:

1. Install development version of Tasks plugin
2. Create a note called `test`
3. Paste in this content:

````
---
custom_number_prop: 42
---

```tasks
path includes {{query.file.path}}
group by function task.file.property('custom_number_prop')
```

- [ ] #task Hello
````

4. Preview the results. It should show this:

![image](https://github.com/user-attachments/assets/52d29bc6-b27f-430e-a318-d9b40e5140cd)


5. Use the 'File properties' panel to edit the property value from 42 to 43

**Expected result**

Group heading changes to 43:

![image](https://github.com/user-attachments/assets/6e273200-bcd6-410e-ad90-aa3e6eb57401)

**Actual result**

Display is unchanged until edits are made to the task line in the file, or Obsidian is restarted.


## How has this been tested?

- TDD addition of automated tests for the fix
- Manual exploratory testing, confirming that the steps recorded above now work

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
