### PR TITLE
feat: check postpone item if its date matches the one in the task

### DIFF
--- a/src/ui/Menus/PostponeMenu.ts
+++ b/src/ui/Menus/PostponeMenu.ts
@@ -42,7 +42,7 @@ export class PostponeMenu extends TaskEditingMenu {
             let isCurrentValue = false;
             const dateFieldToPostpone = getDateFieldToPostpone(task);
             if (dateFieldToPostpone) {
-                const { postponedDate } = postponingFunction(task, dateFieldToPostpone!, timeUnit, amount);
+                const { postponedDate } = postponingFunction(task, dateFieldToPostpone, timeUnit, amount);
 
                 if (task[dateFieldToPostpone]?.isSame(postponedDate, 'day')) {
                     isCurrentValue = true;

--- a/src/ui/Menus/PostponeMenu.ts
+++ b/src/ui/Menus/PostponeMenu.ts
@@ -39,19 +39,19 @@ export class PostponeMenu extends TaskEditingMenu {
             postponingFunction: PostponingFunction,
         ) => {
             // TODO some of the code below is duplicated in postponeOnClickCallback() and may be refactored
-            let postponeDateEqualsTaskFieldDate = false;
+            let isCurrentValue = false;
             const dateFieldToPostpone = getDateFieldToPostpone(task);
             if (dateFieldToPostpone) {
                 const { postponedDate } = postponingFunction(task, dateFieldToPostpone!, timeUnit, amount);
 
                 if (task[dateFieldToPostpone]?.isSame(postponedDate, 'day')) {
-                    postponeDateEqualsTaskFieldDate = true;
+                    isCurrentValue = true;
                 }
             }
 
             const title = itemNamingFunction(task, amount, timeUnit);
 
-            item.setChecked(postponeDateEqualsTaskFieldDate)
+            item.setChecked(isCurrentValue)
                 .setTitle(title)
                 .onClick(() =>
                     PostponeMenu.postponeOnClickCallback(button, task, amount, timeUnit, postponingFunction, taskSaver),

--- a/src/ui/Menus/PostponeMenu.ts
+++ b/src/ui/Menus/PostponeMenu.ts
@@ -40,9 +40,11 @@ export class PostponeMenu extends TaskEditingMenu {
         ) => {
             const title = itemNamingFunction(task, amount, timeUnit);
             // TODO Call setChecked() to put a checkmark against the item, if it represents the current task field value.
-            item.setTitle(title).onClick(() =>
-                PostponeMenu.postponeOnClickCallback(button, task, amount, timeUnit, postponingFunction, taskSaver),
-            );
+            item.setChecked(false)
+                .setTitle(title)
+                .onClick(() =>
+                    PostponeMenu.postponeOnClickCallback(button, task, amount, timeUnit, postponingFunction, taskSaver),
+                );
         };
 
         const fixedTitle = fixedDateMenuItemTitle;

--- a/src/ui/Menus/PostponeMenu.ts
+++ b/src/ui/Menus/PostponeMenu.ts
@@ -38,9 +38,11 @@ export class PostponeMenu extends TaskEditingMenu {
             itemNamingFunction: NamingFunction,
             postponingFunction: PostponingFunction,
         ) => {
+            const postponeDateEqualsTaskFieldDate = false;
+
             const title = itemNamingFunction(task, amount, timeUnit);
             // TODO Call setChecked() to put a checkmark against the item, if it represents the current task field value.
-            item.setChecked(false)
+            item.setChecked(postponeDateEqualsTaskFieldDate)
                 .setTitle(title)
                 .onClick(() =>
                     PostponeMenu.postponeOnClickCallback(button, task, amount, timeUnit, postponingFunction, taskSaver),

--- a/src/ui/Menus/PostponeMenu.ts
+++ b/src/ui/Menus/PostponeMenu.ts
@@ -38,6 +38,7 @@ export class PostponeMenu extends TaskEditingMenu {
             itemNamingFunction: NamingFunction,
             postponingFunction: PostponingFunction,
         ) => {
+            // TODO some of the code below is duplicated in postponeOnClickCallback() and may be refactored
             let postponeDateEqualsTaskFieldDate = false;
             const dateFieldToPostpone = getDateFieldToPostpone(task);
             if (dateFieldToPostpone) {

--- a/src/ui/Menus/PostponeMenu.ts
+++ b/src/ui/Menus/PostponeMenu.ts
@@ -38,10 +38,18 @@ export class PostponeMenu extends TaskEditingMenu {
             itemNamingFunction: NamingFunction,
             postponingFunction: PostponingFunction,
         ) => {
-            const postponeDateEqualsTaskFieldDate = false;
+            let postponeDateEqualsTaskFieldDate = false;
+            const dateFieldToPostpone = getDateFieldToPostpone(task);
+            if (dateFieldToPostpone) {
+                const { postponedDate } = postponingFunction(task, dateFieldToPostpone!, timeUnit, amount);
+
+                if (task[dateFieldToPostpone]?.isSame(postponedDate, 'day')) {
+                    postponeDateEqualsTaskFieldDate = true;
+                }
+            }
 
             const title = itemNamingFunction(task, amount, timeUnit);
-            // TODO Call setChecked() to put a checkmark against the item, if it represents the current task field value.
+
             item.setChecked(postponeDateEqualsTaskFieldDate)
                 .setTitle(title)
                 .onClick(() =>

--- a/tests/ui/Menus/PostponeMenu.test.ts
+++ b/tests/ui/Menus/PostponeMenu.test.ts
@@ -88,7 +88,7 @@ describe('PostponeMenu', () => {
         const itemsAsText = contentsOfPostponeMenuForTask(new TaskBuilder().startDate(today));
         expect(itemsAsText).toMatchInlineSnapshot(`
             "
-              Start today, on Sun 3rd Dec
+            x Start today, on Sun 3rd Dec
               Start tomorrow, on Mon 4th Dec
               ---
               Start in 2 days, on Tue 5th Dec
@@ -114,7 +114,7 @@ describe('PostponeMenu', () => {
         expect(itemsAsText).toMatchInlineSnapshot(`
             "
               Scheduled today, on Sun 3rd Dec
-              Scheduled tomorrow, on Mon 4th Dec
+            x Scheduled tomorrow, on Mon 4th Dec
               ---
               Postpone scheduled date by 2 days, to Wed 6th Dec
               Postpone scheduled date by 3 days, to Thu 7th Dec


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/2452#discussioncomment-10595027

## Description

- the postpone menu has first 2 items with fixed dates - today and tomorrow. In case they match the already set date that will be postponed, add a check sign on that menu item.

## Motivation and Context

- better postpone menu

## How has this been tested?

- unit test with postpone menu output
- manual test in demo vault

## Screenshots (if appropriate)

![Снимок экрана 2024-09-10 в 03 00 05](https://github.com/user-attachments/assets/f65c2c91-8a8e-4447-be89-f6f1a0d19eb9)


## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
