### PR TITLE
feat: Add date picker in Reading mode and Tasks Query results

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,5 +1,5 @@
-import { sassPlugin } from 'esbuild-sass-plugin';
 import process from 'process';
+import { sassPlugin } from 'esbuild-sass-plugin';
 import esbuild from 'esbuild';
 import builtins from 'builtin-modules';
 import esbuildSvelte from 'esbuild-svelte';
@@ -128,6 +128,31 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
+
+/*
+License flatpickr (included library):
+The MIT License (MIT)
+
+Copyright (c) 2017 Gregory Petrosyan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 `;
 
 const prod = process.argv[2] === 'production';
@@ -169,8 +194,8 @@ esbuild
                 preprocess: sveltePreprocess(),
             }),
             sassPlugin({
-                syntax: "scss",
-                style: "expanded",
+                syntax: 'scss',
+                style: 'expanded',
             }),
         ],
         sourcemap: prod ? false : 'inline',

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "chrono-node": "2.3.9",
     "eslint-plugin-svelte3": "^4.0.0",
     "eventemitter2": "^6.4.5",
+    "flatpickr": "^4.6.13",
     "mustache": "^4.2.0",
     "mustache-validator": "^0.2.0",
     "rrule": "^2.7.2",

--- a/src/DateTime/DateFieldTypes.ts
+++ b/src/DateTime/DateFieldTypes.ts
@@ -1,0 +1,3 @@
+import type { Task } from '../Task/Task';
+
+export type HappensDate = keyof Pick<Task, 'startDate' | 'scheduledDate' | 'dueDate'>;

--- a/src/DateTime/DateFieldTypes.ts
+++ b/src/DateTime/DateFieldTypes.ts
@@ -1,3 +1,10 @@
 import type { Task } from '../Task/Task';
 
+// NEW_TASK_FIELD_EDIT_REQUIRED - if new field is included in 'happens' searches.
 export type HappensDate = keyof Pick<Task, 'startDate' | 'scheduledDate' | 'dueDate'>;
+
+// NEW_TASK_FIELD_EDIT_REQUIRED - if new field is a date field.
+export type AllTaskDateFields = keyof Pick<
+    Task,
+    'cancelledDate' | 'createdDate' | 'doneDate' | 'dueDate' | 'scheduledDate' | 'startDate' // alphabetical order, please.
+>;

--- a/src/DateTime/Postponer.ts
+++ b/src/DateTime/Postponer.ts
@@ -3,7 +3,7 @@ import { capitalizeFirstLetter } from '../lib/StringHelpers';
 import { Task } from '../Task/Task';
 import { DateFallback } from './DateFallback';
 import { TasksDate } from './TasksDate';
-import type { HappensDate } from './DateFieldTypes';
+import type { AllTaskDateFields, HappensDate } from './DateFieldTypes';
 
 export function shouldShowPostponeButton(task: Task) {
     // don't postpone if any invalid dates
@@ -189,7 +189,7 @@ function prettyPrintDateFieldName(updatedDateType: HappensDate) {
     return capitalizeFirstLetter(updatedDateType.replace('Date', ''));
 }
 
-function splitDateText(updatedDateType: HappensDate) {
+export function splitDateText(updatedDateType: AllTaskDateFields) {
     return updatedDateType.replace('Date', ' date');
 }
 

--- a/src/DateTime/Postponer.ts
+++ b/src/DateTime/Postponer.ts
@@ -3,6 +3,7 @@ import { capitalizeFirstLetter } from '../lib/StringHelpers';
 import { Task } from '../Task/Task';
 import { DateFallback } from './DateFallback';
 import { TasksDate } from './TasksDate';
+import type { HappensDate } from './DateFieldTypes';
 
 export function shouldShowPostponeButton(task: Task) {
     // don't postpone if any invalid dates
@@ -21,8 +22,6 @@ export function shouldShowPostponeButton(task: Task) {
     // only postpone not done tasks
     return !task.isDone && hasAValidHappensDate;
 }
-
-export type HappensDate = keyof Pick<Task, 'startDate' | 'scheduledDate' | 'dueDate'>;
 
 /**
  * Gets a {@link HappensDate} field from a {@link Task} with the following priority: due > scheduled > start.

--- a/src/Renderer/Renderer.scss
+++ b/src/Renderer/Renderer.scss
@@ -46,6 +46,20 @@ ul.contains-task-list .task-list-item-checkbox {
     }
 }
 
+/* Date fields: make it obvious they can be clicked */
+/* TODO Introduce a CSS class for clickable things, to remove the need to list all the date fields here */
+.task-cancelled,
+.task-created,
+.task-done,
+.task-due,
+.task-scheduled,
+.task-start {
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+}
+
 /* Edit and postpone */
 .tasks-edit, .tasks-postpone {
     width: 1em;

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -6,9 +6,13 @@ import type { QueryLayoutOptions } from '../Layout/QueryLayoutOptions';
 import { TaskLayoutComponent, type TaskLayoutOptions } from '../Layout/TaskLayoutOptions';
 import { replaceTaskWithTasks } from '../Obsidian/File';
 import { StatusRegistry } from '../Statuses/StatusRegistry';
-import type { Task } from '../Task/Task';
+import { Task } from '../Task/Task';
 import { TaskRegularExpressions } from '../Task/TaskRegularExpressions';
 import { StatusMenu } from '../ui/Menus/StatusMenu';
+import type { AllTaskDateFields } from '../DateTime/DateFieldTypes';
+import { defaultTaskSaver } from '../ui/Menus/TaskEditingMenu';
+import { promptForDate } from '../ui/Menus/DatePicker';
+import { splitDateText } from '../DateTime/Postponer';
 import { TaskFieldRenderer } from './TaskFieldRenderer';
 
 /**
@@ -204,6 +208,19 @@ export class TaskLineRenderer {
                 // Add the component's attribute ('priority-medium', 'due-past-1d' etc.)
                 fieldRenderer.addDataAttribute(span, task, component);
                 fieldRenderer.addDataAttribute(li, task, component);
+
+                if (Task.allDateFields().includes(component)) {
+                    const componentDateField = component as AllTaskDateFields;
+
+                    // Note: The more convenient span.onClickEvent() doesn't work here, as it is not available when tests are run.
+                    span.addEventListener('click', (ev: MouseEvent) => {
+                        ev.preventDefault(); // suppress the default click behavior
+                        ev.stopPropagation(); // suppress further event propagation
+                        promptForDate(li, task, componentDateField, defaultTaskSaver);
+                    });
+
+                    span.setAttribute('title', `Click to edit ${splitDateText(componentDateField)}`);
+                }
             }
         }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,3 +1,4 @@
+@import 'flatpickr/dist/flatpickr.css';
 @import './Renderer/Renderer';
 @import './ui/EditTask';
 @import './ui/Dependency';

--- a/src/ui/EditInstructions/DateInstructions.ts
+++ b/src/ui/EditInstructions/DateInstructions.ts
@@ -25,15 +25,14 @@ export class SetTaskDate implements TaskEditingInstruction {
     }
 
     private isSameDate(task: Task) {
-        return task[this.dateFieldToEdit]?.isSame(window.moment(this.newDate));
+        return task[this.dateFieldToEdit]?.isSame(window.moment(this.newDate)) || false;
     }
 
     public instructionDisplayName(): string {
         return `Set Date: ${this.newDate.toDateString()}`;
     }
 
-    public isCheckedForTask(_task: Task): boolean {
-        // TODO Make this check whether field already has the requested date.
-        return false;
+    public isCheckedForTask(task: Task): boolean {
+        return this.isSameDate(task);
     }
 }

--- a/src/ui/EditInstructions/DateInstructions.ts
+++ b/src/ui/EditInstructions/DateInstructions.ts
@@ -1,0 +1,32 @@
+import type { AllTaskDateFields } from '../../DateTime/DateFieldTypes';
+import { Task } from '../../Task/Task';
+import type { TaskEditingInstruction } from './TaskEditingInstruction';
+
+export class SetTaskDate implements TaskEditingInstruction {
+    private readonly newDate: Date;
+    private readonly dateFieldToEdit;
+
+    constructor(dateFieldToEdit: AllTaskDateFields, date: Date) {
+        this.newDate = date;
+        this.dateFieldToEdit = dateFieldToEdit;
+    }
+
+    public apply(task: Task): Task[] {
+        // TODO Should do nothing if the date is unchanged
+        return [
+            new Task({
+                ...task,
+                [this.dateFieldToEdit]: window.moment(this.newDate),
+            }),
+        ];
+    }
+
+    public instructionDisplayName(): string {
+        return `Set Date: ${this.newDate.toDateString()}`;
+    }
+
+    public isCheckedForTask(_task: Task): boolean {
+        // TODO Make this check whether field already has the requested date.
+        return false;
+    }
+}

--- a/src/ui/EditInstructions/DateInstructions.ts
+++ b/src/ui/EditInstructions/DateInstructions.ts
@@ -24,15 +24,11 @@ export class SetTaskDate implements TaskEditingInstruction {
         }
     }
 
-    private isSameDate(task: Task) {
-        return task[this.dateFieldToEdit]?.isSame(window.moment(this.newDate)) || false;
-    }
-
     public instructionDisplayName(): string {
         return `Set Date: ${this.newDate.toDateString()}`;
     }
 
     public isCheckedForTask(task: Task): boolean {
-        return this.isSameDate(task);
+        return task[this.dateFieldToEdit]?.isSame(window.moment(this.newDate)) || false;
     }
 }

--- a/src/ui/EditInstructions/DateInstructions.ts
+++ b/src/ui/EditInstructions/DateInstructions.ts
@@ -12,7 +12,7 @@ export class SetTaskDate implements TaskEditingInstruction {
     }
 
     public apply(task: Task): Task[] {
-        if (this.isSameDate(task)) {
+        if (this.isCheckedForTask(task)) {
             return [task];
         } else {
             return [

--- a/src/ui/EditInstructions/DateInstructions.ts
+++ b/src/ui/EditInstructions/DateInstructions.ts
@@ -12,7 +12,7 @@ export class SetTaskDate implements TaskEditingInstruction {
     }
 
     public apply(task: Task): Task[] {
-        if (task[this.dateFieldToEdit]?.isSame(window.moment(this.newDate))) {
+        if (this.isSameDate(task)) {
             return [task];
         } else {
             return [
@@ -22,6 +22,10 @@ export class SetTaskDate implements TaskEditingInstruction {
                 }),
             ];
         }
+    }
+
+    private isSameDate(task: Task) {
+        return task[this.dateFieldToEdit]?.isSame(window.moment(this.newDate));
     }
 
     public instructionDisplayName(): string {

--- a/src/ui/EditInstructions/DateInstructions.ts
+++ b/src/ui/EditInstructions/DateInstructions.ts
@@ -12,13 +12,16 @@ export class SetTaskDate implements TaskEditingInstruction {
     }
 
     public apply(task: Task): Task[] {
-        // TODO Should do nothing if the date is unchanged
-        return [
-            new Task({
-                ...task,
-                [this.dateFieldToEdit]: window.moment(this.newDate),
-            }),
-        ];
+        if (task[this.dateFieldToEdit]?.isSame(window.moment(this.newDate))) {
+            return [task];
+        } else {
+            return [
+                new Task({
+                    ...task,
+                    [this.dateFieldToEdit]: window.moment(this.newDate),
+                }),
+            ];
+        }
     }
 
     public instructionDisplayName(): string {

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -1,0 +1,50 @@
+import flatpickr from 'flatpickr';
+import type { Task } from '../../Task/Task';
+import { SetTaskDate } from '../EditInstructions/DateInstructions';
+import type { AllTaskDateFields } from '../../DateTime/DateFieldTypes';
+
+export function promptForDate(
+    parentElement: HTMLElement,
+    task: Task,
+    dateFieldToEdit: AllTaskDateFields,
+    taskSaver: (originalTask: Task, newTasks: Task | Task[]) => Promise<void>,
+) {
+    if (!parentElement) {
+        console.log('Parent element not found.');
+        return;
+    }
+
+    const input = document.createElement('input');
+    input.type = 'text'; // Flatpickr can hook into a text input
+    parentElement.appendChild(input);
+
+    // Ensure styles are applied so Flatpickr can render correctly
+    input.style.minWidth = '200px'; // Ensure there's enough room for Flatpickr
+
+    // Delay the initialization of Flatpickr to ensure DOM is ready
+    setTimeout(() => {
+        const currentValue = task[dateFieldToEdit];
+        // TODO figure out how Today's date is determined: if Obsidian is left
+        //      running overnight, the flatpickr modal shows the previous day as Today.
+        const fp = flatpickr(input, {
+            defaultDate: currentValue ? currentValue.format('YYYY-MM-DD') : new Date(),
+            enableTime: false, // Optional: Enable time picker
+            dateFormat: 'Y-m-d', // Adjust the date and time format as needed
+            locale: {
+                firstDayOfWeek: 1, // Sets Monday as the first day of the week
+            },
+            onClose: async (selectedDates, _dateStr, instance) => {
+                if (selectedDates.length > 0) {
+                    const date = selectedDates[0];
+                    const newTask = new SetTaskDate(dateFieldToEdit, date).apply(task);
+                    await taskSaver(task, newTask);
+                }
+                instance.destroy(); // Proper cleanup
+                input.remove(); // Remove the elements after selection
+            },
+        });
+
+        // Open the calendar programmatically
+        fp.open();
+    }, 0);
+}

--- a/src/ui/Menus/PostponeMenu.ts
+++ b/src/ui/Menus/PostponeMenu.ts
@@ -2,7 +2,6 @@ import { MenuItem, Notice } from 'obsidian';
 import type { Moment, unitOfTime } from 'moment/moment';
 import type { Task } from '../../Task/Task';
 import {
-    type HappensDate,
     createFixedDateTask,
     createPostponedTask,
     createTaskWithDateRemoved,
@@ -12,6 +11,7 @@ import {
     postponementSuccessMessage,
     removeDateMenuItemTitle,
 } from '../../DateTime/Postponer';
+import type { HappensDate } from '../../DateTime/DateFieldTypes';
 import { TaskEditingMenu, type TaskSaver, defaultTaskSaver } from './TaskEditingMenu';
 
 type NamingFunction = (task: Task, amount: number, timeUnit: unitOfTime.DurationConstructor) => string;

--- a/tests/DateTime/Postponer.test.ts
+++ b/tests/DateTime/Postponer.test.ts
@@ -4,7 +4,6 @@
 import moment from 'moment';
 import type { Task } from '../../src/Task/Task';
 import {
-    type HappensDate,
     createFixedDateTask,
     createPostponedTask,
     createTaskWithDateRemoved,
@@ -20,6 +19,7 @@ import { Status } from '../../src/Statuses/Status';
 import { StatusConfiguration, StatusType } from '../../src/Statuses/StatusConfiguration';
 import type { PostponingFunction } from '../../src/ui/Menus/PostponeMenu';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import type { HappensDate } from '../../src/DateTime/DateFieldTypes';
 
 window.moment = moment;
 

--- a/tests/Renderer/TaskLineRenderer.test.Visualise_HTML_Full_task_-_full_mode.approved.html
+++ b/tests/Renderer/TaskLineRenderer.test.Visualise_HTML_Full_task_-_full_mode.approved.html
@@ -23,12 +23,20 @@
     <span class="task-priority" data-task-priority="medium"><span>🔼</span></span>
     <span class="task-recurring"><span>🔁 every day when done</span></span>
     <span class="task-onCompletion"><span>🏁 delete</span></span>
-    <span class="task-created" data-task-created="past-4d"><span>➕ 2023-07-01</span></span>
-    <span class="task-start" data-task-start="past-3d"><span>🛫 2023-07-02</span></span>
-    <span class="task-scheduled" data-task-scheduled="past-2d"><span>⏳ 2023-07-03</span></span>
-    <span class="task-due" data-task-due="past-1d"><span>📅 2023-07-04</span></span>
-    <span class="task-cancelled" data-task-cancelled="future-1d"><span>❌ 2023-07-06</span></span>
-    <span class="task-done" data-task-done="today"><span>✅ 2023-07-05</span></span>
+    <span class="task-created" data-task-created="past-4d" title="Click to edit created date">
+      <span>➕ 2023-07-01</span>
+    </span>
+    <span class="task-start" data-task-start="past-3d" title="Click to edit start date">
+      <span>🛫 2023-07-02</span>
+    </span>
+    <span class="task-scheduled" data-task-scheduled="past-2d" title="Click to edit scheduled date">
+      <span>⏳ 2023-07-03</span>
+    </span>
+    <span class="task-due" data-task-due="past-1d" title="Click to edit due date"><span>📅 2023-07-04</span></span>
+    <span class="task-cancelled" data-task-cancelled="future-1d" title="Click to edit cancelled date">
+      <span>❌ 2023-07-06</span>
+    </span>
+    <span class="task-done" data-task-done="today" title="Click to edit done date"><span>✅ 2023-07-05</span></span>
     <span class="task-block-link"><span>^dcf64c</span></span>
   </span>
 </li>

--- a/tests/Renderer/TaskLineRenderer.test.Visualise_HTML_Full_task_-_short_mode.approved.html
+++ b/tests/Renderer/TaskLineRenderer.test.Visualise_HTML_Full_task_-_short_mode.approved.html
@@ -23,12 +23,16 @@
     <span class="task-priority" data-task-priority="medium"><span>🔼</span></span>
     <span class="task-recurring"><span>🔁</span></span>
     <span class="task-onCompletion"><span>🏁</span></span>
-    <span class="task-created" data-task-created="past-4d"><span>➕</span></span>
-    <span class="task-start" data-task-start="past-3d"><span>🛫</span></span>
-    <span class="task-scheduled" data-task-scheduled="past-2d"><span>⏳</span></span>
-    <span class="task-due" data-task-due="past-1d"><span>📅</span></span>
-    <span class="task-cancelled" data-task-cancelled="future-1d"><span>❌</span></span>
-    <span class="task-done" data-task-done="today"><span>✅</span></span>
+    <span class="task-created" data-task-created="past-4d" title="Click to edit created date"><span>➕</span></span>
+    <span class="task-start" data-task-start="past-3d" title="Click to edit start date"><span>🛫</span></span>
+    <span class="task-scheduled" data-task-scheduled="past-2d" title="Click to edit scheduled date">
+      <span>⏳</span>
+    </span>
+    <span class="task-due" data-task-due="past-1d" title="Click to edit due date"><span>📅</span></span>
+    <span class="task-cancelled" data-task-cancelled="future-1d" title="Click to edit cancelled date">
+      <span>❌</span>
+    </span>
+    <span class="task-done" data-task-done="today" title="Click to edit done date"><span>✅</span></span>
     <span class="task-block-link"><span>^dcf64c</span></span>
   </span>
 </li>

--- a/tests/ui/EditInstructions/DateInstructions.test.ts
+++ b/tests/ui/EditInstructions/DateInstructions.test.ts
@@ -33,7 +33,7 @@ describe('SetTaskDate', () => {
         // Assert
         expect(instruction.instructionDisplayName()).toEqual('Set Date: Tue Oct 01 2024');
         expect(instruction.isCheckedForTask(taskWithNoDates)).toEqual(false);
-        expect(instruction.isCheckedForTask(taskDueToday)).toEqual(false); // TODO should be true.
+        expect(instruction.isCheckedForTask(taskDueToday)).toEqual(true);
     });
 
     it('should edit the date', () => {

--- a/tests/ui/EditInstructions/DateInstructions.test.ts
+++ b/tests/ui/EditInstructions/DateInstructions.test.ts
@@ -48,7 +48,7 @@ describe('SetTaskDate', () => {
         expect(newTasks[0].dueDate).toEqualMoment(moment(tomorrow));
     });
 
-    it.failing('should not edit task if already has chosen date', () => {
+    it('should not edit task if already has chosen date', () => {
         // Arrange
         const instruction = new SetTaskDate('dueDate', new Date(tomorrow));
 

--- a/tests/ui/EditInstructions/DateInstructions.test.ts
+++ b/tests/ui/EditInstructions/DateInstructions.test.ts
@@ -24,6 +24,7 @@ afterEach(() => {
 describe('SetTaskDate', () => {
     const taskWithNoDates = new TaskBuilder().build();
     const taskDueToday = new TaskBuilder().dueDate(today).build();
+    const taskDueTomorrow = new TaskBuilder().dueDate(tomorrow).build();
 
     it('should provide information to set up a menu item for due date', () => {
         // Arrange
@@ -45,5 +46,18 @@ describe('SetTaskDate', () => {
         // Assert
         expect(newTasks.length).toEqual(1);
         expect(newTasks[0].dueDate).toEqualMoment(moment(tomorrow));
+    });
+
+    it.failing('should not edit task if already has chosen date', () => {
+        // Arrange
+        const instruction = new SetTaskDate('dueDate', new Date(tomorrow));
+
+        // Assert
+        const newTasks = instruction.apply(taskDueTomorrow);
+
+        // Assert
+        expect(newTasks.length).toEqual(1);
+        // Expect it is the same object
+        expect(Object.is(newTasks[0], taskDueTomorrow)).toBe(true);
     });
 });

--- a/tests/ui/EditInstructions/DateInstructions.test.ts
+++ b/tests/ui/EditInstructions/DateInstructions.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+import moment from 'moment';
+
+import { TaskBuilder } from '../../TestingTools/TaskBuilder';
+import { SetTaskDate } from '../../../src/ui/EditInstructions/DateInstructions';
+
+window.moment = moment;
+
+// const yesterday = '2023-12-02';
+const today = '2024-10-01';
+const tomorrow = '2023-12-04';
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(today));
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
+
+describe('SetTaskDate', () => {
+    const taskWithNoDates = new TaskBuilder().build();
+    const taskDueToday = new TaskBuilder().dueDate(today).build();
+
+    it('should provide information to set up a menu item for due date', () => {
+        // Arrange
+        const instruction = new SetTaskDate('dueDate', new Date(today));
+
+        // Assert
+        expect(instruction.instructionDisplayName()).toEqual('Set Date: Tue Oct 01 2024');
+        expect(instruction.isCheckedForTask(taskWithNoDates)).toEqual(false);
+        expect(instruction.isCheckedForTask(taskDueToday)).toEqual(false); // TODO should be true.
+    });
+
+    it('should edit the date', () => {
+        // Arrange
+        const instruction = new SetTaskDate('dueDate', new Date(tomorrow));
+
+        // Assert
+        const newTasks = instruction.apply(taskWithNoDates);
+
+        // Assert
+        expect(newTasks.length).toEqual(1);
+        expect(newTasks[0].dueDate).toEqualMoment(moment(tomorrow));
+    });
+});

--- a/tests/ui/EditInstructions/DateInstructions.test.ts
+++ b/tests/ui/EditInstructions/DateInstructions.test.ts
@@ -8,7 +8,6 @@ import { SetTaskDate } from '../../../src/ui/EditInstructions/DateInstructions';
 
 window.moment = moment;
 
-// const yesterday = '2023-12-02';
 const today = '2024-10-01';
 const tomorrow = '2023-12-04';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2884,6 +2884,11 @@ flat-cache@^3.0.4:
     keyv "^4.5.3"
     rimraf "^3.0.2"
 
+flatpickr@^4.6.13:
+  version "4.6.13"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.13.tgz#8a029548187fd6e0d670908471e43abe9ad18d94"
+  integrity sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==
+
 flatted@^3.2.9:
   version "3.2.9"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: #2649

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description


**User visible changes:**

- In Reading Mode and in Tasks Query Results, now you can click on a task date field, and a date editor will pop up.
- It will show the current date.
- Selecting any other date will apply that date to the task immediately (there is no save button).
- Clicking outside the date picker will close it.

**Behind the scenes:**

- flatpickr: <https://github.com/flatpickr/flatpickr>
    - Add dependency on this library. It's also used by the Kanban plugin, I see.
    - Add its licence to the distributed `main.js`.
- Main new source files:
    - `src/ui/EditInstructions/DateInstructions.ts` with tests
        - This implements `TaskEditingInstruction`.
    - `src/ui/Menus/DatePicker.ts`
        - Wrapper around `flatpickr`
        - Do we want to move it to `ui/Widgets/`?
- `src/DateTime/DateFieldTypes.ts`
    - Extract `HappensDate` to this file.
    - Add a similar type, `AllTaskDateFields`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is much-needed functionality, and I really want to move it out of my fork and in to the released plugin, for others to use.

## How has this been tested?

- New tests for the non-UI part of the code.
- Extensive manual testing of an earlier version of this code in my personal vault.
- Testing today of this latest code in the sample vault.



## Screenshots (if appropriate)

User steps:

1. Click on a date emoji or value in Reading Mode or Tasks query results
2. A readonly input field appears - I would prefer not to have this, but for now it seems necessary to tie the flatpickr to a field.
    - The Kanban plugin also uses `flatpickr` and does not do this, so I suspect that there may be a  way around it
3. Simultaneously the picker appears, with the current date selected.

<img width="580" alt="image" src="https://github.com/user-attachments/assets/13ba2a62-64ee-4ccf-9f4a-dc9880f930ef">


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
