### PR TITLE
refactor: remove `QueryResultsRenderer` inheritance

### DIFF
--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -1,19 +1,16 @@
 import type { EventRef, MarkdownPostProcessorContext } from 'obsidian';
 import { App, Keymap } from 'obsidian';
-import { GlobalFilter } from '../Config/GlobalFilter';
 import { GlobalQuery } from '../Config/GlobalQuery';
-import { PerformanceTracker } from '../lib/PerformanceTracker';
-import { explainResults, getQueryForQueryRenderer } from '../lib/QueryRendererHelper';
+import { getQueryForQueryRenderer } from '../lib/QueryRendererHelper';
 import type TasksPlugin from '../main';
 import { State } from '../Obsidian/Cache';
 import { getTaskLineAndFile, replaceTaskWithTasks } from '../Obsidian/File';
 import { TaskModal } from '../Obsidian/TaskModal';
 import type { TasksEvents } from '../Obsidian/TasksEvents';
-import type { QueryResult } from '../Query/QueryResult';
 import { TasksFile } from '../Scripting/TasksFile';
 import { DateFallback } from '../Task/DateFallback';
 import type { Task } from '../Task/Task';
-import { type QueryRendererParameters, QueryResultsRenderer } from './QueryResultsRenderer';
+import { QueryResultsRenderer } from './QueryResultsRenderer';
 import { createAndAppendElement } from './TaskLineRenderer';
 
 export class QueryRenderer {
@@ -138,80 +135,6 @@ class QueryRenderChild extends QueryResultsRenderer {
         }
 
         this.containerEl.firstChild?.replaceWith(content);
-    }
-
-    private async renderQuerySearchResults(
-        tasks: Task[],
-        state: State.Warm,
-        content: HTMLDivElement,
-        queryRendererParameters: QueryRendererParameters,
-    ) {
-        const queryResult = this.explainAndPerformSearch(state, tasks, content);
-
-        if (queryResult.searchErrorMessage !== undefined) {
-            // There was an error in the search, for example due to a problem custom function.
-            this.renderErrorMessage(content, queryResult.searchErrorMessage);
-            return;
-        }
-
-        await this.renderSearchResults(queryResult, content, queryRendererParameters);
-    }
-
-    private explainAndPerformSearch(state: State.Warm, tasks: Task[], content: HTMLDivElement) {
-        const measureSearch = new PerformanceTracker(`Search: ${this.query.queryId} - ${this.filePath}`);
-        measureSearch.start();
-
-        this.query.debug(`[render] Render called: plugin state: ${state}; searching ${tasks.length} tasks`);
-
-        if (this.query.queryLayoutOptions.explainQuery) {
-            this.createExplanation(content);
-        }
-
-        const queryResult = this.query.applyQueryToTasks(tasks);
-
-        measureSearch.finish();
-        return queryResult;
-    }
-
-    private async renderSearchResults(
-        queryResult: QueryResult,
-        content: HTMLDivElement,
-        queryRendererParameters: QueryRendererParameters,
-    ) {
-        const measureRender = new PerformanceTracker(`Render: ${this.query.queryId} - ${this.filePath}`);
-        measureRender.start();
-
-        await this.addAllTaskGroups(queryResult.taskGroups, content, queryRendererParameters);
-
-        const totalTasksCount = queryResult.totalTasksCount;
-        this.addTaskCount(content, queryResult);
-
-        this.query.debug(`[render] ${totalTasksCount} tasks displayed`);
-
-        measureRender.finish();
-    }
-
-    private renderErrorMessage(content: HTMLDivElement, errorMessage: string) {
-        content.createDiv().innerHTML = '<pre>' + `Tasks query: ${errorMessage.replace(/\n/g, '<br>')}` + '</pre>';
-    }
-
-    private renderLoadingMessage(content: HTMLDivElement) {
-        content.setText('Loading Tasks ...');
-    }
-
-    // Use the 'explain' instruction to enable this
-    private createExplanation(content: HTMLDivElement) {
-        const explanationAsString = explainResults(
-            this.source,
-            GlobalFilter.getInstance(),
-            GlobalQuery.getInstance(),
-            this.tasksFile,
-        );
-
-        const explanationsBlock = createAndAppendElement('pre', content);
-        explanationsBlock.addClasses(['plugin-tasks-query-explanation']);
-        explanationsBlock.setText(explanationAsString);
-        content.appendChild(explanationsBlock);
     }
 }
 

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -50,6 +50,8 @@ class QueryRenderChild extends QueryResultsRenderer {
     private renderEventRef: EventRef | undefined;
     private queryReloadTimeout: NodeJS.Timeout | undefined;
 
+    private queryResultsRenderer: QueryResultsRenderer = this;
+
     constructor({
         app,
         plugin,
@@ -107,7 +109,11 @@ class QueryRenderChild extends QueryResultsRenderer {
         const millisecondsToMidnight = midnight.getTime() - now.getTime();
 
         this.queryReloadTimeout = setTimeout(() => {
-            this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
+            this.queryResultsRenderer.query = getQueryForQueryRenderer(
+                this.queryResultsRenderer.source,
+                GlobalQuery.getInstance(),
+                this.queryResultsRenderer.tasksFile,
+            );
             // Process the current cache state:
             this.events.triggerRequestCacheUpdate(this.render.bind(this));
             this.reloadQueryAtMidnight();
@@ -116,7 +122,7 @@ class QueryRenderChild extends QueryResultsRenderer {
 
     private async render({ tasks, state }: { tasks: Task[]; state: State }) {
         const content = createAndAppendElement('div', this.containerEl);
-        await this.render2(state, tasks, content, {
+        await this.queryResultsRenderer.render2(state, tasks, content, {
             allTasks: this.plugin.getTasks(),
             allMarkdownFiles: this.app.vault.getMarkdownFiles(),
             backlinksClickHandler,

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -71,6 +71,7 @@ class QueryRenderChild extends MarkdownRenderChild {
 
         this.queryResultsRenderer = new QueryResultsRenderer(
             container,
+            this.containerEl.className,
             source,
             tasksFile,
             MarkdownRenderer.renderMarkdown,

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -115,11 +115,16 @@ class QueryRenderChild extends QueryResultsRenderer {
     }
 
     private async render({ tasks, state }: { tasks: Task[]; state: State }) {
+        const content = createAndAppendElement('div', this.containerEl);
+        await this.render2(state, tasks, content);
+
+        this.containerEl.firstChild?.replaceWith(content);
+    }
+
+    private async render2(state: State | State.Warm, tasks: Task[], content: HTMLDivElement) {
         // Don't log anything here, for any state, as it generates huge amounts of
         // console messages in large vaults, if Obsidian was opened with any
         // notes with tasks code blocks in Reading or Live Preview mode.
-
-        const content = createAndAppendElement('div', this.containerEl);
         if (state === State.Warm && this.query.error === undefined) {
             await this.renderQuerySearchResults(tasks, state, content, {
                 allTasks: this.plugin.getTasks(),
@@ -133,8 +138,6 @@ class QueryRenderChild extends QueryResultsRenderer {
         } else {
             this.renderLoadingMessage(content);
         }
-
-        this.containerEl.firstChild?.replaceWith(content);
     }
 }
 

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -70,7 +70,6 @@ class QueryRenderChild extends MarkdownRenderChild {
         super(container);
 
         this.queryResultsRenderer = new QueryResultsRenderer(
-            container,
             this.containerEl.className,
             source,
             tasksFile,

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -1,4 +1,4 @@
-import { type EventRef, type MarkdownPostProcessorContext, MarkdownRenderer } from 'obsidian';
+import { type EventRef, type MarkdownPostProcessorContext, MarkdownRenderChild, MarkdownRenderer } from 'obsidian';
 import { App, Keymap } from 'obsidian';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import { getQueryForQueryRenderer } from '../lib/QueryRendererHelper';
@@ -42,7 +42,7 @@ export class QueryRenderer {
     }
 }
 
-class QueryRenderChild extends QueryResultsRenderer {
+class QueryRenderChild extends MarkdownRenderChild {
     private readonly app: App;
     private plugin: TasksPlugin;
     private readonly events: TasksEvents;
@@ -50,7 +50,7 @@ class QueryRenderChild extends QueryResultsRenderer {
     private renderEventRef: EventRef | undefined;
     private queryReloadTimeout: NodeJS.Timeout | undefined;
 
-    private queryResultsRenderer: QueryResultsRenderer = this;
+    private queryResultsRenderer: QueryResultsRenderer;
 
     constructor({
         app,
@@ -67,8 +67,14 @@ class QueryRenderChild extends QueryResultsRenderer {
         source: string;
         tasksFile: TasksFile;
     }) {
-        super(container, source, tasksFile, MarkdownRenderer.renderMarkdown);
+        super(container);
 
+        this.queryResultsRenderer = new QueryResultsRenderer(
+            container,
+            source,
+            tasksFile,
+            MarkdownRenderer.renderMarkdown,
+        );
         this.app = app;
         this.plugin = plugin;
         this.events = events;

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -3,14 +3,14 @@ import { App, Keymap } from 'obsidian';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import { getQueryForQueryRenderer } from '../lib/QueryRendererHelper';
 import type TasksPlugin from '../main';
-import { State } from '../Obsidian/Cache';
+import type { State } from '../Obsidian/Cache';
 import { getTaskLineAndFile, replaceTaskWithTasks } from '../Obsidian/File';
 import { TaskModal } from '../Obsidian/TaskModal';
 import type { TasksEvents } from '../Obsidian/TasksEvents';
 import { TasksFile } from '../Scripting/TasksFile';
 import { DateFallback } from '../Task/DateFallback';
 import type { Task } from '../Task/Task';
-import { type QueryRendererParameters, QueryResultsRenderer } from './QueryResultsRenderer';
+import { QueryResultsRenderer } from './QueryResultsRenderer';
 import { createAndAppendElement } from './TaskLineRenderer';
 
 export class QueryRenderer {
@@ -125,24 +125,6 @@ class QueryRenderChild extends QueryResultsRenderer {
         });
 
         this.containerEl.firstChild?.replaceWith(content);
-    }
-
-    private async render2(
-        state: State | State.Warm,
-        tasks: Task[],
-        content: HTMLDivElement,
-        queryRendererParameters: QueryRendererParameters,
-    ) {
-        // Don't log anything here, for any state, as it generates huge amounts of
-        // console messages in large vaults, if Obsidian was opened with any
-        // notes with tasks code blocks in Reading or Live Preview mode.
-        if (state === State.Warm && this.query.error === undefined) {
-            await this.renderQuerySearchResults(tasks, state, content, queryRendererParameters);
-        } else if (this.query.error !== undefined) {
-            this.renderErrorMessage(content, this.query.error);
-        } else {
-            this.renderLoadingMessage(content);
-        }
     }
 }
 

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -74,6 +74,7 @@ class QueryRenderChild extends MarkdownRenderChild {
             source,
             tasksFile,
             MarkdownRenderer.renderMarkdown,
+            this,
         );
         this.app = app;
         this.plugin = plugin;

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -1,4 +1,4 @@
-import type { EventRef, MarkdownPostProcessorContext } from 'obsidian';
+import { type EventRef, type MarkdownPostProcessorContext, MarkdownRenderer } from 'obsidian';
 import { App, Keymap } from 'obsidian';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import { getQueryForQueryRenderer } from '../lib/QueryRendererHelper';
@@ -65,7 +65,7 @@ class QueryRenderChild extends QueryResultsRenderer {
         source: string;
         tasksFile: TasksFile;
     }) {
-        super(container, source, tasksFile);
+        super(container, source, tasksFile, MarkdownRenderer.renderMarkdown);
 
         this.app = app;
         this.plugin = plugin;

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -46,6 +46,8 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
     protected query: IQuery;
     protected queryType: string; // whilst there is only one query type, there is no point logging this value
 
+    private renderMarkdown = MarkdownRenderer.renderMarkdown;
+
     constructor(container: HTMLElement, source: string, tasksFile: TasksFile) {
         super(container);
 
@@ -285,7 +287,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
 
         const headerEl = createAndAppendElement(header, content);
         headerEl.addClass('tasks-group-heading');
-        await MarkdownRenderer.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this);
+        await this.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this);
     }
 
     private addBacklinks(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -47,7 +47,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
     protected queryType: string; // whilst there is only one query type, there is no point logging this value
 
     private readonly renderMarkdown;
-    private obsidianComponent = this;
+    private readonly obsidianComponent: Component;
 
     constructor(
         container: HTMLElement,
@@ -60,6 +60,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         this.source = source;
         this.tasksFile = tasksFile;
         this.renderMarkdown = renderMarkdown;
+        this.obsidianComponent = this;
 
         // The engine is chosen on the basis of the code block language. Currently,
         // there is only the main engine for the plugin, this allows others to be

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -1,4 +1,4 @@
-import { MarkdownRenderChild, MarkdownRenderer, TFile } from 'obsidian';
+import { type Component, MarkdownRenderChild, TFile } from 'obsidian';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import type { IQuery } from '../IQuery';
@@ -48,13 +48,17 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
 
     private readonly renderMarkdown;
 
-    constructor(container: HTMLElement, source: string, tasksFile: TasksFile) {
+    constructor(
+        container: HTMLElement,
+        source: string,
+        tasksFile: TasksFile,
+        renderMarkdown: (markdown: string, el: HTMLElement, sourcePath: string, component: Component) => Promise<void>,
+    ) {
         super(container);
 
         this.source = source;
         this.tasksFile = tasksFile;
-
-        this.renderMarkdown = MarkdownRenderer.renderMarkdown;
+        this.renderMarkdown = renderMarkdown;
 
         // The engine is chosen on the basis of the code block language. Currently,
         // there is only the main engine for the plugin, this allows others to be

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -54,13 +54,14 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         source: string,
         tasksFile: TasksFile,
         renderMarkdown: (markdown: string, el: HTMLElement, sourcePath: string, component: Component) => Promise<void>,
+        obsidianComponent: Component,
     ) {
         super(container);
 
         this.source = source;
         this.tasksFile = tasksFile;
         this.renderMarkdown = renderMarkdown;
-        this.obsidianComponent = this;
+        this.obsidianComponent = obsidianComponent;
 
         // The engine is chosen on the basis of the code block language. Currently,
         // there is only the main engine for the plugin, this allows others to be

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -6,7 +6,7 @@ import { QueryLayout } from '../Layout/QueryLayout';
 import { TaskLayout } from '../Layout/TaskLayout';
 import { PerformanceTracker } from '../lib/PerformanceTracker';
 import { explainResults, getQueryForQueryRenderer } from '../lib/QueryRendererHelper';
-import type { State } from '../Obsidian/Cache';
+import { State } from '../Obsidian/Cache';
 import type { GroupDisplayHeading } from '../Query/Group/GroupDisplayHeading';
 import type { TaskGroups } from '../Query/Group/TaskGroups';
 import type { QueryResult } from '../Query/QueryResult';
@@ -70,6 +70,24 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
 
     public get filePath(): string | undefined {
         return this.tasksFile?.path ?? undefined;
+    }
+
+    protected async render2(
+        state: State | State.Warm,
+        tasks: Task[],
+        content: HTMLDivElement,
+        queryRendererParameters: QueryRendererParameters,
+    ) {
+        // Don't log anything here, for any state, as it generates huge amounts of
+        // console messages in large vaults, if Obsidian was opened with any
+        // notes with tasks code blocks in Reading or Live Preview mode.
+        if (state === State.Warm && this.query.error === undefined) {
+            await this.renderQuerySearchResults(tasks, state, content, queryRendererParameters);
+        } else if (this.query.error !== undefined) {
+            this.renderErrorMessage(content, this.query.error);
+        } else {
+            this.renderLoadingMessage(content);
+        }
     }
 
     protected async renderQuerySearchResults(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -1,4 +1,4 @@
-import { type Component, MarkdownRenderChild, TFile } from 'obsidian';
+import type { Component, TFile } from 'obsidian';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import type { IQuery } from '../IQuery';
@@ -27,7 +27,7 @@ export interface QueryRendererParameters {
     editTaskPencilClickHandler: EditButtonClickHandler;
 }
 
-export class QueryResultsRenderer extends MarkdownRenderChild {
+export class QueryResultsRenderer {
     /**
      * The complete text in the instruction block, such as:
      * ```
@@ -50,15 +50,13 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
     private readonly obsidianComponent: Component;
 
     constructor(
-        container: HTMLElement,
+        _container: HTMLElement,
         className: string,
         source: string,
         tasksFile: TasksFile,
         renderMarkdown: (markdown: string, el: HTMLElement, sourcePath: string, component: Component) => Promise<void>,
         obsidianComponent: Component,
     ) {
-        super(container);
-
         this.source = source;
         this.tasksFile = tasksFile;
         this.renderMarkdown = renderMarkdown;
@@ -207,7 +205,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         if (groupingAttribute && groupingAttribute.length > 0) taskList.dataset.taskGroupBy = groupingAttribute;
 
         const taskLineRenderer = new TaskLineRenderer({
-            obsidianComponent: this,
+            obsidianComponent: this.obsidianComponent,
             parentUlElement: taskList,
             taskLayoutOptions: this.query.taskLayoutOptions,
             queryLayoutOptions: this.query.queryLayoutOptions,

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -38,12 +38,12 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
      * This does not contain the Global Query from the user's settings.
      * Use {@link getQueryForQueryRenderer} to get this value prefixed with the Global Query.
      */
-    protected readonly source: string;
+    public readonly source: string;
 
     // The path of the file that contains the instruction block, and cached data from that file.
-    protected readonly tasksFile: TasksFile;
+    public readonly tasksFile: TasksFile;
 
-    protected query: IQuery;
+    public query: IQuery;
     protected queryType: string; // whilst there is only one query type, there is no point logging this value
 
     private readonly renderMarkdown;

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -46,13 +46,15 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
     protected query: IQuery;
     protected queryType: string; // whilst there is only one query type, there is no point logging this value
 
-    private renderMarkdown = MarkdownRenderer.renderMarkdown;
+    private readonly renderMarkdown;
 
     constructor(container: HTMLElement, source: string, tasksFile: TasksFile) {
         super(container);
 
         this.source = source;
         this.tasksFile = tasksFile;
+
+        this.renderMarkdown = MarkdownRenderer.renderMarkdown;
 
         // The engine is chosen on the basis of the code block language. Currently,
         // there is only the main engine for the plugin, this allows others to be

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -50,7 +50,6 @@ export class QueryResultsRenderer {
     private readonly obsidianComponent: Component;
 
     constructor(
-        _container: HTMLElement,
         className: string,
         source: string,
         tasksFile: TasksFile,

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -51,6 +51,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
 
     constructor(
         container: HTMLElement,
+        className: string,
         source: string,
         tasksFile: TasksFile,
         renderMarkdown: (markdown: string, el: HTMLElement, sourcePath: string, component: Component) => Promise<void>,
@@ -66,7 +67,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         // The engine is chosen on the basis of the code block language. Currently,
         // there is only the main engine for the plugin, this allows others to be
         // added later.
-        switch (this.containerEl.className) {
+        switch (className) {
             case 'block-language-tasks':
                 this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
                 this.queryType = 'tasks';

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -47,6 +47,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
     protected queryType: string; // whilst there is only one query type, there is no point logging this value
 
     private readonly renderMarkdown;
+    private obsidianComponent = this;
 
     constructor(
         container: HTMLElement,
@@ -293,7 +294,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
 
         const headerEl = createAndAppendElement(header, content);
         headerEl.addClass('tasks-group-heading');
-        await this.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this);
+        await this.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this.obsidianComponent);
     }
 
     private addBacklinks(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -72,7 +72,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         return this.tasksFile?.path ?? undefined;
     }
 
-    protected async render2(
+    public async render2(
         state: State | State.Warm,
         tasks: Task[],
         content: HTMLDivElement,
@@ -90,7 +90,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         }
     }
 
-    protected async renderQuerySearchResults(
+    private async renderQuerySearchResults(
         tasks: Task[],
         state: State.Warm,
         content: HTMLDivElement,
@@ -141,11 +141,11 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         measureRender.finish();
     }
 
-    protected renderErrorMessage(content: HTMLDivElement, errorMessage: string) {
+    private renderErrorMessage(content: HTMLDivElement, errorMessage: string) {
         content.createDiv().innerHTML = '<pre>' + `Tasks query: ${errorMessage.replace(/\n/g, '<br>')}` + '</pre>';
     }
 
-    protected renderLoadingMessage(content: HTMLDivElement) {
+    private renderLoadingMessage(content: HTMLDivElement) {
         content.setText('Loading Tasks ...');
     }
 
@@ -164,7 +164,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         content.appendChild(explanationsBlock);
     }
 
-    protected async addAllTaskGroups(
+    private async addAllTaskGroups(
         tasksSortedLimitedGrouped: TaskGroups,
         content: HTMLDivElement,
         queryRendererParameters: QueryRendererParameters,
@@ -361,7 +361,7 @@ export class QueryResultsRenderer extends MarkdownRenderChild {
         });
     }
 
-    protected addTaskCount(content: HTMLDivElement, queryResult: QueryResult) {
+    private addTaskCount(content: HTMLDivElement, queryResult: QueryResult) {
         if (!this.query.queryLayoutOptions.hideTaskCount) {
             content.createDiv({
                 text: queryResult.totalTasksCountDisplayText(),


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

Done by pairing with @claremacrae 

- `QueryRenderChild` now inherits `MarkdownRendererChild`
- `QueryResultsRenderer` has now no inheritance

## Motivation and Context

- prepare `QueryResultsRenderer` for testing

## How has this been tested?

- Smoke test in demo vault (make a minimal tasks query and verify it is rendered)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms


- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
