### PR TITLE
fix: Edit Task modal now retains edits to Cancelled date

### DIFF
--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -247,6 +247,11 @@ export class EditableTask {
         return updatedTask.handleNewStatusWithRecurrenceInUsersOrder(this.status, today);
     }
 
+    /**
+     * If the user has manually edited the Done date or Cancelled date in the modal,
+     * we need to tell Tasks to use a different `today` value in the status-editing code.
+     * Here we calculate that inferred date.
+     */
     private inferTodaysDate(
         newStatusType: StatusType,
         doneDate: moment.Moment | null,

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -242,10 +242,14 @@ export class EditableTask {
 
         // Then apply the new status to the updated task, in case a new recurrence
         // needs to be created.
+        const today = this.getToday(doneDate);
+        return updatedTask.handleNewStatusWithRecurrenceInUsersOrder(this.status, today);
+    }
+
+    private getToday(doneDate: moment.Moment | null) {
         // If there is a 'done' date, use that for today's date for recurrence calculations.
         // Otherwise, use the current date.
-        const today = doneDate ? doneDate : window.moment();
-        return updatedTask.handleNewStatusWithRecurrenceInUsersOrder(this.status, today);
+        return doneDate ? doneDate : window.moment();
     }
 
     public parseAndValidateRecurrence() {

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -243,11 +243,15 @@ export class EditableTask {
 
         // Then apply the new status to the updated task, in case a new recurrence
         // needs to be created.
-        const today = this.getToday(this.status.type, doneDate, cancelledDate);
+        const today = this.inferTodaysDate(this.status.type, doneDate, cancelledDate);
         return updatedTask.handleNewStatusWithRecurrenceInUsersOrder(this.status, today);
     }
 
-    private getToday(newStatusType: StatusType, doneDate: moment.Moment | null, cancelledDate: moment.Moment | null) {
+    private inferTodaysDate(
+        newStatusType: StatusType,
+        doneDate: moment.Moment | null,
+        cancelledDate: moment.Moment | null,
+    ) {
         if (newStatusType === StatusType.DONE && doneDate !== null) {
             // If there is a 'done' date, use that for today's date for recurrence calculations.
             return doneDate;

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -258,11 +258,18 @@ export class EditableTask {
         cancelledDate: moment.Moment | null,
     ) {
         if (newStatusType === StatusType.DONE && doneDate !== null) {
-            // If there is a 'done' date, use that for today's date for recurrence calculations.
+            // The status type of the edited task is DONE, so we need to preserve the
+            // Done Date value in the modal as today's date,
+            // for use in later code.
+            // This is needed for scenarios including:
+            //  - The task already had a done date before being edited
+            //  - The user changed the status to Done, and then edited the machine-generted done date.
             return doneDate;
         }
 
         if (newStatusType === StatusType.CANCELLED && cancelledDate !== null) {
+            // The status type of the edited task is CANCELLED, so we need to preserve the
+            // Cancelled Date value in the modal as today's date.
             return cancelledDate;
         }
 

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -249,7 +249,11 @@ export class EditableTask {
     private getToday(doneDate: moment.Moment | null) {
         // If there is a 'done' date, use that for today's date for recurrence calculations.
         // Otherwise, use the current date.
-        return doneDate ? doneDate : window.moment();
+        if (doneDate) {
+            return doneDate;
+        } else {
+            return window.moment();
+        }
     }
 
     public parseAndValidateRecurrence() {

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -251,9 +251,8 @@ export class EditableTask {
         // Otherwise, use the current date.
         if (doneDate) {
             return doneDate;
-        } else {
-            return window.moment();
         }
+        return window.moment();
     }
 
     public parseAndValidateRecurrence() {

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -248,12 +248,12 @@ export class EditableTask {
     }
 
     private getToday(newStatusType: StatusType, doneDate: moment.Moment | null, cancelledDate: moment.Moment | null) {
-        if (newStatusType === StatusType.DONE && doneDate) {
+        if (newStatusType === StatusType.DONE && doneDate !== null) {
             // If there is a 'done' date, use that for today's date for recurrence calculations.
             return doneDate;
         }
 
-        if (newStatusType === StatusType.CANCELLED && cancelledDate) {
+        if (newStatusType === StatusType.CANCELLED && cancelledDate !== null) {
             return cancelledDate;
         }
 

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -8,6 +8,7 @@ import { Priority } from '../Task/Priority';
 import { Recurrence } from '../Task/Recurrence';
 import { Task } from '../Task/Task';
 import { addDependencyToParent, ensureTaskHasId, generateUniqueId, removeDependency } from '../Task/TaskDependency';
+import { StatusType } from '../Statuses/StatusConfiguration';
 
 type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
 
@@ -242,16 +243,21 @@ export class EditableTask {
 
         // Then apply the new status to the updated task, in case a new recurrence
         // needs to be created.
-        const today = this.getToday(doneDate);
+        const today = this.getToday(this.status.type, doneDate, cancelledDate);
         return updatedTask.handleNewStatusWithRecurrenceInUsersOrder(this.status, today);
     }
 
-    private getToday(doneDate: moment.Moment | null) {
-        // If there is a 'done' date, use that for today's date for recurrence calculations.
-        // Otherwise, use the current date.
-        if (doneDate) {
+    private getToday(newStatusType: StatusType, doneDate: moment.Moment | null, cancelledDate: moment.Moment | null) {
+        if (newStatusType === StatusType.DONE && doneDate) {
+            // If there is a 'done' date, use that for today's date for recurrence calculations.
             return doneDate;
         }
+
+        if (newStatusType === StatusType.CANCELLED && cancelledDate) {
+            return cancelledDate;
+        }
+
+        // Otherwise, use the current date.
         return window.moment();
     }
 

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -418,7 +418,7 @@ describe('Task editing', () => {
 
             submit.click();
             expect(await waitForClose).toMatchInlineSnapshot(
-                '"- [-] expecting cancelled date to be kept ❌ 2024-02-29"',
+                '"- [-] expecting cancelled date to be kept ❌ 2024-09-20"',
             );
         });
 
@@ -476,9 +476,8 @@ describe('Task editing', () => {
                 'cancelled',
                 '2024-09-21',
                 '-',
-                // TODO the difference between the date in the modal and the saved one is a bug:
                 // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3089
-                '- [-] input cancelled date, change status to cancelled and expect the date to be kept ❌ 2024-02-29',
+                '- [-] input cancelled date, change status to cancelled and expect the date to be kept ❌ 2024-09-21',
             ],
         ])(
             'for "%s" task, change %s date to %s and status to %s',


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

When changing status type to CANCELLED, use the Cancelled Date as `today` instead of the `Done Date`.

## Motivation and Context

Fixes #3089

- #3089

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- running existing tests
    - this actually fixed two of the existing tests, not just the one that linked to the issue being fixed here
- manual exploratory testing

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
