### PR TITLE
refactor: introduce parameter object to functions in Suggestor.ts

### DIFF
--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -101,14 +101,7 @@ export function makeDefaultSuggestionBuilder(
 
             // add dependecy suggestions
             suggestions = suggestions.concat(
-                addDependsOnSuggestions(
-                    settings,
-                    symbols.dependsOnSymbol,
-                    allTasks,
-                    dataviewMode,
-                    suggestorParameters,
-                    taskToSuggestFor,
-                ),
+                addDependsOnSuggestions(symbols.dependsOnSymbol, allTasks, suggestorParameters, taskToSuggestFor),
             );
         }
 
@@ -557,11 +550,9 @@ function addIDSuggestion(
  * of what the user is typing.
  */
 function addDependsOnSuggestions(
-    settings: Settings,
     dependsOnSymbol: string,
     allTasks: Task[],
-    dataviewMode: boolean,
-    _suggestorParameters: SuggestorParameters,
+    suggestorParameters: SuggestorParameters,
     taskToSuggestFor?: Task,
 ) {
     const results: SuggestInfo[] = [];
@@ -576,12 +567,14 @@ function addDependsOnSuggestions(
     // In Tasks format:
     //    - Any following field will begin with an emoji.
     // See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2827
-    const charactersExcludedFromDescriptionSearch = dataviewMode ? escapeRegExp('()[]') : allTaskPluginEmojis();
+    const charactersExcludedFromDescriptionSearch = suggestorParameters.dataviewMode
+        ? escapeRegExp('()[]')
+        : allTaskPluginEmojis();
     const dependsOnRegex = new RegExp(
         `(${dependsOnSymbol})([0-9a-zA-Z-_ ^,]*,)*([^,${charactersExcludedFromDescriptionSearch}]*)`,
         'ug',
     );
-    const dependsOnMatch = matchIfCursorInRegex(dependsOnRegex, _suggestorParameters);
+    const dependsOnMatch = matchIfCursorInRegex(dependsOnRegex, suggestorParameters);
     if (dependsOnMatch && dependsOnMatch.length >= 1) {
         // dependsOnMatch[1] = Depends On Symbol
         const existingDependsOnIdStrings = dependsOnMatch[2] || '';
@@ -597,7 +590,7 @@ function addDependsOnSuggestions(
             blockingTasks = allTasks.filter((task) => task.id && idsArray.includes(task.id));
         }
 
-        if (newTaskToAppend.length >= settings.autoSuggestMinMatch) {
+        if (newTaskToAppend.length >= suggestorParameters.settings.autoSuggestMinMatch) {
             const genericMatches = searchForCandidateTasksForDependency(
                 newTaskToAppend.trim(),
                 allTasks,

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -78,15 +78,7 @@ export function makeDefaultSuggestionBuilder(
 
         // add date suggestions if relevant
         suggestions = suggestions.concat(
-            addDatesSuggestions(
-                line,
-                cursorPos,
-                settings,
-                datePrefixRegex,
-                maxGenericSuggestions,
-                dataviewMode,
-                suggestorParameters,
-            ),
+            addDatesSuggestions(line, cursorPos, settings, datePrefixRegex, maxGenericSuggestions, suggestorParameters),
         );
 
         // add recurrence suggestions if relevant
@@ -333,8 +325,7 @@ function addDatesSuggestions(
     settings: Settings,
     datePrefixRegex: string,
     maxGenericSuggestions: number,
-    dataviewMode: boolean,
-    _suggestorParameters: SuggestorParameters,
+    suggestorParameters: SuggestorParameters,
 ): SuggestInfo[] {
     const genericSuggestions = [
         'today',
@@ -350,8 +341,6 @@ function addDatesSuggestions(
         'next month',
         'next year',
     ];
-
-    const { postfix, insertSkip } = getAdjusters(dataviewMode, line, cursorPos);
 
     const results: SuggestInfo[] = [];
     const dateRegex = new RegExp(`(${datePrefixRegex})\\s*([0-9a-zA-Z ]*)`, 'ug');
@@ -404,9 +393,13 @@ function addDatesSuggestions(
             results.push({
                 suggestionType: 'match',
                 displayText: `${match} (${formattedDate})`,
-                appendText: `${datePrefix} ${formattedDate}` + postfix,
+                appendText: `${datePrefix} ${formattedDate}` + suggestorParameters.postfix,
                 insertAt: dateMatch.index,
-                insertSkip: calculateSkipValueForMatch(dataviewMode, insertSkip, dateMatch[0]),
+                insertSkip: calculateSkipValueForMatch(
+                    suggestorParameters.dataviewMode,
+                    suggestorParameters.insertSkip,
+                    dateMatch[0],
+                ),
             });
         }
     }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -83,13 +83,20 @@ export function makeDefaultSuggestionBuilder(
 
         // add recurrence suggestions if relevant
         suggestions = suggestions.concat(
-            addRecurrenceValueSuggestions(line, cursorPos, settings, symbols.recurrenceSymbol, dataviewMode),
+            addRecurrenceValueSuggestions(
+                line,
+                cursorPos,
+                settings,
+                symbols.recurrenceSymbol,
+                dataviewMode,
+                suggestorParameters,
+            ),
         );
 
         // add Auto ID suggestions
         if (includeDependencySuggestions(canSaveEdits)) {
             suggestions = suggestions.concat(
-                addIDSuggestion(line, cursorPos, symbols.idSymbol, dataviewMode, allTasks),
+                addIDSuggestion(line, cursorPos, symbols.idSymbol, dataviewMode, allTasks, suggestorParameters),
             );
 
             // add dependecy suggestions
@@ -108,7 +115,15 @@ export function makeDefaultSuggestionBuilder(
 
         // add task property suggestions ('due', 'recurrence' etc)
         suggestions = suggestions.concat(
-            addTaskPropertySuggestions(line, cursorPos, settings, symbols, dataviewMode, canSaveEdits),
+            addTaskPropertySuggestions(
+                line,
+                cursorPos,
+                settings,
+                symbols,
+                dataviewMode,
+                canSaveEdits,
+                suggestorParameters,
+            ),
         );
 
         // Unless we have a suggestion that is a match for something the user is currently typing, add
@@ -156,6 +171,7 @@ function addTaskPropertySuggestions(
     symbols: DefaultTaskSerializerSymbols,
     dataviewMode: boolean,
     canSaveEdits: boolean,
+    _suggestorParameters: SuggestorParameters,
 ): SuggestInfo[] {
     const genericSuggestions: SuggestInfo[] = [];
     const { postfix, insertSkip } = getAdjusters(dataviewMode, line, cursorPos);
@@ -417,6 +433,7 @@ function addRecurrenceValueSuggestions(
     settings: Settings,
     recurrenceSymbol: string,
     dataviewMode: boolean,
+    _suggestorParameters: SuggestorParameters,
 ) {
     const genericSuggestions = [
         'every',
@@ -508,7 +525,14 @@ function addRecurrenceValueSuggestions(
     return results;
 }
 
-function addIDSuggestion(line: string, cursorPos: number, idSymbol: string, dataviewMode: boolean, allTasks: Task[]) {
+function addIDSuggestion(
+    line: string,
+    cursorPos: number,
+    idSymbol: string,
+    dataviewMode: boolean,
+    allTasks: Task[],
+    _suggestorParameters: SuggestorParameters,
+) {
     const { postfix, insertSkip } = getAdjusters(dataviewMode, line, cursorPos);
 
     const results: SuggestInfo[] = [];

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -95,9 +95,7 @@ export function makeDefaultSuggestionBuilder(
         }
 
         // add task property suggestions ('due', 'recurrence' etc)
-        suggestions = suggestions.concat(
-            addTaskPropertySuggestions(line, settings, symbols, canSaveEdits, suggestorParameters),
-        );
+        suggestions = suggestions.concat(addTaskPropertySuggestions(symbols, canSaveEdits, suggestorParameters));
 
         // Unless we have a suggestion that is a match for something the user is currently typing, add
         // an 'Enter' entry in the beginning of the menu, so an Enter press will move to the next line
@@ -138,8 +136,6 @@ function getAdjusters(dataviewMode: boolean, line: string, cursorPos: number) {
  * Get suggestions for generic task components, e.g. a priority or a 'due' symbol
  */
 function addTaskPropertySuggestions(
-    line: string,
-    settings: Settings,
     symbols: DefaultTaskSerializerSymbols,
     canSaveEdits: boolean,
     suggestorParameters: SuggestorParameters,
@@ -147,6 +143,7 @@ function addTaskPropertySuggestions(
     const genericSuggestions: SuggestInfo[] = [];
 
     // NEW_TASK_FIELD_EDIT_REQUIRED
+    const line = suggestorParameters.line;
     addHappensDatesSuggestions(genericSuggestions, symbols, line);
     addPrioritySuggestions(genericSuggestions, symbols, suggestorParameters);
     addRecurrenceSuggestions(genericSuggestions, symbols, line);
@@ -157,7 +154,8 @@ function addTaskPropertySuggestions(
 
     // That's where we're adding all the suggestions in case there's nothing specific to match
     // (and we're allowed by the settings to bring back a zero-sized match)
-    if (matchingSuggestions.length === 0 && settings.autoSuggestMinMatch === 0) return genericSuggestions;
+    if (matchingSuggestions.length === 0 && suggestorParameters.settings.autoSuggestMinMatch === 0)
+        return genericSuggestions;
 
     return matchingSuggestions;
 }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -108,6 +108,7 @@ export function makeDefaultSuggestionBuilder(
                     symbols.dependsOnSymbol,
                     allTasks,
                     dataviewMode,
+                    suggestorParameters,
                     taskToSuggestFor,
                 ),
             );
@@ -566,6 +567,7 @@ function addDependsOnSuggestions(
     dependsOnSymbol: string,
     allTasks: Task[],
     dataviewMode: boolean,
+    _suggestorParameters: SuggestorParameters,
     taskToSuggestFor?: Task,
 ) {
     const results: SuggestInfo[] = [];

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -1,4 +1,5 @@
 import type { Editor, EditorPosition } from 'obsidian';
+
 import type { Settings } from '../Config/Settings';
 import { DateParser } from '../Query/DateParser';
 import { doAutocomplete } from '../lib/DateAbbreviations';
@@ -36,6 +37,13 @@ function includeDependencySuggestions(canSaveEdits: boolean) {
     return globalThis.SHOW_DEPENDENCY_SUGGESTIONS && canSaveEdits;
 }
 
+export interface SuggestorParameters {
+    line: string;
+    cursorPos: number;
+    settings: Settings;
+    dataviewMode: boolean;
+}
+
 export function makeDefaultSuggestionBuilder(
     symbols: DefaultTaskSerializerSymbols,
     maxGenericSuggestions: number /** See {@link DEFAULT_MAX_GENERIC_SUGGESTIONS} */,
@@ -55,6 +63,14 @@ export function makeDefaultSuggestionBuilder(
         taskToSuggestFor?: Task,
     ): SuggestInfo[] => {
         let suggestions: SuggestInfo[] = [];
+
+        // @ts-expect-error _suggestorParameters is Unused.
+        const _suggestorParameters = {
+            line,
+            cursorPos,
+            settings,
+            dataviewMode,
+        };
 
         // add date suggestions if relevant
         suggestions = suggestions.concat(

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -152,14 +152,14 @@ function addTaskPropertySuggestions(
     symbols: DefaultTaskSerializerSymbols,
     dataviewMode: boolean,
     canSaveEdits: boolean,
-    _suggestorParameters: SuggestorParameters,
+    suggestorParameters: SuggestorParameters,
 ): SuggestInfo[] {
     const genericSuggestions: SuggestInfo[] = [];
     const { postfix, insertSkip } = getAdjusters(dataviewMode, line, cursorPos);
 
     // NEW_TASK_FIELD_EDIT_REQUIRED
     addHappensDatesSuggestions(genericSuggestions, symbols, line);
-    addPrioritySuggestions(genericSuggestions, symbols, line, postfix, dataviewMode, insertSkip);
+    addPrioritySuggestions(genericSuggestions, symbols, suggestorParameters);
     addRecurrenceSuggestions(genericSuggestions, symbols, line);
     addTaskLifecycleDateSuggestions(genericSuggestions, symbols, line, postfix, dataviewMode, insertSkip);
     addDependencySuggestions(genericSuggestions, symbols, line, canSaveEdits);
@@ -169,7 +169,7 @@ function addTaskPropertySuggestions(
         dataviewMode,
         insertSkip,
         settings,
-        _suggestorParameters,
+        suggestorParameters,
     );
 
     // That's where we're adding all the suggestions in case there's nothing specific to match
@@ -200,14 +200,11 @@ function addHappensDatesSuggestions(
 function addPrioritySuggestions(
     genericSuggestions: SuggestInfo[],
     symbols: DefaultTaskSerializerSymbols,
-    line: string,
-    postfix: string,
-    dataviewMode: boolean,
-    insertSkip: number,
+    suggestorParameters: SuggestorParameters,
 ) {
     const hasPriority = (line: string) =>
         Object.values(symbols.prioritySymbols).some((value) => value.length > 0 && line.includes(value));
-    if (!hasPriority(line)) {
+    if (!hasPriority(suggestorParameters.line)) {
         const prioritySymbols: { [key: string]: string } = symbols.prioritySymbols;
         const priorityTexts = ['High', 'Medium', 'Low', 'Highest', 'Lowest'];
 
@@ -215,11 +212,11 @@ function addPrioritySuggestions(
             const prioritySymbol = prioritySymbols[priorityText];
 
             genericSuggestions.push({
-                displayText: dataviewMode
+                displayText: suggestorParameters.dataviewMode
                     ? `${prioritySymbol} priority`
                     : `${prioritySymbol} ${priorityText.toLowerCase()} priority`,
-                appendText: `${prioritySymbol}${postfix}`,
-                insertSkip: dataviewMode ? insertSkip : undefined,
+                appendText: `${prioritySymbol}${suggestorParameters.postfix}`,
+                insertSkip: suggestorParameters.dataviewMode ? suggestorParameters.insertSkip : undefined,
             });
         }
     }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -42,6 +42,8 @@ export interface SuggestorParameters {
     cursorPos: number;
     settings: Settings;
     dataviewMode: boolean;
+    postfix: string;
+    insertSkip: number;
 }
 
 export function makeDefaultSuggestionBuilder(
@@ -64,11 +66,14 @@ export function makeDefaultSuggestionBuilder(
     ): SuggestInfo[] => {
         let suggestions: SuggestInfo[] = [];
 
+        const { postfix, insertSkip } = getAdjusters(dataviewMode, line, cursorPos);
         const suggestorParameters: SuggestorParameters = {
             line,
             cursorPos,
             settings,
             dataviewMode,
+            postfix,
+            insertSkip,
         };
 
         // add date suggestions if relevant

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -64,8 +64,7 @@ export function makeDefaultSuggestionBuilder(
     ): SuggestInfo[] => {
         let suggestions: SuggestInfo[] = [];
 
-        // @ts-expect-error _suggestorParameters is Unused.
-        const _suggestorParameters = {
+        const suggestorParameters: SuggestorParameters = {
             line,
             cursorPos,
             settings,
@@ -74,7 +73,15 @@ export function makeDefaultSuggestionBuilder(
 
         // add date suggestions if relevant
         suggestions = suggestions.concat(
-            addDatesSuggestions(line, cursorPos, settings, datePrefixRegex, maxGenericSuggestions, dataviewMode),
+            addDatesSuggestions(
+                line,
+                cursorPos,
+                settings,
+                datePrefixRegex,
+                maxGenericSuggestions,
+                dataviewMode,
+                suggestorParameters,
+            ),
         );
 
         // add recurrence suggestions if relevant
@@ -322,6 +329,7 @@ function addDatesSuggestions(
     datePrefixRegex: string,
     maxGenericSuggestions: number,
     dataviewMode: boolean,
+    _suggestorParameters: SuggestorParameters,
 ): SuggestInfo[] {
     const genericSuggestions = [
         'today',

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -398,12 +398,7 @@ function addDatesSuggestions(
                 displayText: `${match} (${formattedDate})`,
                 appendText: `${datePrefix} ${formattedDate}` + suggestorParameters.postfix,
                 insertAt: dateMatch.index,
-                insertSkip: calculateSkipValueForMatch(
-                    suggestorParameters.dataviewMode,
-                    suggestorParameters.insertSkip,
-                    dateMatch[0],
-                    suggestorParameters,
-                ),
+                insertSkip: calculateSkipValueForMatch(dateMatch[0], suggestorParameters),
             });
         }
     }
@@ -442,7 +437,7 @@ function addRecurrenceValueSuggestions(
         'every week on Saturday',
     ];
 
-    const { postfix, insertSkip } = getAdjusters(dataviewMode, line, cursorPos);
+    const { postfix } = getAdjusters(dataviewMode, line, cursorPos);
 
     const results: SuggestInfo[] = [];
     const recurrenceRegex = new RegExp(`(${recurrenceSymbol})\\s*([0-9a-zA-Z ]*)`, 'ug');
@@ -469,12 +464,7 @@ function addRecurrenceValueSuggestions(
                     displayText: `✅ ${parsedRecurrence}`,
                     appendText: appendedText,
                     insertAt: recurrenceMatch.index,
-                    insertSkip: calculateSkipValueForMatch(
-                        dataviewMode,
-                        insertSkip,
-                        recurrenceMatch[0],
-                        _suggestorParameters,
-                    ),
+                    insertSkip: calculateSkipValueForMatch(recurrenceMatch[0], _suggestorParameters),
                 });
                 // If the full match includes a complete valid suggestion *ending with space*,
                 // don't suggest anything. The user is trying to continue to type something that is likely
@@ -513,12 +503,7 @@ function addRecurrenceValueSuggestions(
                 displayText: `${match}`,
                 appendText: `${recurrencePrefix} ${match}` + postfix,
                 insertAt: recurrenceMatch.index,
-                insertSkip: calculateSkipValueForMatch(
-                    dataviewMode,
-                    insertSkip,
-                    recurrenceMatch[0],
-                    _suggestorParameters,
-                ),
+                insertSkip: calculateSkipValueForMatch(recurrenceMatch[0], _suggestorParameters),
             });
         }
     }
@@ -534,7 +519,7 @@ function addIDSuggestion(
     allTasks: Task[],
     _suggestorParameters: SuggestorParameters,
 ) {
-    const { postfix, insertSkip } = getAdjusters(dataviewMode, line, cursorPos);
+    const { postfix } = getAdjusters(dataviewMode, line, cursorPos);
 
     const results: SuggestInfo[] = [];
     const idRegex = new RegExp(`(${idSymbol})\\s*(${taskIdRegex.source})?`, 'ug');
@@ -547,7 +532,7 @@ function addIDSuggestion(
             displayText: 'generate unique id',
             appendText: `${idSymbol} ${ID}` + postfix,
             insertAt: idMatch.index,
-            insertSkip: calculateSkipValueForMatch(dataviewMode, insertSkip, idMatch[0], _suggestorParameters),
+            insertSkip: calculateSkipValueForMatch(idMatch[0], _suggestorParameters),
         });
     }
 
@@ -810,11 +795,6 @@ function cursorIsInTaskLineDescription(line: string, cursorPosition: number) {
     return cursorPosition >= beforeDescription.length;
 }
 
-function calculateSkipValueForMatch(
-    dataviewMode: boolean,
-    insertSkip: number,
-    match: string,
-    _suggestorParameters: SuggestorParameters,
-) {
-    return dataviewMode ? match.length + insertSkip : match.length;
+function calculateSkipValueForMatch(match: string, suggestorParameters: SuggestorParameters) {
+    return suggestorParameters.dataviewMode ? match.length + suggestorParameters.insertSkip : match.length;
 }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -155,13 +155,13 @@ function addTaskPropertySuggestions(
     suggestorParameters: SuggestorParameters,
 ): SuggestInfo[] {
     const genericSuggestions: SuggestInfo[] = [];
-    const { postfix, insertSkip } = getAdjusters(dataviewMode, line, cursorPos);
+    const { insertSkip } = getAdjusters(dataviewMode, line, cursorPos);
 
     // NEW_TASK_FIELD_EDIT_REQUIRED
     addHappensDatesSuggestions(genericSuggestions, symbols, line);
     addPrioritySuggestions(genericSuggestions, symbols, suggestorParameters);
     addRecurrenceSuggestions(genericSuggestions, symbols, line);
-    addTaskLifecycleDateSuggestions(genericSuggestions, symbols, line, postfix, dataviewMode, insertSkip);
+    addTaskLifecycleDateSuggestions(genericSuggestions, symbols, suggestorParameters);
     addDependencySuggestions(genericSuggestions, symbols, line, canSaveEdits);
 
     const matchingSuggestions = filterGeneralSuggestionsForWordAtCursor(
@@ -233,21 +233,18 @@ function addRecurrenceSuggestions(
 function addTaskLifecycleDateSuggestions(
     genericSuggestions: SuggestInfo[],
     symbols: DefaultTaskSerializerSymbols,
-    line: string,
-    postfix: string,
-    dataviewMode: boolean,
-    insertSkip: number,
+    suggestorParameters: SuggestorParameters,
 ) {
     // This will eventually also support Done and Cancelled dates
-    if (!line.includes(symbols.createdDateSymbol)) {
+    if (!suggestorParameters.line.includes(symbols.createdDateSymbol)) {
         const parsedDate = DateParser.parseDate('today', true);
         const formattedDate = parsedDate.format(TaskRegularExpressions.dateFormat);
         genericSuggestions.push({
             // We don't want this to match when the user types "today"
             textToMatch: `${symbols.createdDateSymbol} created`,
             displayText: `${symbols.createdDateSymbol} created today (${formattedDate})`,
-            appendText: `${symbols.createdDateSymbol} ${formattedDate}` + postfix,
-            insertSkip: dataviewMode ? insertSkip : undefined,
+            appendText: `${symbols.createdDateSymbol} ${formattedDate}` + suggestorParameters.postfix,
+            insertSkip: suggestorParameters.dataviewMode ? suggestorParameters.insertSkip : undefined,
         });
     }
 }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -402,6 +402,7 @@ function addDatesSuggestions(
                     suggestorParameters.dataviewMode,
                     suggestorParameters.insertSkip,
                     dateMatch[0],
+                    suggestorParameters,
                 ),
             });
         }
@@ -468,7 +469,12 @@ function addRecurrenceValueSuggestions(
                     displayText: `✅ ${parsedRecurrence}`,
                     appendText: appendedText,
                     insertAt: recurrenceMatch.index,
-                    insertSkip: calculateSkipValueForMatch(dataviewMode, insertSkip, recurrenceMatch[0]),
+                    insertSkip: calculateSkipValueForMatch(
+                        dataviewMode,
+                        insertSkip,
+                        recurrenceMatch[0],
+                        _suggestorParameters,
+                    ),
                 });
                 // If the full match includes a complete valid suggestion *ending with space*,
                 // don't suggest anything. The user is trying to continue to type something that is likely
@@ -507,7 +513,12 @@ function addRecurrenceValueSuggestions(
                 displayText: `${match}`,
                 appendText: `${recurrencePrefix} ${match}` + postfix,
                 insertAt: recurrenceMatch.index,
-                insertSkip: calculateSkipValueForMatch(dataviewMode, insertSkip, recurrenceMatch[0]),
+                insertSkip: calculateSkipValueForMatch(
+                    dataviewMode,
+                    insertSkip,
+                    recurrenceMatch[0],
+                    _suggestorParameters,
+                ),
             });
         }
     }
@@ -536,7 +547,7 @@ function addIDSuggestion(
             displayText: 'generate unique id',
             appendText: `${idSymbol} ${ID}` + postfix,
             insertAt: idMatch.index,
-            insertSkip: calculateSkipValueForMatch(dataviewMode, insertSkip, idMatch[0]),
+            insertSkip: calculateSkipValueForMatch(dataviewMode, insertSkip, idMatch[0], _suggestorParameters),
         });
     }
 
@@ -799,6 +810,11 @@ function cursorIsInTaskLineDescription(line: string, cursorPosition: number) {
     return cursorPosition >= beforeDescription.length;
 }
 
-function calculateSkipValueForMatch(dataviewMode: boolean, insertSkip: number, match: string) {
+function calculateSkipValueForMatch(
+    dataviewMode: boolean,
+    insertSkip: number,
+    match: string,
+    _suggestorParameters: SuggestorParameters,
+) {
     return dataviewMode ? match.length + insertSkip : match.length;
 }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -78,7 +78,7 @@ export function makeDefaultSuggestionBuilder(
 
         // add date suggestions if relevant
         suggestions = suggestions.concat(
-            addDatesSuggestions(line, cursorPos, settings, datePrefixRegex, maxGenericSuggestions, suggestorParameters),
+            addDatesSuggestions(datePrefixRegex, maxGenericSuggestions, suggestorParameters),
         );
 
         // add recurrence suggestions if relevant
@@ -320,9 +320,6 @@ function filterGeneralSuggestionsForWordAtCursor(
  * something where a date is expected) or unfiltered
  */
 function addDatesSuggestions(
-    line: string,
-    cursorPos: number,
-    settings: Settings,
     datePrefixRegex: string,
     maxGenericSuggestions: number,
     suggestorParameters: SuggestorParameters,
@@ -344,11 +341,11 @@ function addDatesSuggestions(
 
     const results: SuggestInfo[] = [];
     const dateRegex = new RegExp(`(${datePrefixRegex})\\s*([0-9a-zA-Z ]*)`, 'ug');
-    const dateMatch = matchIfCursorInRegex(line, dateRegex, cursorPos);
+    const dateMatch = matchIfCursorInRegex(suggestorParameters.line, dateRegex, suggestorParameters.cursorPos);
     if (dateMatch && dateMatch.length >= 2) {
         const datePrefix = dateMatch[1];
         const dateString = dateMatch[2];
-        if (dateString.length < settings.autoSuggestMinMatch) {
+        if (dateString.length < suggestorParameters.settings.autoSuggestMinMatch) {
             return [];
         }
         // Try to parse the entered text as a valid date.

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -86,9 +86,7 @@ export function makeDefaultSuggestionBuilder(
 
         // add Auto ID suggestions
         if (includeDependencySuggestions(canSaveEdits)) {
-            suggestions = suggestions.concat(
-                addIDSuggestion(line, cursorPos, symbols.idSymbol, dataviewMode, allTasks, suggestorParameters),
-            );
+            suggestions = suggestions.concat(addIDSuggestion(symbols.idSymbol, allTasks, suggestorParameters));
 
             // add dependecy suggestions
             suggestions = suggestions.concat(
@@ -493,28 +491,19 @@ function addRecurrenceValueSuggestions(recurrenceSymbol: string, suggestorParame
     return results;
 }
 
-function addIDSuggestion(
-    line: string,
-    cursorPos: number,
-    idSymbol: string,
-    dataviewMode: boolean,
-    allTasks: Task[],
-    _suggestorParameters: SuggestorParameters,
-) {
-    const { postfix } = getAdjusters(dataviewMode, line, cursorPos);
-
+function addIDSuggestion(idSymbol: string, allTasks: Task[], suggestorParameters: SuggestorParameters) {
     const results: SuggestInfo[] = [];
     const idRegex = new RegExp(`(${idSymbol})\\s*(${taskIdRegex.source})?`, 'ug');
-    const idMatch = matchIfCursorInRegex(idRegex, _suggestorParameters);
+    const idMatch = matchIfCursorInRegex(idRegex, suggestorParameters);
 
     if (idMatch && idMatch[0].trim().length <= idSymbol.length) {
         const ID = generateUniqueId(allTasks.map((task) => task.id));
         results.push({
             suggestionType: 'match',
             displayText: 'generate unique id',
-            appendText: `${idSymbol} ${ID}` + postfix,
+            appendText: `${idSymbol} ${ID}` + suggestorParameters.postfix,
             insertAt: idMatch.index,
-            insertSkip: calculateSkipValueForMatch(idMatch[0], _suggestorParameters),
+            insertSkip: calculateSkipValueForMatch(idMatch[0], suggestorParameters),
         });
     }
 


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

Introduce `SuggestorParameters` parameter object to many functions in `Suggestor.ts`.

## Motivation and Context

As a next step, I want to refactor `Suggestor.ts` to reduce some repetition.

## How has this been tested?

- Existing automated tests
- Exploratory testing

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
