### PR TITLE
fix: Tasks in renamed files forgot about any properties/frontmatter values in the file

### DIFF
--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -293,7 +293,7 @@ export class Cache {
                         } else {
                             return DateFallback.updateTaskPath(
                                 task,
-                                task.taskLocation.fromRenamedFile(new TasksFile(file.path)),
+                                task.taskLocation.fromRenamedFile(tasksFile),
                                 fallbackDate.value,
                             );
                         }

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -286,16 +286,15 @@ export class Cache {
                 this.tasks = this.tasks.map((task: Task): Task => {
                     if (task.path !== oldPath) {
                         return task;
+                    }
+                    const taskLocation = task.taskLocation.fromRenamedFile(tasksFile);
+                    if (!useFilenameAsScheduledDate) {
+                        return new Task({
+                            ...task,
+                            taskLocation: taskLocation,
+                        });
                     } else {
-                        const taskLocation = task.taskLocation.fromRenamedFile(tasksFile);
-                        if (!useFilenameAsScheduledDate) {
-                            return new Task({
-                                ...task,
-                                taskLocation: taskLocation,
-                            });
-                        } else {
-                            return DateFallback.updateTaskPath(task, taskLocation, fallbackDate.value);
-                        }
+                        return DateFallback.updateTaskPath(task, taskLocation, fallbackDate.value);
                     }
                 });
 

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -293,7 +293,6 @@ export class Cache {
                         } else {
                             return DateFallback.updateTaskPath(
                                 task,
-                                file.path,
                                 task.taskLocation.fromRenamedFile(new TasksFile(file.path)),
                                 fallbackDate.value,
                             );

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -285,17 +285,14 @@ export class Cache {
 
                 this.tasks = this.tasks.map((task: Task): Task => {
                     if (task.path === oldPath) {
+                        const taskLocation = task.taskLocation.fromRenamedFile(tasksFile);
                         if (!useFilenameAsScheduledDate) {
                             return new Task({
                                 ...task,
-                                taskLocation: task.taskLocation.fromRenamedFile(tasksFile),
+                                taskLocation: taskLocation,
                             });
                         } else {
-                            return DateFallback.updateTaskPath(
-                                task,
-                                task.taskLocation.fromRenamedFile(tasksFile),
-                                fallbackDate.value,
-                            );
+                            return DateFallback.updateTaskPath(task, taskLocation, fallbackDate.value);
                         }
                     } else {
                         return task;

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -293,7 +293,7 @@ export class Cache {
                     }
                     return new Task({
                         ...task,
-                        taskLocation: taskLocation,
+                        taskLocation,
                     });
                 });
 

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -290,12 +290,11 @@ export class Cache {
                     const taskLocation = task.taskLocation.fromRenamedFile(tasksFile);
                     if (useFilenameAsScheduledDate) {
                         return DateFallback.updateTaskPath(task, taskLocation, fallbackDate.value);
-                    } else {
-                        return new Task({
-                            ...task,
-                            taskLocation: taskLocation,
-                        });
                     }
+                    return new Task({
+                        ...task,
+                        taskLocation: taskLocation,
+                    });
                 });
 
                 this.notifySubscribers();

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -284,7 +284,9 @@ export class Cache {
                 const fallbackDate = new Lazy(() => DateFallback.fromPath(file.path));
 
                 this.tasks = this.tasks.map((task: Task): Task => {
-                    if (task.path === oldPath) {
+                    if (task.path !== oldPath) {
+                        return task;
+                    } else {
                         const taskLocation = task.taskLocation.fromRenamedFile(tasksFile);
                         if (!useFilenameAsScheduledDate) {
                             return new Task({
@@ -294,8 +296,6 @@ export class Cache {
                         } else {
                             return DateFallback.updateTaskPath(task, taskLocation, fallbackDate.value);
                         }
-                    } else {
-                        return task;
                     }
                 });
 

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -288,13 +288,13 @@ export class Cache {
                         return task;
                     }
                     const taskLocation = task.taskLocation.fromRenamedFile(tasksFile);
-                    if (!useFilenameAsScheduledDate) {
+                    if (useFilenameAsScheduledDate) {
+                        return DateFallback.updateTaskPath(task, taskLocation, fallbackDate.value);
+                    } else {
                         return new Task({
                             ...task,
                             taskLocation: taskLocation,
                         });
-                    } else {
-                        return DateFallback.updateTaskPath(task, taskLocation, fallbackDate.value);
                     }
                 });
 

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -291,7 +291,12 @@ export class Cache {
                                 taskLocation: task.taskLocation.fromRenamedFile(tasksFile),
                             });
                         } else {
-                            return DateFallback.updateTaskPath(task, file.path, fallbackDate.value);
+                            return DateFallback.updateTaskPath(
+                                task,
+                                file.path,
+                                task.taskLocation.fromRenamedFile(new TasksFile(file.path)),
+                                fallbackDate.value,
+                            );
                         }
                     } else {
                         return task;

--- a/src/Task/DateFallback.ts
+++ b/src/Task/DateFallback.ts
@@ -113,7 +113,7 @@ export class DateFallback {
                 scheduledDate = fallbackDate;
             } else if (this.canApplyFallback(task)) {
                 // ...and the task is candidate to date fallback
-                // sest the scheduled date from the new path
+                // set the scheduled date from the new path
                 scheduledDate = fallbackDate;
                 scheduledDateIsInferred = true;
             } else {

--- a/src/Task/DateFallback.ts
+++ b/src/Task/DateFallback.ts
@@ -85,16 +85,10 @@ export class DateFallback {
     /**
      * Implement the logic to update the fields related to date fallback of a task when its file has moved
      * @param task         - task to update
-     * @param _newPath     - new location
      * @param newLocation  - new location
      * @param fallbackDate - fallback date from new location, for efficiency. Can be null
      */
-    public static updateTaskPath(
-        task: Task,
-        _newPath: string,
-        newLocation: TaskLocation,
-        fallbackDate: moment.Moment | null,
-    ): Task {
+    public static updateTaskPath(task: Task, newLocation: TaskLocation, fallbackDate: moment.Moment | null): Task {
         // initialize with values from before the path was changed
         let scheduledDate = task.scheduledDate;
         let scheduledDateIsInferred = task.scheduledDateIsInferred;

--- a/src/Task/DateFallback.ts
+++ b/src/Task/DateFallback.ts
@@ -1,6 +1,6 @@
 import type { Moment } from 'moment';
 import { getSettings } from '../Config/Settings';
-import { TasksFile } from '../Scripting/TasksFile';
+import type { TaskLocation } from './TaskLocation';
 import { Task } from './Task';
 
 /**
@@ -85,10 +85,16 @@ export class DateFallback {
     /**
      * Implement the logic to update the fields related to date fallback of a task when its file has moved
      * @param task         - task to update
-     * @param newPath      - new location
+     * @param _newPath     - new location
+     * @param newLocation  - new location
      * @param fallbackDate - fallback date from new location, for efficiency. Can be null
      */
-    public static updateTaskPath(task: Task, newPath: string, fallbackDate: Moment | null): Task {
+    public static updateTaskPath(
+        task: Task,
+        _newPath: string,
+        newLocation: TaskLocation,
+        fallbackDate: moment.Moment | null,
+    ): Task {
         // initialize with values from before the path was changed
         let scheduledDate = task.scheduledDate;
         let scheduledDateIsInferred = task.scheduledDateIsInferred;
@@ -123,7 +129,7 @@ export class DateFallback {
 
         return new Task({
             ...task,
-            taskLocation: task.taskLocation.fromRenamedFile(new TasksFile(newPath)),
+            taskLocation: newLocation,
             scheduledDate,
             scheduledDateIsInferred,
         });

--- a/src/Task/DateFallback.ts
+++ b/src/Task/DateFallback.ts
@@ -88,7 +88,7 @@ export class DateFallback {
      * @param newLocation  - new location
      * @param fallbackDate - fallback date from new location, for efficiency. Can be null
      */
-    public static updateTaskPath(task: Task, newLocation: TaskLocation, fallbackDate: moment.Moment | null): Task {
+    public static updateTaskPath(task: Task, newLocation: TaskLocation, fallbackDate: Moment | null): Task {
         // initialize with values from before the path was changed
         let scheduledDate = task.scheduledDate;
         let scheduledDateIsInferred = task.scheduledDateIsInferred;

--- a/tests/Task/DateFallback.test.ts
+++ b/tests/Task/DateFallback.test.ts
@@ -407,7 +407,6 @@ describe('update fallback date when path is changed', () => {
         // Act
         const updatedTask = DateFallback.updateTaskPath(
             task,
-            newPath,
             task.taskLocation.fromRenamedFile(new TasksFile(newPath)),
             fallbackDate,
         );

--- a/tests/Task/DateFallback.test.ts
+++ b/tests/Task/DateFallback.test.ts
@@ -405,7 +405,12 @@ describe('update fallback date when path is changed', () => {
         const fallbackDate = DateFallback.fromPath(newPath);
 
         // Act
-        const updatedTask = DateFallback.updateTaskPath(task, newPath, fallbackDate);
+        const updatedTask = DateFallback.updateTaskPath(
+            task,
+            newPath,
+            task.taskLocation.fromRenamedFile(new TasksFile(newPath)),
+            fallbackDate,
+        );
 
         // Assert
         if (expectedScheduledDate === null) {


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue - _in an unreleased feature_)

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

Fix an unreported bug (in unreleased code)...

The actual fix is c09a8846f562cbf3131f2390763b33c2febd9412 - the rest is refactoring, initially to make the fix easy, and then to tidy it up a bit, with suggestions from @ilandikov.

Steps to reproduce:


### Preparation

1. Install the latest development build, for example from commit b42ead68505f99e6543c1f27d6e4e63d9d1a2d69
2. Create a new note called `test 2024-01-23`
3. Paste in this content:

~~~
---
custom_number_prop: 422
---

- [ ] #task Hellox
~~~

4. Create a note called `test query`
5. Paste in this content:

~~~
```tasks
description includes Hellox

group by path
group by function \
    `custom_number_prop: ==${task.file.property('custom_number_prop')}==`
group by scheduled
```
~~~

6. View `test query` in Reading Mode. It should look like this:

![Types of changes - 2024-08-02 21-19-24](https://github.com/user-attachments/assets/44f77127-0885-4b53-9d14-f476d7b667ac)

### Testing

7. Rename `test 2024-01-23` to `test 2024-01-23 xxx`

**Expected result**

a. The `group by path` heading gets ` xxx` added
b. The `custom_number_prop:` heading value remains `422`
c. The Backlink name gets  ` xxx` added


![Types of changes - 2024-08-02 21-24-43](https://github.com/user-attachments/assets/d7d10fcc-bfbc-49c3-8b17-5d3cd3161854)




**Actual result**

a. ✅ The `group by path` heading gets ` xxx` added
b. ❌ The `custom_number_prop:` heading value becomes `NULL`, not `422`
c. ✅ The Backlink name gets  ` xxx` added



![Types of changes - 2024-08-02 21-24-01](https://github.com/user-attachments/assets/853633db-034f-4342-8ae5-0cdd33935e95)




## Motivation and Context

## How has this been tested?

- Automated tests
- Exploratory testing

## Screenshots (if appropriate)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
