### PR TITLE
fix: Restore 'collapsed' state of Status setting sections

### DIFF
--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -155,7 +155,9 @@ export class SettingsTab extends PluginSettingTab {
         const { headingOpened } = getSettings();
 
         settingsJson.forEach((heading) => {
-            this.addOneSettingsBlock(containerEl, heading, headingOpened);
+            const initiallyOpen = headingOpened[heading.text] ?? true;
+            const detailsContainer = this.addOneSettingsBlock(containerEl, heading, headingOpened);
+            detailsContainer.open = initiallyOpen;
         });
 
         // ---------------------------------------------------------------------------
@@ -379,7 +381,11 @@ export class SettingsTab extends PluginSettingTab {
             });
     }
 
-    private addOneSettingsBlock(containerEl: HTMLElement, heading: any, headingOpened: HeadingState) {
+    private addOneSettingsBlock(
+        containerEl: HTMLElement,
+        heading: any,
+        headingOpened: HeadingState,
+    ): HTMLDetailsElement {
         const detailsContainer = containerEl.createEl('details', {
             cls: 'tasks-nested-settings',
             attr: {
@@ -488,6 +494,8 @@ export class SettingsTab extends PluginSettingTab {
                 }
             }
         });
+
+        return detailsContainer;
     }
 
     private static parseCommaSeparatedFolders(input: string): string[] {


### PR DESCRIPTION

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)


## Description

There has been an un-reported bug for a long time, that the open/closed state of the collapse buttons on the Core Status and Custom Status sections of the Tasks Settings were not restored when the settings were re-opened, either in the same session, or when restarting Obsidian.

<img width="976" alt="image" src="https://github.com/user-attachments/assets/4888adb0-9710-4fdc-81c0-3aaf0ddf2df3">


This fixes that bug. The collapse state is now correctly preserved.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To hide away the details of Status settings once they are correctly set up.

## How has this been tested?

Lots of exploratory testing, including deleting the settings file and ensuring that the Status sections are sill expanded by  default.

## Screenshots (if appropriate)

See above.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
