### PR TITLE
refactor: Small improvements to the 'On Completion' implementation

### DIFF
--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -11,29 +11,29 @@ function returnWithoutCompletedInstance(tasks: Task[], changedStatusTask: Task) 
     return tasks.filter((task) => task !== changedStatusTask);
 }
 
-export function handleOnCompletion(task: Task, tasks: Task[]): Task[] {
-    const tasksArrayLength = tasks.length;
+export function handleOnCompletion(originalTask: Task, newTasks: Task[]): Task[] {
+    const tasksArrayLength = newTasks.length;
     if (tasksArrayLength === 0) {
-        return tasks;
+        return newTasks;
     }
-    const startStatus = task.status;
+    const startStatus = originalTask.status;
 
-    const changedStatusTask = tasks[tasksArrayLength - 1];
+    const changedStatusTask = newTasks[tasksArrayLength - 1];
     const endStatus = changedStatusTask.status;
 
-    if (!task.onCompletion || endStatus.type !== StatusType.DONE || endStatus.type === startStatus.type) {
-        return tasks;
+    if (!originalTask.onCompletion || endStatus.type !== StatusType.DONE || endStatus.type === startStatus.type) {
+        return newTasks;
     }
 
-    const ocAction = task.onCompletion.toLowerCase();
+    const ocAction = originalTask.onCompletion.toLowerCase();
 
     if ('delete' === ocAction) {
-        return returnWithoutCompletedInstance(tasks, changedStatusTask);
+        return returnWithoutCompletedInstance(newTasks, changedStatusTask);
     }
 
-    const errorText = 'Unknown "On Completion" action: ' + task.onCompletion;
+    const errorText = 'Unknown "On Completion" action: ' + originalTask.onCompletion;
     const hintText = '\nClick here to clear';
     const noticeText = errorText + hintText;
     new Notice(noticeText, 0);
-    return tasks;
+    return newTasks;
 }

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -25,9 +25,9 @@ export function handleOnCompletion(originalTask: Task, newTasks: Task[]): Task[]
         return newTasks;
     }
 
-    const ocAction = originalTask.onCompletion.toLowerCase();
+    const ocAction: OnCompletion = originalTask.onCompletion;
 
-    if ('delete' === ocAction) {
+    if (OnCompletion.Delete === ocAction) {
         return returnWithoutCompletedInstance(newTasks, changedStatusTask);
     }
 

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -7,6 +7,15 @@ export enum OnCompletion {
     Delete = 'delete',
 }
 
+export function parseOnCompletionValue(inputOnCompletionValue: string) {
+    const onCompletionString = inputOnCompletionValue.trim().toLowerCase();
+    if (onCompletionString === 'delete') {
+        return OnCompletion.Delete;
+    } else {
+        return OnCompletion.Ignore;
+    }
+}
+
 function returnWithoutCompletedInstance(tasks: Task[], changedStatusTask: Task) {
     return tasks.filter((task) => task !== changedStatusTask);
 }

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -129,6 +129,15 @@ export function allTaskPluginEmojis() {
     return allEmojis;
 }
 
+function parseOnCompletionValue(inputOnCompletionValue: string) {
+    const onCompletionString = inputOnCompletionValue.trim().toLowerCase();
+    if (onCompletionString === 'delete') {
+        return OnCompletion.Delete;
+    } else {
+        return OnCompletion.Ignore;
+    }
+}
+
 export class DefaultTaskSerializer implements TaskSerializer {
     constructor(public readonly symbols: DefaultTaskSerializerSymbols) {}
 
@@ -344,12 +353,8 @@ export class DefaultTaskSerializer implements TaskSerializer {
             const onCompletionMatch = line.match(TaskFormatRegularExpressions.onCompletionRegex);
             if (onCompletionMatch != null) {
                 line = line.replace(TaskFormatRegularExpressions.onCompletionRegex, '').trim();
-                const onCompletionString = onCompletionMatch[1].trim().toLowerCase();
-                if (onCompletionString === 'delete') {
-                    onCompletion = OnCompletion.Delete;
-                } else {
-                    onCompletion = OnCompletion.Ignore;
-                }
+                const inputOnCompletionValue = onCompletionMatch[1];
+                onCompletion = parseOnCompletionValue(inputOnCompletionValue);
                 matched = true;
             }
 

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -1,6 +1,6 @@
 import type { Moment } from 'moment';
 import { TaskLayoutComponent, TaskLayoutOptions } from '../Layout/TaskLayoutOptions';
-import { OnCompletion } from '../Task/OnCompletion';
+import { OnCompletion, parseOnCompletionValue } from '../Task/OnCompletion';
 import { Occurrence } from '../Task/Occurrence';
 import { Recurrence } from '../Task/Recurrence';
 import { Task } from '../Task/Task';
@@ -127,15 +127,6 @@ export function allTaskPluginEmojis() {
         }
     });
     return allEmojis;
-}
-
-function parseOnCompletionValue(inputOnCompletionValue: string) {
-    const onCompletionString = inputOnCompletionValue.trim().toLowerCase();
-    if (onCompletionString === 'delete') {
-        return OnCompletion.Delete;
-    } else {
-        return OnCompletion.Ignore;
-    }
 }
 
 export class DefaultTaskSerializer implements TaskSerializer {

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -2,7 +2,7 @@ import { GlobalFilter } from '../Config/GlobalFilter';
 import { parseTypedDateForSaving } from '../lib/DateTools';
 import { replaceTaskWithTasks } from '../Obsidian/File';
 import type { Status } from '../Statuses/Status';
-import { OnCompletion } from '../Task/OnCompletion';
+import type { OnCompletion } from '../Task/OnCompletion';
 import { Occurrence } from '../Task/Occurrence';
 import { Priority } from '../Task/Priority';
 import { Recurrence } from '../Task/Recurrence';
@@ -188,14 +188,7 @@ export class EditableTask {
                 parsedPriority = Priority.None;
         }
 
-        let parsedOnCompletion: OnCompletion;
-        switch (this.onCompletion) {
-            case 'delete':
-                parsedOnCompletion = OnCompletion.Delete;
-                break;
-            default:
-                parsedOnCompletion = OnCompletion.Ignore;
-        }
+        const parsedOnCompletion: OnCompletion = this.onCompletion;
 
         const blockedByWithIds = [];
 

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -25,7 +25,6 @@ export class EditableTask {
     status: Status;
     priority: EditableTaskPriority;
     recurrenceRule: string;
-    // onCompletion: 'ignore' | 'delete';
     onCompletion: OnCompletion;
     createdDate: string;
     startDate: string;
@@ -45,7 +44,6 @@ export class EditableTask {
         description: string;
         status: Status;
         priority: EditableTaskPriority;
-        // onCompletion: 'ignore' | 'delete';
         onCompletion: OnCompletion;
         recurrenceRule: string;
         createdDate: string;

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -9,7 +9,7 @@ import { StatusConfiguration, StatusType } from '../../src/Statuses/StatusConfig
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { fromLine, toLines, toMarkdown } from '../TestingTools/TestHelpers';
 import type { Task } from '../../src/Task/Task';
-import { handleOnCompletion } from '../../src/Task/OnCompletion';
+import { OnCompletion, handleOnCompletion } from '../../src/Task/OnCompletion';
 
 window.moment = moment;
 
@@ -34,7 +34,7 @@ describe('OnCompletion feature', () => {
         const dueDate = '2024-02-10';
         const task = new TaskBuilder()
             .description('An already-DONE, non-recurring task')
-            .onCompletion('delete')
+            .onCompletion(OnCompletion.Delete)
             .dueDate(dueDate)
             .doneDate(dueDate)
             .status(Status.DONE)
@@ -96,7 +96,7 @@ describe('OnCompletion feature', () => {
         const task = new TaskBuilder()
             .description('A recurring task with OC_DELETE trigger')
             .recurrence(recurrence)
-            .onCompletion('delete')
+            .onCompletion(OnCompletion.Delete)
             .dueDate(dueDate)
             .build();
 
@@ -114,7 +114,7 @@ describe('OnCompletion feature', () => {
         const done2 = new Status(new StatusConfiguration('X', 'DONE', ' ', true, StatusType.DONE));
         const task = new TaskBuilder()
             .description('A simple done task with')
-            .onCompletion('delete')
+            .onCompletion(OnCompletion.Delete)
             .status(done1)
             .build();
 
@@ -129,7 +129,10 @@ describe('OnCompletion feature', () => {
 
     it('should return a task featuring the On Completion flag trigger but an empty string Action', () => {
         // Arrange
-        const task = new TaskBuilder().description('A non-recurring task with').onCompletion('').build();
+        const task = new TaskBuilder()
+            .description('A non-recurring task with')
+            .onCompletion(OnCompletion.Ignore)
+            .build();
 
         // Act
         const tasks = applyStatusAndOnCompletionAction(task, Status.makeDone());
@@ -146,7 +149,7 @@ describe('OnCompletion - Delete action', () => {
         const task = new TaskBuilder()
             .description('A non-recurring task with OC_DELETE trigger')
             .dueDate(dueDate)
-            .onCompletion('delete')
+            .onCompletion(OnCompletion.Delete)
             .build();
         expect(task.status.type).toEqual(StatusType.TODO);
 
@@ -165,7 +168,7 @@ describe('OnCompletion - Delete action', () => {
             .description('A recurring task with OC_DELETE trigger')
             .recurrence(recurrence)
             .dueDate(dueDate)
-            .onCompletion('delete')
+            .onCompletion(OnCompletion.Delete)
             .build();
         expect(task.status.type).toEqual(StatusType.TODO);
 
@@ -182,7 +185,7 @@ describe('OnCompletion - Delete action', () => {
         // Arrange
         const task = new TaskBuilder()
             .description('A non-recurring task with OC_DELETE trigger')
-            .onCompletion('delete')
+            .onCompletion(OnCompletion.Delete)
             .build();
 
         // Act

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -21,6 +21,7 @@ import { booleanToEmoji } from '../TestingTools/FilterTestHelpers';
 import type { TasksDate } from '../../src/Scripting/TasksDate';
 import { example_kanban } from '../Obsidian/__test_data__/example_kanban';
 import { jason_properties } from '../Obsidian/__test_data__/jason_properties';
+import { OnCompletion } from '../../src/Task/OnCompletion';
 
 window.moment = moment;
 
@@ -1705,9 +1706,9 @@ describe('identicalTo', () => {
     });
 
     it('should check onCompletion', () => {
-        const lhs = new TaskBuilder().onCompletion('');
-        expect(lhs).toBeIdenticalTo(new TaskBuilder().onCompletion(''));
-        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().onCompletion('delete'));
+        const lhs = new TaskBuilder().onCompletion(OnCompletion.Ignore);
+        expect(lhs).toBeIdenticalTo(new TaskBuilder().onCompletion(OnCompletion.Ignore));
+        expect(lhs).not.toBeIdenticalTo(new TaskBuilder().onCompletion(OnCompletion.Delete));
     });
 
     it('should correctly compare a task with status read from user settings', () => {

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -327,7 +327,7 @@ describe('DataviewTaskSerializer', () => {
         });
 
         it('should serialize onCompletion', () => {
-            const task = new TaskBuilder().onCompletion('delete').description('').build();
+            const task = new TaskBuilder().onCompletion(OnCompletion.Delete).description('').build();
             const serialized = serialize(task);
             expect(serialized).toEqual('  [onCompletion:: delete]');
         });

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -258,7 +258,7 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
         });
 
         it('should serialize onCompletion', () => {
-            const task = new TaskBuilder().onCompletion('delete').description('').build();
+            const task = new TaskBuilder().onCompletion(OnCompletion.Delete).description('').build();
             const serialized = serialize(task);
             expect(serialized).toEqual(` ${onCompletionSymbol} delete`);
         });

--- a/tests/TestingTools/SampleTasks.ts
+++ b/tests/TestingTools/SampleTasks.ts
@@ -5,6 +5,7 @@ import { Status } from '../../src/Statuses/Status';
 import { StatusType } from '../../src/Statuses/StatusConfiguration';
 import { Priority } from '../../src/Task/Priority';
 import { PriorityTools } from '../../src/lib/PriorityTools';
+import { OnCompletion } from '../../src/Task/OnCompletion';
 import { TaskBuilder } from './TaskBuilder';
 import { fromLine, fromLines } from './TestHelpers';
 
@@ -289,10 +290,13 @@ export class SampleTasks {
                 dueDate: null,
             }),
         });
-        const task1 = new TaskBuilder().description('#task Remove this task when done').onCompletion('delete').build();
+        const task1 = new TaskBuilder()
+            .description('#task Remove this task when done')
+            .onCompletion(OnCompletion.Delete)
+            .build();
         const task2 = new TaskBuilder()
             .description('#task Remove completed instance of this recurring task when done')
-            .onCompletion('delete')
+            .onCompletion(OnCompletion.Delete)
             .recurrence(everyDay)
             .build();
         return [task1, task2];

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -292,12 +292,8 @@ export class TaskBuilder {
         return this;
     }
 
-    public onCompletion(onCompletion: string): this {
-        if (onCompletion === 'delete') {
-            this._onCompletion = OnCompletion.Delete;
-        } else {
-            this._onCompletion = OnCompletion.Ignore;
-        }
+    public onCompletion(onCompletion: OnCompletion): this {
+        this._onCompletion = onCompletion;
         return this;
     }
 

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -129,7 +129,7 @@ export class TaskBuilder {
             .dueDate('2023-07-04')
             .doneDate('2023-07-05')
             .cancelledDate('2023-07-06')
-            .onCompletion('delete')
+            .onCompletion(OnCompletion.Delete)
             .dependsOn(['123456', 'abc123'])
             .id('abcdef')
             .blockLink(' ^dcf64c')

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -450,6 +450,16 @@ describe('Task editing', () => {
             expect(await editFieldAndSave(line, 'start', '2024-01-01')).toEqual('- [ ] simple 🛫 2024-01-01');
         });
     });
+
+    describe('OnCompletion editing', () => {
+        it('should retain any OnCompletion value', async () => {
+            // We cannot yet edit the OnCompletion in the modal.
+            // So for now, just test to ensure that any initial value is retained.
+            expect(await editFieldAndSave('- [ ] description  🏁 delete', 'start', '2024-01-01')).toEqual(
+                '- [ ] description 🏁 delete 🛫 2024-01-01',
+            );
+        });
+    });
 });
 
 /**


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- Refactor the On Completion code to make wider use of the `OnCompletion` enum.
- Move the code for parsing On Completion values from `DefaultTaskSerializer.ts` to `OnCompletion.ts` so that all edits for new or changed options are in the same file.
- Add new test to ensure that the EditTask modal retains any `OnCompletion` value (it cannot yet edit the value)

## Motivation and Context

Getting ready to release the work done in:

- #2840

## How has this been tested?

- Automated tests
- Exploratory testing

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
