### PR TITLE
fix: recur correctly at start of Daylight Savings Time

### DIFF
--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -151,7 +151,7 @@ export class Recurrence {
         // calculates in UTC.
         // The timezone is added again before returning the next date.
         after.utc(true);
-        let next = window.moment(rrule.after(after.toDate()));
+        let next = window.moment.utc(rrule.after(after.toDate()));
 
         // If this is a monthly recurrence, treat it special.
         const asText = this.toText();
@@ -261,11 +261,11 @@ export class Recurrence {
         options.dtstart = after.startOf('day').toDate();
         rrule = new RRule(options);
 
-        return window.moment(rrule.after(after.toDate()));
+        return window.moment.utc(rrule.after(after.toDate()));
     }
 
     private static addTimezone(date: Moment): Moment {
-        const localTimeZone = window.moment.utc(date).local(true);
+        const localTimeZone = window.moment.utc(date).add(12, 'hours').local(true);
 
         return localTimeZone.startOf('day');
     }

--- a/src/Task/Recurrence.ts
+++ b/src/Task/Recurrence.ts
@@ -265,7 +265,11 @@ export class Recurrence {
     }
 
     private static addTimezone(date: Moment): Moment {
-        const localTimeZone = window.moment.utc(date).add(12, 'hours').local(true);
+        // Moment's local(true) method has a bug where it returns incorrect result if the input is of
+        // the day of the year when DST kicks in and the time of day is before DST actually kicks in
+        // (typically between midnight and very early morning, varying across geographies).
+        // We workaround the bug by setting the time of day to noon before calling local(true)
+        const localTimeZone = window.moment.utc(date).set({hour:12,minute:0,second:0,millisecond:0}).local(true);
 
         return localTimeZone.startOf('day');
     }


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

`moment().local(true)` incorrectly handles the early hours of the day on which DST is entered into. This PR is a workaround for that bug by doing the conversion at noon instead of midnight. Additionally it also replaces the incorrect use of `window.moment` with `window.moment.utc` when the intending to work with UTC time.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2309

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested the individual functions used with example inputs in a node interpreter.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
