### PR TITLE
refactor: Replace Status factory functions with static objects

### DIFF
--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -22,7 +22,7 @@ export class StatusSettings {
         this.coreStatuses = [
             // The two statuses that do not need CSS styling
             Status.makeTodo().configuration,
-            Status.makeDone().configuration,
+            Status.DONE.configuration,
         ]; // Do not modify directly: use the static mutation methods in this class.
         this.customStatuses = [
             // Any statuses that are always supported, but need custom CSS styling

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -27,7 +27,7 @@ export class StatusSettings {
         this.customStatuses = [
             // Any statuses that are always supported, but need custom CSS styling
             Status.makeInProgress().configuration,
-            Status.makeCancelled().configuration,
+            Status.makeCancelled.configuration,
         ]; // Do not modify directly: use the static mutation methods in this class.
     }
     readonly coreStatuses: StatusConfiguration[];

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -26,7 +26,7 @@ export class StatusSettings {
         ]; // Do not modify directly: use the static mutation methods in this class.
         this.customStatuses = [
             // Any statuses that are always supported, but need custom CSS styling
-            Status.makeInProgress().configuration,
+            Status.makeInProgress.configuration,
             Status.CANCELLED.configuration,
         ]; // Do not modify directly: use the static mutation methods in this class.
     }

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -27,7 +27,7 @@ export class StatusSettings {
         this.customStatuses = [
             // Any statuses that are always supported, but need custom CSS styling
             Status.makeInProgress().configuration,
-            Status.makeCancelled.configuration,
+            Status.CANCELLED.configuration,
         ]; // Do not modify directly: use the static mutation methods in this class.
     }
     readonly coreStatuses: StatusConfiguration[];

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -26,7 +26,7 @@ export class StatusSettings {
         ]; // Do not modify directly: use the static mutation methods in this class.
         this.customStatuses = [
             // Any statuses that are always supported, but need custom CSS styling
-            Status.makeInProgress.configuration,
+            Status.IN_PROGRESS.configuration,
             Status.CANCELLED.configuration,
         ]; // Do not modify directly: use the static mutation methods in this class.
     }

--- a/src/Config/StatusSettings.ts
+++ b/src/Config/StatusSettings.ts
@@ -21,7 +21,7 @@ export class StatusSettings {
     constructor() {
         this.coreStatuses = [
             // The two statuses that do not need CSS styling
-            Status.makeTodo().configuration,
+            Status.TODO.configuration,
             Status.DONE.configuration,
         ]; // Do not modify directly: use the static mutation methods in this class.
         this.customStatuses = [

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -157,13 +157,6 @@ export class Status {
     }
 
     /**
-     * The default Done status. Goes to Todo when toggled.
-     */
-    static makeDone(): Status {
-        return Status.DONE;
-    }
-
-    /**
      * A default status of empty, used when things go wrong.
      */
     static makeEmpty(): Status {

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -159,7 +159,7 @@ export class Status {
     /**
      * The default Cancelled status. Goes to Todo when toggled.
      */
-    static makeCancelled(): Status {
+    public static get makeCancelled(): Status {
         return new Status(new StatusConfiguration('-', 'Cancelled', ' ', true, StatusType.CANCELLED));
     }
 

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -173,7 +173,7 @@ export class Status {
     /**
      * A sample Non-Task status. Goes to NON_TASK when toggled.
      */
-    public static get makeNonTask(): Status {
+    public static get NON_TASK(): Status {
         return new Status(new StatusConfiguration('Q', 'Non-Task', 'A', true, StatusType.NON_TASK));
     }
 

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -22,7 +22,7 @@ export class Status {
      * @type {Status}
      * @memberof Status
      */
-    public static DONE: Status = Status.makeDone();
+    public static DONE: Status = new Status(new StatusConfiguration('x', 'Done', ' ', true, StatusType.DONE));
 
     /**
      * A default status of empty, used when things go wrong.
@@ -30,7 +30,7 @@ export class Status {
      * @static
      * @memberof Status
      */
-    public static EMPTY: Status = Status.makeEmpty();
+    public static EMPTY: Status = new Status(new StatusConfiguration('', 'EMPTY', '', true, StatusType.EMPTY));
 
     /**
      * The default Todo status. Goes to Done when toggled.
@@ -40,7 +40,7 @@ export class Status {
      * @type {Status}
      * @memberof Status
      */
-    public static TODO: Status = Status.makeTodo();
+    public static TODO: Status = new Status(new StatusConfiguration(' ', 'Todo', 'x', true, StatusType.TODO));
 
     /**
      * The configuration stored in the data.json file.

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -166,7 +166,7 @@ export class Status {
     /**
      * The default In Progress status. Goes to Done when toggled.
      */
-    public static get makeInProgress(): Status {
+    public static get IN_PROGRESS(): Status {
         return new Status(new StatusConfiguration('/', 'In Progress', 'x', true, StatusType.IN_PROGRESS));
     }
 

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -159,7 +159,7 @@ export class Status {
     /**
      * The default Cancelled status. Goes to Todo when toggled.
      */
-    public static get makeCancelled(): Status {
+    public static get CANCELLED(): Status {
         return new Status(new StatusConfiguration('-', 'Cancelled', ' ', true, StatusType.CANCELLED));
     }
 

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -157,14 +157,6 @@ export class Status {
     }
 
     /**
-     * The default Todo status. Goes to Done when toggled.
-     * User may later be able to override this to go to In Progress instead.
-     */
-    static makeTodo(): Status {
-        return Status.TODO;
-    }
-
-    /**
      * The default Cancelled status. Goes to Todo when toggled.
      */
     static makeCancelled(): Status {

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -157,13 +157,6 @@ export class Status {
     }
 
     /**
-     * A default status of empty, used when things go wrong.
-     */
-    static makeEmpty(): Status {
-        return Status.EMPTY;
-    }
-
-    /**
      * The default Todo status. Goes to Done when toggled.
      * User may later be able to override this to go to In Progress instead.
      */

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -22,7 +22,7 @@ export class Status {
      * @type {Status}
      * @memberof Status
      */
-    public static DONE: Status = new Status(new StatusConfiguration('x', 'Done', ' ', true, StatusType.DONE));
+    public static readonly DONE: Status = new Status(new StatusConfiguration('x', 'Done', ' ', true, StatusType.DONE));
 
     /**
      * A default status of empty, used when things go wrong.
@@ -31,7 +31,7 @@ export class Status {
      * @type {Status}
      * @memberof Status
      */
-    public static EMPTY: Status = new Status(new StatusConfiguration('', 'EMPTY', '', true, StatusType.EMPTY));
+    public static readonly EMPTY: Status = new Status(new StatusConfiguration('', 'EMPTY', '', true, StatusType.EMPTY));
 
     /**
      * The default Todo status. Goes to Done when toggled.
@@ -41,7 +41,7 @@ export class Status {
      * @type {Status}
      * @memberof Status
      */
-    public static TODO: Status = new Status(new StatusConfiguration(' ', 'Todo', 'x', true, StatusType.TODO));
+    public static readonly TODO: Status = new Status(new StatusConfiguration(' ', 'Todo', 'x', true, StatusType.TODO));
 
     /**
      * The default Cancelled status. Goes to Todo when toggled.
@@ -50,7 +50,7 @@ export class Status {
      * @type {Status}
      * @memberof Status
      */
-    public static CANCELLED: Status = new Status(
+    public static readonly CANCELLED: Status = new Status(
         new StatusConfiguration('-', 'Cancelled', ' ', true, StatusType.CANCELLED),
     );
 
@@ -61,7 +61,7 @@ export class Status {
      * @type {Status}
      * @memberof Status
      */
-    public static IN_PROGRESS: Status = new Status(
+    public static readonly IN_PROGRESS: Status = new Status(
         new StatusConfiguration('/', 'In Progress', 'x', true, StatusType.IN_PROGRESS),
     );
 
@@ -72,7 +72,7 @@ export class Status {
      * @type {Status}
      * @memberof Status
      */
-    public static NON_TASK: Status = new Status(
+    public static readonly NON_TASK: Status = new Status(
         new StatusConfiguration('Q', 'Non-Task', 'A', true, StatusType.NON_TASK),
     );
 

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -160,14 +160,14 @@ export class Status {
      * The default Done status. Goes to Todo when toggled.
      */
     static makeDone(): Status {
-        return new Status(new StatusConfiguration('x', 'Done', ' ', true, StatusType.DONE));
+        return Status.DONE;
     }
 
     /**
      * A default status of empty, used when things go wrong.
      */
     static makeEmpty(): Status {
-        return new Status(new StatusConfiguration('', 'EMPTY', '', true, StatusType.EMPTY));
+        return Status.EMPTY;
     }
 
     /**
@@ -175,7 +175,7 @@ export class Status {
      * User may later be able to override this to go to In Progress instead.
      */
     static makeTodo(): Status {
-        return new Status(new StatusConfiguration(' ', 'Todo', 'x', true, StatusType.TODO));
+        return Status.TODO;
     }
 
     /**

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -43,6 +43,27 @@ export class Status {
     public static TODO: Status = new Status(new StatusConfiguration(' ', 'Todo', 'x', true, StatusType.TODO));
 
     /**
+     * The default Cancelled status. Goes to Todo when toggled.
+     */
+    public static get CANCELLED(): Status {
+        return new Status(new StatusConfiguration('-', 'Cancelled', ' ', true, StatusType.CANCELLED));
+    }
+
+    /**
+     * The default In Progress status. Goes to Done when toggled.
+     */
+    public static get IN_PROGRESS(): Status {
+        return new Status(new StatusConfiguration('/', 'In Progress', 'x', true, StatusType.IN_PROGRESS));
+    }
+
+    /**
+     * A sample Non-Task status. Goes to NON_TASK when toggled.
+     */
+    public static get NON_TASK(): Status {
+        return new Status(new StatusConfiguration('Q', 'Non-Task', 'A', true, StatusType.NON_TASK));
+    }
+
+    /**
      * The configuration stored in the data.json file.
      *
      * @type {StatusConfiguration}
@@ -154,27 +175,6 @@ export class Status {
      */
     constructor(configuration: StatusConfiguration) {
         this.configuration = configuration;
-    }
-
-    /**
-     * The default Cancelled status. Goes to Todo when toggled.
-     */
-    public static get CANCELLED(): Status {
-        return new Status(new StatusConfiguration('-', 'Cancelled', ' ', true, StatusType.CANCELLED));
-    }
-
-    /**
-     * The default In Progress status. Goes to Done when toggled.
-     */
-    public static get IN_PROGRESS(): Status {
-        return new Status(new StatusConfiguration('/', 'In Progress', 'x', true, StatusType.IN_PROGRESS));
-    }
-
-    /**
-     * A sample Non-Task status. Goes to NON_TASK when toggled.
-     */
-    public static get NON_TASK(): Status {
-        return new Status(new StatusConfiguration('Q', 'Non-Task', 'A', true, StatusType.NON_TASK));
     }
 
     /**

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -166,7 +166,7 @@ export class Status {
     /**
      * The default In Progress status. Goes to Done when toggled.
      */
-    static makeInProgress(): Status {
+    public static get makeInProgress(): Status {
         return new Status(new StatusConfiguration('/', 'In Progress', 'x', true, StatusType.IN_PROGRESS));
     }
 

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -28,6 +28,7 @@ export class Status {
      * A default status of empty, used when things go wrong.
      *
      * @static
+     * @type {Status}
      * @memberof Status
      */
     public static EMPTY: Status = new Status(new StatusConfiguration('', 'EMPTY', '', true, StatusType.EMPTY));
@@ -44,6 +45,10 @@ export class Status {
 
     /**
      * The default Cancelled status. Goes to Todo when toggled.
+     *
+     * @static
+     * @type {Status}
+     * @memberof Status
      */
     public static CANCELLED: Status = new Status(
         new StatusConfiguration('-', 'Cancelled', ' ', true, StatusType.CANCELLED),
@@ -51,6 +56,10 @@ export class Status {
 
     /**
      * The default In Progress status. Goes to Done when toggled.
+     *
+     * @static
+     * @type {Status}
+     * @memberof Status
      */
     public static IN_PROGRESS: Status = new Status(
         new StatusConfiguration('/', 'In Progress', 'x', true, StatusType.IN_PROGRESS),
@@ -58,6 +67,10 @@ export class Status {
 
     /**
      * A sample Non-Task status. Goes to NON_TASK when toggled.
+     *
+     * @static
+     * @type {Status}
+     * @memberof Status
      */
     public static NON_TASK: Status = new Status(
         new StatusConfiguration('Q', 'Non-Task', 'A', true, StatusType.NON_TASK),

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -173,7 +173,7 @@ export class Status {
     /**
      * A sample Non-Task status. Goes to NON_TASK when toggled.
      */
-    static makeNonTask(): Status {
+    public static get makeNonTask(): Status {
         return new Status(new StatusConfiguration('Q', 'Non-Task', 'A', true, StatusType.NON_TASK));
     }
 

--- a/src/Statuses/Status.ts
+++ b/src/Statuses/Status.ts
@@ -45,23 +45,23 @@ export class Status {
     /**
      * The default Cancelled status. Goes to Todo when toggled.
      */
-    public static get CANCELLED(): Status {
-        return new Status(new StatusConfiguration('-', 'Cancelled', ' ', true, StatusType.CANCELLED));
-    }
+    public static CANCELLED: Status = new Status(
+        new StatusConfiguration('-', 'Cancelled', ' ', true, StatusType.CANCELLED),
+    );
 
     /**
      * The default In Progress status. Goes to Done when toggled.
      */
-    public static get IN_PROGRESS(): Status {
-        return new Status(new StatusConfiguration('/', 'In Progress', 'x', true, StatusType.IN_PROGRESS));
-    }
+    public static IN_PROGRESS: Status = new Status(
+        new StatusConfiguration('/', 'In Progress', 'x', true, StatusType.IN_PROGRESS),
+    );
 
     /**
      * A sample Non-Task status. Goes to NON_TASK when toggled.
      */
-    public static get NON_TASK(): Status {
-        return new Status(new StatusConfiguration('Q', 'Non-Task', 'A', true, StatusType.NON_TASK));
-    }
+    public static NON_TASK: Status = new Status(
+        new StatusConfiguration('Q', 'Non-Task', 'A', true, StatusType.NON_TASK),
+    );
 
     /**
      * The configuration stored in the data.json file.

--- a/src/Statuses/StatusRegistry.ts
+++ b/src/Statuses/StatusRegistry.ts
@@ -333,7 +333,7 @@ export class StatusRegistry {
      * @memberof StatusRegistry
      */
     private addDefaultStatusTypes(): void {
-        const defaultStatuses = [Status.TODO, Status.makeInProgress(), Status.DONE, Status.makeCancelled()];
+        const defaultStatuses = [Status.TODO, Status.makeInProgress(), Status.DONE, Status.makeCancelled];
 
         defaultStatuses.forEach((status) => {
             this.add(status);

--- a/src/Statuses/StatusRegistry.ts
+++ b/src/Statuses/StatusRegistry.ts
@@ -333,7 +333,7 @@ export class StatusRegistry {
      * @memberof StatusRegistry
      */
     private addDefaultStatusTypes(): void {
-        const defaultStatuses = [Status.makeTodo(), Status.makeInProgress(), Status.DONE, Status.makeCancelled()];
+        const defaultStatuses = [Status.TODO, Status.makeInProgress(), Status.DONE, Status.makeCancelled()];
 
         defaultStatuses.forEach((status) => {
             this.add(status);

--- a/src/Statuses/StatusRegistry.ts
+++ b/src/Statuses/StatusRegistry.ts
@@ -333,7 +333,7 @@ export class StatusRegistry {
      * @memberof StatusRegistry
      */
     private addDefaultStatusTypes(): void {
-        const defaultStatuses = [Status.TODO, Status.makeInProgress, Status.DONE, Status.CANCELLED];
+        const defaultStatuses = [Status.TODO, Status.IN_PROGRESS, Status.DONE, Status.CANCELLED];
 
         defaultStatuses.forEach((status) => {
             this.add(status);

--- a/src/Statuses/StatusRegistry.ts
+++ b/src/Statuses/StatusRegistry.ts
@@ -333,7 +333,7 @@ export class StatusRegistry {
      * @memberof StatusRegistry
      */
     private addDefaultStatusTypes(): void {
-        const defaultStatuses = [Status.makeTodo(), Status.makeInProgress(), Status.makeDone(), Status.makeCancelled()];
+        const defaultStatuses = [Status.makeTodo(), Status.makeInProgress(), Status.DONE, Status.makeCancelled()];
 
         defaultStatuses.forEach((status) => {
             this.add(status);

--- a/src/Statuses/StatusRegistry.ts
+++ b/src/Statuses/StatusRegistry.ts
@@ -333,7 +333,7 @@ export class StatusRegistry {
      * @memberof StatusRegistry
      */
     private addDefaultStatusTypes(): void {
-        const defaultStatuses = [Status.TODO, Status.makeInProgress(), Status.DONE, Status.makeCancelled];
+        const defaultStatuses = [Status.TODO, Status.makeInProgress(), Status.DONE, Status.CANCELLED];
 
         defaultStatuses.forEach((status) => {
             this.add(status);

--- a/src/Statuses/StatusRegistry.ts
+++ b/src/Statuses/StatusRegistry.ts
@@ -333,7 +333,7 @@ export class StatusRegistry {
      * @memberof StatusRegistry
      */
     private addDefaultStatusTypes(): void {
-        const defaultStatuses = [Status.TODO, Status.makeInProgress(), Status.DONE, Status.CANCELLED];
+        const defaultStatuses = [Status.TODO, Status.makeInProgress, Status.DONE, Status.CANCELLED];
 
         defaultStatuses.forEach((status) => {
             this.add(status);

--- a/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
+++ b/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
@@ -15,7 +15,7 @@ describe('DefaultStatuses', () => {
     });
 
     it('custom-statuses', () => {
-        VerifyStatuses.verifyStatusesInMultipleFormats([Status.makeInProgress(), Status.makeCancelled()], true);
+        VerifyStatuses.verifyStatusesInMultipleFormats([Status.makeInProgress(), Status.makeCancelled], true);
     });
 
     it('important-cycle', () => {
@@ -98,7 +98,7 @@ describe('Status Transitions', () => {
             Status.TODO,
             Status.makeInProgress(),
             Status.DONE,
-            Status.makeCancelled(),
+            Status.makeCancelled,
             new Status(new StatusConfiguration('~', 'My custom status', ' ', false, StatusType.NON_TASK)),
         ];
         VerifyStatuses.verifyTransitionsAsMarkdownTable(statuses);

--- a/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
+++ b/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
@@ -11,7 +11,7 @@ describe('DefaultStatuses', () => {
     // These "test" write out a markdown representation of the default task statuses,
     // for embedding in the user docs.
     it('core-statuses', () => {
-        VerifyStatuses.verifyStatusesInMultipleFormats([Status.makeTodo(), Status.makeDone()], true);
+        VerifyStatuses.verifyStatusesInMultipleFormats([Status.makeTodo(), Status.DONE], true);
     });
 
     it('custom-statuses', () => {
@@ -97,7 +97,7 @@ describe('Status Transitions', () => {
         const statuses = [
             Status.makeTodo(),
             Status.makeInProgress(),
-            Status.makeDone(),
+            Status.DONE,
             Status.makeCancelled(),
             new Status(new StatusConfiguration('~', 'My custom status', ' ', false, StatusType.NON_TASK)),
         ];

--- a/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
+++ b/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
@@ -15,7 +15,7 @@ describe('DefaultStatuses', () => {
     });
 
     it('custom-statuses', () => {
-        VerifyStatuses.verifyStatusesInMultipleFormats([Status.makeInProgress, Status.CANCELLED], true);
+        VerifyStatuses.verifyStatusesInMultipleFormats([Status.IN_PROGRESS, Status.CANCELLED], true);
     });
 
     it('important-cycle', () => {
@@ -96,7 +96,7 @@ describe('Status Transitions', () => {
     it('status-types', () => {
         const statuses = [
             Status.TODO,
-            Status.makeInProgress,
+            Status.IN_PROGRESS,
             Status.DONE,
             Status.CANCELLED,
             new Status(new StatusConfiguration('~', 'My custom status', ' ', false, StatusType.NON_TASK)),

--- a/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
+++ b/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
@@ -15,7 +15,7 @@ describe('DefaultStatuses', () => {
     });
 
     it('custom-statuses', () => {
-        VerifyStatuses.verifyStatusesInMultipleFormats([Status.makeInProgress(), Status.makeCancelled], true);
+        VerifyStatuses.verifyStatusesInMultipleFormats([Status.makeInProgress(), Status.CANCELLED], true);
     });
 
     it('important-cycle', () => {
@@ -98,7 +98,7 @@ describe('Status Transitions', () => {
             Status.TODO,
             Status.makeInProgress(),
             Status.DONE,
-            Status.makeCancelled,
+            Status.CANCELLED,
             new Status(new StatusConfiguration('~', 'My custom status', ' ', false, StatusType.NON_TASK)),
         ];
         VerifyStatuses.verifyTransitionsAsMarkdownTable(statuses);

--- a/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
+++ b/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
@@ -11,7 +11,7 @@ describe('DefaultStatuses', () => {
     // These "test" write out a markdown representation of the default task statuses,
     // for embedding in the user docs.
     it('core-statuses', () => {
-        VerifyStatuses.verifyStatusesInMultipleFormats([Status.makeTodo(), Status.DONE], true);
+        VerifyStatuses.verifyStatusesInMultipleFormats([Status.TODO, Status.DONE], true);
     });
 
     it('custom-statuses', () => {
@@ -95,7 +95,7 @@ describe('Theme', () => {
 describe('Status Transitions', () => {
     it('status-types', () => {
         const statuses = [
-            Status.makeTodo(),
+            Status.TODO,
             Status.makeInProgress(),
             Status.DONE,
             Status.makeCancelled(),

--- a/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
+++ b/tests/DocumentationSamples/DocsSamplesForStatuses.test.ts
@@ -15,7 +15,7 @@ describe('DefaultStatuses', () => {
     });
 
     it('custom-statuses', () => {
-        VerifyStatuses.verifyStatusesInMultipleFormats([Status.makeInProgress(), Status.CANCELLED], true);
+        VerifyStatuses.verifyStatusesInMultipleFormats([Status.makeInProgress, Status.CANCELLED], true);
     });
 
     it('important-cycle', () => {
@@ -96,7 +96,7 @@ describe('Status Transitions', () => {
     it('status-types', () => {
         const statuses = [
             Status.TODO,
-            Status.makeInProgress(),
+            Status.makeInProgress,
             Status.DONE,
             Status.CANCELLED,
             new Status(new StatusConfiguration('~', 'My custom status', ' ', false, StatusType.NON_TASK)),

--- a/tests/Query/Filter/BlockingField.test.ts
+++ b/tests/Query/Filter/BlockingField.test.ts
@@ -8,7 +8,7 @@ describe('blocking', () => {
     const notBlocking = new TaskBuilder().build();
     const child = new TaskBuilder().id('12345').build();
     const childWithoutParent = new TaskBuilder().id('23456').build();
-    const childThatIsDone = new TaskBuilder().id('34567').status(Status.makeDone()).build();
+    const childThatIsDone = new TaskBuilder().id('34567').status(Status.DONE).build();
     const parent = new TaskBuilder().dependsOn(['12345', '34567']).build();
     const allTasks = [notBlocking, child, childWithoutParent, childThatIsDone, parent];
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -590,7 +590,7 @@ describe('FunctionField - grouping - example functions', () => {
     it('group by status nextStatusSymbol', () => {
         const line = 'group by function task.status.nextStatusSymbol.replace(" ", "space")';
         const grouper = createGrouper(line);
-        toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.makeInProgress), ['x']);
+        toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.IN_PROGRESS), ['x']);
         toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.DONE), ['space']);
     });
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -591,7 +591,7 @@ describe('FunctionField - grouping - example functions', () => {
         const line = 'group by function task.status.nextStatusSymbol.replace(" ", "space")';
         const grouper = createGrouper(line);
         toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.makeInProgress()), ['x']);
-        toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.makeDone()), ['space']);
+        toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.DONE), ['space']);
     });
 
     it('group by using number', () => {

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -583,7 +583,7 @@ describe('FunctionField - grouping - example functions', () => {
         // A single space as the character in a heading is not useful, so replace with something displayable:
         const line = 'group by function task.status.symbol.replace(" ", "space")';
         const grouper = createGrouper(line);
-        toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.makeCancelled()), ['-']);
+        toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.makeCancelled), ['-']);
         toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.TODO), ['space']);
     });
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -590,7 +590,7 @@ describe('FunctionField - grouping - example functions', () => {
     it('group by status nextStatusSymbol', () => {
         const line = 'group by function task.status.nextStatusSymbol.replace(" ", "space")';
         const grouper = createGrouper(line);
-        toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.makeInProgress()), ['x']);
+        toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.makeInProgress), ['x']);
         toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.DONE), ['space']);
     });
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -583,7 +583,7 @@ describe('FunctionField - grouping - example functions', () => {
         // A single space as the character in a heading is not useful, so replace with something displayable:
         const line = 'group by function task.status.symbol.replace(" ", "space")';
         const grouper = createGrouper(line);
-        toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.makeCancelled), ['-']);
+        toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.CANCELLED), ['-']);
         toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.TODO), ['space']);
     });
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -584,7 +584,7 @@ describe('FunctionField - grouping - example functions', () => {
         const line = 'group by function task.status.symbol.replace(" ", "space")';
         const grouper = createGrouper(line);
         toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.makeCancelled()), ['-']);
-        toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.makeTodo()), ['space']);
+        toGroupTaskFromBuilder(grouper, new TaskBuilder().status(Status.TODO), ['space']);
     });
 
     it('group by status nextStatusSymbol', () => {

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -20,7 +20,7 @@ describe('status', () => {
         expect(filter).toMatchTaskWithStatus(Status.DONE.configuration);
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('X', 'Really Done', 'x', true, StatusType.DONE));
         expect(filter).not.toMatchTaskWithStatus(Status.makeInProgress().configuration);
-        expect(filter).toMatchTaskWithStatus(Status.makeCancelled.configuration);
+        expect(filter).toMatchTaskWithStatus(Status.CANCELLED.configuration);
         expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('!', 'Todo', 'x', true, StatusType.TODO)); // 'done' checks type.
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));
     });
@@ -36,7 +36,7 @@ describe('status', () => {
             new StatusConfiguration('X', 'Really Done', 'x', true, StatusType.DONE),
         );
         expect(filter).toMatchTaskWithStatus(Status.makeInProgress().configuration);
-        expect(filter).not.toMatchTaskWithStatus(Status.makeCancelled.configuration);
+        expect(filter).not.toMatchTaskWithStatus(Status.CANCELLED.configuration);
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('!', 'Todo', 'x', true, StatusType.TODO)); // 'not done' type.
         expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));
     });

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -16,7 +16,7 @@ describe('status', () => {
         const filter = new StatusField().createFilterOrErrorMessage('done');
 
         // Assert
-        expect(filter).not.toMatchTaskWithStatus(Status.makeTodo().configuration);
+        expect(filter).not.toMatchTaskWithStatus(Status.TODO.configuration);
         expect(filter).toMatchTaskWithStatus(Status.DONE.configuration);
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('X', 'Really Done', 'x', true, StatusType.DONE));
         expect(filter).not.toMatchTaskWithStatus(Status.makeInProgress().configuration);
@@ -30,7 +30,7 @@ describe('status', () => {
         const filter = new StatusField().createFilterOrErrorMessage('not done');
 
         // Assert
-        expect(filter).toMatchTaskWithStatus(Status.makeTodo().configuration);
+        expect(filter).toMatchTaskWithStatus(Status.TODO.configuration);
         expect(filter).not.toMatchTaskWithStatus(Status.DONE.configuration);
         expect(filter).not.toMatchTaskWithStatus(
             new StatusConfiguration('X', 'Really Done', 'x', true, StatusType.DONE),

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -19,7 +19,7 @@ describe('status', () => {
         expect(filter).not.toMatchTaskWithStatus(Status.TODO.configuration);
         expect(filter).toMatchTaskWithStatus(Status.DONE.configuration);
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('X', 'Really Done', 'x', true, StatusType.DONE));
-        expect(filter).not.toMatchTaskWithStatus(Status.makeInProgress.configuration);
+        expect(filter).not.toMatchTaskWithStatus(Status.IN_PROGRESS.configuration);
         expect(filter).toMatchTaskWithStatus(Status.CANCELLED.configuration);
         expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('!', 'Todo', 'x', true, StatusType.TODO)); // 'done' checks type.
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));
@@ -35,7 +35,7 @@ describe('status', () => {
         expect(filter).not.toMatchTaskWithStatus(
             new StatusConfiguration('X', 'Really Done', 'x', true, StatusType.DONE),
         );
-        expect(filter).toMatchTaskWithStatus(Status.makeInProgress.configuration);
+        expect(filter).toMatchTaskWithStatus(Status.IN_PROGRESS.configuration);
         expect(filter).not.toMatchTaskWithStatus(Status.CANCELLED.configuration);
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('!', 'Todo', 'x', true, StatusType.TODO)); // 'not done' type.
         expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -17,7 +17,7 @@ describe('status', () => {
 
         // Assert
         expect(filter).not.toMatchTaskWithStatus(Status.makeTodo().configuration);
-        expect(filter).toMatchTaskWithStatus(Status.makeDone().configuration);
+        expect(filter).toMatchTaskWithStatus(Status.DONE.configuration);
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('X', 'Really Done', 'x', true, StatusType.DONE));
         expect(filter).not.toMatchTaskWithStatus(Status.makeInProgress().configuration);
         expect(filter).toMatchTaskWithStatus(Status.makeCancelled().configuration);
@@ -31,7 +31,7 @@ describe('status', () => {
 
         // Assert
         expect(filter).toMatchTaskWithStatus(Status.makeTodo().configuration);
-        expect(filter).not.toMatchTaskWithStatus(Status.makeDone().configuration);
+        expect(filter).not.toMatchTaskWithStatus(Status.DONE.configuration);
         expect(filter).not.toMatchTaskWithStatus(
             new StatusConfiguration('X', 'Really Done', 'x', true, StatusType.DONE),
         );

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -20,7 +20,7 @@ describe('status', () => {
         expect(filter).toMatchTaskWithStatus(Status.DONE.configuration);
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('X', 'Really Done', 'x', true, StatusType.DONE));
         expect(filter).not.toMatchTaskWithStatus(Status.makeInProgress().configuration);
-        expect(filter).toMatchTaskWithStatus(Status.makeCancelled().configuration);
+        expect(filter).toMatchTaskWithStatus(Status.makeCancelled.configuration);
         expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('!', 'Todo', 'x', true, StatusType.TODO)); // 'done' checks type.
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));
     });
@@ -36,7 +36,7 @@ describe('status', () => {
             new StatusConfiguration('X', 'Really Done', 'x', true, StatusType.DONE),
         );
         expect(filter).toMatchTaskWithStatus(Status.makeInProgress().configuration);
-        expect(filter).not.toMatchTaskWithStatus(Status.makeCancelled().configuration);
+        expect(filter).not.toMatchTaskWithStatus(Status.makeCancelled.configuration);
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('!', 'Todo', 'x', true, StatusType.TODO)); // 'not done' type.
         expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));
     });

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -19,7 +19,7 @@ describe('status', () => {
         expect(filter).not.toMatchTaskWithStatus(Status.TODO.configuration);
         expect(filter).toMatchTaskWithStatus(Status.DONE.configuration);
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('X', 'Really Done', 'x', true, StatusType.DONE));
-        expect(filter).not.toMatchTaskWithStatus(Status.makeInProgress().configuration);
+        expect(filter).not.toMatchTaskWithStatus(Status.makeInProgress.configuration);
         expect(filter).toMatchTaskWithStatus(Status.CANCELLED.configuration);
         expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('!', 'Todo', 'x', true, StatusType.TODO)); // 'done' checks type.
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));
@@ -35,7 +35,7 @@ describe('status', () => {
         expect(filter).not.toMatchTaskWithStatus(
             new StatusConfiguration('X', 'Really Done', 'x', true, StatusType.DONE),
         );
-        expect(filter).toMatchTaskWithStatus(Status.makeInProgress().configuration);
+        expect(filter).toMatchTaskWithStatus(Status.makeInProgress.configuration);
         expect(filter).not.toMatchTaskWithStatus(Status.CANCELLED.configuration);
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('!', 'Todo', 'x', true, StatusType.TODO)); // 'not done' type.
         expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));

--- a/tests/Query/Filter/StatusTypeField.test.ts
+++ b/tests/Query/Filter/StatusTypeField.test.ts
@@ -21,7 +21,7 @@ const non_Task = new TaskBuilder()
     .statusValues('^', 'non-task', 'x', false, StatusType.NON_TASK)
     .description('Non-task')
     .build();
-const emptTask = new TaskBuilder().status(Status.makeEmpty()).description('Empty task').build();
+const emptTask = new TaskBuilder().status(Status.EMPTY).description('Empty task').build();
 
 describe('status.name', () => {
     it('value', () => {

--- a/tests/Scripting/TaskProperties.test.ts
+++ b/tests/Scripting/TaskProperties.test.ts
@@ -23,7 +23,7 @@ window.moment = moment;
 describe('task', () => {
     function verifyFieldDataForReferenceDocs(fields: string[]) {
         const task1 = TaskBuilder.createFullyPopulatedTask();
-        const task2 = new TaskBuilder().description('minimal task').status(Status.makeInProgress).build();
+        const task2 = new TaskBuilder().description('minimal task').status(Status.IN_PROGRESS).build();
         verifyFieldDataFromTasksForReferenceDocs([task1, task2], fields);
     }
 

--- a/tests/Scripting/TaskProperties.test.ts
+++ b/tests/Scripting/TaskProperties.test.ts
@@ -23,7 +23,7 @@ window.moment = moment;
 describe('task', () => {
     function verifyFieldDataForReferenceDocs(fields: string[]) {
         const task1 = TaskBuilder.createFullyPopulatedTask();
-        const task2 = new TaskBuilder().description('minimal task').status(Status.makeInProgress()).build();
+        const task2 = new TaskBuilder().description('minimal task').status(Status.makeInProgress).build();
         verifyFieldDataFromTasksForReferenceDocs([task1, task2], fields);
     }
 

--- a/tests/Statuses/Status.test.ts
+++ b/tests/Statuses/Status.test.ts
@@ -27,7 +27,7 @@ describe('Status', () => {
         expect(Status.TODO.previewText()).toEqual("- [ ] => [x], name: 'Todo', type: 'TODO'.");
         expect(Status.CANCELLED.previewText()).toEqual("- [-] => [ ], name: 'Cancelled', type: 'CANCELLED'.");
         expect(Status.IN_PROGRESS.previewText()).toEqual("- [/] => [x], name: 'In Progress', type: 'IN_PROGRESS'.");
-        expect(Status.makeNonTask.previewText()).toEqual("- [Q] => [A], name: 'Non-Task', type: 'NON_TASK'.");
+        expect(Status.NON_TASK.previewText()).toEqual("- [Q] => [A], name: 'Non-Task', type: 'NON_TASK'.");
     });
 
     it('should initialize with valid properties', () => {

--- a/tests/Statuses/Status.test.ts
+++ b/tests/Statuses/Status.test.ts
@@ -25,7 +25,7 @@ describe('Status', () => {
         expect(Status.DONE.previewText()).toEqual("- [x] => [ ], name: 'Done', type: 'DONE'.");
         expect(Status.EMPTY.previewText()).toEqual("- [] => [], name: 'EMPTY', type: 'EMPTY'.");
         expect(Status.TODO.previewText()).toEqual("- [ ] => [x], name: 'Todo', type: 'TODO'.");
-        expect(Status.makeCancelled.previewText()).toEqual("- [-] => [ ], name: 'Cancelled', type: 'CANCELLED'.");
+        expect(Status.CANCELLED.previewText()).toEqual("- [-] => [ ], name: 'Cancelled', type: 'CANCELLED'.");
         expect(Status.makeInProgress().previewText()).toEqual(
             "- [/] => [x], name: 'In Progress', type: 'IN_PROGRESS'.",
         );
@@ -126,7 +126,7 @@ describe('Status', () => {
     });
 
     it('should provide text with sorting comments for convenience of custom grouping', () => {
-        const status = Status.makeCancelled;
+        const status = Status.CANCELLED;
         expect(status.typeGroupText).toEqual('%%4%%CANCELLED');
     });
 });

--- a/tests/Statuses/Status.test.ts
+++ b/tests/Statuses/Status.test.ts
@@ -23,7 +23,7 @@ describe('Status', () => {
 
     it('factory methods for default statuses', () => {
         expect(Status.DONE.previewText()).toEqual("- [x] => [ ], name: 'Done', type: 'DONE'.");
-        expect(Status.makeEmpty().previewText()).toEqual("- [] => [], name: 'EMPTY', type: 'EMPTY'.");
+        expect(Status.EMPTY.previewText()).toEqual("- [] => [], name: 'EMPTY', type: 'EMPTY'.");
         expect(Status.makeTodo().previewText()).toEqual("- [ ] => [x], name: 'Todo', type: 'TODO'.");
         expect(Status.makeCancelled().previewText()).toEqual("- [-] => [ ], name: 'Cancelled', type: 'CANCELLED'.");
         expect(Status.makeInProgress().previewText()).toEqual(

--- a/tests/Statuses/Status.test.ts
+++ b/tests/Statuses/Status.test.ts
@@ -27,7 +27,7 @@ describe('Status', () => {
         expect(Status.TODO.previewText()).toEqual("- [ ] => [x], name: 'Todo', type: 'TODO'.");
         expect(Status.CANCELLED.previewText()).toEqual("- [-] => [ ], name: 'Cancelled', type: 'CANCELLED'.");
         expect(Status.IN_PROGRESS.previewText()).toEqual("- [/] => [x], name: 'In Progress', type: 'IN_PROGRESS'.");
-        expect(Status.makeNonTask().previewText()).toEqual("- [Q] => [A], name: 'Non-Task', type: 'NON_TASK'.");
+        expect(Status.makeNonTask.previewText()).toEqual("- [Q] => [A], name: 'Non-Task', type: 'NON_TASK'.");
     });
 
     it('should initialize with valid properties', () => {

--- a/tests/Statuses/Status.test.ts
+++ b/tests/Statuses/Status.test.ts
@@ -24,7 +24,7 @@ describe('Status', () => {
     it('factory methods for default statuses', () => {
         expect(Status.DONE.previewText()).toEqual("- [x] => [ ], name: 'Done', type: 'DONE'.");
         expect(Status.EMPTY.previewText()).toEqual("- [] => [], name: 'EMPTY', type: 'EMPTY'.");
-        expect(Status.makeTodo().previewText()).toEqual("- [ ] => [x], name: 'Todo', type: 'TODO'.");
+        expect(Status.TODO.previewText()).toEqual("- [ ] => [x], name: 'Todo', type: 'TODO'.");
         expect(Status.makeCancelled().previewText()).toEqual("- [-] => [ ], name: 'Cancelled', type: 'CANCELLED'.");
         expect(Status.makeInProgress().previewText()).toEqual(
             "- [/] => [x], name: 'In Progress', type: 'IN_PROGRESS'.",

--- a/tests/Statuses/Status.test.ts
+++ b/tests/Statuses/Status.test.ts
@@ -26,9 +26,7 @@ describe('Status', () => {
         expect(Status.EMPTY.previewText()).toEqual("- [] => [], name: 'EMPTY', type: 'EMPTY'.");
         expect(Status.TODO.previewText()).toEqual("- [ ] => [x], name: 'Todo', type: 'TODO'.");
         expect(Status.CANCELLED.previewText()).toEqual("- [-] => [ ], name: 'Cancelled', type: 'CANCELLED'.");
-        expect(Status.makeInProgress().previewText()).toEqual(
-            "- [/] => [x], name: 'In Progress', type: 'IN_PROGRESS'.",
-        );
+        expect(Status.makeInProgress.previewText()).toEqual("- [/] => [x], name: 'In Progress', type: 'IN_PROGRESS'.");
         expect(Status.makeNonTask().previewText()).toEqual("- [Q] => [A], name: 'Non-Task', type: 'NON_TASK'.");
     });
 

--- a/tests/Statuses/Status.test.ts
+++ b/tests/Statuses/Status.test.ts
@@ -26,7 +26,7 @@ describe('Status', () => {
         expect(Status.EMPTY.previewText()).toEqual("- [] => [], name: 'EMPTY', type: 'EMPTY'.");
         expect(Status.TODO.previewText()).toEqual("- [ ] => [x], name: 'Todo', type: 'TODO'.");
         expect(Status.CANCELLED.previewText()).toEqual("- [-] => [ ], name: 'Cancelled', type: 'CANCELLED'.");
-        expect(Status.makeInProgress.previewText()).toEqual("- [/] => [x], name: 'In Progress', type: 'IN_PROGRESS'.");
+        expect(Status.IN_PROGRESS.previewText()).toEqual("- [/] => [x], name: 'In Progress', type: 'IN_PROGRESS'.");
         expect(Status.makeNonTask().previewText()).toEqual("- [Q] => [A], name: 'Non-Task', type: 'NON_TASK'.");
     });
 

--- a/tests/Statuses/Status.test.ts
+++ b/tests/Statuses/Status.test.ts
@@ -22,7 +22,7 @@ describe('Status', () => {
     });
 
     it('factory methods for default statuses', () => {
-        expect(Status.makeDone().previewText()).toEqual("- [x] => [ ], name: 'Done', type: 'DONE'.");
+        expect(Status.DONE.previewText()).toEqual("- [x] => [ ], name: 'Done', type: 'DONE'.");
         expect(Status.makeEmpty().previewText()).toEqual("- [] => [], name: 'EMPTY', type: 'EMPTY'.");
         expect(Status.makeTodo().previewText()).toEqual("- [ ] => [x], name: 'Todo', type: 'TODO'.");
         expect(Status.makeCancelled().previewText()).toEqual("- [-] => [ ], name: 'Cancelled', type: 'CANCELLED'.");

--- a/tests/Statuses/Status.test.ts
+++ b/tests/Statuses/Status.test.ts
@@ -25,7 +25,7 @@ describe('Status', () => {
         expect(Status.DONE.previewText()).toEqual("- [x] => [ ], name: 'Done', type: 'DONE'.");
         expect(Status.EMPTY.previewText()).toEqual("- [] => [], name: 'EMPTY', type: 'EMPTY'.");
         expect(Status.TODO.previewText()).toEqual("- [ ] => [x], name: 'Todo', type: 'TODO'.");
-        expect(Status.makeCancelled().previewText()).toEqual("- [-] => [ ], name: 'Cancelled', type: 'CANCELLED'.");
+        expect(Status.makeCancelled.previewText()).toEqual("- [-] => [ ], name: 'Cancelled', type: 'CANCELLED'.");
         expect(Status.makeInProgress().previewText()).toEqual(
             "- [/] => [x], name: 'In Progress', type: 'IN_PROGRESS'.",
         );
@@ -126,7 +126,7 @@ describe('Status', () => {
     });
 
     it('should provide text with sorting comments for convenience of custom grouping', () => {
-        const status = Status.makeCancelled();
+        const status = Status.makeCancelled;
         expect(status.typeGroupText).toEqual('%%4%%CANCELLED');
     });
 });

--- a/tests/Statuses/StatusRegistry.test.ts
+++ b/tests/Statuses/StatusRegistry.test.ts
@@ -38,9 +38,9 @@ describe('StatusRegistry', () => {
         // Assert
         expect(statusRegistry).not.toBeNull();
 
-        expect(doneStatus.symbol).toEqual(Status.makeDone().symbol);
+        expect(doneStatus.symbol).toEqual(Status.DONE.symbol);
 
-        expect(statusRegistry.bySymbol('x').symbol).toEqual(Status.makeDone().symbol);
+        expect(statusRegistry.bySymbol('x').symbol).toEqual(Status.DONE.symbol);
         expect(statusRegistry.bySymbol('').symbol).toEqual(Status.makeEmpty().symbol);
         expect(statusRegistry.bySymbol(' ').symbol).toEqual(Status.makeTodo().symbol);
         expect(statusRegistry.bySymbol('-').symbol).toEqual(Status.makeCancelled().symbol);
@@ -398,7 +398,7 @@ describe('StatusRegistry', () => {
             expect(task!.status.symbol).toEqual(Status.makeTodo().symbol);
 
             const toggledDone = task?.toggle()[0];
-            expect(toggledDone?.status.symbol).toEqual(Status.makeDone().symbol);
+            expect(toggledDone?.status.symbol).toEqual(Status.DONE.symbol);
 
             const toggledTodo = toggledDone?.toggle()[0];
             expect(toggledTodo?.status.symbol).toEqual(Status.makeTodo().symbol);

--- a/tests/Statuses/StatusRegistry.test.ts
+++ b/tests/Statuses/StatusRegistry.test.ts
@@ -44,7 +44,7 @@ describe('StatusRegistry', () => {
         expect(statusRegistry.bySymbol('').symbol).toEqual(Status.EMPTY.symbol);
         expect(statusRegistry.bySymbol(' ').symbol).toEqual(Status.TODO.symbol);
         expect(statusRegistry.bySymbol('-').symbol).toEqual(Status.CANCELLED.symbol);
-        expect(statusRegistry.bySymbol('/').symbol).toEqual(Status.makeInProgress().symbol);
+        expect(statusRegistry.bySymbol('/').symbol).toEqual(Status.makeInProgress.symbol);
 
         // Detect unrecognised symbol:
         expect(statusRegistry.bySymbol('?').symbol).toEqual(Status.EMPTY.symbol);

--- a/tests/Statuses/StatusRegistry.test.ts
+++ b/tests/Statuses/StatusRegistry.test.ts
@@ -42,7 +42,7 @@ describe('StatusRegistry', () => {
 
         expect(statusRegistry.bySymbol('x').symbol).toEqual(Status.DONE.symbol);
         expect(statusRegistry.bySymbol('').symbol).toEqual(Status.EMPTY.symbol);
-        expect(statusRegistry.bySymbol(' ').symbol).toEqual(Status.makeTodo().symbol);
+        expect(statusRegistry.bySymbol(' ').symbol).toEqual(Status.TODO.symbol);
         expect(statusRegistry.bySymbol('-').symbol).toEqual(Status.makeCancelled().symbol);
         expect(statusRegistry.bySymbol('/').symbol).toEqual(Status.makeInProgress().symbol);
 
@@ -395,13 +395,13 @@ describe('StatusRegistry', () => {
 
             // Assert
             expect(task).not.toBeNull();
-            expect(task!.status.symbol).toEqual(Status.makeTodo().symbol);
+            expect(task!.status.symbol).toEqual(Status.TODO.symbol);
 
             const toggledDone = task?.toggle()[0];
             expect(toggledDone?.status.symbol).toEqual(Status.DONE.symbol);
 
             const toggledTodo = toggledDone?.toggle()[0];
-            expect(toggledTodo?.status.symbol).toEqual(Status.makeTodo().symbol);
+            expect(toggledTodo?.status.symbol).toEqual(Status.TODO.symbol);
         });
 
         it('should allow task to toggle from cancelled to todo', () => {
@@ -422,7 +422,7 @@ describe('StatusRegistry', () => {
             expect(task!.status.symbol).toEqual(Status.makeCancelled().symbol);
 
             const toggledTodo = task?.toggle()[0];
-            expect(toggledTodo?.status.symbol).toEqual(Status.makeTodo().symbol);
+            expect(toggledTodo?.status.symbol).toEqual(Status.TODO.symbol);
         });
 
         it('should allow task to toggle through custom transitions', () => {

--- a/tests/Statuses/StatusRegistry.test.ts
+++ b/tests/Statuses/StatusRegistry.test.ts
@@ -43,7 +43,7 @@ describe('StatusRegistry', () => {
         expect(statusRegistry.bySymbol('x').symbol).toEqual(Status.DONE.symbol);
         expect(statusRegistry.bySymbol('').symbol).toEqual(Status.EMPTY.symbol);
         expect(statusRegistry.bySymbol(' ').symbol).toEqual(Status.TODO.symbol);
-        expect(statusRegistry.bySymbol('-').symbol).toEqual(Status.makeCancelled.symbol);
+        expect(statusRegistry.bySymbol('-').symbol).toEqual(Status.CANCELLED.symbol);
         expect(statusRegistry.bySymbol('/').symbol).toEqual(Status.makeInProgress().symbol);
 
         // Detect unrecognised symbol:
@@ -419,7 +419,7 @@ describe('StatusRegistry', () => {
 
             // Assert
             expect(task).not.toBeNull();
-            expect(task!.status.symbol).toEqual(Status.makeCancelled.symbol);
+            expect(task!.status.symbol).toEqual(Status.CANCELLED.symbol);
 
             const toggledTodo = task?.toggle()[0];
             expect(toggledTodo?.status.symbol).toEqual(Status.TODO.symbol);

--- a/tests/Statuses/StatusRegistry.test.ts
+++ b/tests/Statuses/StatusRegistry.test.ts
@@ -44,7 +44,7 @@ describe('StatusRegistry', () => {
         expect(statusRegistry.bySymbol('').symbol).toEqual(Status.EMPTY.symbol);
         expect(statusRegistry.bySymbol(' ').symbol).toEqual(Status.TODO.symbol);
         expect(statusRegistry.bySymbol('-').symbol).toEqual(Status.CANCELLED.symbol);
-        expect(statusRegistry.bySymbol('/').symbol).toEqual(Status.makeInProgress.symbol);
+        expect(statusRegistry.bySymbol('/').symbol).toEqual(Status.IN_PROGRESS.symbol);
 
         // Detect unrecognised symbol:
         expect(statusRegistry.bySymbol('?').symbol).toEqual(Status.EMPTY.symbol);

--- a/tests/Statuses/StatusRegistry.test.ts
+++ b/tests/Statuses/StatusRegistry.test.ts
@@ -41,13 +41,13 @@ describe('StatusRegistry', () => {
         expect(doneStatus.symbol).toEqual(Status.DONE.symbol);
 
         expect(statusRegistry.bySymbol('x').symbol).toEqual(Status.DONE.symbol);
-        expect(statusRegistry.bySymbol('').symbol).toEqual(Status.makeEmpty().symbol);
+        expect(statusRegistry.bySymbol('').symbol).toEqual(Status.EMPTY.symbol);
         expect(statusRegistry.bySymbol(' ').symbol).toEqual(Status.makeTodo().symbol);
         expect(statusRegistry.bySymbol('-').symbol).toEqual(Status.makeCancelled().symbol);
         expect(statusRegistry.bySymbol('/').symbol).toEqual(Status.makeInProgress().symbol);
 
         // Detect unrecognised symbol:
-        expect(statusRegistry.bySymbol('?').symbol).toEqual(Status.makeEmpty().symbol);
+        expect(statusRegistry.bySymbol('?').symbol).toEqual(Status.EMPTY.symbol);
     });
 
     it('should clear the statuses', () => {

--- a/tests/Statuses/StatusRegistry.test.ts
+++ b/tests/Statuses/StatusRegistry.test.ts
@@ -43,7 +43,7 @@ describe('StatusRegistry', () => {
         expect(statusRegistry.bySymbol('x').symbol).toEqual(Status.DONE.symbol);
         expect(statusRegistry.bySymbol('').symbol).toEqual(Status.EMPTY.symbol);
         expect(statusRegistry.bySymbol(' ').symbol).toEqual(Status.TODO.symbol);
-        expect(statusRegistry.bySymbol('-').symbol).toEqual(Status.makeCancelled().symbol);
+        expect(statusRegistry.bySymbol('-').symbol).toEqual(Status.makeCancelled.symbol);
         expect(statusRegistry.bySymbol('/').symbol).toEqual(Status.makeInProgress().symbol);
 
         // Detect unrecognised symbol:
@@ -419,7 +419,7 @@ describe('StatusRegistry', () => {
 
             // Assert
             expect(task).not.toBeNull();
-            expect(task!.status.symbol).toEqual(Status.makeCancelled().symbol);
+            expect(task!.status.symbol).toEqual(Status.makeCancelled.symbol);
 
             const toggledTodo = task?.toggle()[0];
             expect(toggledTodo?.status.symbol).toEqual(Status.TODO.symbol);

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -97,7 +97,7 @@ describe('OnCompletion - cases where all tasks are retained', () => {
         const task = makeTask('- [ ] A recurring task with "delete" Action 🔁 every day 🏁 delete 📅 2024-02-10');
 
         // Act
-        const tasks = applyStatusAndOnCompletionAction(task, Status.makeInProgress);
+        const tasks = applyStatusAndOnCompletionAction(task, Status.IN_PROGRESS);
 
         // Assert
         expect(tasks.length).toEqual(1);
@@ -216,7 +216,7 @@ function getCases(): ToggleCase[] {
         },
 
         {
-            nextStatus: Status.makeInProgress,
+            nextStatus: Status.IN_PROGRESS,
             line: '- [ ] A recurring task with 🏁 delete 🔁 every day 📅 2024-02-10',
         },
 

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -97,7 +97,7 @@ describe('OnCompletion - cases where all tasks are retained', () => {
         const task = makeTask('- [ ] A recurring task with "delete" Action 🔁 every day 🏁 delete 📅 2024-02-10');
 
         // Act
-        const tasks = applyStatusAndOnCompletionAction(task, Status.makeInProgress());
+        const tasks = applyStatusAndOnCompletionAction(task, Status.makeInProgress);
 
         // Assert
         expect(tasks.length).toEqual(1);
@@ -216,7 +216,7 @@ function getCases(): ToggleCase[] {
         },
 
         {
-            nextStatus: Status.makeInProgress(),
+            nextStatus: Status.makeInProgress,
             line: '- [ ] A recurring task with 🏁 delete 🔁 every day 📅 2024-02-10',
         },
 

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -58,7 +58,7 @@ describe('OnCompletion - cases where all tasks are retained', () => {
         const task = makeTask(line);
 
         // Act
-        const returnedTasks = applyStatusAndOnCompletionAction(task, Status.makeDone());
+        const returnedTasks = applyStatusAndOnCompletionAction(task, Status.DONE);
 
         // Assert
         expect(returnedTasks.length).toEqual(1);
@@ -70,7 +70,7 @@ describe('OnCompletion - cases where all tasks are retained', () => {
         const task = makeTask('- [ ] A non-recurring task with no trigger 📅 2024-02-10');
 
         // Act
-        const tasks = applyStatusAndOnCompletionAction(task, Status.makeDone());
+        const tasks = applyStatusAndOnCompletionAction(task, Status.DONE);
 
         // Assert
         expect(toMarkdown(tasks)).toMatchInlineSnapshot(
@@ -83,7 +83,7 @@ describe('OnCompletion - cases where all tasks are retained', () => {
         const task = makeTask('- [ ] A recurring task with no trigger 🔁 every day 📅 2024-02-10');
 
         // Act
-        const tasks = applyStatusAndOnCompletionAction(task, Status.makeDone());
+        const tasks = applyStatusAndOnCompletionAction(task, Status.DONE);
 
         // Assert
         expect(toMarkdown(tasks)).toMatchInlineSnapshot(`
@@ -123,7 +123,7 @@ describe('OnCompletion - cases where all tasks are retained', () => {
         const task = makeTask('- [ ] A non-recurring task with');
 
         // Act
-        const tasks = applyStatusAndOnCompletionAction(task, Status.makeDone());
+        const tasks = applyStatusAndOnCompletionAction(task, Status.DONE);
 
         // Assert
         expect(tasks.length).toEqual(1);
@@ -136,7 +136,7 @@ describe('OnCompletion - "keep" action', () => {
         const task = makeTask('- [ ] A non-recurring task with "keep" Action 🏁 keep');
 
         // Act
-        const tasks = applyStatusAndOnCompletionAction(task, Status.makeDone());
+        const tasks = applyStatusAndOnCompletionAction(task, Status.DONE);
 
         // Assert
         expect(tasks.length).toEqual(1);
@@ -149,7 +149,7 @@ describe('OnCompletion - "delete" action', () => {
         const task = makeTask('- [ ] A recurring task with "delete" Action 🔁 every day 🏁 delete 📅 2024-02-10');
 
         // Act
-        const tasks = applyStatusAndOnCompletionAction(task, Status.makeDone());
+        const tasks = applyStatusAndOnCompletionAction(task, Status.DONE);
 
         // Assert
         expect(toMarkdown(tasks)).toMatchInlineSnapshot(
@@ -162,7 +162,7 @@ describe('OnCompletion - "delete" action', () => {
         const task = makeTask('- [ ] A non-recurring task with "delete" Action 🏁 delete');
 
         // Act
-        const tasks = applyStatusAndOnCompletionAction(task, Status.makeDone());
+        const tasks = applyStatusAndOnCompletionAction(task, Status.DONE);
 
         // Assert
         expect(tasks.length).toEqual(0);
@@ -179,39 +179,39 @@ function getCases(): ToggleCase[] {
     return [
         // Non-recurring
         {
-            nextStatus: Status.makeDone(),
+            nextStatus: Status.DONE,
             line: '- [ ] A non-recurring task with no trigger 📅 2024-02-10',
         },
 
         {
-            nextStatus: Status.makeDone(),
+            nextStatus: Status.DONE,
             line: '- [ ] A non-recurring task with 🏁 delete',
         },
 
         {
-            nextStatus: Status.makeDone(),
+            nextStatus: Status.DONE,
             line: '- [ ] A non-recurring task with 🏁 delete 📅 2024-02-10',
         },
 
         {
-            nextStatus: Status.makeDone(),
+            nextStatus: Status.DONE,
             line: '- [ ] A non-recurring task with invalid OC trigger 🏁 INVALID_ACTION 📅 2024-02-10',
         },
 
         {
-            nextStatus: Status.makeDone(),
+            nextStatus: Status.DONE,
             line: '- [ ] A non-recurring task with 🏁',
         },
 
         // Recurring
 
         {
-            nextStatus: Status.makeDone(),
+            nextStatus: Status.DONE,
             line: '- [ ] A recurring task with no trigger 🔁 every day 📅 2024-02-10',
         },
 
         {
-            nextStatus: Status.makeDone(),
+            nextStatus: Status.DONE,
             line: '- [ ] A recurring task with 🏁 delete 🔁 every day 📅 2024-02-10',
         },
 
@@ -223,7 +223,7 @@ function getCases(): ToggleCase[] {
         // Other
 
         {
-            nextStatus: Status.makeDone(),
+            nextStatus: Status.DONE,
             line: '- [x] An already-DONE task, changing to Same      DONE status 🏁 delete 📅 2024-02-10 ✅ 2024-02-10',
         },
 
@@ -235,12 +235,12 @@ function getCases(): ToggleCase[] {
         // Indented, within callout/code block
 
         {
-            nextStatus: Status.makeDone(),
+            nextStatus: Status.DONE,
             line: '    - [ ] An indented task with 🏁 delete',
         },
 
         {
-            nextStatus: Status.makeDone(),
+            nextStatus: Status.DONE,
             line: '> - [ ] A task within a block quote or callout and 🏁 delete',
         },
     ];

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -528,7 +528,7 @@ describe('properties for scripting', () => {
         expect(new TaskBuilder().status(Status.TODO).build().isDone).toEqual(false);
         expect(new TaskBuilder().status(Status.makeInProgress()).build().isDone).toEqual(false);
         expect(new TaskBuilder().status(Status.DONE).build().isDone).toEqual(true);
-        expect(new TaskBuilder().status(Status.makeCancelled).build().isDone).toEqual(true);
+        expect(new TaskBuilder().status(Status.CANCELLED).build().isDone).toEqual(true);
         expect(
             new TaskBuilder()
                 .status(new Status(new StatusConfiguration('%', 'Non-task', ' ', true, StatusType.NON_TASK)))
@@ -1392,7 +1392,7 @@ describe('handle new status', () => {
             });
 
             // Act
-            const newTasks = doneTask.handleNewStatus(Status.makeCancelled);
+            const newTasks = doneTask.handleNewStatus(Status.CANCELLED);
 
             // Assert
             expect(newTasks).toMatchMarkdownLines(['- [-] Stuff 📅 2023-12-15 ❌ 2023-06-26']);
@@ -1406,7 +1406,7 @@ describe('handle new status', () => {
             });
 
             // Act
-            const newTasks = task.handleNewStatus(Status.makeCancelled);
+            const newTasks = task.handleNewStatus(Status.CANCELLED);
 
             // Assert
             expect(newTasks).toMatchMarkdownLines(['- [-] Stuff']);
@@ -1419,7 +1419,7 @@ describe('handle new status', () => {
             });
 
             // Act
-            const newTasks = cancelledTask.handleNewStatus(Status.makeCancelled);
+            const newTasks = cancelledTask.handleNewStatus(Status.CANCELLED);
 
             // Assert
             // Check that the cancelled date was not modified:

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -525,7 +525,7 @@ describe('task parsing VS global filter', () => {
 
 describe('properties for scripting', () => {
     it('should provide isDone for convenience', () => {
-        expect(new TaskBuilder().status(Status.makeTodo()).build().isDone).toEqual(false);
+        expect(new TaskBuilder().status(Status.TODO).build().isDone).toEqual(false);
         expect(new TaskBuilder().status(Status.makeInProgress()).build().isDone).toEqual(false);
         expect(new TaskBuilder().status(Status.DONE).build().isDone).toEqual(true);
         expect(new TaskBuilder().status(Status.makeCancelled()).build().isDone).toEqual(true);
@@ -1553,7 +1553,7 @@ describe('identicalTo', () => {
     // NEW_TASK_FIELD_EDIT_REQUIRED
 
     it('should check status', () => {
-        const lhs = new TaskBuilder().status(Status.makeTodo());
+        const lhs = new TaskBuilder().status(Status.TODO);
         expect(lhs).toBeIdenticalTo(new TaskBuilder().status(Status.TODO));
         expect(lhs).not.toBeIdenticalTo(new TaskBuilder().status(Status.DONE));
     });

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -528,7 +528,7 @@ describe('properties for scripting', () => {
         expect(new TaskBuilder().status(Status.TODO).build().isDone).toEqual(false);
         expect(new TaskBuilder().status(Status.makeInProgress()).build().isDone).toEqual(false);
         expect(new TaskBuilder().status(Status.DONE).build().isDone).toEqual(true);
-        expect(new TaskBuilder().status(Status.makeCancelled()).build().isDone).toEqual(true);
+        expect(new TaskBuilder().status(Status.makeCancelled).build().isDone).toEqual(true);
         expect(
             new TaskBuilder()
                 .status(new Status(new StatusConfiguration('%', 'Non-task', ' ', true, StatusType.NON_TASK)))
@@ -1392,7 +1392,7 @@ describe('handle new status', () => {
             });
 
             // Act
-            const newTasks = doneTask.handleNewStatus(Status.makeCancelled());
+            const newTasks = doneTask.handleNewStatus(Status.makeCancelled);
 
             // Assert
             expect(newTasks).toMatchMarkdownLines(['- [-] Stuff 📅 2023-12-15 ❌ 2023-06-26']);
@@ -1406,7 +1406,7 @@ describe('handle new status', () => {
             });
 
             // Act
-            const newTasks = task.handleNewStatus(Status.makeCancelled());
+            const newTasks = task.handleNewStatus(Status.makeCancelled);
 
             // Assert
             expect(newTasks).toMatchMarkdownLines(['- [-] Stuff']);
@@ -1419,7 +1419,7 @@ describe('handle new status', () => {
             });
 
             // Act
-            const newTasks = cancelledTask.handleNewStatus(Status.makeCancelled());
+            const newTasks = cancelledTask.handleNewStatus(Status.makeCancelled);
 
             // Assert
             // Check that the cancelled date was not modified:

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -526,7 +526,7 @@ describe('task parsing VS global filter', () => {
 describe('properties for scripting', () => {
     it('should provide isDone for convenience', () => {
         expect(new TaskBuilder().status(Status.TODO).build().isDone).toEqual(false);
-        expect(new TaskBuilder().status(Status.makeInProgress()).build().isDone).toEqual(false);
+        expect(new TaskBuilder().status(Status.makeInProgress).build().isDone).toEqual(false);
         expect(new TaskBuilder().status(Status.DONE).build().isDone).toEqual(true);
         expect(new TaskBuilder().status(Status.CANCELLED).build().isDone).toEqual(true);
         expect(

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -527,7 +527,7 @@ describe('properties for scripting', () => {
     it('should provide isDone for convenience', () => {
         expect(new TaskBuilder().status(Status.makeTodo()).build().isDone).toEqual(false);
         expect(new TaskBuilder().status(Status.makeInProgress()).build().isDone).toEqual(false);
-        expect(new TaskBuilder().status(Status.makeDone()).build().isDone).toEqual(true);
+        expect(new TaskBuilder().status(Status.DONE).build().isDone).toEqual(true);
         expect(new TaskBuilder().status(Status.makeCancelled()).build().isDone).toEqual(true);
         expect(
             new TaskBuilder()
@@ -1339,7 +1339,7 @@ describe('handle new status', () => {
         });
 
         // Act
-        const newTasks = doneTask.handleNewStatus(Status.makeDone());
+        const newTasks = doneTask.handleNewStatus(Status.DONE);
 
         // Assert
         expect(newTasks.length).toEqual(1);
@@ -1433,7 +1433,7 @@ describe('handle new status', () => {
             });
 
             // Act
-            const newTasks = cancelledTask.handleNewStatus(Status.makeDone());
+            const newTasks = cancelledTask.handleNewStatus(Status.DONE);
 
             // Assert
             expect(newTasks).toMatchMarkdownLines([
@@ -1507,7 +1507,7 @@ describe('order of recurring tasks', () => {
 
     function expectLineToApplyDoneStatusInUsersOrder(line: string, expectedLines: string[]) {
         const task = fromLine({ line: line });
-        const tasks = task.handleNewStatusWithRecurrenceInUsersOrder(Status.makeDone());
+        const tasks = task.handleNewStatusWithRecurrenceInUsersOrder(Status.DONE);
         expect(tasks).toMatchMarkdownLines(expectedLines);
     }
 

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -526,7 +526,7 @@ describe('task parsing VS global filter', () => {
 describe('properties for scripting', () => {
     it('should provide isDone for convenience', () => {
         expect(new TaskBuilder().status(Status.TODO).build().isDone).toEqual(false);
-        expect(new TaskBuilder().status(Status.makeInProgress).build().isDone).toEqual(false);
+        expect(new TaskBuilder().status(Status.IN_PROGRESS).build().isDone).toEqual(false);
         expect(new TaskBuilder().status(Status.DONE).build().isDone).toEqual(true);
         expect(new TaskBuilder().status(Status.CANCELLED).build().isDone).toEqual(true);
         expect(

--- a/tests/TestingTools/SampleTasks.ts
+++ b/tests/TestingTools/SampleTasks.ts
@@ -165,7 +165,7 @@ export class SampleTasks {
             Status.CANCELLED,
             Status.DONE,
             Status.EMPTY,
-            Status.makeInProgress(),
+            Status.makeInProgress,
             Status.TODO,
             Status.makeNonTask(),
         ];

--- a/tests/TestingTools/SampleTasks.ts
+++ b/tests/TestingTools/SampleTasks.ts
@@ -165,7 +165,7 @@ export class SampleTasks {
             Status.CANCELLED,
             Status.DONE,
             Status.EMPTY,
-            Status.makeInProgress,
+            Status.IN_PROGRESS,
             Status.TODO,
             Status.makeNonTask(),
         ];

--- a/tests/TestingTools/SampleTasks.ts
+++ b/tests/TestingTools/SampleTasks.ts
@@ -167,7 +167,7 @@ export class SampleTasks {
             Status.EMPTY,
             Status.IN_PROGRESS,
             Status.TODO,
-            Status.makeNonTask,
+            Status.NON_TASK,
         ];
 
         return statuses.map((status) => {

--- a/tests/TestingTools/SampleTasks.ts
+++ b/tests/TestingTools/SampleTasks.ts
@@ -164,7 +164,7 @@ export class SampleTasks {
         const statuses = [
             Status.makeCancelled(),
             Status.DONE,
-            Status.makeEmpty(),
+            Status.EMPTY,
             Status.makeInProgress(),
             Status.makeTodo(),
             Status.makeNonTask(),
@@ -186,7 +186,7 @@ export class SampleTasks {
             .statusValues('^', 'non-task', 'x', false, StatusType.NON_TASK)
             .description('Non-task')
             .build();
-        const emptTask = new TaskBuilder().status(Status.makeEmpty()).description('Empty task').build();
+        const emptTask = new TaskBuilder().status(Status.EMPTY).description('Empty task').build();
 
         return [todoTask, inprTask, doneTask, cancTask, unknTask, non_Task, emptTask];
     }

--- a/tests/TestingTools/SampleTasks.ts
+++ b/tests/TestingTools/SampleTasks.ts
@@ -150,7 +150,7 @@ export class SampleTasks {
             new TaskBuilder().status(Status.TODO).description(desc('start')).startDate('2023-04-15'),
             new TaskBuilder().status(Status.TODO).description(desc('due')).dueDate('2023-04-16'),
             new TaskBuilder().status(Status.DONE).description(desc('done')).doneDate('2023-04-17'),
-            new TaskBuilder().status(Status.makeCancelled()).description(desc('cancelled')).cancelledDate('2023-04-18'),
+            new TaskBuilder().status(Status.makeCancelled).description(desc('cancelled')).cancelledDate('2023-04-18'),
         ];
         // If this test fails, a new date format is now supported, and needs to be added to the above list:
         const documentedDateFieldsCount = taskBuilders.length;
@@ -162,7 +162,7 @@ export class SampleTasks {
 
     public static withAllStatuses(): Task[] {
         const statuses = [
-            Status.makeCancelled(),
+            Status.makeCancelled,
             Status.DONE,
             Status.EMPTY,
             Status.makeInProgress(),

--- a/tests/TestingTools/SampleTasks.ts
+++ b/tests/TestingTools/SampleTasks.ts
@@ -149,7 +149,7 @@ export class SampleTasks {
             new TaskBuilder().status(Status.makeTodo()).description(desc('scheduled')).scheduledDate('2023-04-14'),
             new TaskBuilder().status(Status.makeTodo()).description(desc('start')).startDate('2023-04-15'),
             new TaskBuilder().status(Status.makeTodo()).description(desc('due')).dueDate('2023-04-16'),
-            new TaskBuilder().status(Status.makeDone()).description(desc('done')).doneDate('2023-04-17'),
+            new TaskBuilder().status(Status.DONE).description(desc('done')).doneDate('2023-04-17'),
             new TaskBuilder().status(Status.makeCancelled()).description(desc('cancelled')).cancelledDate('2023-04-18'),
         ];
         // If this test fails, a new date format is now supported, and needs to be added to the above list:
@@ -163,7 +163,7 @@ export class SampleTasks {
     public static withAllStatuses(): Task[] {
         const statuses = [
             Status.makeCancelled(),
-            Status.makeDone(),
+            Status.DONE,
             Status.makeEmpty(),
             Status.makeInProgress(),
             Status.makeTodo(),

--- a/tests/TestingTools/SampleTasks.ts
+++ b/tests/TestingTools/SampleTasks.ts
@@ -150,7 +150,7 @@ export class SampleTasks {
             new TaskBuilder().status(Status.TODO).description(desc('start')).startDate('2023-04-15'),
             new TaskBuilder().status(Status.TODO).description(desc('due')).dueDate('2023-04-16'),
             new TaskBuilder().status(Status.DONE).description(desc('done')).doneDate('2023-04-17'),
-            new TaskBuilder().status(Status.makeCancelled).description(desc('cancelled')).cancelledDate('2023-04-18'),
+            new TaskBuilder().status(Status.CANCELLED).description(desc('cancelled')).cancelledDate('2023-04-18'),
         ];
         // If this test fails, a new date format is now supported, and needs to be added to the above list:
         const documentedDateFieldsCount = taskBuilders.length;
@@ -162,7 +162,7 @@ export class SampleTasks {
 
     public static withAllStatuses(): Task[] {
         const statuses = [
-            Status.makeCancelled,
+            Status.CANCELLED,
             Status.DONE,
             Status.EMPTY,
             Status.makeInProgress(),

--- a/tests/TestingTools/SampleTasks.ts
+++ b/tests/TestingTools/SampleTasks.ts
@@ -167,7 +167,7 @@ export class SampleTasks {
             Status.EMPTY,
             Status.IN_PROGRESS,
             Status.TODO,
-            Status.makeNonTask(),
+            Status.makeNonTask,
         ];
 
         return statuses.map((status) => {

--- a/tests/TestingTools/SampleTasks.ts
+++ b/tests/TestingTools/SampleTasks.ts
@@ -145,10 +145,10 @@ export class SampleTasks {
         }
 
         const taskBuilders = [
-            new TaskBuilder().status(Status.makeTodo()).description(desc('created')).createdDate('2023-04-13'),
-            new TaskBuilder().status(Status.makeTodo()).description(desc('scheduled')).scheduledDate('2023-04-14'),
-            new TaskBuilder().status(Status.makeTodo()).description(desc('start')).startDate('2023-04-15'),
-            new TaskBuilder().status(Status.makeTodo()).description(desc('due')).dueDate('2023-04-16'),
+            new TaskBuilder().status(Status.TODO).description(desc('created')).createdDate('2023-04-13'),
+            new TaskBuilder().status(Status.TODO).description(desc('scheduled')).scheduledDate('2023-04-14'),
+            new TaskBuilder().status(Status.TODO).description(desc('start')).startDate('2023-04-15'),
+            new TaskBuilder().status(Status.TODO).description(desc('due')).dueDate('2023-04-16'),
             new TaskBuilder().status(Status.DONE).description(desc('done')).doneDate('2023-04-17'),
             new TaskBuilder().status(Status.makeCancelled()).description(desc('cancelled')).cancelledDate('2023-04-18'),
         ];
@@ -166,7 +166,7 @@ export class SampleTasks {
             Status.DONE,
             Status.EMPTY,
             Status.makeInProgress(),
-            Status.makeTodo(),
+            Status.TODO,
             Status.makeNonTask(),
         ];
 

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -26,7 +26,7 @@ import { setCurrentCacheFile } from '../__mocks__/obsidian';
  */
 export class TaskBuilder {
     // NEW_TASK_FIELD_EDIT_REQUIRED
-    private _status: Status = Status.makeTodo();
+    private _status: Status = Status.TODO;
     private _description: string = 'my description';
     private _path: string = '';
     private _indentation: string = '';

--- a/tests/ui/EditInstructions/StatusInstructions.test.ts
+++ b/tests/ui/EditInstructions/StatusInstructions.test.ts
@@ -26,7 +26,7 @@ afterEach(() => {
 
 describe('SetStatus', () => {
     const todoTask = new TaskBuilder().status(Status.makeTodo()).build();
-    const doneTask = new TaskBuilder().status(Status.makeDone()).build();
+    const doneTask = new TaskBuilder().status(Status.DONE).build();
 
     it('should provide information to set up a menu item for setting status', () => {
         // Arrange
@@ -41,7 +41,7 @@ describe('SetStatus', () => {
 
     it('should edit status', () => {
         // Arrange
-        const instruction = new SetStatus(Status.makeDone());
+        const instruction = new SetStatus(Status.DONE);
 
         // Act
         const newTasks = instruction.apply(todoTask);

--- a/tests/ui/EditInstructions/StatusInstructions.test.ts
+++ b/tests/ui/EditInstructions/StatusInstructions.test.ts
@@ -25,12 +25,12 @@ afterEach(() => {
 });
 
 describe('SetStatus', () => {
-    const todoTask = new TaskBuilder().status(Status.makeTodo()).build();
+    const todoTask = new TaskBuilder().status(Status.TODO).build();
     const doneTask = new TaskBuilder().status(Status.DONE).build();
 
     it('should provide information to set up a menu item for setting status', () => {
         // Arrange
-        const status = Status.makeTodo();
+        const status = Status.TODO;
         const instruction = new SetStatus(status);
 
         // Assert
@@ -53,7 +53,7 @@ describe('SetStatus', () => {
 
     it('should not edit task if already has chosen status', () => {
         // Arrange
-        const instruction = new SetStatus(Status.makeTodo());
+        const instruction = new SetStatus(Status.TODO);
 
         // Act
         const newTasks = instruction.apply(todoTask);

--- a/tests/ui/Menus/StatusMenu.test.ts
+++ b/tests/ui/Menus/StatusMenu.test.ts
@@ -28,7 +28,7 @@ describe('StatusMenu', () => {
 
     it('should show checkmark against the current task status', () => {
         // Arrange
-        const task = new TaskBuilder().status(Status.makeInProgress).build();
+        const task = new TaskBuilder().status(Status.IN_PROGRESS).build();
         const statusRegistry = new StatusRegistry();
 
         // Act

--- a/tests/ui/Menus/StatusMenu.test.ts
+++ b/tests/ui/Menus/StatusMenu.test.ts
@@ -78,7 +78,7 @@ describe('StatusMenu', () => {
         // Arrange
         const onlyShowCancelled = new StatusRegistry();
         onlyShowCancelled.clearStatuses();
-        onlyShowCancelled.add(Status.makeCancelled());
+        onlyShowCancelled.add(Status.makeCancelled);
 
         const task = new TaskBuilder().status(Status.TODO).build();
         const menu = new StatusMenu(onlyShowCancelled, task, TestableTaskSaver.testableTaskSaver);

--- a/tests/ui/Menus/StatusMenu.test.ts
+++ b/tests/ui/Menus/StatusMenu.test.ts
@@ -78,7 +78,7 @@ describe('StatusMenu', () => {
         // Arrange
         const onlyShowCancelled = new StatusRegistry();
         onlyShowCancelled.clearStatuses();
-        onlyShowCancelled.add(Status.makeCancelled);
+        onlyShowCancelled.add(Status.CANCELLED);
 
         const task = new TaskBuilder().status(Status.TODO).build();
         const menu = new StatusMenu(onlyShowCancelled, task, TestableTaskSaver.testableTaskSaver);

--- a/tests/ui/Menus/StatusMenu.test.ts
+++ b/tests/ui/Menus/StatusMenu.test.ts
@@ -28,7 +28,7 @@ describe('StatusMenu', () => {
 
     it('should show checkmark against the current task status', () => {
         // Arrange
-        const task = new TaskBuilder().status(Status.makeInProgress()).build();
+        const task = new TaskBuilder().status(Status.makeInProgress).build();
         const statusRegistry = new StatusRegistry();
 
         // Act

--- a/tests/ui/Menus/StatusMenu.test.ts
+++ b/tests/ui/Menus/StatusMenu.test.ts
@@ -80,7 +80,7 @@ describe('StatusMenu', () => {
         onlyShowCancelled.clearStatuses();
         onlyShowCancelled.add(Status.makeCancelled());
 
-        const task = new TaskBuilder().status(Status.makeTodo()).build();
+        const task = new TaskBuilder().status(Status.TODO).build();
         const menu = new StatusMenu(onlyShowCancelled, task, TestableTaskSaver.testableTaskSaver);
 
         // Act


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- `Status.make*()` are same as the existing `Status.*` calls (`*` is any status), so
  - Replace `Status.make*()` status methods with existing `Status.*` static class fields
  - For other statuses, refactor `Status.make*()` method calls to `Status.*` static class fields

For reference: existing `Status.*` static class fields were calling `Status.make*()` methods, so the behaviour was same.

_Note from @claremacrae: the behaviour differed in how many `Status` instances were created, however._

## Motivation and Context

- remove code duplication and use shorter calls to `Status` static methods
- better code

## How has this been tested?

- unit tests

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
