### PR TITLE
fix: Better dataview space & cursor in date suggestions

### DIFF
--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -318,7 +318,6 @@ function addDatesSuggestions(
     const dateRegex = new RegExp(`(${datePrefixRegex})\\s*([0-9a-zA-Z ]*)`, 'ug');
     const dateMatch = matchIfCursorInRegex(dateRegex, parameters);
     if (dateMatch && dateMatch.length >= 2) {
-        const datePrefix = dateMatch[1];
         const dateString = dateMatch[2];
         if (dateString.length < parameters.settings.autoSuggestMinMatch) {
             return [];
@@ -333,13 +332,7 @@ function addDatesSuggestions(
             // Seems like the text that the user typed can be parsed as a valid date.
             // Present its completed form as a 1st suggestion
             const absoluteDate = possibleDate.format(TaskRegularExpressions.dateFormat);
-            const { displayText, appendText } = defaultExtractor(datePrefix, absoluteDate);
-            results.push({
-                displayText: displayText,
-                appendText: `${appendText} `,
-                insertAt: dateMatch.index,
-                insertSkip: dateMatch[0].length,
-            });
+            constructSuggestions(parameters, dateMatch, [absoluteDate], defaultExtractor, results);
         }
 
         const genericMatches = filterGenericSuggestions(genericSuggestions, dateString, maxGenericSuggestions);

--- a/tests/Suggestor/Suggestor.test.auto-complete_with__dataview__symbols_offers_correct_options_for_partial_due_date_lines.approved.txt
+++ b/tests/Suggestor/Suggestor.test.auto-complete_with__dataview__symbols_offers_correct_options_for_partial_due_date_lines.approved.txt
@@ -19,8 +19,9 @@ For this markdown line:
 
 The first suggestion is:
 {
+    "suggestionType": "match",
     "displayText": "2022-10-27",
-    "appendText": "due:: 2022-10-27 ",
+    "appendText": "due:: 2022-10-27] ",
     "insertAt": 16,
     "insertSkip": 12
 }
@@ -31,8 +32,9 @@ For this markdown line:
 
 The first suggestion is:
 {
+    "suggestionType": "match",
     "displayText": "2023-07-11",
-    "appendText": "due:: 2023-07-11 ",
+    "appendText": "due:: 2023-07-11] ",
     "insertAt": 16,
     "insertSkip": 12
 }

--- a/tests/Suggestor/Suggestor.test.auto-complete_with__emoji__symbols_offers_correct_options_for_partial_due_date_lines.approved.txt
+++ b/tests/Suggestor/Suggestor.test.auto-complete_with__emoji__symbols_offers_correct_options_for_partial_due_date_lines.approved.txt
@@ -19,6 +19,7 @@ For this markdown line:
 
 The first suggestion is:
 {
+    "suggestionType": "match",
     "displayText": "2022-10-27",
     "appendText": "📅 2022-10-27 ",
     "insertAt": 16,
@@ -31,6 +32,7 @@ For this markdown line:
 
 The first suggestion is:
 {
+    "suggestionType": "match",
     "displayText": "2023-07-11",
     "appendText": "📅 2023-07-11 ",
     "insertAt": 16,


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Like <https://github.com/obsidian-tasks-group/obsidian-tasks/pull/3020> but for date suggestions where the user typed their own date value, such as '21 oct' or '1 year'.

## Motivation and Context

More improvements to the Auto Suggest code before adding support for On Completion.

## How has this been tested?

- Automated tests
- Exploratory testing

## Screenshots (if appropriate)

In the following text, the `|` represents the cursor position after the change.

Before:

```
- [ ] #task Normal priority [due:: 2024-10-21 |]
```

After
```
- [ ] #task Normal priority [due:: 2024-10-21] |
```

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
