### PR TITLE
refactor: make `StatusEditor` act on `Status` object instead of `Status.symbol`

### DIFF
--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -11,7 +11,6 @@
     export let statusOptions: Status[];
     export let accesskey: string | null;
 
-    let statusSymbol = task.status.symbol;
     let jsonStatus = JSON.stringify(task.status);
 
     function setStatusRelatedDate(currentValue: string, isInStatus: boolean, editedValue: TasksDate) {
@@ -32,7 +31,7 @@
 
     const _onStatusChange = () => {
         const newStatus = new Status(JSON.parse(jsonStatus).configuration as StatusConfiguration);
-        statusSymbol = newStatus.symbol;
+        const statusSymbol = newStatus.symbol;
 
         // Use statusSymbol to find the status to save to editableTask.status
         const selectedStatus: Status | undefined = statusOptions.find((s) => s.symbol === statusSymbol);

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import type { TasksDate } from '../DateTime/TasksDate';
     import { Status } from '../Statuses/Status';
-    import type { StatusConfiguration } from '../Statuses/StatusConfiguration';
     import type { Task } from '../Task/Task';
     import type { EditableTask } from './EditableTask';
     import { labelContentWithAccessKey } from './EditTaskHelpers';
@@ -30,7 +29,7 @@
     }
 
     const _onStatusChange = () => {
-        const newStatus = new Status(JSON.parse(jsonStatus).configuration as StatusConfiguration);
+        const newStatus = new Status(JSON.parse(jsonStatus).configuration);
 
         const selectedStatus = newStatus;
         editableTask.status = selectedStatus;

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -32,14 +32,8 @@
     const _onStatusChange = () => {
         const newStatus = new Status(JSON.parse(jsonStatus).configuration as StatusConfiguration);
 
-        // Use statusSymbol to find the status to save to editableTask.status
-        const selectedStatus: Status | undefined = statusOptions.find((s) => s.symbol === newStatus.symbol);
-        if (selectedStatus) {
-            editableTask.status = selectedStatus;
-        } else {
-            console.log(`Error in EditTask: cannot find status with symbol ${newStatus.symbol}`);
-            return;
-        }
+        const selectedStatus = newStatus;
+        editableTask.status = selectedStatus;
 
         // Obtain a temporary task with the new status applied, to see what would
         // happen to the done date:

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -31,23 +31,22 @@
     const _onStatusChange = () => {
         const newStatus = new Status(JSON.parse(jsonStatus).configuration);
 
-        const selectedStatus = newStatus;
-        editableTask.status = selectedStatus;
+        editableTask.status = newStatus;
 
         // Obtain a temporary task with the new status applied, to see what would
         // happen to the done date:
-        const taskWithEditedStatusApplied = task.handleNewStatus(selectedStatus).pop();
+        const taskWithEditedStatusApplied = task.handleNewStatus(newStatus).pop();
 
         if (taskWithEditedStatusApplied) {
             editableTask.doneDate = setStatusRelatedDate(
                 editableTask.doneDate,
-                selectedStatus.isCompleted(),
+                newStatus.isCompleted(),
                 taskWithEditedStatusApplied.done,
             );
 
             editableTask.cancelledDate = setStatusRelatedDate(
                 editableTask.cancelledDate,
-                selectedStatus.isCancelled(),
+                newStatus.isCancelled(),
                 taskWithEditedStatusApplied.cancelled,
             );
         }

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -10,7 +10,7 @@
     export let statusOptions: Status[];
     export let accesskey: string | null;
 
-    let jsonStatus = JSON.stringify(task.status);
+    let selectedStatus = JSON.stringify(task.status);
 
     function setStatusRelatedDate(currentValue: string, isInStatus: boolean, editedValue: TasksDate) {
         const dateFieldIsEmpty = currentValue === '';
@@ -29,7 +29,7 @@
     }
 
     const _onStatusChange = () => {
-        const newStatus = new Status(JSON.parse(jsonStatus).configuration);
+        const newStatus = new Status(JSON.parse(selectedStatus).configuration);
 
         editableTask.status = newStatus;
 
@@ -56,7 +56,7 @@
 <label for="status">{@html labelContentWithAccessKey('Status', accesskey)}</label>
 <!-- svelte-ignore a11y-accesskey -->
 <select
-    bind:value={jsonStatus}
+    bind:value={selectedStatus}
     on:change={_onStatusChange}
     id="status-type"
     class="status-editor-status-selector"

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { TasksDate } from '../DateTime/TasksDate';
-    import type { Status } from '../Statuses/Status';
+    import { Status } from '../Statuses/Status';
+    import type { StatusConfiguration } from '../Statuses/StatusConfiguration';
     import type { Task } from '../Task/Task';
     import type { EditableTask } from './EditableTask';
     import { labelContentWithAccessKey } from './EditTaskHelpers';
@@ -11,6 +12,7 @@
     export let accesskey: string | null;
 
     let statusSymbol = task.status.symbol;
+    let jsonStatus = JSON.stringify(task.status);
 
     function setStatusRelatedDate(currentValue: string, isInStatus: boolean, editedValue: TasksDate) {
         const dateFieldIsEmpty = currentValue === '';
@@ -29,6 +31,9 @@
     }
 
     const _onStatusChange = () => {
+        const newStatus = new Status(JSON.parse(jsonStatus).configuration as StatusConfiguration);
+        statusSymbol = newStatus.symbol;
+
         // Use statusSymbol to find the status to save to editableTask.status
         const selectedStatus: Status | undefined = statusOptions.find((s) => s.symbol === statusSymbol);
         if (selectedStatus) {
@@ -61,13 +66,13 @@
 <label for="status">{@html labelContentWithAccessKey('Status', accesskey)}</label>
 <!-- svelte-ignore a11y-accesskey -->
 <select
-    bind:value={statusSymbol}
+    bind:value={jsonStatus}
     on:change={_onStatusChange}
     id="status-type"
     class="status-editor-status-selector"
     {accesskey}
 >
     {#each statusOptions as status}
-        <option value={status.symbol}>{status.name} [{status.symbol}]</option>
+        <option value={JSON.stringify(status)}>{status.name} [{status.symbol}]</option>
     {/each}
 </select>

--- a/src/ui/StatusEditor.svelte
+++ b/src/ui/StatusEditor.svelte
@@ -31,14 +31,13 @@
 
     const _onStatusChange = () => {
         const newStatus = new Status(JSON.parse(jsonStatus).configuration as StatusConfiguration);
-        const statusSymbol = newStatus.symbol;
 
         // Use statusSymbol to find the status to save to editableTask.status
-        const selectedStatus: Status | undefined = statusOptions.find((s) => s.symbol === statusSymbol);
+        const selectedStatus: Status | undefined = statusOptions.find((s) => s.symbol === newStatus.symbol);
         if (selectedStatus) {
             editableTask.status = selectedStatus;
         } else {
-            console.log(`Error in EditTask: cannot find status with symbol ${statusSymbol}`);
+            console.log(`Error in EditTask: cannot find status with symbol ${newStatus.symbol}`);
             return;
         }
 

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
@@ -206,10 +206,22 @@
         s
       </label>
       <select id="status-type" class="status-editor-status-selector" accesskey="u">
-        <option value=" ">Todo [ ]</option>
-        <option value="/">In Progress [/]</option>
-        <option value="x">Done [x]</option>
-        <option value="-">Cancelled [-]</option>
+        <option
+          value='{"configuration":{"symbol":" ","name":"Todo","nextStatusSymbol":"x","availableAsCommand":true,"type":"TODO"}}'>
+          Todo [ ]
+        </option>
+        <option
+          value='{"configuration":{"symbol":"/","name":"In Progress","nextStatusSymbol":"x","availableAsCommand":true,"type":"IN_PROGRESS"}}'>
+          In Progress [/]
+        </option>
+        <option
+          value='{"configuration":{"symbol":"x","name":"Done","nextStatusSymbol":" ","availableAsCommand":true,"type":"DONE"}}'>
+          Done [x]
+        </option>
+        <option
+          value='{"configuration":{"symbol":"-","name":"Cancelled","nextStatusSymbol":" ","availableAsCommand":true,"type":"CANCELLED"}}'>
+          Cancelled [-]
+        </option>
       </select>
       <label for="created">
         <span class="accesskey">C</span>

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
@@ -134,10 +134,22 @@
     <section class="tasks-modal-dates-section">
       <label for="status">Status</label>
       <select id="status-type" class="status-editor-status-selector">
-        <option value=" ">Todo [ ]</option>
-        <option value="/">In Progress [/]</option>
-        <option value="x">Done [x]</option>
-        <option value="-">Cancelled [-]</option>
+        <option
+          value='{"configuration":{"symbol":" ","name":"Todo","nextStatusSymbol":"x","availableAsCommand":true,"type":"TODO"}}'>
+          Todo [ ]
+        </option>
+        <option
+          value='{"configuration":{"symbol":"/","name":"In Progress","nextStatusSymbol":"x","availableAsCommand":true,"type":"IN_PROGRESS"}}'>
+          In Progress [/]
+        </option>
+        <option
+          value='{"configuration":{"symbol":"x","name":"Done","nextStatusSymbol":" ","availableAsCommand":true,"type":"DONE"}}'>
+          Done [x]
+        </option>
+        <option
+          value='{"configuration":{"symbol":"-","name":"Cancelled","nextStatusSymbol":" ","availableAsCommand":true,"type":"CANCELLED"}}'>
+          Cancelled [-]
+        </option>
       </select>
       <label for="created">Created</label>
       <input id="created" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- `StatusEditor` uses `Status.symbol` in the `<select>`'s value, which means we need to use the symbol everywhere:
  - in the `<option>`s
  - in the tests
- This PR changes the used object from symbol to the actual `Status` object. It has to be stringified since `<option>` accepts only string values for `value` fields

## Motivation and Context

- Simplify `StatusEditor._onStatusChange()` - now the block of resolving status symbol to status is gone
  - Now that whole code may move to `EditableTask`, where it can be tested in a simpler way than with rendering `EditTask` modal. This will also separate logic from the UI
- Test now use more expressive `Status.TODO` instead of `'[ ]'` string values

## How has this been tested?

- unit tests
- manual test in demo vault: create a task, change status and save the task, verify that the status changed correctly (done for all the 4 default statuses)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
