### PR TITLE
vault: Add smoke tests for date picker and date context menu

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Tasks-Demo-VerifyCommit-Build${{ github.run_number }}-Run${{ github.run_attempt }}
+          include-hidden-files: true
           path: |
             resources/sample_vaults/Tasks-Demo
 

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
@@ -1,5 +1,7 @@
 # Smoke Testing the Tasks Plugin
 
+*[[#Remaining tests|Jump to the tests...]]*
+
 ## Introduction
 
 - **Intended audience of this note**
@@ -117,6 +119,34 @@ heading includes Rendering of Task Blocks
 
 ---
 
+### Edit dates in Rendered Task Blocks
+
+> [!Example]
+>
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-09-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06
+
+- View this file in **Reading mode**...
+- On the task line above:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+  - [ ] #task **left**-click on a date value, and click outside the date picker, to confirm that the picker closes.
+  - [ ] #task **right**-click on a date value, and use the context menu to select and save a different date. Check that the date is updated.
+  - [ ] #task **right**-click on a date value, and click outside the context menu, to confirm that the menu closes.
+- In the tasks search block below:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+  - [ ] #task **left**-click on a date value, and click outside the date picker, to confirm that the picker closes.
+  - [ ] #task **right**-click on a date value, and use the context menu to select and save a different date. Check that the date is updated.
+  - [ ] #task **right**-click on a date value, and click outside the context menu, to confirm that the menu closes.
+- [ ] #task **check**: Checked all above steps for **editing dates** worked
+
+```tasks
+path includes {{query.file.path}}
+description includes I have all the supported date types
+hide backlink
+hide postpone button
+```
+
+---
+
 ### Create or edit Task modal
 
 - This text should copied in to the task Description, after following steps below
@@ -125,10 +155,12 @@ heading includes Rendering of Task Blocks
     2. **Check** that the text in the list item is copied in to the Description field
     3. Type some values in to the fields
     4. In one of the date fields, type `tm` (including the space afterwards) and **Check** it is expanded in to `tomorrow`
-    5. Hit Return or click **Apply**
-    6. **Check** that the list item above is converted in to a task
-    7. **Check** that values you entered in the modal have been copied in to the list item above
-    8. **Check** that the `#task` tag has been added to the start of the task
+    5. In one of the date fields, left-click the calendar button, and use the context menu to select and save a date. Check that the date is saved.
+    6. In one of the date fields, left-click the calendar button, and click outside the date picker, to confirm that the picker closes and the modal is still usable.
+    7. Hit Return or click **Apply**
+    8. **Check** that the list item above is converted in to a task
+    9. **Check** that values you entered in the modal have been copied in to the list item above
+    10. **Check** that the `#task` tag has been added to the start of the task
 - [ ] #task **check**: Checked all above steps for **creating a task via the modal** worked
 
 ---


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

- Add smoke tests for date picker and date context menu
- Fix the sample vaults created by GitHub Actions - problem caused by:
    - https://github.com/actions/upload-artifact/issues/602

## Motivation and Context

I needed to test the new date picker and context menu on iPhone and iPad.

In doing so, I found that the test vault artefact no longer included the `.obsidian/` folder!

See `Tasks-Demo-VerifyCommit-Build4986-Run1.zip` in [this build](https://github.com/obsidian-tasks-group/obsidian-tasks/actions/runs/10708099778). 

## How has this been tested?

Running the new smoke tests on iPad and iPhone.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
