### PR TITLE
feat: add experimental rendering of child tasks and list items

### DIFF
--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -220,7 +220,7 @@ export class QueryResultsRenderer {
         });
 
         for (const [taskIndex, task] of tasks.entries()) {
-            if (renderedTasks.has(task)) {
+            if (this.alreadyRendered(task, renderedTasks)) {
                 continue;
             }
 
@@ -256,6 +256,10 @@ export class QueryResultsRenderer {
         }
 
         content.appendChild(taskList);
+    }
+
+    private alreadyRendered(task: ListItem, renderedTasks: Set<ListItem>) {
+        return renderedTasks.has(task);
     }
 
     private async addTaskOrListItem(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -224,6 +224,11 @@ export class QueryResultsRenderer {
                 continue;
             }
 
+            const parentIsATask = task.parent instanceof Task;
+            if (parentIsATask && !renderedTasks.has(task.parent)) {
+                continue;
+            }
+
             const listItem = await this.addTaskOrListItem(
                 taskList,
                 taskLineRenderer,

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -12,7 +12,7 @@ import type { TaskGroups } from '../Query/Group/TaskGroups';
 import type { QueryResult } from '../Query/QueryResult';
 import { postponeButtonTitle, shouldShowPostponeButton } from '../DateTime/Postponer';
 import type { TasksFile } from '../Scripting/TasksFile';
-import type { Task } from '../Task/Task';
+import { Task } from '../Task/Task';
 import { PostponeMenu } from '../ui/Menus/PostponeMenu';
 import { TaskLineRenderer, type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
 
@@ -194,7 +194,7 @@ export class QueryResultsRenderer {
 
     private async createTaskList(
         tasks: Task[],
-        content: HTMLDivElement,
+        content: HTMLElement,
         queryRendererParameters: QueryRendererParameters,
     ): Promise<void> {
         const taskList = createAndAppendElement('ul', content);
@@ -217,7 +217,18 @@ export class QueryResultsRenderer {
         });
 
         for (const [taskIndex, task] of tasks.entries()) {
-            await this.addTask(taskList, taskLineRenderer, task, taskIndex, queryRendererParameters);
+            const listItem = await this.addTask(taskList, taskLineRenderer, task, taskIndex, queryRendererParameters);
+
+            const childTasks: Task[] = task.children
+                .filter((listItemOrTask) => {
+                    return listItemOrTask instanceof Task;
+                })
+                .map((listItemThatIsATask) => {
+                    return listItemThatIsATask as Task;
+                });
+            if (childTasks.length > 0) {
+                await this.createTaskList(childTasks, listItem, queryRendererParameters);
+            }
         }
 
         content.appendChild(taskList);
@@ -259,6 +270,8 @@ export class QueryResultsRenderer {
         }
 
         taskList.appendChild(listItem);
+
+        return listItem;
     }
 
     private addEditButton(listItem: HTMLElement, task: Task, queryRendererParameters: QueryRendererParameters) {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -224,8 +224,15 @@ export class QueryResultsRenderer {
                 continue;
             }
 
-            const parentIsATask = task.parent instanceof Task;
-            if (parentIsATask && !renderedTasks.has(task.parent)) {
+            // Try to find the closest parent that is a task
+            let closestParent = task.parent;
+            while (closestParent !== null && !(closestParent instanceof Task)) {
+                closestParent = closestParent.parent;
+            }
+
+            if (closestParent && !renderedTasks.has(closestParent)) {
+                // This task is a direct or indirect child of another task that we are waiting to draw,
+                // so don't draw it yet, it will be done recursively later.
                 continue;
             }
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -257,11 +257,13 @@ export class QueryResultsRenderer {
             closestParent = closestParent.parent;
         }
 
-        if (closestParent && !renderedTasks.has(closestParent)) {
-            // This task is a direct or indirect child of another task that we are waiting to draw,
-            // so don't draw it yet, it will be done recursively later.
-            if (tasks.includes(closestParent)) {
-                willBeRenderedLater = true;
+        if (closestParent) {
+            if (!renderedTasks.has(closestParent)) {
+                // This task is a direct or indirect child of another task that we are waiting to draw,
+                // so don't draw it yet, it will be done recursively later.
+                if (tasks.includes(closestParent)) {
+                    willBeRenderedLater = true;
+                }
             }
         }
         return willBeRenderedLater;

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -217,7 +217,13 @@ export class QueryResultsRenderer {
             queryLayoutOptions: this.query.queryLayoutOptions,
         });
 
+        const renderedTasks: Set<ListItem> = new Set();
+
         for (const [taskIndex, task] of tasks.entries()) {
+            if (renderedTasks.has(task)) {
+                continue;
+            }
+
             const listItem = await this.addTaskOrListItem(
                 taskList,
                 taskLineRenderer,
@@ -225,9 +231,13 @@ export class QueryResultsRenderer {
                 taskIndex,
                 queryRendererParameters,
             );
+            renderedTasks.add(task);
 
             if (task.children.length > 0) {
                 await this.createTaskList(task.children, listItem, queryRendererParameters);
+                task.children.forEach((childTask) => {
+                    renderedTasks.add(childTask);
+                });
             }
         }
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -249,8 +249,6 @@ export class QueryResultsRenderer {
     }
 
     private willBeRenderedLater(task: ListItem, renderedTasks: Set<ListItem>, tasks: ListItem[]) {
-        const willBeRenderedLater = false;
-
         // Try to find the closest parent that is a task
         let closestParent = task.parent;
         while (closestParent !== null && !(closestParent instanceof Task)) {
@@ -266,7 +264,8 @@ export class QueryResultsRenderer {
                 }
             }
         }
-        return willBeRenderedLater;
+
+        return false;
     }
 
     private alreadyRendered(task: ListItem, renderedTasks: Set<ListItem>) {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -222,7 +222,13 @@ export class QueryResultsRenderer {
                 continue;
             }
 
-            const listItem = await this.addTask(taskList, taskLineRenderer, task, taskIndex, queryRendererParameters);
+            const listItem = await this.addTaskOrListItem(
+                taskList,
+                taskLineRenderer,
+                task,
+                taskIndex,
+                queryRendererParameters,
+            );
 
             const numberOfChildTasks = task.children.filter((listItemOrTask) => {
                 return listItemOrTask instanceof Task;
@@ -233,6 +239,16 @@ export class QueryResultsRenderer {
         }
 
         content.appendChild(taskList);
+    }
+
+    private async addTaskOrListItem(
+        taskList: HTMLUListElement,
+        taskLineRenderer: TaskLineRenderer,
+        task: Task,
+        taskIndex: number,
+        queryRendererParameters: QueryRendererParameters,
+    ) {
+        return await this.addTask(taskList, taskLineRenderer, task, taskIndex, queryRendererParameters);
     }
 
     private async addTask(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -218,10 +218,6 @@ export class QueryResultsRenderer {
         });
 
         for (const [taskIndex, task] of tasks.entries()) {
-            if (!(task instanceof Task)) {
-                continue;
-            }
-
             const listItem = await this.addTaskOrListItem(
                 taskList,
                 taskLineRenderer,
@@ -230,10 +226,7 @@ export class QueryResultsRenderer {
                 queryRendererParameters,
             );
 
-            const numberOfChildTasks = task.children.filter((listItemOrTask) => {
-                return listItemOrTask instanceof Task;
-            }).length;
-            if (numberOfChildTasks > 0) {
+            if (task.children.length > 0) {
                 await this.createTaskList(task.children, listItem, queryRendererParameters);
             }
         }
@@ -244,11 +237,21 @@ export class QueryResultsRenderer {
     private async addTaskOrListItem(
         taskList: HTMLUListElement,
         taskLineRenderer: TaskLineRenderer,
-        task: Task,
+        task: ListItem,
         taskIndex: number,
         queryRendererParameters: QueryRendererParameters,
     ) {
-        return await this.addTask(taskList, taskLineRenderer, task, taskIndex, queryRendererParameters);
+        if (task instanceof Task) {
+            return await this.addTask(taskList, taskLineRenderer, task, taskIndex, queryRendererParameters);
+        }
+
+        return this.addListItem(taskList, task);
+    }
+
+    private addListItem(taskList: HTMLUListElement, listItem: ListItem) {
+        const li = createAndAppendElement('li', taskList);
+        li.textContent = listItem.originalMarkdown;
+        return li;
     }
 
     private async addTask(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -255,7 +255,9 @@ export class QueryResultsRenderer {
             closestParent = closestParent.parent;
         }
 
-        if (closestParent) {
+        if (!closestParent) {
+            return false;
+        } else {
             if (!renderedTasks.has(closestParent)) {
                 // This task is a direct or indirect child of another task that we are waiting to draw,
                 // so don't draw it yet, it will be done recursively later.

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -257,13 +257,13 @@ export class QueryResultsRenderer {
 
         if (!closestParent) {
             return false;
-        } else {
-            if (!renderedTasks.has(closestParent)) {
-                // This task is a direct or indirect child of another task that we are waiting to draw,
-                // so don't draw it yet, it will be done recursively later.
-                if (tasks.includes(closestParent)) {
-                    return true;
-                }
+        }
+
+        if (!renderedTasks.has(closestParent)) {
+            // This task is a direct or indirect child of another task that we are waiting to draw,
+            // so don't draw it yet, it will be done recursively later.
+            if (tasks.includes(closestParent)) {
+                return true;
             }
         }
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -224,15 +224,11 @@ export class QueryResultsRenderer {
 
             const listItem = await this.addTask(taskList, taskLineRenderer, task, taskIndex, queryRendererParameters);
 
-            const childTasks: Task[] = task.children
-                .filter((listItemOrTask) => {
-                    return listItemOrTask instanceof Task;
-                })
-                .map((listItemThatIsATask) => {
-                    return listItemThatIsATask as Task;
-                });
-            if (childTasks.length > 0) {
-                await this.createTaskList(childTasks, listItem, queryRendererParameters);
+            const numberOfChildTasks = task.children.filter((listItemOrTask) => {
+                return listItemOrTask instanceof Task;
+            }).length;
+            if (numberOfChildTasks > 0) {
+                await this.createTaskList(task.children, listItem, queryRendererParameters);
             }
         }
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -224,6 +224,8 @@ export class QueryResultsRenderer {
                 continue;
             }
 
+            let willBeRenderedLater = false;
+
             // Try to find the closest parent that is a task
             let closestParent = task.parent;
             while (closestParent !== null && !(closestParent instanceof Task)) {
@@ -234,8 +236,12 @@ export class QueryResultsRenderer {
                 // This task is a direct or indirect child of another task that we are waiting to draw,
                 // so don't draw it yet, it will be done recursively later.
                 if (tasks.includes(closestParent)) {
-                    continue;
+                    willBeRenderedLater = true;
                 }
+            }
+
+            if (willBeRenderedLater) {
+                continue;
             }
 
             const listItem = await this.addTaskOrListItem(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -12,6 +12,7 @@ import type { TaskGroups } from '../Query/Group/TaskGroups';
 import type { QueryResult } from '../Query/QueryResult';
 import { postponeButtonTitle, shouldShowPostponeButton } from '../DateTime/Postponer';
 import type { TasksFile } from '../Scripting/TasksFile';
+import type { ListItem } from '../Task/ListItem';
 import { Task } from '../Task/Task';
 import { PostponeMenu } from '../ui/Menus/PostponeMenu';
 import { TaskLineRenderer, type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
@@ -193,7 +194,7 @@ export class QueryResultsRenderer {
     }
 
     private async createTaskList(
-        tasks: Task[],
+        tasks: ListItem[],
         content: HTMLElement,
         queryRendererParameters: QueryRendererParameters,
     ): Promise<void> {
@@ -217,6 +218,10 @@ export class QueryResultsRenderer {
         });
 
         for (const [taskIndex, task] of tasks.entries()) {
+            if (!(task instanceof Task)) {
+                continue;
+            }
+
             const listItem = await this.addTask(taskList, taskLineRenderer, task, taskIndex, queryRendererParameters);
 
             const childTasks: Task[] = task.children

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -249,7 +249,7 @@ export class QueryResultsRenderer {
     }
 
     private willBeRenderedLater(task: ListItem, renderedTasks: Set<ListItem>, tasks: ListItem[]) {
-        let willBeRenderedLater = false;
+        const willBeRenderedLater = false;
 
         // Try to find the closest parent that is a task
         let closestParent = task.parent;
@@ -262,7 +262,7 @@ export class QueryResultsRenderer {
                 // This task is a direct or indirect child of another task that we are waiting to draw,
                 // so don't draw it yet, it will be done recursively later.
                 if (tasks.includes(closestParent)) {
-                    willBeRenderedLater = true;
+                    return true;
                 }
             }
         }

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -233,7 +233,9 @@ export class QueryResultsRenderer {
             if (closestParent && !renderedTasks.has(closestParent)) {
                 // This task is a direct or indirect child of another task that we are waiting to draw,
                 // so don't draw it yet, it will be done recursively later.
-                continue;
+                if (tasks.includes(closestParent)) {
+                    continue;
+                }
             }
 
             const listItem = await this.addTaskOrListItem(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -189,7 +189,8 @@ export class QueryResultsRenderer {
             // will be empty, and no headings will be added.
             await this.addGroupHeadings(content, group.groupHeadings);
 
-            await this.createTaskList(group.tasks, content, queryRendererParameters);
+            const renderedTasks: Set<ListItem> = new Set();
+            await this.createTaskList(group.tasks, content, queryRendererParameters, renderedTasks);
         }
     }
 
@@ -197,6 +198,7 @@ export class QueryResultsRenderer {
         tasks: ListItem[],
         content: HTMLElement,
         queryRendererParameters: QueryRendererParameters,
+        renderedTasks: Set<ListItem>,
     ): Promise<void> {
         const taskList = createAndAppendElement('ul', content);
 
@@ -217,8 +219,6 @@ export class QueryResultsRenderer {
             queryLayoutOptions: this.query.queryLayoutOptions,
         });
 
-        const renderedTasks: Set<ListItem> = new Set();
-
         for (const [taskIndex, task] of tasks.entries()) {
             if (renderedTasks.has(task)) {
                 continue;
@@ -234,7 +234,7 @@ export class QueryResultsRenderer {
             renderedTasks.add(task);
 
             if (task.children.length > 0) {
-                await this.createTaskList(task.children, listItem, queryRendererParameters);
+                await this.createTaskList(task.children, listItem, queryRendererParameters, renderedTasks);
                 task.children.forEach((childTask) => {
                     renderedTasks.add(childTask);
                 });

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -250,19 +250,19 @@ export class QueryResultsRenderer {
 
     private willBeRenderedLater(task: ListItem, renderedTasks: Set<ListItem>, tasks: ListItem[]) {
         // Try to find the closest parent that is a task
-        let closestParent = task.parent;
-        while (closestParent !== null && !(closestParent instanceof Task)) {
-            closestParent = closestParent.parent;
+        let closestParentTask = task.parent;
+        while (closestParentTask !== null && !(closestParentTask instanceof Task)) {
+            closestParentTask = closestParentTask.parent;
         }
 
-        if (!closestParent) {
+        if (!closestParentTask) {
             return false;
         }
 
-        if (!renderedTasks.has(closestParent)) {
+        if (!renderedTasks.has(closestParentTask)) {
             // This task is a direct or indirect child of another task that we are waiting to draw,
             // so don't draw it yet, it will be done recursively later.
-            if (tasks.includes(closestParent)) {
+            if (tasks.includes(closestParentTask)) {
                 return true;
             }
         }

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items.approved.html
@@ -122,51 +122,6 @@
       class="task-list-item plugin-tasks-list-item"
       data-task-priority="normal"
       data-task=""
-      data-line="1"
-      data-task-status-name="Todo"
-      data-task-status-type="TODO">
-      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="1" />
-      <span class="tasks-list-text">
-        <span class="task-description"><span>child 1</span></span>
-      </span>
-      <span class="task-extras">
-        <span class="tasks-backlink">
-          (
-          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-          )
-        </span>
-        <a class="tasks-edit" title="Edit task" href="#"></a>
-      </span>
-      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-        <li
-          class="task-list-item plugin-tasks-list-item"
-          data-task-priority="normal"
-          data-task=""
-          data-line="0"
-          data-task-status-name="Todo"
-          data-task-status-type="TODO">
-          <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
-          <span class="tasks-list-text">
-            <span class="task-description"><span>grandchild 1</span></span>
-          </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              (
-              <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-              )
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
-          <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-            <li>- list item grand grand child</li>
-          </ul>
-        </li>
-      </ul>
-    </li>
-    <li
-      class="task-list-item plugin-tasks-list-item"
-      data-task-priority="normal"
-      data-task=""
       data-line="2"
       data-task-status-name="Todo"
       data-task-status-type="TODO">
@@ -184,53 +139,6 @@
       </span>
       <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
         <li>- list item grand grand child</li>
-      </ul>
-    </li>
-    <li
-      class="task-list-item plugin-tasks-list-item"
-      data-task-priority="normal"
-      data-task=""
-      data-line="3"
-      data-task-status-name="Todo"
-      data-task-status-type="TODO">
-      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="3" />
-      <span class="tasks-list-text">
-        <span class="task-description"><span>child 2</span></span>
-      </span>
-      <span class="task-extras">
-        <span class="tasks-backlink">
-          (
-          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-          )
-        </span>
-        <a class="tasks-edit" title="Edit task" href="#"></a>
-      </span>
-      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-        <li>
-          - non task grandchild
-          <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-            <li
-              class="task-list-item plugin-tasks-list-item"
-              data-task-priority="normal"
-              data-task=""
-              data-line="0"
-              data-task-status-name="Todo"
-              data-task-status-type="TODO">
-              <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
-              <span class="tasks-list-text">
-                <span class="task-description"><span>grand grand child</span></span>
-              </span>
-              <span class="task-extras">
-                <span class="tasks-backlink">
-                  (
-                  <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-                  )
-                </span>
-                <a class="tasks-edit" title="Edit task" href="#"></a>
-              </span>
-            </li>
-          </ul>
-        </li>
       </ul>
     </li>
     <li

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items.approved.html
@@ -122,49 +122,6 @@
       class="task-list-item plugin-tasks-list-item"
       data-task-priority="normal"
       data-task=""
-      data-line="2"
-      data-task-status-name="Todo"
-      data-task-status-type="TODO">
-      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="2" />
-      <span class="tasks-list-text">
-        <span class="task-description"><span>grandchild 1</span></span>
-      </span>
-      <span class="task-extras">
-        <span class="tasks-backlink">
-          (
-          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-          )
-        </span>
-        <a class="tasks-edit" title="Edit task" href="#"></a>
-      </span>
-      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-        <li>- list item grand grand child</li>
-      </ul>
-    </li>
-    <li
-      class="task-list-item plugin-tasks-list-item"
-      data-task-priority="normal"
-      data-task=""
-      data-line="4"
-      data-task-status-name="Todo"
-      data-task-status-type="TODO">
-      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="4" />
-      <span class="tasks-list-text">
-        <span class="task-description"><span>grand grand child</span></span>
-      </span>
-      <span class="task-extras">
-        <span class="tasks-backlink">
-          (
-          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-          )
-        </span>
-        <a class="tasks-edit" title="Edit task" href="#"></a>
-      </span>
-    </li>
-    <li
-      class="task-list-item plugin-tasks-list-item"
-      data-task-priority="normal"
-      data-task=""
       data-line="5"
       data-task-status-name="Todo"
       data-task-status-type="TODO">

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items.approved.html
@@ -59,6 +59,9 @@
                 </span>
                 <a class="tasks-edit" title="Edit task" href="#"></a>
               </span>
+              <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+                <li>- list item grand grand child</li>
+              </ul>
             </li>
           </ul>
         </li>
@@ -81,6 +84,37 @@
             </span>
             <a class="tasks-edit" title="Edit task" href="#"></a>
           </span>
+          <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+            <li>
+              - non task grandchild
+              <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+                <li
+                  class="task-list-item plugin-tasks-list-item"
+                  data-task-priority="normal"
+                  data-task=""
+                  data-line="0"
+                  data-task-status-name="Todo"
+                  data-task-status-type="TODO">
+                  <input
+                    class="task-list-item-checkbox"
+                    type="checkbox"
+                    title="Right-click for options"
+                    data-line="0" />
+                  <span class="tasks-list-text">
+                    <span class="task-description"><span>grand grand child</span></span>
+                  </span>
+                  <span class="task-extras">
+                    <span class="tasks-backlink">
+                      (
+                      <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+                      )
+                    </span>
+                    <a class="tasks-edit" title="Edit task" href="#"></a>
+                  </span>
+                </li>
+              </ul>
+            </li>
+          </ul>
         </li>
       </ul>
     </li>
@@ -123,6 +157,9 @@
             </span>
             <a class="tasks-edit" title="Edit task" href="#"></a>
           </span>
+          <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+            <li>- list item grand grand child</li>
+          </ul>
         </li>
       </ul>
     </li>
@@ -145,6 +182,9 @@
         </span>
         <a class="tasks-edit" title="Edit task" href="#"></a>
       </span>
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+        <li>- list item grand grand child</li>
+      </ul>
     </li>
     <li
       class="task-list-item plugin-tasks-list-item"
@@ -165,6 +205,33 @@
         </span>
         <a class="tasks-edit" title="Edit task" href="#"></a>
       </span>
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+        <li>
+          - non task grandchild
+          <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+            <li
+              class="task-list-item plugin-tasks-list-item"
+              data-task-priority="normal"
+              data-task=""
+              data-line="0"
+              data-task-status-name="Todo"
+              data-task-status-type="TODO">
+              <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+              <span class="tasks-list-text">
+                <span class="task-description"><span>grand grand child</span></span>
+              </span>
+              <span class="task-extras">
+                <span class="tasks-backlink">
+                  (
+                  <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+                  )
+                </span>
+                <a class="tasks-edit" title="Edit task" href="#"></a>
+              </span>
+            </li>
+          </ul>
+        </li>
+      </ul>
     </li>
     <li
       class="task-list-item plugin-tasks-list-item"

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items.approved.html
@@ -19,6 +19,70 @@
         </span>
         <a class="tasks-edit" title="Edit task" href="#"></a>
       </span>
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="normal"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>child 1</span></span>
+          </span>
+          <span class="task-extras">
+            <span class="tasks-backlink">
+              (
+              <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+              )
+            </span>
+            <a class="tasks-edit" title="Edit task" href="#"></a>
+          </span>
+          <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+            <li
+              class="task-list-item plugin-tasks-list-item"
+              data-task-priority="normal"
+              data-task=""
+              data-line="0"
+              data-task-status-name="Todo"
+              data-task-status-type="TODO">
+              <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+              <span class="tasks-list-text">
+                <span class="task-description"><span>grandchild 1</span></span>
+              </span>
+              <span class="task-extras">
+                <span class="tasks-backlink">
+                  (
+                  <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+                  )
+                </span>
+                <a class="tasks-edit" title="Edit task" href="#"></a>
+              </span>
+            </li>
+          </ul>
+        </li>
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="normal"
+          data-task=""
+          data-line="1"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="1" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>child 2</span></span>
+          </span>
+          <span class="task-extras">
+            <span class="tasks-backlink">
+              (
+              <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+              )
+            </span>
+            <a class="tasks-edit" title="Edit task" href="#"></a>
+          </span>
+        </li>
+      </ul>
     </li>
     <li
       class="task-list-item plugin-tasks-list-item"
@@ -39,6 +103,28 @@
         </span>
         <a class="tasks-edit" title="Edit task" href="#"></a>
       </span>
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="normal"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>grandchild 1</span></span>
+          </span>
+          <span class="task-extras">
+            <span class="tasks-backlink">
+              (
+              <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+              )
+            </span>
+            <a class="tasks-edit" title="Edit task" href="#"></a>
+          </span>
+        </li>
+      </ul>
     </li>
     <li
       class="task-list-item plugin-tasks-list-item"

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items_reverse_sorted.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items_reverse_sorted.approved.html
@@ -1,0 +1,136 @@
+<div>
+  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="0"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>parent 2</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="1"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="1" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>grand grand child</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="2"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="2" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>child 2</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+        <li>
+          - non task grandchild
+          <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency"></ul>
+        </li>
+      </ul>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="3"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="3" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>grandchild 1</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+        <li>- list item grand grand child</li>
+      </ul>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="4"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="4" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>child 1</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency"></ul>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="5"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="5" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>parent 1</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency"></ul>
+    </li>
+  </ul>
+  <div class="task-count">6 tasks</div>
+</div>

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items_reverse_sorted.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items_reverse_sorted.approved.html
@@ -1,17 +1,17 @@
 <div>
-    <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-        <li
-            class="task-list-item plugin-tasks-list-item"
-            data-task-priority="normal"
-            data-task=""
-            data-line="5"
-            data-task-status-name="Todo"
-            data-task-status-type="TODO">
-            <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="5" />
-            <span class="tasks-list-text">
+  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="0"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+      <span class="tasks-list-text">
         <span class="task-description"><span>parent 2</span></span>
       </span>
-            <span class="task-extras">
+      <span class="task-extras">
         <span class="tasks-backlink">
           (
           <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
@@ -19,19 +19,19 @@
         </span>
         <a class="tasks-edit" title="Edit task" href="#"></a>
       </span>
-        </li>
-        <li
-            class="task-list-item plugin-tasks-list-item"
-            data-task-priority="normal"
-            data-task=""
-            data-line="0"
-            data-task-status-name="Todo"
-            data-task-status-type="TODO">
-            <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
-            <span class="tasks-list-text">
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="5"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="5" />
+      <span class="tasks-list-text">
         <span class="task-description"><span>parent 1</span></span>
       </span>
-            <span class="task-extras">
+      <span class="task-extras">
         <span class="tasks-backlink">
           (
           <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
@@ -39,19 +39,19 @@
         </span>
         <a class="tasks-edit" title="Edit task" href="#"></a>
       </span>
-            <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-                <li
-                    class="task-list-item plugin-tasks-list-item"
-                    data-task-priority="normal"
-                    data-task=""
-                    data-line="0"
-                    data-task-status-name="Todo"
-                    data-task-status-type="TODO">
-                    <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
-                    <span class="tasks-list-text">
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="normal"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+          <span class="tasks-list-text">
             <span class="task-description"><span>child 1</span></span>
           </span>
-                    <span class="task-extras">
+          <span class="task-extras">
             <span class="tasks-backlink">
               (
               <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
@@ -59,19 +59,19 @@
             </span>
             <a class="tasks-edit" title="Edit task" href="#"></a>
           </span>
-                    <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-                        <li
-                            class="task-list-item plugin-tasks-list-item"
-                            data-task-priority="normal"
-                            data-task=""
-                            data-line="0"
-                            data-task-status-name="Todo"
-                            data-task-status-type="TODO">
-                            <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
-                            <span class="tasks-list-text">
+          <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+            <li
+              class="task-list-item plugin-tasks-list-item"
+              data-task-priority="normal"
+              data-task=""
+              data-line="0"
+              data-task-status-name="Todo"
+              data-task-status-type="TODO">
+              <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+              <span class="tasks-list-text">
                 <span class="task-description"><span>grandchild 1</span></span>
               </span>
-                            <span class="task-extras">
+              <span class="task-extras">
                 <span class="tasks-backlink">
                   (
                   <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
@@ -79,24 +79,24 @@
                 </span>
                 <a class="tasks-edit" title="Edit task" href="#"></a>
               </span>
-                            <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-                                <li>- list item grand grand child</li>
-                            </ul>
-                        </li>
-                    </ul>
-                </li>
-                <li
-                    class="task-list-item plugin-tasks-list-item"
-                    data-task-priority="normal"
-                    data-task=""
-                    data-line="1"
-                    data-task-status-name="Todo"
-                    data-task-status-type="TODO">
-                    <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="1" />
-                    <span class="tasks-list-text">
+              <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+                <li>- list item grand grand child</li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="normal"
+          data-task=""
+          data-line="1"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="1" />
+          <span class="tasks-list-text">
             <span class="task-description"><span>child 2</span></span>
           </span>
-                    <span class="task-extras">
+          <span class="task-extras">
             <span class="tasks-backlink">
               (
               <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
@@ -104,26 +104,26 @@
             </span>
             <a class="tasks-edit" title="Edit task" href="#"></a>
           </span>
-                    <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-                        <li>
-                            - non task grandchild
-                            <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-                                <li
-                                    class="task-list-item plugin-tasks-list-item"
-                                    data-task-priority="normal"
-                                    data-task=""
-                                    data-line="0"
-                                    data-task-status-name="Todo"
-                                    data-task-status-type="TODO">
-                                    <input
-                                        class="task-list-item-checkbox"
-                                        type="checkbox"
-                                        title="Right-click for options"
-                                        data-line="0" />
-                                    <span class="tasks-list-text">
+          <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+            <li>
+              - non task grandchild
+              <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+                <li
+                  class="task-list-item plugin-tasks-list-item"
+                  data-task-priority="normal"
+                  data-task=""
+                  data-line="0"
+                  data-task-status-name="Todo"
+                  data-task-status-type="TODO">
+                  <input
+                    class="task-list-item-checkbox"
+                    type="checkbox"
+                    title="Right-click for options"
+                    data-line="0" />
+                  <span class="tasks-list-text">
                     <span class="task-description"><span>grand grand child</span></span>
                   </span>
-                                    <span class="task-extras">
+                  <span class="task-extras">
                     <span class="tasks-backlink">
                       (
                       <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
@@ -131,13 +131,13 @@
                     </span>
                     <a class="tasks-edit" title="Edit task" href="#"></a>
                   </span>
-                                </li>
-                            </ul>
-                        </li>
-                    </ul>
                 </li>
-            </ul>
+              </ul>
+            </li>
+          </ul>
         </li>
-    </ul>
-    <div class="task-count">6 tasks</div>
+      </ul>
+    </li>
+  </ul>
+  <div class="task-count">6 tasks</div>
 </div>

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items_reverse_sorted.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items_reverse_sorted.approved.html
@@ -1,17 +1,17 @@
 <div>
-  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-    <li
-      class="task-list-item plugin-tasks-list-item"
-      data-task-priority="normal"
-      data-task=""
-      data-line="0"
-      data-task-status-name="Todo"
-      data-task-status-type="TODO">
-      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
-      <span class="tasks-list-text">
+    <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+        <li
+            class="task-list-item plugin-tasks-list-item"
+            data-task-priority="normal"
+            data-task=""
+            data-line="5"
+            data-task-status-name="Todo"
+            data-task-status-type="TODO">
+            <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="5" />
+            <span class="tasks-list-text">
         <span class="task-description"><span>parent 2</span></span>
       </span>
-      <span class="task-extras">
+            <span class="task-extras">
         <span class="tasks-backlink">
           (
           <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
@@ -19,109 +19,19 @@
         </span>
         <a class="tasks-edit" title="Edit task" href="#"></a>
       </span>
-    </li>
-    <li
-      class="task-list-item plugin-tasks-list-item"
-      data-task-priority="normal"
-      data-task=""
-      data-line="1"
-      data-task-status-name="Todo"
-      data-task-status-type="TODO">
-      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="1" />
-      <span class="tasks-list-text">
-        <span class="task-description"><span>grand grand child</span></span>
-      </span>
-      <span class="task-extras">
-        <span class="tasks-backlink">
-          (
-          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-          )
-        </span>
-        <a class="tasks-edit" title="Edit task" href="#"></a>
-      </span>
-    </li>
-    <li
-      class="task-list-item plugin-tasks-list-item"
-      data-task-priority="normal"
-      data-task=""
-      data-line="2"
-      data-task-status-name="Todo"
-      data-task-status-type="TODO">
-      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="2" />
-      <span class="tasks-list-text">
-        <span class="task-description"><span>child 2</span></span>
-      </span>
-      <span class="task-extras">
-        <span class="tasks-backlink">
-          (
-          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-          )
-        </span>
-        <a class="tasks-edit" title="Edit task" href="#"></a>
-      </span>
-      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-        <li>
-          - non task grandchild
-          <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency"></ul>
         </li>
-      </ul>
-    </li>
-    <li
-      class="task-list-item plugin-tasks-list-item"
-      data-task-priority="normal"
-      data-task=""
-      data-line="3"
-      data-task-status-name="Todo"
-      data-task-status-type="TODO">
-      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="3" />
-      <span class="tasks-list-text">
-        <span class="task-description"><span>grandchild 1</span></span>
-      </span>
-      <span class="task-extras">
-        <span class="tasks-backlink">
-          (
-          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-          )
-        </span>
-        <a class="tasks-edit" title="Edit task" href="#"></a>
-      </span>
-      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-        <li>- list item grand grand child</li>
-      </ul>
-    </li>
-    <li
-      class="task-list-item plugin-tasks-list-item"
-      data-task-priority="normal"
-      data-task=""
-      data-line="4"
-      data-task-status-name="Todo"
-      data-task-status-type="TODO">
-      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="4" />
-      <span class="tasks-list-text">
-        <span class="task-description"><span>child 1</span></span>
-      </span>
-      <span class="task-extras">
-        <span class="tasks-backlink">
-          (
-          <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-          )
-        </span>
-        <a class="tasks-edit" title="Edit task" href="#"></a>
-      </span>
-      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency"></ul>
-    </li>
-    <li
-      class="task-list-item plugin-tasks-list-item"
-      data-task-priority="normal"
-      data-task=""
-      data-line="5"
-      data-task-status-name="Todo"
-      data-task-status-type="TODO">
-      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="5" />
-      <span class="tasks-list-text">
+        <li
+            class="task-list-item plugin-tasks-list-item"
+            data-task-priority="normal"
+            data-task=""
+            data-line="0"
+            data-task-status-name="Todo"
+            data-task-status-type="TODO">
+            <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+            <span class="tasks-list-text">
         <span class="task-description"><span>parent 1</span></span>
       </span>
-      <span class="task-extras">
+            <span class="task-extras">
         <span class="tasks-backlink">
           (
           <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
@@ -129,8 +39,105 @@
         </span>
         <a class="tasks-edit" title="Edit task" href="#"></a>
       </span>
-      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency"></ul>
-    </li>
-  </ul>
-  <div class="task-count">6 tasks</div>
+            <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+                <li
+                    class="task-list-item plugin-tasks-list-item"
+                    data-task-priority="normal"
+                    data-task=""
+                    data-line="0"
+                    data-task-status-name="Todo"
+                    data-task-status-type="TODO">
+                    <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+                    <span class="tasks-list-text">
+            <span class="task-description"><span>child 1</span></span>
+          </span>
+                    <span class="task-extras">
+            <span class="tasks-backlink">
+              (
+              <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+              )
+            </span>
+            <a class="tasks-edit" title="Edit task" href="#"></a>
+          </span>
+                    <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+                        <li
+                            class="task-list-item plugin-tasks-list-item"
+                            data-task-priority="normal"
+                            data-task=""
+                            data-line="0"
+                            data-task-status-name="Todo"
+                            data-task-status-type="TODO">
+                            <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+                            <span class="tasks-list-text">
+                <span class="task-description"><span>grandchild 1</span></span>
+              </span>
+                            <span class="task-extras">
+                <span class="tasks-backlink">
+                  (
+                  <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+                  )
+                </span>
+                <a class="tasks-edit" title="Edit task" href="#"></a>
+              </span>
+                            <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+                                <li>- list item grand grand child</li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+                <li
+                    class="task-list-item plugin-tasks-list-item"
+                    data-task-priority="normal"
+                    data-task=""
+                    data-line="1"
+                    data-task-status-name="Todo"
+                    data-task-status-type="TODO">
+                    <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="1" />
+                    <span class="tasks-list-text">
+            <span class="task-description"><span>child 2</span></span>
+          </span>
+                    <span class="task-extras">
+            <span class="tasks-backlink">
+              (
+              <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+              )
+            </span>
+            <a class="tasks-edit" title="Edit task" href="#"></a>
+          </span>
+                    <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+                        <li>
+                            - non task grandchild
+                            <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+                                <li
+                                    class="task-list-item plugin-tasks-list-item"
+                                    data-task-priority="normal"
+                                    data-task=""
+                                    data-line="0"
+                                    data-task-status-name="Todo"
+                                    data-task-status-type="TODO">
+                                    <input
+                                        class="task-list-item-checkbox"
+                                        type="checkbox"
+                                        title="Right-click for options"
+                                        data-line="0" />
+                                    <span class="tasks-list-text">
+                    <span class="task-description"><span>grand grand child</span></span>
+                  </span>
+                                    <span class="task-extras">
+                    <span class="tasks-backlink">
+                      (
+                      <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
+                      )
+                    </span>
+                    <a class="tasks-edit" title="Edit task" href="#"></a>
+                  </span>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </li>
+    </ul>
+    <div class="task-count">6 tasks</div>
 </div>

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_should_render_tasks_without_their_parents.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_should_render_tasks_without_their_parents.approved.html
@@ -1,0 +1,4 @@
+<div>
+  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency"></ul>
+  <div class="task-count">3 tasks</div>
+</div>

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_should_render_tasks_without_their_parents.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_should_render_tasks_without_their_parents.approved.html
@@ -1,4 +1,65 @@
 <div>
-  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency"></ul>
+  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="0"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>grandchild task 1</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">inheritance_task_2listitem_3task</a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="1"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="1" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>grandchild task 2</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">inheritance_task_2listitem_3task</a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="2"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="2" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>grandchild task 3</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">inheritance_task_2listitem_3task</a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
+  </ul>
   <div class="task-count">3 tasks</div>
 </div>

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -7,6 +7,7 @@ import { State } from '../../src/Obsidian/Cache';
 import { QueryResultsRenderer } from '../../src/Renderer/QueryResultsRenderer';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 import { inheritance_rendering_sample } from '../Obsidian/__test_data__/inheritance_rendering_sample';
+import { inheritance_task_2listitem_3task } from '../Obsidian/__test_data__/inheritance_task_2listitem_3task';
 import { readTasksFromSimulatedFile } from '../Obsidian/SimulatedFile';
 import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
 import { prettifyHTML } from '../TestingTools/HTMLHelpers';
@@ -62,5 +63,11 @@ describe('QueryResultsRenderer tests', () => {
     it('parent-child items reverse sorted', async () => {
         const allTasks = readTasksFromSimulatedFile(inheritance_rendering_sample);
         await verifyRenderedTasksHTML(allTasks, 'sort by function reverse task.lineNumber');
+    });
+
+    it('should render tasks without their parents', async () => {
+        // example chosen to match subtasks whose parents do not match the query
+        const allTasks = readTasksFromSimulatedFile(inheritance_task_2listitem_3task);
+        await verifyRenderedTasksHTML(allTasks, 'description includes grandchild');
     });
 });

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -58,4 +58,9 @@ describe('QueryResultsRenderer tests', () => {
         const allTasks = readTasksFromSimulatedFile(inheritance_rendering_sample);
         await verifyRenderedTasksHTML(allTasks);
     });
+
+    it('parent-child items reverse sorted', async () => {
+        const allTasks = readTasksFromSimulatedFile(inheritance_rendering_sample);
+        await verifyRenderedTasksHTML(allTasks, 'sort by function reverse task.lineNumber');
+    });
 });

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -56,7 +56,7 @@ describe('QueryResultsRenderer tests', () => {
 
     it('parent-child items', async () => {
         const allTasks = readTasksFromSimulatedFile(inheritance_rendering_sample);
-        await verifyRenderedTasksHTML(allTasks);
+        await verifyRenderedTasksHTML(allTasks, 'sort by function task.lineNumber');
     });
 
     it('parent-child items reverse sorted', async () => {

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -25,10 +25,10 @@ afterEach(() => {
 });
 
 describe('QueryResultsRenderer tests', () => {
-    async function verifyRenderedTasksHTML(allTasks: Task[]) {
+    async function verifyRenderedTasksHTML(allTasks: Task[], source: string = '') {
         const renderer = new QueryResultsRenderer(
             'block-language-tasks',
-            '',
+            source,
             new TasksFile('query.md'),
             () => Promise.resolve(),
             null,

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -59,7 +59,7 @@ describe('QueryResultsRenderer tests', () => {
         await verifyRenderedTasksHTML(allTasks, 'sort by function task.lineNumber');
     });
 
-    it.failing('parent-child items reverse sorted', async () => {
+    it('parent-child items reverse sorted', async () => {
         const allTasks = readTasksFromSimulatedFile(inheritance_rendering_sample);
         await verifyRenderedTasksHTML(allTasks, 'sort by function reverse task.lineNumber');
     });

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -59,7 +59,7 @@ describe('QueryResultsRenderer tests', () => {
         await verifyRenderedTasksHTML(allTasks, 'sort by function task.lineNumber');
     });
 
-    it('parent-child items reverse sorted', async () => {
+    it.failing('parent-child items reverse sorted', async () => {
         const allTasks = readTasksFromSimulatedFile(inheritance_rendering_sample);
         await verifyRenderedTasksHTML(allTasks, 'sort by function reverse task.lineNumber');
     });


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: #60 

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- task query results now render all child list items and tasks of the tasks that match the search
- this is an experimental feature that needs more testing to ensure that it really does show every matching task

## Motivation and Context

- #60 

## How has this been tested?

- new unit tests
- exploratory testing

## Screenshots

<img width="307" alt="Снимок экрана 2024-10-14 в 18 15 49" src="https://github.com/user-attachments/assets/6ffa56ad-6c9d-4c6d-88d1-6a46426334d1">


## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
