### PR TITLE
refactor: add `QueryResultsRenderer` class

### DIFF
--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -368,11 +368,11 @@ class QueryRenderChild extends QueryResultsRenderer {
         // Go to the line the task is defined at
         const app = this.app;
         link.addEventListener('click', async (ev: MouseEvent) => {
-            await addBacklinksClickHandler(ev, app, task);
+            await backlinksClickHandler(ev, app, task);
         });
 
         link.addEventListener('mousedown', async (ev: MouseEvent) => {
-            await addBacklinksMousedownHandler(ev, app, task);
+            await backlinksMousedownHandler(ev, app, task);
         });
 
         if (!shortMode) {
@@ -381,7 +381,7 @@ class QueryRenderChild extends QueryResultsRenderer {
     }
 }
 
-async function addBacklinksClickHandler(ev: MouseEvent, app: App, task: Task) {
+async function backlinksClickHandler(ev: MouseEvent, app: App, task: Task) {
     const result = await getTaskLineAndFile(task, app.vault);
     if (result) {
         const [line, file] = result;
@@ -395,7 +395,7 @@ async function addBacklinksClickHandler(ev: MouseEvent, app: App, task: Task) {
     }
 }
 
-async function addBacklinksMousedownHandler(ev: MouseEvent, app: App, task: Task) {
+async function backlinksMousedownHandler(ev: MouseEvent, app: App, task: Task) {
     // Open in a new tab on middle-click.
     // This distinction is not available in the 'click' event, so we handle the 'mousedown' event
     // solely for this.

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -368,17 +368,7 @@ class QueryRenderChild extends QueryResultsRenderer {
         // Go to the line the task is defined at
         const app = this.app;
         link.addEventListener('click', async (ev: MouseEvent) => {
-            const result = await getTaskLineAndFile(task, app.vault);
-            if (result) {
-                const [line, file] = result;
-                const leaf = app.workspace.getLeaf(Keymap.isModEvent(ev));
-                // When the corresponding task has been found,
-                // suppress the default behavior of the mouse click event
-                // (which would interfere e.g. if the query is rendered inside a callout).
-                ev.preventDefault();
-                // Instead of the default behavior, open the file with the required line highlighted.
-                await leaf.openFile(file, { eState: { line: line } });
-            }
+            await addBacklinksClickHandler(ev, app, task);
         });
 
         link.addEventListener('mousedown', async (ev: MouseEvent) => {
@@ -401,5 +391,19 @@ class QueryRenderChild extends QueryResultsRenderer {
         if (!shortMode) {
             backLink.append(')');
         }
+    }
+}
+
+async function addBacklinksClickHandler(ev: MouseEvent, app: App, task: Task) {
+    const result = await getTaskLineAndFile(task, app.vault);
+    if (result) {
+        const [line, file] = result;
+        const leaf = app.workspace.getLeaf(Keymap.isModEvent(ev));
+        // When the corresponding task has been found,
+        // suppress the default behavior of the mouse click event
+        // (which would interfere e.g. if the query is rendered inside a callout).
+        ev.preventDefault();
+        // Instead of the default behavior, open the file with the required line highlighted.
+        await leaf.openFile(file, { eState: { line: line } });
     }
 }

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -241,7 +241,7 @@ class QueryRenderChild extends QueryResultsRenderer {
         task: Task,
         taskIndex: number,
     ) {
-        const isFilenameUnique = this.isFilenameUnique({ task });
+        const isFilenameUnique = this.isFilenameUnique({ task }, this.app.vault.getMarkdownFiles());
         const listItem = await taskLineRenderer.renderTaskLine(task, taskIndex, isFilenameUnique);
 
         // Remove all footnotes. They don't re-appear in another document.
@@ -441,7 +441,7 @@ class QueryRenderChild extends QueryResultsRenderer {
         }
     }
 
-    private isFilenameUnique({ task }: { task: Task }): boolean | undefined {
+    private isFilenameUnique({ task }: { task: Task }, allMarkdownFiles: TFile[]): boolean | undefined {
         // Will match the filename without extension (the file's "basename").
         const filenameMatch = task.path.match(/([^/]*)\..+$/i);
         if (filenameMatch === null) {
@@ -449,7 +449,7 @@ class QueryRenderChild extends QueryResultsRenderer {
         }
 
         const filename = filenameMatch[1];
-        const allFilesWithSameName = this.app.vault.getMarkdownFiles().filter((file: TFile) => {
+        const allFilesWithSameName = allMarkdownFiles.filter((file: TFile) => {
             if (file.basename === filename) {
                 // Found a file with the same name (it might actually be the same file, but we'll take that into account later.)
                 return true;

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -458,12 +458,4 @@ class QueryRenderChild extends QueryResultsRenderer {
 
         return allFilesWithSameName.length < 2;
     }
-
-    private getGroupingAttribute() {
-        const groupingRules: string[] = [];
-        for (const group of this.query.grouping) {
-            groupingRules.push(group.property);
-        }
-        return groupingRules.join(',');
-    }
 }

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -366,12 +366,13 @@ class QueryRenderChild extends QueryResultsRenderer {
         link.setText(linkText);
 
         // Go to the line the task is defined at
-        const vault = this.app.vault;
+        const app = this.app;
+        const vault = app.vault;
         link.addEventListener('click', async (ev: MouseEvent) => {
             const result = await getTaskLineAndFile(task, vault);
             if (result) {
                 const [line, file] = result;
-                const leaf = this.app.workspace.getLeaf(Keymap.isModEvent(ev));
+                const leaf = app.workspace.getLeaf(Keymap.isModEvent(ev));
                 // When the corresponding task has been found,
                 // suppress the default behavior of the mouse click event
                 // (which would interfere e.g. if the query is rendered inside a callout).
@@ -391,7 +392,7 @@ class QueryRenderChild extends QueryResultsRenderer {
                 const result = await getTaskLineAndFile(task, vault);
                 if (result) {
                     const [line, file] = result;
-                    const leaf = this.app.workspace.getLeaf('tab');
+                    const leaf = app.workspace.getLeaf('tab');
                     ev.preventDefault();
                     await leaf.openFile(file, { eState: { line: line } });
                 }

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -17,7 +17,7 @@ import { shouldShowPostponeButton } from '../Scripting/Postponer';
 import { TasksFile } from '../Scripting/TasksFile';
 import { DateFallback } from '../Task/DateFallback';
 import type { Task } from '../Task/Task';
-import { QueryResultsRenderer } from './QueryResultsRenderer';
+import { type BacklinksEventHandler, QueryResultsRenderer } from './QueryResultsRenderer';
 import { TaskLineRenderer, createAndAppendElement } from './TaskLineRenderer';
 
 export class QueryRenderer {
@@ -236,6 +236,9 @@ class QueryRenderChild extends QueryResultsRenderer {
                 taskIndex,
                 this.plugin.getTasks(),
                 this.app.vault.getMarkdownFiles(),
+                backlinksClickHandler,
+                backlinksMousedownHandler,
+                editTaskPencilClickHandler,
             );
         }
 
@@ -249,6 +252,9 @@ class QueryRenderChild extends QueryResultsRenderer {
         taskIndex: number,
         allTasks: Task[],
         allMarkdownFiles: TFile[],
+        backlinksClickHandler: BacklinksEventHandler,
+        backlinksMousedownHandler: BacklinksEventHandler,
+        editTaskPencilClickHandler: EditButtonClickHandler,
     ) {
         const isFilenameUnique = this.isFilenameUnique({ task }, allMarkdownFiles);
         const listItem = await taskLineRenderer.renderTaskLine(task, taskIndex, isFilenameUnique);

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -2,8 +2,6 @@ import type { EventRef, MarkdownPostProcessorContext } from 'obsidian';
 import { App, Keymap, MarkdownRenderer, TFile } from 'obsidian';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { GlobalQuery } from '../Config/GlobalQuery';
-
-import type { IQuery } from '../IQuery';
 import { QueryLayout } from '../Layout/QueryLayout';
 import { TaskLayout } from '../Layout/TaskLayout';
 import { PerformanceTracker } from '../lib/PerformanceTracker';
@@ -58,10 +56,6 @@ class QueryRenderChild extends QueryResultsRenderer {
     private plugin: TasksPlugin;
     private readonly events: TasksEvents;
 
-    private query: IQuery;
-    // @ts-expect-error: TS6133: 'queryType' is declared but its value is never read
-    private queryType: string; // whilst there is only one query type, there is no point logging this value
-
     private renderEventRef: EventRef | undefined;
     private queryReloadTimeout: NodeJS.Timeout | undefined;
 
@@ -85,21 +79,6 @@ class QueryRenderChild extends QueryResultsRenderer {
         this.app = app;
         this.plugin = plugin;
         this.events = events;
-
-        // The engine is chosen on the basis of the code block language. Currently,
-        // there is only the main engine for the plugin, this allows others to be
-        // added later.
-        switch (this.containerEl.className) {
-            case 'block-language-tasks':
-                this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
-                this.queryType = 'tasks';
-                break;
-
-            default:
-                this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
-                this.queryType = 'tasks';
-                break;
-        }
     }
 
     onload() {

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -352,8 +352,8 @@ class QueryRenderChild extends QueryResultsRenderer {
         task: Task,
         shortMode: boolean,
         isFilenameUnique: boolean | undefined,
-        clickHandler: (ev: MouseEvent, app: App, task: Task) => Promise<void>,
-        mousedownHandler: (ev: MouseEvent, app: App, task: Task) => Promise<void>,
+        clickHandler: (ev: MouseEvent, task: Task) => Promise<void>,
+        mousedownHandler: (ev: MouseEvent, task: Task) => Promise<void>,
     ) {
         const backLink = listItem.createSpan({ cls: 'tasks-backlink' });
 
@@ -380,13 +380,12 @@ class QueryRenderChild extends QueryResultsRenderer {
         link.setText(linkText);
 
         // Go to the line the task is defined at
-        const app = this.app;
         link.addEventListener('click', async (ev: MouseEvent) => {
-            await clickHandler(ev, app, task);
+            await clickHandler(ev, task);
         });
 
         link.addEventListener('mousedown', async (ev: MouseEvent) => {
-            await mousedownHandler(ev, app, task);
+            await mousedownHandler(ev, task);
         });
 
         if (!shortMode) {
@@ -395,7 +394,7 @@ class QueryRenderChild extends QueryResultsRenderer {
     }
 }
 
-async function backlinksClickHandler(ev: MouseEvent, app: App, task: Task) {
+async function backlinksClickHandler(ev: MouseEvent, task: Task) {
     const result = await getTaskLineAndFile(task, app.vault);
     if (result) {
         const [line, file] = result;
@@ -409,7 +408,7 @@ async function backlinksClickHandler(ev: MouseEvent, app: App, task: Task) {
     }
 }
 
-async function backlinksMousedownHandler(ev: MouseEvent, app: App, task: Task) {
+async function backlinksMousedownHandler(ev: MouseEvent, task: Task) {
     // Open in a new tab on middle-click.
     // This distinction is not available in the 'click' event, so we handle the 'mousedown' event
     // solely for this.

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -2,8 +2,6 @@ import type { EventRef, MarkdownPostProcessorContext } from 'obsidian';
 import { App, Keymap } from 'obsidian';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { GlobalQuery } from '../Config/GlobalQuery';
-import { QueryLayout } from '../Layout/QueryLayout';
-import { TaskLayout } from '../Layout/TaskLayout';
 import { PerformanceTracker } from '../lib/PerformanceTracker';
 import { explainResults, getQueryForQueryRenderer } from '../lib/QueryRendererHelper';
 import type TasksPlugin from '../main';
@@ -16,8 +14,8 @@ import type { QueryResult } from '../Query/QueryResult';
 import { TasksFile } from '../Scripting/TasksFile';
 import { DateFallback } from '../Task/DateFallback';
 import type { Task } from '../Task/Task';
-import { type QueryRendererParameters, QueryResultsRenderer } from './QueryResultsRenderer';
-import { TaskLineRenderer, createAndAppendElement } from './TaskLineRenderer';
+import { QueryResultsRenderer } from './QueryResultsRenderer';
+import { createAndAppendElement } from './TaskLineRenderer';
 
 export class QueryRenderer {
     private readonly app: App;
@@ -204,36 +202,6 @@ class QueryRenderChild extends QueryResultsRenderer {
         explanationsBlock.addClasses(['plugin-tasks-query-explanation']);
         explanationsBlock.setText(explanationAsString);
         content.appendChild(explanationsBlock);
-    }
-
-    private async createTaskList(
-        tasks: Task[],
-        content: HTMLDivElement,
-        queryRendererParameters: QueryRendererParameters,
-    ): Promise<void> {
-        const taskList = createAndAppendElement('ul', content);
-
-        taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);
-        const taskLayout = new TaskLayout(this.query.taskLayoutOptions);
-        taskList.addClasses(taskLayout.generateHiddenClasses());
-        const queryLayout = new QueryLayout(this.query.queryLayoutOptions);
-        taskList.addClasses(queryLayout.getHiddenClasses());
-
-        const groupingAttribute = this.getGroupingAttribute();
-        if (groupingAttribute && groupingAttribute.length > 0) taskList.dataset.taskGroupBy = groupingAttribute;
-
-        const taskLineRenderer = new TaskLineRenderer({
-            obsidianComponent: this,
-            parentUlElement: taskList,
-            taskLayoutOptions: this.query.taskLayoutOptions,
-            queryLayoutOptions: this.query.queryLayoutOptions,
-        });
-
-        for (const [taskIndex, task] of tasks.entries()) {
-            await this.addTask(taskList, taskLineRenderer, task, taskIndex, queryRendererParameters);
-        }
-
-        content.appendChild(taskList);
     }
 
     private async addAllTaskGroups(tasksSortedLimitedGrouped: TaskGroups, content: HTMLDivElement) {

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -1,5 +1,5 @@
 import type { EventRef, MarkdownPostProcessorContext } from 'obsidian';
-import { App, Keymap, MarkdownRenderChild, MarkdownRenderer, TFile } from 'obsidian';
+import { App, Keymap, MarkdownRenderer, TFile } from 'obsidian';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import { QueryLayout } from '../Layout/QueryLayout';
@@ -21,6 +21,7 @@ import { getTaskLineAndFile, replaceTaskWithTasks } from '../Obsidian/File';
 import { State } from '../Obsidian/Cache';
 import { PerformanceTracker } from '../lib/PerformanceTracker';
 import { TasksFile } from '../Scripting/TasksFile';
+import { QueryResultsRenderer } from './QueryResultsRenderer';
 import { TaskLineRenderer, createAndAppendElement } from './TaskLineRenderer';
 
 export class QueryRenderer {
@@ -52,7 +53,7 @@ export class QueryRenderer {
     }
 }
 
-class QueryRenderChild extends MarkdownRenderChild {
+class QueryRenderChild extends QueryResultsRenderer {
     private readonly app: App;
     private plugin: TasksPlugin;
     private readonly events: TasksEvents;

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -1,5 +1,5 @@
 import type { EventRef, MarkdownPostProcessorContext } from 'obsidian';
-import { App, Keymap, MarkdownRenderer, TFile } from 'obsidian';
+import { App, Keymap, MarkdownRenderer } from 'obsidian';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import { QueryLayout } from '../Layout/QueryLayout';
@@ -439,23 +439,5 @@ class QueryRenderChild extends QueryResultsRenderer {
                 cls: 'tasks-count',
             });
         }
-    }
-
-    private isFilenameUnique({ task }: { task: Task }, allMarkdownFiles: TFile[]): boolean | undefined {
-        // Will match the filename without extension (the file's "basename").
-        const filenameMatch = task.path.match(/([^/]*)\..+$/i);
-        if (filenameMatch === null) {
-            return undefined;
-        }
-
-        const filename = filenameMatch[1];
-        const allFilesWithSameName = allMarkdownFiles.filter((file: TFile) => {
-            if (file.basename === filename) {
-                // Found a file with the same name (it might actually be the same file, but we'll take that into account later.)
-                return true;
-            }
-        });
-
-        return allFilesWithSameName.length < 2;
     }
 }

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -206,7 +206,11 @@ class QueryRenderChild extends QueryResultsRenderer {
         content.appendChild(explanationsBlock);
     }
 
-    private async createTaskList(tasks: Task[], content: HTMLDivElement): Promise<void> {
+    private async createTaskList(
+        tasks: Task[],
+        content: HTMLDivElement,
+        queryRendererParameters: QueryRendererParameters,
+    ): Promise<void> {
         const taskList = createAndAppendElement('ul', content);
 
         taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);
@@ -225,13 +229,6 @@ class QueryRenderChild extends QueryResultsRenderer {
             queryLayoutOptions: this.query.queryLayoutOptions,
         });
 
-        const queryRendererParameters: QueryRendererParameters = {
-            allTasks: this.plugin.getTasks(),
-            allMarkdownFiles: this.app.vault.getMarkdownFiles(),
-            backlinksClickHandler,
-            backlinksMousedownHandler,
-            editTaskPencilClickHandler,
-        };
         for (const [taskIndex, task] of tasks.entries()) {
             await this.addTask(taskList, taskLineRenderer, task, taskIndex, queryRendererParameters);
         }
@@ -245,7 +242,13 @@ class QueryRenderChild extends QueryResultsRenderer {
             // will be empty, and no headings will be added.
             await this.addGroupHeadings(content, group.groupHeadings);
 
-            await this.createTaskList(group.tasks, content);
+            await this.createTaskList(group.tasks, content, {
+                allTasks: this.plugin.getTasks(),
+                allMarkdownFiles: this.app.vault.getMarkdownFiles(),
+                backlinksClickHandler,
+                backlinksMousedownHandler,
+                editTaskPencilClickHandler,
+            });
         }
     }
 }

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -367,9 +367,8 @@ class QueryRenderChild extends QueryResultsRenderer {
 
         // Go to the line the task is defined at
         const app = this.app;
-        const vault = app.vault;
         link.addEventListener('click', async (ev: MouseEvent) => {
-            const result = await getTaskLineAndFile(task, vault);
+            const result = await getTaskLineAndFile(task, app.vault);
             if (result) {
                 const [line, file] = result;
                 const leaf = app.workspace.getLeaf(Keymap.isModEvent(ev));
@@ -389,7 +388,7 @@ class QueryRenderChild extends QueryResultsRenderer {
             // (for regular left-click we prefer the 'click' event, and not to just do everything here, because
             // the 'click' event is more generic for touch devices etc.)
             if (ev.button === 1) {
-                const result = await getTaskLineAndFile(task, vault);
+                const result = await getTaskLineAndFile(task, app.vault);
                 if (result) {
                     const [line, file] = result;
                     const leaf = app.workspace.getLeaf('tab');

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -431,13 +431,4 @@ class QueryRenderChild extends QueryResultsRenderer {
             menu.showAtPosition({ x: ev.clientX, y: ev.clientY });
         });
     }
-
-    private addTaskCount(content: HTMLDivElement, queryResult: QueryResult) {
-        if (!this.query.queryLayoutOptions.hideTaskCount) {
-            content.createDiv({
-                text: queryResult.totalTasksCountDisplayText(),
-                cls: 'tasks-count',
-            });
-        }
-    }
 }

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -267,7 +267,6 @@ class QueryRenderChild extends QueryResultsRenderer {
         }
 
         if (!this.query.queryLayoutOptions.hideEditButton) {
-            // TODO Need to explore what happens if a tasks code block is rendered before the Cache has been created.
             this.addEditButton(extrasSpan, task, allTasks);
         }
 

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -9,12 +9,11 @@ import { State } from '../Obsidian/Cache';
 import { getTaskLineAndFile, replaceTaskWithTasks } from '../Obsidian/File';
 import { TaskModal } from '../Obsidian/TaskModal';
 import type { TasksEvents } from '../Obsidian/TasksEvents';
-import type { TaskGroups } from '../Query/Group/TaskGroups';
 import type { QueryResult } from '../Query/QueryResult';
 import { TasksFile } from '../Scripting/TasksFile';
 import { DateFallback } from '../Task/DateFallback';
 import type { Task } from '../Task/Task';
-import { type QueryRendererParameters, QueryResultsRenderer } from './QueryResultsRenderer';
+import { QueryResultsRenderer } from './QueryResultsRenderer';
 import { createAndAppendElement } from './TaskLineRenderer';
 
 export class QueryRenderer {
@@ -208,20 +207,6 @@ class QueryRenderChild extends QueryResultsRenderer {
         explanationsBlock.addClasses(['plugin-tasks-query-explanation']);
         explanationsBlock.setText(explanationAsString);
         content.appendChild(explanationsBlock);
-    }
-
-    private async addAllTaskGroups(
-        tasksSortedLimitedGrouped: TaskGroups,
-        content: HTMLDivElement,
-        queryRendererParameters: QueryRendererParameters,
-    ) {
-        for (const group of tasksSortedLimitedGrouped.groups) {
-            // If there were no 'group by' instructions, group.groupHeadings
-            // will be empty, and no headings will be added.
-            await this.addGroupHeadings(content, group.groupHeadings);
-
-            await this.createTaskList(group.tasks, content, queryRendererParameters);
-        }
     }
 }
 

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -303,7 +303,7 @@ class QueryRenderChild extends QueryResultsRenderer {
 
             // Need to create a new instance every time, as cursor/task can change.
             const taskModal = new TaskModal({
-                app: this.app,
+                app,
                 task,
                 onSubmit,
                 allTasks,

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -11,7 +11,6 @@ import { State } from '../Obsidian/Cache';
 import { getTaskLineAndFile, replaceTaskWithTasks } from '../Obsidian/File';
 import { TaskModal } from '../Obsidian/TaskModal';
 import type { TasksEvents } from '../Obsidian/TasksEvents';
-import type { GroupDisplayHeading } from '../Query/Group/GroupDisplayHeading';
 import type { TaskGroups } from '../Query/Group/TaskGroups';
 import type { QueryResult } from '../Query/QueryResult';
 import { shouldShowPostponeButton } from '../Scripting/Postponer';
@@ -317,19 +316,6 @@ class QueryRenderChild extends QueryResultsRenderer {
             await this.addGroupHeadings(content, group.groupHeadings);
 
             await this.createTaskList(group.tasks, content);
-        }
-    }
-
-    /**
-     * Display headings for a group of tasks.
-     * @param content
-     * @param groupHeadings - The headings to display. This can be an empty array,
-     *                        in which case no headings will be added.
-     * @private
-     */
-    private async addGroupHeadings(content: HTMLDivElement, groupHeadings: GroupDisplayHeading[]) {
-        for (const heading of groupHeadings) {
-            await this.addGroupHeading(content, heading);
         }
     }
 }

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -94,10 +94,6 @@ class QueryRenderChild extends QueryResultsRenderer {
         }
     }
 
-    public get filePath(): string | undefined {
-        return this.tasksFile?.path ?? undefined;
-    }
-
     /**
      * Reloads the query after midnight to update results from relative date queries.
      *

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -372,20 +372,7 @@ class QueryRenderChild extends QueryResultsRenderer {
         });
 
         link.addEventListener('mousedown', async (ev: MouseEvent) => {
-            // Open in a new tab on middle-click.
-            // This distinction is not available in the 'click' event, so we handle the 'mousedown' event
-            // solely for this.
-            // (for regular left-click we prefer the 'click' event, and not to just do everything here, because
-            // the 'click' event is more generic for touch devices etc.)
-            if (ev.button === 1) {
-                const result = await getTaskLineAndFile(task, app.vault);
-                if (result) {
-                    const [line, file] = result;
-                    const leaf = app.workspace.getLeaf('tab');
-                    ev.preventDefault();
-                    await leaf.openFile(file, { eState: { line: line } });
-                }
-            }
+            await addBacklinksMousedownHandler(ev, app, task);
         });
 
         if (!shortMode) {
@@ -405,5 +392,22 @@ async function addBacklinksClickHandler(ev: MouseEvent, app: App, task: Task) {
         ev.preventDefault();
         // Instead of the default behavior, open the file with the required line highlighted.
         await leaf.openFile(file, { eState: { line: line } });
+    }
+}
+
+async function addBacklinksMousedownHandler(ev: MouseEvent, app: App, task: Task) {
+    // Open in a new tab on middle-click.
+    // This distinction is not available in the 'click' event, so we handle the 'mousedown' event
+    // solely for this.
+    // (for regular left-click we prefer the 'click' event, and not to just do everything here, because
+    // the 'click' event is more generic for touch devices etc.)
+    if (ev.button === 1) {
+        const result = await getTaskLineAndFile(task, app.vault);
+        if (result) {
+            const [line, file] = result;
+            const leaf = app.workspace.getLeaf('tab');
+            ev.preventDefault();
+            await leaf.openFile(file, { eState: { line: line } });
+        }
     }
 }

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -14,11 +14,10 @@ import type { TasksEvents } from '../Obsidian/TasksEvents';
 import type { GroupDisplayHeading } from '../Query/Group/GroupDisplayHeading';
 import type { TaskGroups } from '../Query/Group/TaskGroups';
 import type { QueryResult } from '../Query/QueryResult';
-import { postponeButtonTitle, shouldShowPostponeButton } from '../Scripting/Postponer';
+import { shouldShowPostponeButton } from '../Scripting/Postponer';
 import { TasksFile } from '../Scripting/TasksFile';
 import { DateFallback } from '../Task/DateFallback';
 import type { Task } from '../Task/Task';
-import { PostponeMenu } from '../ui/Menus/PostponeMenu';
 import { QueryResultsRenderer } from './QueryResultsRenderer';
 import { TaskLineRenderer, createAndAppendElement } from './TaskLineRenderer';
 
@@ -402,33 +401,5 @@ class QueryRenderChild extends QueryResultsRenderer {
         if (!shortMode) {
             backLink.append(')');
         }
-    }
-
-    private addPostponeButton(listItem: HTMLElement, task: Task, shortMode: boolean) {
-        const amount = 1;
-        const timeUnit = 'day';
-        const buttonTooltipText = postponeButtonTitle(task, amount, timeUnit);
-
-        const button = createAndAppendElement('a', listItem);
-        button.addClass('tasks-postpone');
-        if (shortMode) {
-            button.addClass('tasks-postpone-short-mode');
-        }
-        button.title = buttonTooltipText;
-
-        button.addEventListener('click', (ev: MouseEvent) => {
-            ev.preventDefault(); // suppress the default click behavior
-            ev.stopPropagation(); // suppress further event propagation
-            PostponeMenu.postponeOnClickCallback(button, task, amount, timeUnit);
-        });
-
-        /** Open a context menu on right-click.
-         */
-        button.addEventListener('contextmenu', async (ev: MouseEvent) => {
-            ev.preventDefault(); // suppress the default context menu
-            ev.stopPropagation(); // suppress further event propagation
-            const menu = new PostponeMenu(button, task);
-            menu.showAtPosition({ x: ev.clientX, y: ev.clientY });
-        });
     }
 }

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -233,17 +233,7 @@ class QueryRenderChild extends QueryResultsRenderer {
             editTaskPencilClickHandler,
         };
         for (const [taskIndex, task] of tasks.entries()) {
-            await this.addTask(
-                taskList,
-                taskLineRenderer,
-                task,
-                taskIndex,
-                this.app.vault.getMarkdownFiles(),
-                backlinksClickHandler,
-                backlinksMousedownHandler,
-                editTaskPencilClickHandler,
-                queryRendererParameters,
-            );
+            await this.addTask(taskList, taskLineRenderer, task, taskIndex, queryRendererParameters);
         }
 
         content.appendChild(taskList);

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -256,7 +256,14 @@ class QueryRenderChild extends QueryResultsRenderer {
         const shortMode = this.query.queryLayoutOptions.shortMode;
 
         if (!this.query.queryLayoutOptions.hideBacklinks) {
-            this.addBacklinks(extrasSpan, task, shortMode, isFilenameUnique);
+            this.addBacklinks(
+                extrasSpan,
+                task,
+                shortMode,
+                isFilenameUnique,
+                backlinksClickHandler,
+                backlinksMousedownHandler,
+            );
         }
 
         if (!this.query.queryLayoutOptions.hideEditButton) {
@@ -340,7 +347,14 @@ class QueryRenderChild extends QueryResultsRenderer {
         await MarkdownRenderer.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this);
     }
 
-    private addBacklinks(listItem: HTMLElement, task: Task, shortMode: boolean, isFilenameUnique: boolean | undefined) {
+    private addBacklinks(
+        listItem: HTMLElement,
+        task: Task,
+        shortMode: boolean,
+        isFilenameUnique: boolean | undefined,
+        clickHandler: (ev: MouseEvent, app: App, task: Task) => Promise<void>,
+        mousedownHandler: (ev: MouseEvent, app: App, task: Task) => Promise<void>,
+    ) {
         const backLink = listItem.createSpan({ cls: 'tasks-backlink' });
 
         if (!shortMode) {
@@ -368,11 +382,11 @@ class QueryRenderChild extends QueryResultsRenderer {
         // Go to the line the task is defined at
         const app = this.app;
         link.addEventListener('click', async (ev: MouseEvent) => {
-            await backlinksClickHandler(ev, app, task);
+            await clickHandler(ev, app, task);
         });
 
         link.addEventListener('mousedown', async (ev: MouseEvent) => {
-            await backlinksMousedownHandler(ev, app, task);
+            await mousedownHandler(ev, app, task);
         });
 
         if (!shortMode) {

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -238,7 +238,6 @@ class QueryRenderChild extends QueryResultsRenderer {
                 taskLineRenderer,
                 task,
                 taskIndex,
-                this.plugin.getTasks(),
                 this.app.vault.getMarkdownFiles(),
                 backlinksClickHandler,
                 backlinksMousedownHandler,

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -1,5 +1,5 @@
 import type { EventRef, MarkdownPostProcessorContext } from 'obsidian';
-import { App, Keymap, MarkdownRenderer } from 'obsidian';
+import { App, Keymap } from 'obsidian';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import { QueryLayout } from '../Layout/QueryLayout';
@@ -331,20 +331,6 @@ class QueryRenderChild extends QueryResultsRenderer {
         for (const heading of groupHeadings) {
             await this.addGroupHeading(content, heading);
         }
-    }
-
-    private async addGroupHeading(content: HTMLDivElement, group: GroupDisplayHeading) {
-        // Headings nested to 2 or more levels are all displayed with 'h6:
-        let header: keyof HTMLElementTagNameMap = 'h6';
-        if (group.nestingLevel === 0) {
-            header = 'h4';
-        } else if (group.nestingLevel === 1) {
-            header = 'h5';
-        }
-
-        const headerEl = createAndAppendElement(header, content);
-        headerEl.addClass('tasks-group-heading');
-        await MarkdownRenderer.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this);
     }
 }
 

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -292,23 +292,7 @@ class QueryRenderChild extends QueryResultsRenderer {
         editTaskPencil.href = '#';
 
         editTaskPencil.onClickEvent((event: MouseEvent) => {
-            event.preventDefault();
-
-            const onSubmit = async (updatedTasks: Task[]): Promise<void> => {
-                await replaceTaskWithTasks({
-                    originalTask: task,
-                    newTasks: DateFallback.removeInferredStatusIfNeeded(task, updatedTasks),
-                });
-            };
-
-            // Need to create a new instance every time, as cursor/task can change.
-            const taskModal = new TaskModal({
-                app,
-                task,
-                onSubmit,
-                allTasks,
-            });
-            taskModal.open();
+            editTaskPencilClickHandler(event, task, allTasks);
         });
     }
 
@@ -326,6 +310,26 @@ class QueryRenderChild extends QueryResultsRenderer {
             await this.createTaskList(group.tasks, content);
         }
     }
+}
+
+function editTaskPencilClickHandler(event: MouseEvent, task: Task, allTasks: Task[]) {
+    event.preventDefault();
+
+    const onSubmit = async (updatedTasks: Task[]): Promise<void> => {
+        await replaceTaskWithTasks({
+            originalTask: task,
+            newTasks: DateFallback.removeInferredStatusIfNeeded(task, updatedTasks),
+        });
+    };
+
+    // Need to create a new instance every time, as cursor/task can change.
+    const taskModal = new TaskModal({
+        app,
+        task,
+        onSubmit,
+        allTasks,
+    });
+    taskModal.open();
 }
 
 async function backlinksClickHandler(ev: MouseEvent, task: Task) {

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -1,4 +1,4 @@
-import type { EventRef, MarkdownPostProcessorContext } from 'obsidian';
+import type { EventRef, MarkdownPostProcessorContext, TFile } from 'obsidian';
 import { App, Keymap } from 'obsidian';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { GlobalQuery } from '../Config/GlobalQuery';
@@ -227,7 +227,14 @@ class QueryRenderChild extends QueryResultsRenderer {
         });
 
         for (const [taskIndex, task] of tasks.entries()) {
-            await this.addTask(taskList, taskLineRenderer, task, taskIndex, this.plugin.getTasks());
+            await this.addTask(
+                taskList,
+                taskLineRenderer,
+                task,
+                taskIndex,
+                this.plugin.getTasks(),
+                this.app.vault.getMarkdownFiles(),
+            );
         }
 
         content.appendChild(taskList);
@@ -239,8 +246,9 @@ class QueryRenderChild extends QueryResultsRenderer {
         task: Task,
         taskIndex: number,
         allTasks: Task[],
+        allMarkdownFiles: TFile[],
     ) {
-        const isFilenameUnique = this.isFilenameUnique({ task }, this.app.vault.getMarkdownFiles());
+        const isFilenameUnique = this.isFilenameUnique({ task }, allMarkdownFiles);
         const listItem = await taskLineRenderer.renderTaskLine(task, taskIndex, isFilenameUnique);
 
         // Remove all footnotes. They don't re-appear in another document.

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -275,7 +275,7 @@ class QueryRenderChild extends QueryResultsRenderer {
         }
 
         if (!this.query.queryLayoutOptions.hideEditButton) {
-            this.addEditButton(extrasSpan, task, allTasks);
+            this.addEditButton(extrasSpan, task, allTasks, editTaskPencilClickHandler);
         }
 
         if (!this.query.queryLayoutOptions.hidePostponeButton && shouldShowPostponeButton(task)) {
@@ -285,14 +285,19 @@ class QueryRenderChild extends QueryResultsRenderer {
         taskList.appendChild(listItem);
     }
 
-    private addEditButton(listItem: HTMLElement, task: Task, allTasks: Task[]) {
+    private addEditButton(
+        listItem: HTMLElement,
+        task: Task,
+        allTasks: Task[],
+        clickHandler: (event: MouseEvent, task: Task, allTasks: Task[]) => void,
+    ) {
         const editTaskPencil = createAndAppendElement('a', listItem);
         editTaskPencil.addClass('tasks-edit');
         editTaskPencil.title = 'Edit task';
         editTaskPencil.href = '#';
 
         editTaskPencil.onClickEvent((event: MouseEvent) => {
-            editTaskPencilClickHandler(event, task, allTasks);
+            clickHandler(event, task, allTasks);
         });
     }
 

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -346,52 +346,6 @@ class QueryRenderChild extends QueryResultsRenderer {
         headerEl.addClass('tasks-group-heading');
         await MarkdownRenderer.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this);
     }
-
-    private addBacklinks(
-        listItem: HTMLElement,
-        task: Task,
-        shortMode: boolean,
-        isFilenameUnique: boolean | undefined,
-        clickHandler: (ev: MouseEvent, task: Task) => Promise<void>,
-        mousedownHandler: (ev: MouseEvent, task: Task) => Promise<void>,
-    ) {
-        const backLink = listItem.createSpan({ cls: 'tasks-backlink' });
-
-        if (!shortMode) {
-            backLink.append(' (');
-        }
-
-        const link = createAndAppendElement('a', backLink);
-
-        link.rel = 'noopener';
-        link.target = '_blank';
-        link.addClass('internal-link');
-        if (shortMode) {
-            link.addClass('internal-link-short-mode');
-        }
-
-        let linkText: string;
-        if (shortMode) {
-            linkText = ' 🔗';
-        } else {
-            linkText = task.getLinkText({ isFilenameUnique }) ?? '';
-        }
-
-        link.setText(linkText);
-
-        // Go to the line the task is defined at
-        link.addEventListener('click', async (ev: MouseEvent) => {
-            await clickHandler(ev, task);
-        });
-
-        link.addEventListener('mousedown', async (ev: MouseEvent) => {
-            await mousedownHandler(ev, task);
-        });
-
-        if (!shortMode) {
-            backLink.append(')');
-        }
-    }
 }
 
 async function backlinksClickHandler(ev: MouseEvent, task: Task) {

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -49,6 +49,8 @@ export class QueryRenderer {
     }
 }
 
+type EditButtonClickHandler = (event: MouseEvent, task: Task, allTasks: Task[]) => void;
+
 class QueryRenderChild extends QueryResultsRenderer {
     private readonly app: App;
     private plugin: TasksPlugin;
@@ -285,12 +287,7 @@ class QueryRenderChild extends QueryResultsRenderer {
         taskList.appendChild(listItem);
     }
 
-    private addEditButton(
-        listItem: HTMLElement,
-        task: Task,
-        allTasks: Task[],
-        clickHandler: (event: MouseEvent, task: Task, allTasks: Task[]) => void,
-    ) {
+    private addEditButton(listItem: HTMLElement, task: Task, allTasks: Task[], clickHandler: EditButtonClickHandler) {
         const editTaskPencil = createAndAppendElement('a', listItem);
         editTaskPencil.addClass('tasks-edit');
         editTaskPencil.title = 'Edit task';

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -16,7 +16,7 @@ import type { QueryResult } from '../Query/QueryResult';
 import { TasksFile } from '../Scripting/TasksFile';
 import { DateFallback } from '../Task/DateFallback';
 import type { Task } from '../Task/Task';
-import { QueryResultsRenderer } from './QueryResultsRenderer';
+import { type QueryRendererParameters, QueryResultsRenderer } from './QueryResultsRenderer';
 import { TaskLineRenderer, createAndAppendElement } from './TaskLineRenderer';
 
 export class QueryRenderer {
@@ -225,6 +225,13 @@ class QueryRenderChild extends QueryResultsRenderer {
             queryLayoutOptions: this.query.queryLayoutOptions,
         });
 
+        const queryRendererParameters: QueryRendererParameters = {
+            allTasks: this.plugin.getTasks(),
+            allMarkdownFiles: this.app.vault.getMarkdownFiles(),
+            backlinksClickHandler,
+            backlinksMousedownHandler,
+            editTaskPencilClickHandler,
+        };
         for (const [taskIndex, task] of tasks.entries()) {
             await this.addTask(
                 taskList,
@@ -236,6 +243,7 @@ class QueryRenderChild extends QueryResultsRenderer {
                 backlinksClickHandler,
                 backlinksMousedownHandler,
                 editTaskPencilClickHandler,
+                queryRendererParameters,
             );
         }
 

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -58,9 +58,6 @@ class QueryRenderChild extends QueryResultsRenderer {
     private plugin: TasksPlugin;
     private readonly events: TasksEvents;
 
-    // The path of the file that contains the instruction block, and cached data from that file.
-    private readonly tasksFile: TasksFile;
-
     private query: IQuery;
     // @ts-expect-error: TS6133: 'queryType' is declared but its value is never read
     private queryType: string; // whilst there is only one query type, there is no point logging this value
@@ -83,12 +80,11 @@ class QueryRenderChild extends QueryResultsRenderer {
         source: string;
         tasksFile: TasksFile;
     }) {
-        super(container, source);
+        super(container, source, tasksFile);
 
         this.app = app;
         this.plugin = plugin;
         this.events = events;
-        this.tasksFile = tasksFile;
 
         // The engine is chosen on the basis of the code block language. Currently,
         // there is only the main engine for the plugin, this allows others to be

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -227,7 +227,7 @@ class QueryRenderChild extends QueryResultsRenderer {
         });
 
         for (const [taskIndex, task] of tasks.entries()) {
-            await this.addTask(taskList, taskLineRenderer, task, taskIndex);
+            await this.addTask(taskList, taskLineRenderer, task, taskIndex, this.plugin.getTasks());
         }
 
         content.appendChild(taskList);
@@ -238,6 +238,7 @@ class QueryRenderChild extends QueryResultsRenderer {
         taskLineRenderer: TaskLineRenderer,
         task: Task,
         taskIndex: number,
+        allTasks: Task[],
     ) {
         const isFilenameUnique = this.isFilenameUnique({ task }, this.app.vault.getMarkdownFiles());
         const listItem = await taskLineRenderer.renderTaskLine(task, taskIndex, isFilenameUnique);
@@ -267,7 +268,7 @@ class QueryRenderChild extends QueryResultsRenderer {
 
         if (!this.query.queryLayoutOptions.hideEditButton) {
             // TODO Need to explore what happens if a tasks code block is rendered before the Cache has been created.
-            this.addEditButton(extrasSpan, task, this.plugin.getTasks()!);
+            this.addEditButton(extrasSpan, task, allTasks);
         }
 
         if (!this.query.queryLayoutOptions.hidePostponeButton && shouldShowPostponeButton(task)) {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -1,7 +1,21 @@
 import { MarkdownRenderChild } from 'obsidian';
 
 export class QueryResultsRenderer extends MarkdownRenderChild {
-    constructor(container: HTMLElement) {
+    /**
+     * The complete text in the instruction block, such as:
+     * ```
+     *   not done
+     *   short mode
+     * ```
+     *
+     * This does not contain the Global Query from the user's settings.
+     * Use {@link getQueryForQueryRenderer} to get this value prefixed with the Global Query.
+     */
+    protected readonly source: string;
+
+    constructor(container: HTMLElement, source: string) {
         super(container);
+
+        this.source = source;
     }
 }

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -1,0 +1,3 @@
+import { MarkdownRenderChild } from 'obsidian';
+
+export class QueryResultsRenderer extends MarkdownRenderChild {}

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -43,10 +43,6 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
     protected query: IQuery;
     protected queryType: string; // whilst there is only one query type, there is no point logging this value
 
-    public get filePath(): string | undefined {
-        return this.tasksFile?.path ?? undefined;
-    }
-
     constructor(container: HTMLElement, source: string, tasksFile: TasksFile) {
         super(container);
 
@@ -67,6 +63,10 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
                 this.queryType = 'tasks';
                 break;
         }
+    }
+
+    public get filePath(): string | undefined {
+        return this.tasksFile?.path ?? undefined;
     }
 
     protected async addAllTaskGroups(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -50,6 +50,52 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         }
     }
 
+    protected addBacklinks(
+        listItem: HTMLElement,
+        task: Task,
+        shortMode: boolean,
+        isFilenameUnique: boolean | undefined,
+        clickHandler: (ev: MouseEvent, task: Task) => Promise<void>,
+        mousedownHandler: (ev: MouseEvent, task: Task) => Promise<void>,
+    ) {
+        const backLink = listItem.createSpan({ cls: 'tasks-backlink' });
+
+        if (!shortMode) {
+            backLink.append(' (');
+        }
+
+        const link = createAndAppendElement('a', backLink);
+
+        link.rel = 'noopener';
+        link.target = '_blank';
+        link.addClass('internal-link');
+        if (shortMode) {
+            link.addClass('internal-link-short-mode');
+        }
+
+        let linkText: string;
+        if (shortMode) {
+            linkText = ' 🔗';
+        } else {
+            linkText = task.getLinkText({ isFilenameUnique }) ?? '';
+        }
+
+        link.setText(linkText);
+
+        // Go to the line the task is defined at
+        link.addEventListener('click', async (ev: MouseEvent) => {
+            await clickHandler(ev, task);
+        });
+
+        link.addEventListener('mousedown', async (ev: MouseEvent) => {
+            await mousedownHandler(ev, task);
+        });
+
+        if (!shortMode) {
+            backLink.append(')');
+        }
+    }
+
     protected addPostponeButton(listItem: HTMLElement, task: Task, shortMode: boolean) {
         const amount = 1;
         const timeUnit = 'day';

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -19,9 +19,9 @@ type EditButtonClickHandler = (event: MouseEvent, task: Task, allTasks: Task[]) 
 export interface QueryRendererParameters {
     allTasks: Task[];
     allMarkdownFiles: TFile[];
-    backlinksClickHandler: (ev: MouseEvent, task: Task) => Promise<void>;
-    backlinksMousedownHandler: (ev: MouseEvent, task: Task) => Promise<void>;
-    editTaskPencilClickHandler: (event: MouseEvent, task: Task, allTasks: Task[]) => void;
+    backlinksClickHandler: BacklinksEventHandler;
+    backlinksMousedownHandler: BacklinksEventHandler;
+    editTaskPencilClickHandler: EditButtonClickHandler;
 }
 
 export class QueryResultsRenderer extends MarkdownRenderChild {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -2,6 +2,7 @@ import { MarkdownRenderChild, TFile } from 'obsidian';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import type { IQuery } from '../IQuery';
 import { getQueryForQueryRenderer } from '../lib/QueryRendererHelper';
+import type { QueryResult } from '../Query/QueryResult';
 import type { TasksFile } from '../Scripting/TasksFile';
 import type { Task } from '../Task/Task';
 
@@ -43,6 +44,15 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
                 this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
                 this.queryType = 'tasks';
                 break;
+        }
+    }
+
+    protected addTaskCount(content: HTMLDivElement, queryResult: QueryResult) {
+        if (!this.query.queryLayoutOptions.hideTaskCount) {
+            content.createDiv({
+                text: queryResult.totalTasksCountDisplayText(),
+                cls: 'tasks-count',
+            });
         }
     }
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -1,3 +1,7 @@
 import { MarkdownRenderChild } from 'obsidian';
 
-export class QueryResultsRenderer extends MarkdownRenderChild {}
+export class QueryResultsRenderer extends MarkdownRenderChild {
+    constructor(container: HTMLElement) {
+        super(container);
+    }
+}

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -44,4 +44,12 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
                 break;
         }
     }
+
+    protected getGroupingAttribute() {
+        const groupingRules: string[] = [];
+        for (const group of this.query.grouping) {
+            groupingRules.push(group.property);
+        }
+        return groupingRules.join(',');
+    }
 }

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -140,12 +140,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         }
 
         if (!this.query.queryLayoutOptions.hideEditButton) {
-            this.addEditButton(
-                extrasSpan,
-                task,
-                queryRendererParameters.allTasks,
-                queryRendererParameters.editTaskPencilClickHandler,
-            );
+            this.addEditButton(extrasSpan, task, queryRendererParameters);
         }
 
         if (!this.query.queryLayoutOptions.hidePostponeButton && shouldShowPostponeButton(task)) {
@@ -155,14 +150,14 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         taskList.appendChild(listItem);
     }
 
-    private addEditButton(listItem: HTMLElement, task: Task, allTasks: Task[], clickHandler: EditButtonClickHandler) {
+    private addEditButton(listItem: HTMLElement, task: Task, queryRendererParameters: QueryRendererParameters) {
         const editTaskPencil = createAndAppendElement('a', listItem);
         editTaskPencil.addClass('tasks-edit');
         editTaskPencil.title = 'Edit task';
         editTaskPencil.href = '#';
 
         editTaskPencil.onClickEvent((event: MouseEvent) => {
-            clickHandler(event, task, allTasks);
+            queryRendererParameters.editTaskPencilClickHandler(event, task, queryRendererParameters.allTasks);
         });
     }
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -43,6 +43,10 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
     protected query: IQuery;
     protected queryType: string; // whilst there is only one query type, there is no point logging this value
 
+    public get filePath(): string | undefined {
+        return this.tasksFile?.path ?? undefined;
+    }
+
     constructor(container: HTMLElement, source: string, tasksFile: TasksFile) {
         super(container);
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -67,12 +67,11 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         taskLineRenderer: TaskLineRenderer,
         task: Task,
         taskIndex: number,
-        allTasks: Task[],
         allMarkdownFiles: TFile[],
         backlinksClickHandler: BacklinksEventHandler,
         backlinksMousedownHandler: BacklinksEventHandler,
         editTaskPencilClickHandler: EditButtonClickHandler,
-        _queryRendererParameters: QueryRendererParameters,
+        queryRendererParameters: QueryRendererParameters,
     ) {
         const isFilenameUnique = this.isFilenameUnique({ task }, allMarkdownFiles);
         const listItem = await taskLineRenderer.renderTaskLine(task, taskIndex, isFilenameUnique);
@@ -101,7 +100,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         }
 
         if (!this.query.queryLayoutOptions.hideEditButton) {
-            this.addEditButton(extrasSpan, task, allTasks, editTaskPencilClickHandler);
+            this.addEditButton(extrasSpan, task, queryRendererParameters.allTasks, editTaskPencilClickHandler);
         }
 
         if (!this.query.queryLayoutOptions.hidePostponeButton && shouldShowPostponeButton(task)) {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -51,6 +51,19 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         }
     }
 
+    /**
+     * Display headings for a group of tasks.
+     * @param content
+     * @param groupHeadings - The headings to display. This can be an empty array,
+     *                        in which case no headings will be added.
+     * @private
+     */
+    protected async addGroupHeadings(content: HTMLDivElement, groupHeadings: GroupDisplayHeading[]) {
+        for (const heading of groupHeadings) {
+            await this.addGroupHeading(content, heading);
+        }
+    }
+
     protected async addGroupHeading(content: HTMLDivElement, group: GroupDisplayHeading) {
         // Headings nested to 2 or more levels are all displayed with 'h6:
         let header: keyof HTMLElementTagNameMap = 'h6';

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -1,8 +1,9 @@
-import { MarkdownRenderChild } from 'obsidian';
+import { MarkdownRenderChild, TFile } from 'obsidian';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import type { IQuery } from '../IQuery';
 import { getQueryForQueryRenderer } from '../lib/QueryRendererHelper';
 import type { TasksFile } from '../Scripting/TasksFile';
+import type { Task } from '../Task/Task';
 
 export class QueryResultsRenderer extends MarkdownRenderChild {
     /**
@@ -43,6 +44,24 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
                 this.queryType = 'tasks';
                 break;
         }
+    }
+
+    protected isFilenameUnique({ task }: { task: Task }, allMarkdownFiles: TFile[]): boolean | undefined {
+        // Will match the filename without extension (the file's "basename").
+        const filenameMatch = task.path.match(/([^/]*)\..+$/i);
+        if (filenameMatch === null) {
+            return undefined;
+        }
+
+        const filename = filenameMatch[1];
+        const allFilesWithSameName = allMarkdownFiles.filter((file: TFile) => {
+            if (file.basename === filename) {
+                // Found a file with the same name (it might actually be the same file, but we'll take that into account later.)
+                return true;
+            }
+        });
+
+        return allFilesWithSameName.length < 2;
     }
 
     protected getGroupingAttribute() {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -1,4 +1,5 @@
 import { MarkdownRenderChild } from 'obsidian';
+import type { TasksFile } from '../Scripting/TasksFile';
 
 export class QueryResultsRenderer extends MarkdownRenderChild {
     /**
@@ -13,9 +14,13 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
      */
     protected readonly source: string;
 
-    constructor(container: HTMLElement, source: string) {
+    // The path of the file that contains the instruction block, and cached data from that file.
+    protected readonly tasksFile: TasksFile;
+
+    constructor(container: HTMLElement, source: string, tasksFile: TasksFile) {
         super(container);
 
         this.source = source;
+        this.tasksFile = tasksFile;
     }
 }

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -10,6 +10,8 @@ import type { Task } from '../Task/Task';
 import { PostponeMenu } from '../ui/Menus/PostponeMenu';
 import { createAndAppendElement } from './TaskLineRenderer';
 
+type BacklinksEventHandler = (ev: MouseEvent, task: Task) => Promise<void>;
+
 export class QueryResultsRenderer extends MarkdownRenderChild {
     /**
      * The complete text in the instruction block, such as:
@@ -83,8 +85,8 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         task: Task,
         shortMode: boolean,
         isFilenameUnique: boolean | undefined,
-        clickHandler: (ev: MouseEvent, task: Task) => Promise<void>,
-        mousedownHandler: (ev: MouseEvent, task: Task) => Promise<void>,
+        clickHandler: BacklinksEventHandler,
+        mousedownHandler: BacklinksEventHandler,
     ) {
         const backLink = listItem.createSpan({ cls: 'tasks-backlink' });
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -1,4 +1,7 @@
 import { MarkdownRenderChild } from 'obsidian';
+import { GlobalQuery } from '../Config/GlobalQuery';
+import type { IQuery } from '../IQuery';
+import { getQueryForQueryRenderer } from '../lib/QueryRendererHelper';
 import type { TasksFile } from '../Scripting/TasksFile';
 
 export class QueryResultsRenderer extends MarkdownRenderChild {
@@ -17,10 +20,28 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
     // The path of the file that contains the instruction block, and cached data from that file.
     protected readonly tasksFile: TasksFile;
 
+    protected query: IQuery;
+    protected queryType: string; // whilst there is only one query type, there is no point logging this value
+
     constructor(container: HTMLElement, source: string, tasksFile: TasksFile) {
         super(container);
 
         this.source = source;
         this.tasksFile = tasksFile;
+
+        // The engine is chosen on the basis of the code block language. Currently,
+        // there is only the main engine for the plugin, this allows others to be
+        // added later.
+        switch (this.containerEl.className) {
+            case 'block-language-tasks':
+                this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
+                this.queryType = 'tasks';
+                break;
+
+            default:
+                this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
+                this.queryType = 'tasks';
+                break;
+        }
     }
 }

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -67,13 +67,9 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         taskLineRenderer: TaskLineRenderer,
         task: Task,
         taskIndex: number,
-        allMarkdownFiles: TFile[],
-        backlinksClickHandler: BacklinksEventHandler,
-        backlinksMousedownHandler: BacklinksEventHandler,
-        editTaskPencilClickHandler: EditButtonClickHandler,
         queryRendererParameters: QueryRendererParameters,
     ) {
-        const isFilenameUnique = this.isFilenameUnique({ task }, allMarkdownFiles);
+        const isFilenameUnique = this.isFilenameUnique({ task }, queryRendererParameters.allMarkdownFiles);
         const listItem = await taskLineRenderer.renderTaskLine(task, taskIndex, isFilenameUnique);
 
         // Remove all footnotes. They don't re-appear in another document.
@@ -94,13 +90,18 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
                 task,
                 shortMode,
                 isFilenameUnique,
-                backlinksClickHandler,
-                backlinksMousedownHandler,
+                queryRendererParameters.backlinksClickHandler,
+                queryRendererParameters.backlinksMousedownHandler,
             );
         }
 
         if (!this.query.queryLayoutOptions.hideEditButton) {
-            this.addEditButton(extrasSpan, task, queryRendererParameters.allTasks, editTaskPencilClickHandler);
+            this.addEditButton(
+                extrasSpan,
+                task,
+                queryRendererParameters.allTasks,
+                queryRendererParameters.editTaskPencilClickHandler,
+            );
         }
 
         if (!this.query.queryLayoutOptions.hidePostponeButton && shouldShowPostponeButton(task)) {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -136,14 +136,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         const shortMode = this.query.queryLayoutOptions.shortMode;
 
         if (!this.query.queryLayoutOptions.hideBacklinks) {
-            this.addBacklinks(
-                extrasSpan,
-                task,
-                shortMode,
-                isFilenameUnique,
-                queryRendererParameters.backlinksClickHandler,
-                queryRendererParameters.backlinksMousedownHandler,
-            );
+            this.addBacklinks(extrasSpan, task, shortMode, isFilenameUnique, queryRendererParameters);
         }
 
         if (!this.query.queryLayoutOptions.hideEditButton) {
@@ -210,8 +203,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         task: Task,
         shortMode: boolean,
         isFilenameUnique: boolean | undefined,
-        clickHandler: BacklinksEventHandler,
-        mousedownHandler: BacklinksEventHandler,
+        queryRendererParameters: QueryRendererParameters,
     ) {
         const backLink = listItem.createSpan({ cls: 'tasks-backlink' });
 
@@ -239,11 +231,11 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
 
         // Go to the line the task is defined at
         link.addEventListener('click', async (ev: MouseEvent) => {
-            await clickHandler(ev, task);
+            await queryRendererParameters.backlinksClickHandler(ev, task);
         });
 
         link.addEventListener('mousedown', async (ev: MouseEvent) => {
-            await mousedownHandler(ev, task);
+            await queryRendererParameters.backlinksMousedownHandler(ev, task);
         });
 
         if (!shortMode) {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -10,7 +10,7 @@ import type { Task } from '../Task/Task';
 import { PostponeMenu } from '../ui/Menus/PostponeMenu';
 import { createAndAppendElement } from './TaskLineRenderer';
 
-type BacklinksEventHandler = (ev: MouseEvent, task: Task) => Promise<void>;
+export type BacklinksEventHandler = (ev: MouseEvent, task: Task) => Promise<void>;
 
 export class QueryResultsRenderer extends MarkdownRenderChild {
     /**

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -5,6 +5,7 @@ import { QueryLayout } from '../Layout/QueryLayout';
 import { TaskLayout } from '../Layout/TaskLayout';
 import { getQueryForQueryRenderer } from '../lib/QueryRendererHelper';
 import type { GroupDisplayHeading } from '../Query/Group/GroupDisplayHeading';
+import type { TaskGroups } from '../Query/Group/TaskGroups';
 import type { QueryResult } from '../Query/QueryResult';
 import { postponeButtonTitle, shouldShowPostponeButton } from '../Scripting/Postponer';
 import type { TasksFile } from '../Scripting/TasksFile';
@@ -61,6 +62,20 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
                 this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
                 this.queryType = 'tasks';
                 break;
+        }
+    }
+
+    protected async addAllTaskGroups(
+        tasksSortedLimitedGrouped: TaskGroups,
+        content: HTMLDivElement,
+        queryRendererParameters: QueryRendererParameters,
+    ) {
+        for (const group of tasksSortedLimitedGrouped.groups) {
+            // If there were no 'group by' instructions, group.groupHeadings
+            // will be empty, and no headings will be added.
+            await this.addGroupHeadings(content, group.groupHeadings);
+
+            await this.createTaskList(group.tasks, content, queryRendererParameters);
         }
     }
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -1,7 +1,8 @@
-import { MarkdownRenderChild, TFile } from 'obsidian';
+import { MarkdownRenderChild, MarkdownRenderer, TFile } from 'obsidian';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import type { IQuery } from '../IQuery';
 import { getQueryForQueryRenderer } from '../lib/QueryRendererHelper';
+import type { GroupDisplayHeading } from '../Query/Group/GroupDisplayHeading';
 import type { QueryResult } from '../Query/QueryResult';
 import { postponeButtonTitle } from '../Scripting/Postponer';
 import type { TasksFile } from '../Scripting/TasksFile';
@@ -48,6 +49,20 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
                 this.queryType = 'tasks';
                 break;
         }
+    }
+
+    protected async addGroupHeading(content: HTMLDivElement, group: GroupDisplayHeading) {
+        // Headings nested to 2 or more levels are all displayed with 'h6:
+        let header: keyof HTMLElementTagNameMap = 'h6';
+        if (group.nestingLevel === 0) {
+            header = 'h4';
+        } else if (group.nestingLevel === 1) {
+            header = 'h5';
+        }
+
+        const headerEl = createAndAppendElement(header, content);
+        headerEl.addClass('tasks-group-heading');
+        await MarkdownRenderer.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this);
     }
 
     protected addBacklinks(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -13,6 +13,14 @@ import { TaskLineRenderer, createAndAppendElement } from './TaskLineRenderer';
 type BacklinksEventHandler = (ev: MouseEvent, task: Task) => Promise<void>;
 type EditButtonClickHandler = (event: MouseEvent, task: Task, allTasks: Task[]) => void;
 
+export interface QueryRendererParameters {
+    allTasks: Task[];
+    allMarkdownFiles: TFile[];
+    backlinksClickHandler: (ev: MouseEvent, task: Task) => Promise<void>;
+    backlinksMousedownHandler: (ev: MouseEvent, task: Task) => Promise<void>;
+    editTaskPencilClickHandler: (event: MouseEvent, task: Task, allTasks: Task[]) => void;
+}
+
 export class QueryResultsRenderer extends MarkdownRenderChild {
     /**
      * The complete text in the instruction block, such as:
@@ -64,6 +72,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         backlinksClickHandler: BacklinksEventHandler,
         backlinksMousedownHandler: BacklinksEventHandler,
         editTaskPencilClickHandler: EditButtonClickHandler,
+        _queryRendererParameters: QueryRendererParameters,
     ) {
         const isFilenameUnique = this.isFilenameUnique({ task }, allMarkdownFiles);
         const listItem = await taskLineRenderer.renderTaskLine(task, taskIndex, isFilenameUnique);

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -83,7 +83,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         }
     }
 
-    protected async createTaskList(
+    private async createTaskList(
         tasks: Task[],
         content: HTMLDivElement,
         queryRendererParameters: QueryRendererParameters,
@@ -113,7 +113,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         content.appendChild(taskList);
     }
 
-    protected async addTask(
+    private async addTask(
         taskList: HTMLUListElement,
         taskLineRenderer: TaskLineRenderer,
         task: Task,
@@ -185,13 +185,13 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
      *                        in which case no headings will be added.
      * @private
      */
-    protected async addGroupHeadings(content: HTMLDivElement, groupHeadings: GroupDisplayHeading[]) {
+    private async addGroupHeadings(content: HTMLDivElement, groupHeadings: GroupDisplayHeading[]) {
         for (const heading of groupHeadings) {
             await this.addGroupHeading(content, heading);
         }
     }
 
-    protected async addGroupHeading(content: HTMLDivElement, group: GroupDisplayHeading) {
+    private async addGroupHeading(content: HTMLDivElement, group: GroupDisplayHeading) {
         // Headings nested to 2 or more levels are all displayed with 'h6:
         let header: keyof HTMLElementTagNameMap = 'h6';
         if (group.nestingLevel === 0) {
@@ -205,7 +205,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         await MarkdownRenderer.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this);
     }
 
-    protected addBacklinks(
+    private addBacklinks(
         listItem: HTMLElement,
         task: Task,
         shortMode: boolean,
@@ -251,7 +251,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         }
     }
 
-    protected addPostponeButton(listItem: HTMLElement, task: Task, shortMode: boolean) {
+    private addPostponeButton(listItem: HTMLElement, task: Task, shortMode: boolean) {
         const amount = 1;
         const timeUnit = 'day';
         const buttonTooltipText = postponeButtonTitle(task, amount, timeUnit);
@@ -288,7 +288,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         }
     }
 
-    protected isFilenameUnique({ task }: { task: Task }, allMarkdownFiles: TFile[]): boolean | undefined {
+    private isFilenameUnique({ task }: { task: Task }, allMarkdownFiles: TFile[]): boolean | undefined {
         // Will match the filename without extension (the file's "basename").
         const filenameMatch = task.path.match(/([^/]*)\..+$/i);
         if (filenameMatch === null) {
@@ -306,7 +306,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         return allFilesWithSameName.length < 2;
     }
 
-    protected getGroupingAttribute() {
+    private getGroupingAttribute() {
         const groupingRules: string[] = [];
         for (const group of this.query.grouping) {
             groupingRules.push(group.property);


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

Done by pairing with @claremacrae 

- add `QueryResultsRenderer` class
- move some methods from `QueryRenderer`

## Motivation and Context

- prepare to test rendering of sub-tasks

## How has this been tested?

- manual exploratory testing

## Checklist


- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
