### PR TITLE
fix: retain manually added Done & Cancelled dates in modal

### DIFF
--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -26,9 +26,18 @@
         const taskWithEditedStatusApplied = task.handleNewStatus(selectedStatus).pop();
 
         if (taskWithEditedStatusApplied) {
-            // Update the doneDate field, in case changing the status changed the value:
-            editableTask.doneDate = taskWithEditedStatusApplied.done.formatAsDate();
-            editableTask.cancelledDate = taskWithEditedStatusApplied.cancelled.formatAsDate();
+            // change the done date using XNOR logic:
+            //  done date is empty and new status is DONE
+            // OR
+            //  done date is filled and new status is not DONE
+            if ((editableTask.doneDate === '') === selectedStatus.isCompleted()) {
+                editableTask.doneDate = taskWithEditedStatusApplied.done.formatAsDate();
+            }
+
+            // same logic for cancelled date & CANCELLED status
+            if ((editableTask.cancelledDate === '') === selectedStatus.isCancelled()) {
+                editableTask.cancelledDate = taskWithEditedStatusApplied.cancelled.formatAsDate();
+            }
         }
     };
 </script>

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -11,6 +11,17 @@
 
     let statusSymbol = task.status.symbol;
 
+    function appleSauce(
+        editableTaskDateField: keyof Pick<EditableTask, 'doneDate' | 'cancelledDate'>,
+        isInStatus: boolean,
+        taskWithEditedStatusApplied: Task,
+        taskDateField: keyof Pick<Task, 'done' | 'cancelled'>,
+    ) {
+        if ((editableTask[editableTaskDateField] === '') === isInStatus) {
+            editableTask[editableTaskDateField] = taskWithEditedStatusApplied[taskDateField].formatAsDate();
+        }
+    }
+
     const _onStatusChange = () => {
         // Use statusSymbol to find the status to save to editableTask.status
         const selectedStatus: Status | undefined = statusOptions.find((s) => s.symbol === statusSymbol);
@@ -33,9 +44,7 @@
             const editableTaskDateField = 'doneDate';
             const isInStatus = selectedStatus.isCompleted();
             const taskDateField = 'done';
-            if ((editableTask[editableTaskDateField] === '') === isInStatus) {
-                editableTask[editableTaskDateField] = taskWithEditedStatusApplied[taskDateField].formatAsDate();
-            }
+            appleSauce(editableTaskDateField, isInStatus, taskWithEditedStatusApplied, taskDateField);
 
             // same logic for cancelled date & CANCELLED status
             if ((editableTask.cancelledDate === '') === selectedStatus.isCancelled()) {

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -11,7 +11,20 @@
 
     let statusSymbol = task.status.symbol;
 
-    function appleSauce(
+    /**
+     * Set the done or cancelled date field of the editable task.
+     * These fields are connected with the status.
+     *
+     * The date should be set in either of 2 cases:
+     * - the date field is empty and the status was set (set the date from the task with the applied status)
+     * - the date field is not empty but another status was set (clean the date field)
+     *
+     * @param editableTaskDateField
+     * @param isInStatus
+     * @param taskWithEditedStatusApplied
+     * @param taskDateField
+     */
+    function setStatusRelatedDate(
         editableTaskDateField: keyof Pick<EditableTask, 'doneDate' | 'cancelledDate'>,
         isInStatus: boolean,
         taskWithEditedStatusApplied: Task,
@@ -43,13 +56,7 @@
         const taskWithEditedStatusApplied = task.handleNewStatus(selectedStatus).pop();
 
         if (taskWithEditedStatusApplied) {
-            // change the done date using XNOR logic:
-            //  done date is empty and new status is DONE
-            // OR
-            //  done date is filled and new status is not DONE
-            appleSauce('doneDate', selectedStatus.isCompleted(), taskWithEditedStatusApplied, 'done');
-
-            // same logic for cancelled date & CANCELLED status
+            setStatusRelatedDate('doneDate', selectedStatus.isCompleted(), taskWithEditedStatusApplied, 'done');
             if ((editableTask.cancelledDate === '') === selectedStatus.isCancelled()) {
                 editableTask.cancelledDate = taskWithEditedStatusApplied.cancelled.formatAsDate();
             }

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import type { TasksDate } from '../DateTime/TasksDate';
     import type { Status } from '../Statuses/Status';
     import type { Task } from '../Task/Task';
     import type { EditableTask } from './EditableTask';
@@ -11,34 +12,20 @@
 
     let statusSymbol = task.status.symbol;
 
-    /**
-     * Set the done or cancelled date field of the editable task.
-     * These fields are connected with the status.
-     *
-     * The date should be set in either of 2 cases:
-     * - the date field is empty and the status was set (set the date from the task with the applied status)
-     * - the date field is not empty but another status was set (clean the date field)
-     *
-     * @param editableTaskDateField
-     * @param isInStatus
-     * @param taskWithEditedStatusApplied
-     * @param taskDateField
-     */
-    function setStatusRelatedDate(
-        editableTaskDateField: keyof Pick<EditableTask, 'doneDate' | 'cancelledDate'>,
-        isInStatus: boolean,
-        taskWithEditedStatusApplied: Task,
-        taskDateField: keyof Pick<Task, 'done' | 'cancelled'>,
-    ) {
-        const dateFieldIsEmpty = editableTask[editableTaskDateField] === '';
+    function setStatusRelatedDate(currentValue: string, isInStatus: boolean, editedValue: TasksDate) {
+        const dateFieldIsEmpty = currentValue === '';
 
         if (dateFieldIsEmpty && isInStatus) {
-            editableTask[editableTaskDateField] = taskWithEditedStatusApplied[taskDateField].formatAsDate();
+            // the date field is empty and the status was set (set the date from the task with the applied status)
+            return editedValue.formatAsDate();
         }
 
         if (!dateFieldIsEmpty && !isInStatus) {
-            editableTask[editableTaskDateField] = '';
+            // the date field is not empty but another status was set (clean the date field)
+            return '';
         }
+
+        return currentValue;
     }
 
     const _onStatusChange = () => {
@@ -56,12 +43,16 @@
         const taskWithEditedStatusApplied = task.handleNewStatus(selectedStatus).pop();
 
         if (taskWithEditedStatusApplied) {
-            setStatusRelatedDate('doneDate', selectedStatus.isCompleted(), taskWithEditedStatusApplied, 'done');
-            setStatusRelatedDate(
-                'cancelledDate',
+            editableTask.doneDate = setStatusRelatedDate(
+                editableTask.doneDate,
+                selectedStatus.isCompleted(),
+                taskWithEditedStatusApplied.done,
+            );
+
+            editableTask.cancelledDate = setStatusRelatedDate(
+                editableTask.cancelledDate,
                 selectedStatus.isCancelled(),
-                taskWithEditedStatusApplied,
-                'cancelled',
+                taskWithEditedStatusApplied.cancelled,
             );
         }
     };

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -15,12 +15,12 @@
     function setStatusRelatedDate(currentValue: string, isInStatus: boolean, editedValue: TasksDate) {
         const dateFieldIsEmpty = currentValue === '';
 
-        if (dateFieldIsEmpty && isInStatus) {
+        if (isInStatus && dateFieldIsEmpty) {
             // the date field is empty and the status was set (set the date from the task with the applied status)
             return editedValue.formatAsDate();
         }
 
-        if (!dateFieldIsEmpty && !isInStatus) {
+        if (!isInStatus && !dateFieldIsEmpty) {
             // the date field is not empty but another status was set (clean the date field)
             return '';
         }

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -17,7 +17,9 @@
         taskWithEditedStatusApplied: Task,
         taskDateField: keyof Pick<Task, 'done' | 'cancelled'>,
     ) {
-        if ((editableTask[editableTaskDateField] === '') === isInStatus) {
+        const dateFieldIsEmpty = editableTask[editableTaskDateField] === '';
+
+        if (dateFieldIsEmpty === isInStatus) {
             editableTask[editableTaskDateField] = taskWithEditedStatusApplied[taskDateField].formatAsDate();
         }
     }

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -57,9 +57,12 @@
 
         if (taskWithEditedStatusApplied) {
             setStatusRelatedDate('doneDate', selectedStatus.isCompleted(), taskWithEditedStatusApplied, 'done');
-            if ((editableTask.cancelledDate === '') === selectedStatus.isCancelled()) {
-                editableTask.cancelledDate = taskWithEditedStatusApplied.cancelled.formatAsDate();
-            }
+            setStatusRelatedDate(
+                'cancelledDate',
+                selectedStatus.isCancelled(),
+                taskWithEditedStatusApplied,
+                'cancelled',
+            );
         }
     };
 </script>

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -24,7 +24,7 @@
         }
 
         if (!dateFieldIsEmpty && !isInStatus) {
-            editableTask[editableTaskDateField] = taskWithEditedStatusApplied[taskDateField].formatAsDate();
+            editableTask[editableTaskDateField] = '';
         }
     }
 

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -30,8 +30,11 @@
             //  done date is empty and new status is DONE
             // OR
             //  done date is filled and new status is not DONE
-            if ((editableTask['doneDate'] === '') === selectedStatus.isCompleted()) {
-                editableTask['doneDate'] = taskWithEditedStatusApplied['done'].formatAsDate();
+            const editableTaskDateField = 'doneDate';
+            const isInStatus = selectedStatus.isCompleted();
+            const taskDateField = 'done';
+            if ((editableTask[editableTaskDateField] === '') === isInStatus) {
+                editableTask[editableTaskDateField] = taskWithEditedStatusApplied[taskDateField].formatAsDate();
             }
 
             // same logic for cancelled date & CANCELLED status

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -31,7 +31,7 @@
             // OR
             //  done date is filled and new status is not DONE
             if ((editableTask.doneDate === '') === selectedStatus.isCompleted()) {
-                editableTask.doneDate = taskWithEditedStatusApplied.done.formatAsDate();
+                editableTask.doneDate = taskWithEditedStatusApplied['done'].formatAsDate();
             }
 
             // same logic for cancelled date & CANCELLED status

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -41,10 +41,7 @@
             //  done date is empty and new status is DONE
             // OR
             //  done date is filled and new status is not DONE
-            const editableTaskDateField = 'doneDate';
-            const isInStatus = selectedStatus.isCompleted();
-            const taskDateField = 'done';
-            appleSauce(editableTaskDateField, isInStatus, taskWithEditedStatusApplied, taskDateField);
+            appleSauce('doneDate', selectedStatus.isCompleted(), taskWithEditedStatusApplied, 'done');
 
             // same logic for cancelled date & CANCELLED status
             if ((editableTask.cancelledDate === '') === selectedStatus.isCancelled()) {

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -19,7 +19,11 @@
     ) {
         const dateFieldIsEmpty = editableTask[editableTaskDateField] === '';
 
-        if (dateFieldIsEmpty === isInStatus) {
+        if (dateFieldIsEmpty && isInStatus) {
+            editableTask[editableTaskDateField] = taskWithEditedStatusApplied[taskDateField].formatAsDate();
+        }
+
+        if (!dateFieldIsEmpty && !isInStatus) {
             editableTask[editableTaskDateField] = taskWithEditedStatusApplied[taskDateField].formatAsDate();
         }
     }

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -30,8 +30,8 @@
             //  done date is empty and new status is DONE
             // OR
             //  done date is filled and new status is not DONE
-            if ((editableTask.doneDate === '') === selectedStatus.isCompleted()) {
-                editableTask.doneDate = taskWithEditedStatusApplied['done'].formatAsDate();
+            if ((editableTask['doneDate'] === '') === selectedStatus.isCompleted()) {
+                editableTask['doneDate'] = taskWithEditedStatusApplied['done'].formatAsDate();
             }
 
             // same logic for cancelled date & CANCELLED status

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -393,6 +393,17 @@ describe('Task editing', () => {
             );
         });
 
+        it('should change status to Todo and remove cancelledDate', async () => {
+            const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(
+                '- [-] expecting cancelled date to be removed ❌ 2024-02-29',
+                ' ',
+            );
+            expect(getElementValue(container, 'cancelled')).toEqual('');
+
+            submit.click();
+            expect(await waitForClose).toMatchInlineSnapshot('"- [ ] expecting cancelled date to be removed"');
+        });
+
         it('should create new instance of recurring task, with doneDate set to today', async () => {
             updateSettings({ recurrenceOnNextLine: false });
             const { waitForClose, submit } = await renderTaskModalAndChangeStatus(

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -434,19 +434,23 @@ describe('Task editing', () => {
         });
 
         it('should keep the done date and change status to done', async () => {
+            const line = '- [ ] input done date, change status to done and expect the date to be kept';
+            const dateElementToChange = 'done';
+            const dateValue = '2024-09-20';
+            const newStatusSymbol = 'x';
+            const expectedTaskAfterEdits =
+                '"- [x] input done date, change status to done and expect the date to be kept ✅ 2024-09-20"';
             const { waitForClose, container, submit } = await renderChangeDateAndStatus(
-                '- [ ] input done date, change status to done and expect the date to be kept',
-                'done',
-                '2024-09-20',
-                'x',
+                line,
+                dateElementToChange,
+                dateValue,
+                newStatusSymbol,
             );
 
-            expect(getElementValue(container, 'done')).toEqual('2024-09-20');
+            expect(getElementValue(container, dateElementToChange)).toEqual(dateValue);
 
             submit.click();
-            expect(await waitForClose).toMatchInlineSnapshot(
-                '"- [x] input done date, change status to done and expect the date to be kept ✅ 2024-09-20"',
-            );
+            expect(await waitForClose).toMatchInlineSnapshot(expectedTaskAfterEdits);
         });
 
         it('should create new instance of recurring task, with doneDate set to today', async () => {

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -345,6 +345,17 @@ describe('Task editing', () => {
             expect(await waitForClose).toMatchInlineSnapshot('"- [x] expecting done date to be added ✅ 2024-02-29"');
         });
 
+        it('should change status to Done and change doneDate', async () => {
+            const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(
+                '- [ ] expecting done date to be changed ✅ 2024-09-19',
+                'x',
+            );
+            expect(getElementValue(container, 'done')).toEqual(today);
+
+            submit.click();
+            expect(await waitForClose).toMatchInlineSnapshot('"- [x] expecting done date to be changed ✅ 2024-02-29"');
+        });
+
         it('should change status to Todo and remove doneDate', async () => {
             const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(
                 '- [x] expecting done date to be removed ✅ 2024-02-29',
@@ -366,6 +377,19 @@ describe('Task editing', () => {
             submit.click();
             expect(await waitForClose).toMatchInlineSnapshot(
                 '"- [-] expecting cancelled date to be added ❌ 2024-02-29"',
+            );
+        });
+
+        it('should change status to Cancelled and change cancelledDate', async () => {
+            const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(
+                '- [ ] expecting cancelled date to be changed ❌ 2024-09-20',
+                '-',
+            );
+            expect(getElementValue(container, 'cancelled')).toEqual(today);
+
+            submit.click();
+            expect(await waitForClose).toMatchInlineSnapshot(
+                '"- [-] expecting cancelled date to be changed ❌ 2024-02-29"',
             );
         });
 

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -345,7 +345,7 @@ describe('Task editing', () => {
             expect(await waitForClose).toMatchInlineSnapshot('"- [x] expecting done date to be added ✅ 2024-02-29"');
         });
 
-        it('should change status to Done and change doneDate', async () => {
+        it('should change status to Done and keep doneDate', async () => {
             const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(
                 '- [ ] expecting done date to be kept ✅ 2024-09-19',
                 'x',
@@ -380,7 +380,7 @@ describe('Task editing', () => {
             );
         });
 
-        it('should change status to Cancelled and change cancelledDate', async () => {
+        it('should change status to Cancelled and keep cancelledDate', async () => {
             const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(
                 '- [ ] expecting cancelled date to be kept ❌ 2024-09-20',
                 '-',

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -439,7 +439,7 @@ describe('Task editing', () => {
             const dateValue = '2024-09-20';
             const newStatusSymbol = 'x';
             const expectedTaskAfterEdits =
-                '"- [x] input done date, change status to done and expect the date to be kept ✅ 2024-09-20"';
+                '- [x] input done date, change status to done and expect the date to be kept ✅ 2024-09-20';
             const { waitForClose, container, submit } = await renderChangeDateAndStatus(
                 line,
                 dateElementToChange,
@@ -450,7 +450,7 @@ describe('Task editing', () => {
             expect(getElementValue(container, dateElementToChange)).toEqual(dateValue);
 
             submit.click();
-            expect(await waitForClose).toMatchInlineSnapshot(expectedTaskAfterEdits);
+            expect(await waitForClose).toEqual(expectedTaskAfterEdits);
         });
 
         it('should create new instance of recurring task, with doneDate set to today', async () => {

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -433,6 +433,16 @@ describe('Task editing', () => {
             expect(await waitForClose).toMatchInlineSnapshot('"- [ ] expecting cancelled date to be removed"');
         });
 
+        /**
+         * Test opening task modal for a given line, changing a date to a value, changing the status,
+         * clicking Apply, verifying the final line.
+         *
+         * @param line
+         * @param dateElementToChange
+         * @param dateValue
+         * @param newStatusSymbol
+         * @param expectedTaskAfterEdits
+         */
         async function testDateInputAndStatusChange(
             line: string,
             dateElementToChange: string,

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -453,21 +453,32 @@ describe('Task editing', () => {
             expect(await waitForClose).toEqual(expectedTaskAfterEdits);
         }
 
-        it('should keep the done date and change status to done', async () => {
-            const line = '- [ ] input done date, change status to done and expect the date to be kept';
-            const dateElementToChange = 'done';
-            const dateValue = '2024-09-20';
-            const newStatusSymbol = 'x';
-            const expectedTaskAfterEdits =
-                '- [x] input done date, change status to done and expect the date to be kept ✅ 2024-09-20';
-            await testDateInputAndStatusChange(
-                line,
-                dateElementToChange,
-                dateValue,
-                newStatusSymbol,
-                expectedTaskAfterEdits,
-            );
-        });
+        it.each([
+            [
+                '- [ ] input done date, change status to done and expect the date to be kept',
+                'done',
+                '2024-09-20',
+                'x',
+                '- [x] input done date, change status to done and expect the date to be kept ✅ 2024-09-20',
+            ],
+        ])(
+            'should keep the done date and change status to done',
+            async (
+                line: string,
+                dateElementToChange: string,
+                dateValue: string,
+                newStatusSymbol: string,
+                expectedTaskAfterEdits: string,
+            ) => {
+                await testDateInputAndStatusChange(
+                    line,
+                    dateElementToChange,
+                    dateValue,
+                    newStatusSymbol,
+                    expectedTaskAfterEdits,
+                );
+            },
+        );
 
         it('should create new instance of recurring task, with doneDate set to today', async () => {
             updateSettings({ recurrenceOnNextLine: false });

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -433,13 +433,13 @@ describe('Task editing', () => {
             expect(await waitForClose).toMatchInlineSnapshot('"- [ ] expecting cancelled date to be removed"');
         });
 
-        it('should keep the done date and change status to done', async () => {
-            const line = '- [ ] input done date, change status to done and expect the date to be kept';
-            const dateElementToChange = 'done';
-            const dateValue = '2024-09-20';
-            const newStatusSymbol = 'x';
-            const expectedTaskAfterEdits =
-                '- [x] input done date, change status to done and expect the date to be kept ✅ 2024-09-20';
+        async function testDateInputAndStatusChange(
+            line: string,
+            dateElementToChange: string,
+            dateValue: string,
+            newStatusSymbol: string,
+            expectedTaskAfterEdits: string,
+        ) {
             const { waitForClose, container, submit } = await renderChangeDateAndStatus(
                 line,
                 dateElementToChange,
@@ -451,6 +451,22 @@ describe('Task editing', () => {
 
             submit.click();
             expect(await waitForClose).toEqual(expectedTaskAfterEdits);
+        }
+
+        it('should keep the done date and change status to done', async () => {
+            const line = '- [ ] input done date, change status to done and expect the date to be kept';
+            const dateElementToChange = 'done';
+            const dateValue = '2024-09-20';
+            const newStatusSymbol = 'x';
+            const expectedTaskAfterEdits =
+                '- [x] input done date, change status to done and expect the date to be kept ✅ 2024-09-20';
+            await testDateInputAndStatusChange(
+                line,
+                dateElementToChange,
+                dateValue,
+                newStatusSymbol,
+                expectedTaskAfterEdits,
+            );
         });
 
         it('should create new instance of recurring task, with doneDate set to today', async () => {

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -335,30 +335,38 @@ describe('Task editing', () => {
         });
 
         it('should change status to Done and add doneDate', async () => {
-            const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus('- [ ] simple', 'x');
+            const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(
+                '- [ ] expecting done date to be added',
+                'x',
+            );
             expect(getElementValue(container, 'done')).toEqual(today);
 
             submit.click();
-            expect(await waitForClose).toMatchInlineSnapshot('"- [x] simple ✅ 2024-02-29"');
+            expect(await waitForClose).toMatchInlineSnapshot('"- [x] expecting done date to be added ✅ 2024-02-29"');
         });
 
         it('should change status to Todo and remove doneDate', async () => {
             const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(
-                '- [x] simple ✅ 2024-02-29',
+                '- [x] expecting done date to be removed ✅ 2024-02-29',
                 ' ',
             );
             expect(getElementValue(container, 'done')).toEqual('');
 
             submit.click();
-            expect(await waitForClose).toMatchInlineSnapshot('"- [ ] simple"');
+            expect(await waitForClose).toMatchInlineSnapshot('"- [ ] expecting done date to be removed"');
         });
 
         it('should change status to Cancelled and add cancelledDate', async () => {
-            const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus('- [ ] simple', '-');
+            const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(
+                '- [ ] expecting cancelled date to be added',
+                '-',
+            );
             expect(getElementValue(container, 'cancelled')).toEqual(today);
 
             submit.click();
-            expect(await waitForClose).toMatchInlineSnapshot('"- [-] simple ❌ 2024-02-29"');
+            expect(await waitForClose).toMatchInlineSnapshot(
+                '"- [-] expecting cancelled date to be added ❌ 2024-02-29"',
+            );
         });
 
         it('should create new instance of recurring task, with doneDate set to today', async () => {

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -347,13 +347,13 @@ describe('Task editing', () => {
 
         it('should change status to Done and change doneDate', async () => {
             const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(
-                '- [ ] expecting done date to be changed ✅ 2024-09-19',
+                '- [ ] expecting done date to be kept ✅ 2024-09-19',
                 'x',
             );
-            expect(getElementValue(container, 'done')).toEqual(today);
+            expect(getElementValue(container, 'done')).toEqual('2024-09-19');
 
             submit.click();
-            expect(await waitForClose).toMatchInlineSnapshot('"- [x] expecting done date to be changed ✅ 2024-02-29"');
+            expect(await waitForClose).toMatchInlineSnapshot('"- [x] expecting done date to be kept ✅ 2024-09-19"');
         });
 
         it('should change status to Todo and remove doneDate', async () => {
@@ -382,14 +382,14 @@ describe('Task editing', () => {
 
         it('should change status to Cancelled and change cancelledDate', async () => {
             const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(
-                '- [ ] expecting cancelled date to be changed ❌ 2024-09-20',
+                '- [ ] expecting cancelled date to be kept ❌ 2024-09-20',
                 '-',
             );
-            expect(getElementValue(container, 'cancelled')).toEqual(today);
+            expect(getElementValue(container, 'cancelled')).toEqual('2024-09-20');
 
             submit.click();
             expect(await waitForClose).toMatchInlineSnapshot(
-                '"- [-] expecting cancelled date to be changed ❌ 2024-02-29"',
+                '"- [-] expecting cancelled date to be kept ❌ 2024-02-29"',
             );
         });
 

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -6,8 +6,8 @@ import moment from 'moment';
 import { taskFromLine } from '../../src/Commands/CreateOrEditTaskParser';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { resetSettings, updateSettings } from '../../src/Config/Settings';
-import { StatusRegistry } from '../../src/Statuses/StatusRegistry';
 import { DateFallback } from '../../src/DateTime/DateFallback';
+import { StatusRegistry } from '../../src/Statuses/StatusRegistry';
 import type { Task } from '../../src/Task/Task';
 import EditTask from '../../src/ui/EditTask.svelte';
 import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
@@ -334,9 +334,8 @@ describe('Task editing', () => {
             resetSettings();
         });
 
-        const line = '- [ ] simple';
         it('should change status to Done and add doneDate', async () => {
-            const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(line, 'x');
+            const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus('- [ ] simple', 'x');
             expect(getElementValue(container, 'done')).toEqual(today);
 
             submit.click();
@@ -355,7 +354,7 @@ describe('Task editing', () => {
         });
 
         it('should change status to Cancelled and add cancelledDate', async () => {
-            const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus(line, '-');
+            const { waitForClose, container, submit } = await renderTaskModalAndChangeStatus('- [ ] simple', '-');
             expect(getElementValue(container, 'cancelled')).toEqual(today);
 
             submit.click();

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -461,6 +461,15 @@ describe('Task editing', () => {
                 'x',
                 '- [x] input done date, change status to done and expect the date to be kept ✅ 2024-09-20',
             ],
+            [
+                '- [ ] input cancelled date, change status to cancelled and expect the date to be kept',
+                'cancelled',
+                '2024-09-21',
+                '-',
+                // TODO the difference between the date in the modal and the saved one is a bug:
+                // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3089
+                '- [-] input cancelled date, change status to cancelled and expect the date to be kept ❌ 2024-02-29',
+            ],
         ])(
             'should keep the done date and change status to done',
             async (

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -168,9 +168,9 @@ async function renderTaskModalAndChangeStatus(line: string, newStatusSymbol: str
  * @param line
  * @param elementId - specifying the field to edit
  * @param newValue - the new value for the field
- * @param newStatus - new Status value
+ * @param newStatusSymbol - new Status symbol value
  */
-async function renderChangeDateAndStatus(line: string, elementId: string, newValue: string, newStatus: string) {
+async function renderChangeDateAndStatus(line: string, elementId: string, newValue: string, newStatusSymbol: string) {
     const task = taskFromLine({ line: line, path: '' });
     const { waitForClose, onSubmit } = constructSerialisingOnSubmit(task);
     const { result, container } = renderAndCheckModal(task, onSubmit);
@@ -180,7 +180,7 @@ async function renderChangeDateAndStatus(line: string, elementId: string, newVal
 
     const statusSelector = getAndCheckRenderedElement<HTMLSelectElement>(container, 'status-type');
     await fireEvent.change(statusSelector, {
-        target: { value: newStatus },
+        target: { value: newStatusSymbol },
     });
 
     const submit = getAndCheckApplyButton(result);

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -481,7 +481,7 @@ describe('Task editing', () => {
                 '- [-] input cancelled date, change status to cancelled and expect the date to be kept ❌ 2024-02-29',
             ],
         ])(
-            'should keep the done date and change status to done',
+            'for "%s" task, change %s date to %s and status to %s',
             async (
                 line: string,
                 dateElementToChange: string,


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- Done/Cancelled date have to be kept if they are already present in the respective date editor while the status is set to Done/Cancelled respectively. 

_Don't overwrite a user-entered Done date if changing status to DONE_
_Don't overwrite a user-entered Cancelled date if changing status to CANCELLED_


## Motivation and Context

- Fixes #3085 

## How has this been tested?

- new unit tests added
- manual test in demo vault

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
