### PR TITLE
fix: sub-list items now render OK - no bullet, number, callout/blockquote etc

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Callouts and Block Quotes.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Callouts and Block Quotes.md
@@ -35,6 +35,7 @@ sort by description
 ## 2 Vanilla
 
 - [ ] #task Task 1 Vanilla
+  - Child list item of 'Task 1 Vanilla'
 - [ ] #task Task 2 Vanilla
 
 ## 3 Callout
@@ -42,6 +43,7 @@ sort by description
 > [!NOTE]
 >
 > - [ ] #task Task 1 Callout
+>   - Child list item of 'Task 1 Callout'
 > - [ ] #task Task 2 Callout
 
 ### 3.1 Callout containing Blockquote
@@ -49,12 +51,14 @@ sort by description
 > [!NOTE]
 > >
 > > - [ ] #task Task 1 Callout containing Blockquote
+> >   - Child list item of 'Task 1 Callout containing Blockquote'
 > > - [ ] #task Task 2 Callout containing Blockquote
 >
 
 ## 4 Blockquote
 
 > - [ ] #task Task 1 Blockquote
+>   - Child list item of 'Task 1 Blockquote'
 > - [ ] #task Task 2 Blockquote
 
 ### 4.1 Blockquote containing Callout
@@ -62,6 +66,7 @@ sort by description
 > > [!NOTE]
 > >
 > > - [ ] #task Task 1 Blockquote containing Callout
+> >   - Child list item of 'Task 1 Blockquote containing Callout'
 > > - [ ] #task Task 2 Blockquote containing Callout
 
 ## 5 Numbered task in unordered list
@@ -82,4 +87,5 @@ x - [ ] #task  wibble
 ### 6.1 Task in numbered list
 
 1. [ ] #task Task 1 Task in numbered list
+    1. Child list item of 'Task 1 Task in numbered list'
 2. [ ] #task Task 2 Task in numbered list

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -290,7 +290,7 @@ export class QueryResultsRenderer {
 
     private addListItem(taskList: HTMLUListElement, listItem: ListItem) {
         const li = createAndAppendElement('li', taskList);
-        li.textContent = listItem.originalMarkdown;
+        li.textContent = listItem.description;
         return li;
     }
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -10,7 +10,7 @@ export class ListItem {
     public readonly description: string;
 
     constructor(originalMarkdown: string, parent: ListItem | null) {
-        this.description = originalMarkdown;
+        this.description = originalMarkdown.replace(/^- /, '');
         this.originalMarkdown = originalMarkdown;
         this.parent = parent;
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -1,3 +1,5 @@
+import { TaskRegularExpressions } from './TaskRegularExpressions';
+
 export class ListItem {
     /** The original line read from file.
      *
@@ -10,7 +12,7 @@ export class ListItem {
     public readonly description: string;
 
     constructor(originalMarkdown: string, parent: ListItem | null) {
-        this.description = originalMarkdown.replace(/^\s*- /, '');
+        this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         this.originalMarkdown = originalMarkdown;
         this.parent = parent;
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -7,8 +7,10 @@ export class ListItem {
 
     public readonly parent: ListItem | null = null;
     public readonly children: ListItem[] = [];
+    public readonly description: string;
 
     constructor(originalMarkdown: string, parent: ListItem | null) {
+        this.description = originalMarkdown;
         this.originalMarkdown = originalMarkdown;
         this.parent = parent;
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -10,7 +10,7 @@ export class ListItem {
     public readonly description: string;
 
     constructor(originalMarkdown: string, parent: ListItem | null) {
-        this.description = originalMarkdown.replace(/^- /, '');
+        this.description = originalMarkdown.replace(/^\s*- /, '');
         this.originalMarkdown = originalMarkdown;
         this.parent = parent;
 

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items.approved.html
@@ -60,7 +60,7 @@
                 <a class="tasks-edit" title="Edit task" href="#"></a>
               </span>
               <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-                <li>- list item grand grand child</li>
+                <li>list item grand grand child</li>
               </ul>
             </li>
           </ul>
@@ -86,7 +86,7 @@
           </span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li>
-              - non task grandchild
+              non task grandchild
               <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
                 <li
                   class="task-list-item plugin-tasks-list-item"

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items_reverse_sorted.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items_reverse_sorted.approved.html
@@ -80,7 +80,7 @@
                 <a class="tasks-edit" title="Edit task" href="#"></a>
               </span>
               <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-                <li>- list item grand grand child</li>
+                <li>list item grand grand child</li>
               </ul>
             </li>
           </ul>
@@ -106,7 +106,7 @@
           </span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li>
-              - non task grandchild
+              non task grandchild
               <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
                 <li
                   class="task-list-item plugin-tasks-list-item"

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -82,6 +82,12 @@ describe('list item tests', () => {
         expect(listItem.description).toEqual('the dash should not be in the description');
     });
 
+    it('should parse description from indented markdown line', () => {
+        const listItem = new ListItem('    - do stuff', null);
+        expect(listItem.originalMarkdown).toEqual('    - do stuff');
+        expect(listItem.description).toEqual('do stuff');
+    });
+
     it.failing('should parse description from numbered list', () => {
         const listItem = new ListItem('17. the number and the dot should not be in the description', null);
         expect(listItem.originalMarkdown).toEqual('17. the number and the dot should not be in the description');

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -78,12 +78,12 @@ describe('list item tests', () => {
 
     it.each([
         ['- ', true],
-        ['* ', false],
-        ['+ ', false],
-        ['17. ', false],
+        ['* ', true],
+        ['+ ', true],
+        ['17. ', true],
         ['    - ', true],
-        ['>   - ', false],
-        ['> >   - ', false],
+        ['>   - ', true],
+        ['> >   - ', true],
     ])('should parse description with list item prefix: "%s"', (prefix: string, shouldPass) => {
         const description = 'stuff';
         const line = prefix + description;

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -78,8 +78,12 @@ describe('list item tests', () => {
 
     it.each([
         ['- ', true],
-        ['    - ', true],
+        ['* ', false],
+        ['+ ', false],
         ['17. ', false],
+        ['    - ', true],
+        ['>   - ', false],
+        ['> >   - ', false],
     ])('should parse description with list item prefix: "%s"', (prefix: string, shouldPass) => {
         const description = 'stuff';
         const line = prefix + description;

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -80,7 +80,7 @@ describe('list item tests', () => {
         ['- ', true],
         ['    - ', true],
         ['17. ', false],
-    ])('list item description: "%s"', (prefix: string, shouldPass) => {
+    ])('should parse description with list item prefix: "%s"', (prefix: string, shouldPass) => {
         const description = 'stuff';
         const line = prefix + description;
         const listItem = new ListItem(line, null);

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -79,6 +79,6 @@ describe('list item tests', () => {
     it('should parse description from markdown line', () => {
         const listItem = new ListItem('- the dash should not be in the description', null);
         expect(listItem.originalMarkdown).toEqual('- the dash should not be in the description');
-        expect(listItem.description).toEqual('- the dash should not be in the description');
+        expect(listItem.description).toEqual('the dash should not be in the description');
     });
 });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -81,4 +81,10 @@ describe('list item tests', () => {
         expect(listItem.originalMarkdown).toEqual('- the dash should not be in the description');
         expect(listItem.description).toEqual('the dash should not be in the description');
     });
+
+    it.failing('should parse description from numbered list', () => {
+        const listItem = new ListItem('17. the number and the dot should not be in the description', null);
+        expect(listItem.originalMarkdown).toEqual('17. the number and the dot should not be in the description');
+        expect(listItem.description).toEqual('the number and the dot should not be in the description');
+    });
 });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -77,15 +77,18 @@ describe('list item tests', () => {
     });
 
     it.each([
-        ['- the dash should not be in the description', 'the dash should not be in the description'],
-        ['    - do stuff', 'do stuff'],
-        [
-            '17. the number and the dot should not be in the description',
-            '17. the number and the dot should not be in the description',
-        ],
-    ])('list item description: "%s"', (line: string, expectedDescription: string) => {
+        ['- ', true],
+        ['    - ', true],
+        ['17. ', false],
+    ])('list item description: "%s"', (prefix: string, shouldPass) => {
+        const description = 'stuff';
+        const line = prefix + description;
         const listItem = new ListItem(line, null);
         expect(listItem.originalMarkdown).toEqual(line);
-        expect(listItem.description).toEqual(expectedDescription);
+        if (shouldPass) {
+            expect(listItem.description).toEqual(description);
+        } else {
+            expect(listItem.description).not.toEqual(description);
+        }
     });
 });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -75,4 +75,10 @@ describe('list item tests', () => {
         expect(parent.isRoot).toEqual(false);
         expect(child.isRoot).toEqual(false);
     });
+
+    it('should parse description from markdown line', () => {
+        const listItem = new ListItem('- the dash should not be in the description', null);
+        expect(listItem.originalMarkdown).toEqual('- the dash should not be in the description');
+        expect(listItem.description).toEqual('- the dash should not be in the description');
+    });
 });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -76,21 +76,16 @@ describe('list item tests', () => {
         expect(child.isRoot).toEqual(false);
     });
 
-    it('should parse description from markdown line', () => {
-        const listItem = new ListItem('- the dash should not be in the description', null);
-        expect(listItem.originalMarkdown).toEqual('- the dash should not be in the description');
-        expect(listItem.description).toEqual('the dash should not be in the description');
-    });
-
-    it('should parse description from indented markdown line', () => {
-        const listItem = new ListItem('    - do stuff', null);
-        expect(listItem.originalMarkdown).toEqual('    - do stuff');
-        expect(listItem.description).toEqual('do stuff');
-    });
-
-    it.failing('should parse description from numbered list', () => {
-        const listItem = new ListItem('17. the number and the dot should not be in the description', null);
-        expect(listItem.originalMarkdown).toEqual('17. the number and the dot should not be in the description');
-        expect(listItem.description).toEqual('the number and the dot should not be in the description');
+    it.each([
+        ['- the dash should not be in the description', 'the dash should not be in the description'],
+        ['    - do stuff', 'do stuff'],
+        [
+            '17. the number and the dot should not be in the description',
+            '17. the number and the dot should not be in the description',
+        ],
+    ])('list item description: "%s"', (line: string, expectedDescription: string) => {
+        const listItem = new ListItem(line, null);
+        expect(listItem.originalMarkdown).toEqual(line);
+        expect(listItem.description).toEqual(expectedDescription);
     });
 });


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- render the proper description of list items without the list bullet, number, etc.

## Motivation and Context

- #60 

## How has this been tested?

- unit tests
- exploratory testing

## Screenshots

<img width="1196" alt="image" src="https://github.com/user-attachments/assets/f37d139e-f92c-4ac0-84d1-76f34b2b331d">


## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
