### PR TITLE
fix: postpone to current date keeps postpone button active

### DIFF
--- a/src/ui/Menus/PostponeMenu.ts
+++ b/src/ui/Menus/PostponeMenu.ts
@@ -103,6 +103,10 @@ export class PostponeMenu extends TaskEditingMenu {
 
         const { postponedDate, postponedTask } = postponingFunction(task, dateFieldToPostpone, timeUnit, amount);
 
+        if (task[dateFieldToPostpone]?.isSame(postponedDate, 'day')) {
+            return;
+        }
+
         await taskSaver(task, postponedTask);
         PostponeMenu.postponeSuccessCallback(button, dateFieldToPostpone, postponedDate);
     }


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Description

- do nothing when the task date to postpone and the postponed date match (this is a case when a date field is postponed to a date that is already set in the postpone menu)

## Motivation and Context

- Fixes #2816 

## How has this been tested?

- manual test in demo vault:
  - set scheduled date to today
  - right click on postpone menu, today's date is checked
  - click on today's date
  - verify that right click on postpone still works
  - verify that left click on postpone still works
  - repeat the test with tomorrow date

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - nope, manual test

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
