### PR TITLE
fix: load cache when workspace is ready

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,7 @@ export default class TasksPlugin extends Plugin {
         this.cache = new Cache({
             metadataCache: this.app.metadataCache,
             vault: this.app.vault,
+            workspace: this.app.workspace,
             events,
         });
         this.inlineRenderer = new InlineRenderer({ plugin: this });


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
    - Fixes https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2152

## Description

Load Vault and subscribe to changes when workspace is ready. 

### Original behaviour

After turning on logging and debugging the plugins startup, especially the Cache creation i noticed the following effects:
- Files are checked twice: Once by loadVault and once by subscribeToVault.
- Whereas loadVault is fast, subscribeToVault added significantly delays
- subscribeToVault (https://docs.obsidian.md/Reference/TypeScript+API/Vault/on('create')) registers for create events where for every file available the event is triggered when called in the plugins onload routine
- https://docs.obsidian.md/Reference/TypeScript+API/Vault/on('create') added significant delays in the Tasks plugin even if the event handler is an empty function doing nothing (to be validated with an blank plugin and a sample vault, which was not yet done)


### Changes made

Changes done in detail:
- Moved both functions to Workspace#onLayoutReady which omits the create events for every file, reducing the startup significantly #2152 
- Every file is stilled loaded to cache by loadVault
- For details see:  https://docs.obsidian.md/Reference/TypeScript+API/Vault/on('create')

## Motivation and Context

As discussed on Discord the loading time of Obsidian on Android has been significantly delayed by the Tasks plugin for my Vault. Due to the new feature of Obsidian, allowing to see the timing details on the App startup i was able to find the Task plugin delaying my startup between 3 to 5 seconds.

## How has this been tested?

- I used it the last days in my main Vault having better startup times
- Logs not showing any errors
- Tasks behave normally
- Since it changes the caches loading behavior I recommend additional users testing it, since a broken cache could result in wrong task states or views

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
