### PR TITLE
refactor:  test QueryResultsRenderer

### DIFF
--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -129,7 +129,7 @@ class QueryRenderChild extends MarkdownRenderChild {
 
     private async render({ tasks, state }: { tasks: Task[]; state: State }) {
         const content = createAndAppendElement('div', this.containerEl);
-        await this.queryResultsRenderer.render2(state, tasks, content, {
+        await this.queryResultsRenderer.render(state, tasks, content, {
             allTasks: this.plugin.getTasks(),
             allMarkdownFiles: this.app.vault.getMarkdownFiles(),
             backlinksClickHandler,

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -296,9 +296,10 @@ export class QueryResultsRenderer {
         const headerEl = createAndAppendElement(header, content);
         headerEl.classList.add('tasks-group-heading');
 
-        if (this.obsidianComponent !== null) {
-            await this.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this.obsidianComponent);
+        if (this.obsidianComponent === null) {
+            return;
         }
+        await this.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this.obsidianComponent);
     }
 
     private addBacklinks(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -81,7 +81,7 @@ export class QueryResultsRenderer {
         return this.tasksFile?.path ?? undefined;
     }
 
-    public async render2(
+    public async render(
         state: State | State.Warm,
         tasks: Task[],
         content: HTMLDivElement,

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -47,14 +47,14 @@ export class QueryResultsRenderer {
     protected queryType: string; // whilst there is only one query type, there is no point logging this value
 
     private readonly renderMarkdown;
-    private readonly obsidianComponent: Component;
+    private readonly obsidianComponent: Component | null;
 
     constructor(
         className: string,
         source: string,
         tasksFile: TasksFile,
         renderMarkdown: (markdown: string, el: HTMLElement, sourcePath: string, component: Component) => Promise<void>,
-        obsidianComponent: Component,
+        obsidianComponent: Component | null,
     ) {
         this.source = source;
         this.tasksFile = tasksFile;
@@ -168,7 +168,7 @@ export class QueryResultsRenderer {
         );
 
         const explanationsBlock = createAndAppendElement('pre', content);
-        explanationsBlock.addClasses(['plugin-tasks-query-explanation']);
+        explanationsBlock.classList.add('plugin-tasks-query-explanation');
         explanationsBlock.setText(explanationAsString);
         content.appendChild(explanationsBlock);
     }
@@ -194,11 +194,11 @@ export class QueryResultsRenderer {
     ): Promise<void> {
         const taskList = createAndAppendElement('ul', content);
 
-        taskList.addClasses(['contains-task-list', 'plugin-tasks-query-result']);
+        taskList.classList.add('contains-task-list', 'plugin-tasks-query-result');
         const taskLayout = new TaskLayout(this.query.taskLayoutOptions);
-        taskList.addClasses(taskLayout.generateHiddenClasses());
+        taskList.classList.add(...taskLayout.generateHiddenClasses());
         const queryLayout = new QueryLayout(this.query.queryLayoutOptions);
-        taskList.addClasses(queryLayout.getHiddenClasses());
+        taskList.classList.add(...queryLayout.getHiddenClasses());
 
         const groupingAttribute = this.getGroupingAttribute();
         if (groupingAttribute && groupingAttribute.length > 0) taskList.dataset.taskGroupBy = groupingAttribute;
@@ -231,7 +231,8 @@ export class QueryResultsRenderer {
         const footnotes = listItem.querySelectorAll('[data-footnote-id]');
         footnotes.forEach((footnote) => footnote.remove());
 
-        const extrasSpan = listItem.createSpan('task-extras');
+        const extrasSpan = createAndAppendElement('span', listItem);
+        extrasSpan.classList.add('task-extras');
 
         if (!this.query.queryLayoutOptions.hideUrgency) {
             this.addUrgency(extrasSpan, task);
@@ -256,13 +257,13 @@ export class QueryResultsRenderer {
 
     private addEditButton(listItem: HTMLElement, task: Task, queryRendererParameters: QueryRendererParameters) {
         const editTaskPencil = createAndAppendElement('a', listItem);
-        editTaskPencil.addClass('tasks-edit');
+        editTaskPencil.classList.add('tasks-edit');
         editTaskPencil.title = 'Edit task';
         editTaskPencil.href = '#';
 
-        editTaskPencil.onClickEvent((event: MouseEvent) => {
-            queryRendererParameters.editTaskPencilClickHandler(event, task, queryRendererParameters.allTasks);
-        });
+        editTaskPencil.addEventListener('click', (event: MouseEvent) =>
+            queryRendererParameters.editTaskPencilClickHandler(event, task, queryRendererParameters.allTasks),
+        );
     }
 
     private addUrgency(listItem: HTMLElement, task: Task) {
@@ -293,8 +294,11 @@ export class QueryResultsRenderer {
         }
 
         const headerEl = createAndAppendElement(header, content);
-        headerEl.addClass('tasks-group-heading');
-        await this.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this.obsidianComponent);
+        headerEl.classList.add('tasks-group-heading');
+
+        if (this.obsidianComponent !== null) {
+            await this.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this.obsidianComponent);
+        }
     }
 
     private addBacklinks(
@@ -304,7 +308,8 @@ export class QueryResultsRenderer {
         isFilenameUnique: boolean | undefined,
         queryRendererParameters: QueryRendererParameters,
     ) {
-        const backLink = listItem.createSpan({ cls: 'tasks-backlink' });
+        const backLink = createAndAppendElement('span', listItem);
+        backLink.classList.add('tasks-backlink');
 
         if (!shortMode) {
             backLink.append(' (');
@@ -314,9 +319,9 @@ export class QueryResultsRenderer {
 
         link.rel = 'noopener';
         link.target = '_blank';
-        link.addClass('internal-link');
+        link.classList.add('internal-link');
         if (shortMode) {
-            link.addClass('internal-link-short-mode');
+            link.classList.add('internal-link-short-mode');
         }
 
         let linkText: string;
@@ -326,7 +331,7 @@ export class QueryResultsRenderer {
             linkText = task.getLinkText({ isFilenameUnique }) ?? '';
         }
 
-        link.setText(linkText);
+        link.text = linkText;
 
         // Go to the line the task is defined at
         link.addEventListener('click', async (ev: MouseEvent) => {
@@ -348,9 +353,9 @@ export class QueryResultsRenderer {
         const buttonTooltipText = postponeButtonTitle(task, amount, timeUnit);
 
         const button = createAndAppendElement('a', listItem);
-        button.addClass('tasks-postpone');
+        button.classList.add('tasks-postpone');
         if (shortMode) {
-            button.addClass('tasks-postpone-short-mode');
+            button.classList.add('tasks-postpone-short-mode');
         }
         button.title = buttonTooltipText;
 
@@ -372,10 +377,9 @@ export class QueryResultsRenderer {
 
     private addTaskCount(content: HTMLDivElement, queryResult: QueryResult) {
         if (!this.query.queryLayoutOptions.hideTaskCount) {
-            content.createDiv({
-                text: queryResult.totalTasksCountDisplayText(),
-                cls: 'tasks-count',
-            });
+            const taskCount = createAndAppendElement('div', content);
+            taskCount.classList.add('task-count');
+            taskCount.textContent = queryResult.totalTasksCountDisplayText();
         }
     }
 

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -65,7 +65,9 @@ export class TaskLineRenderer {
         path: string,
         obsidianComponent: Component | null,
     ) {
-        if (!obsidianComponent) throw new Error('Must call the Obsidian renderer with an Obsidian Component object');
+        if (!obsidianComponent) {
+            return;
+        }
         await MarkdownRenderer.renderMarkdown(text, element, path, obsidianComponent);
     }
 

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task.approved.html
@@ -1,0 +1,54 @@
+<div>
+  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="medium"
+      data-task-created="past-far"
+      data-task-start="past-far"
+      data-task-scheduled="past-far"
+      data-task-due="past-far"
+      data-task-cancelled="past-far"
+      data-task-done="past-far"
+      data-task=""
+      data-line="0"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span></span></span>
+        <span class="task-id"><span>🆔 abcdef</span></span>
+        <span class="task-dependsOn"><span>⛔ 123456,abc123</span></span>
+        <span class="task-priority" data-task-priority="medium"><span>🔼</span></span>
+        <span class="task-recurring"><span>🔁 every day when done</span></span>
+        <span class="task-onCompletion"><span>🏁 delete</span></span>
+        <span class="task-created" data-task-created="past-far" title="Click to edit created date">
+          <span>➕ 2023-07-01</span>
+        </span>
+        <span class="task-start" data-task-start="past-far" title="Click to edit start date">
+          <span>🛫 2023-07-02</span>
+        </span>
+        <span class="task-scheduled" data-task-scheduled="past-far" title="Click to edit scheduled date">
+          <span>⏳ 2023-07-03</span>
+        </span>
+        <span class="task-due" data-task-due="past-far" title="Click to edit due date"><span>📅 2023-07-04</span></span>
+        <span class="task-cancelled" data-task-cancelled="past-far" title="Click to edit cancelled date">
+          <span>❌ 2023-07-06</span>
+        </span>
+        <span class="task-done" data-task-done="past-far" title="Click to edit done date">
+          <span>✅ 2023-07-05</span>
+        </span>
+        <span class="task-block-link"><span>^dcf64c</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">fileName &gt; My Header</a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+        <a class="tasks-postpone" title="ℹ️ Due tomorrow, on Tue 20th Aug (right-click for more options)"></a>
+      </span>
+    </li>
+  </ul>
+  <div class="task-count">1 task</div>
+</div>

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment jsdom
+ */
+import moment from 'moment';
+import { State } from '../../src/Obsidian/Cache';
+import { QueryResultsRenderer } from '../../src/Renderer/QueryResultsRenderer';
+import { TasksFile } from '../../src/Scripting/TasksFile';
+import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
+import { prettifyHTML } from '../TestingTools/HTMLHelpers';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
+
+window.moment = moment;
+
+describe('QueryResultsRenderer tests', () => {
+    it('fully populated task', async () => {
+        const renderer = new QueryResultsRenderer(
+            'block-language-tasks',
+            '',
+            new TasksFile('query.md'),
+            () => Promise.resolve(),
+            null,
+        );
+        const allTasks = [TaskBuilder.createFullyPopulatedTask()];
+        const queryRendererParameters = {
+            allTasks,
+            allMarkdownFiles: [],
+            backlinksClickHandler: () => Promise.resolve(),
+            backlinksMousedownHandler: () => Promise.resolve(),
+            editTaskPencilClickHandler: () => Promise.resolve(),
+        };
+        const container = document.createElement('div');
+
+        await renderer.render2(State.Warm, allTasks, container, queryRendererParameters);
+
+        const prettyHTML = prettifyHTML(container.outerHTML);
+        verifyWithFileExtension(prettyHTML, 'html');
+    });
+});

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -30,7 +30,7 @@ describe('QueryResultsRenderer tests', () => {
         };
         const container = document.createElement('div');
 
-        await renderer.render2(State.Warm, allTasks, container, queryRendererParameters);
+        await renderer.render(State.Warm, allTasks, container, queryRendererParameters);
 
         const prettyHTML = prettifyHTML(container.outerHTML);
         verifyWithFileExtension(prettyHTML, 'html');


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Refactor `QueryResultsRenderer` to enable us to save the generated HTML with approval tests.

This replicates edits made previously to allow `TaskLineRenderer` to be tested:

- Replace use of Obsidian convenience methods (such as `createDiv()`) with the native equivalents, so that the code can be called via tests
- Allow `obsidianComponent` to be `null`.

## Motivation and Context

- To be able to write tests of rendering nested task lines and list items.

## How has this been tested?

- With a new test
- Running the existing smoke tests (done by @claremacrae)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
