### PR TITLE
fix: Render numbered sub-tasks and list items in Reading view

### DIFF
--- a/src/Obsidian/InlineRenderer.ts
+++ b/src/Obsidian/InlineRenderer.ts
@@ -122,9 +122,10 @@ export class InlineRenderer {
             const renderedChildren = renderedElement.childNodes;
             for (let i = 0; i < renderedChildren.length; i = i + 1) {
                 const renderedChild = renderedChildren[i];
-                if (renderedChild.nodeName.toLowerCase() === 'div') {
+                const nodeName = renderedChild.nodeName.toLowerCase();
+                if (nodeName === 'div') {
                     taskElement.prepend(renderedChild);
-                } else if (renderedChild.nodeName.toLowerCase() === 'ul') {
+                } else if (nodeName === 'ul') {
                     taskElement.append(renderedChild);
                 }
             }

--- a/src/Obsidian/InlineRenderer.ts
+++ b/src/Obsidian/InlineRenderer.ts
@@ -125,7 +125,7 @@ export class InlineRenderer {
                 const nodeName = renderedChild.nodeName.toLowerCase();
                 if (nodeName === 'div') {
                     taskElement.prepend(renderedChild);
-                } else if (nodeName === 'ul') {
+                } else if (nodeName === 'ul' || nodeName === 'ol') {
                     taskElement.append(renderedChild);
                 }
             }

--- a/src/Task/OnCompletion.ts
+++ b/src/Task/OnCompletion.ts
@@ -36,7 +36,7 @@ export function handleOnCompletion(originalTask: Task, newTasks: Task[]): Task[]
 
     const ocAction: OnCompletion = originalTask.onCompletion;
 
-    if (OnCompletion.Delete === ocAction) {
+    if (ocAction === OnCompletion.Delete) {
         return returnWithoutCompletedInstance(newTasks, changedStatusTask);
     }
 


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #1395

## Description

Numbered sub-tasks (and plain list items) are now rendered in reading mode.

## Motivation and Context

Fixes #1395

## How has this been tested?

- Exploratory testing (there are no unit tests).

## Screenshots (if appropriate)

### Test file

~~~
- [ ] #task Item 1 📅 2024-03-08
  - Item a 📅 2024-03-08
  - Item b 📅 2024-03-08
  - [ ] #task Item c 📅 2024-03-08
  - [ ] #task Item c 📅 2024-03-08
- [ ] #task Item 2 📅 2024-03-08
    1. Item a 📅 2024-03-08
    1. Item b 📅 2024-03-08
    1. [ ] #task Item c 📅 2024-03-08
    1. [ ] #task Item d 📅 2024-03-08
1. [ ] #task Item c 📅 2024-03-08
1. [ ] #task Item d 📅 2024-03-08
~~~

### Notes

1. All screenshots are in Default theme.
2. The only enabled snippet draws a blue border around Tasks code blocks.
3. The odd overlapping of checkbox and list item number happens in Restricted mode (all plugins off) so is not a Tasks issue.

### Restricted mode:


<img width="1451" alt="image" src="https://github.com/user-attachments/assets/c5aef0aa-382c-469c-b361-050b43139a7d">


### Before the bug fix:

<img width="1447" alt="image" src="https://github.com/user-attachments/assets/29725859-79be-4b46-8869-6986afbc3572">


### After the bug fix:

<img width="1450" alt="image" src="https://github.com/user-attachments/assets/f5dd5fe8-d0cb-4b52-8034-32c29bf99c2d">



## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
    - I checked, and could not find any mention of this bug in the documentation.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
