### PR TITLE
fix: rerender search results when child list items are edited

### DIFF
--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -377,7 +377,7 @@ export class Cache {
 
         // If there are no changes in any of the tasks, there's
         // nothing to do, so just return.
-        if (Task.tasksListsIdentical(oldTasks, newTasks)) {
+        if (ListItem.listsAreIdentical(oldTasks, newTasks)) {
             // This code kept for now, to allow for debugging during development.
             // It is too verbose to release to users.
             // if (this.getState() == State.Warm) {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -48,4 +48,8 @@ export class ListItem {
     get isRoot(): boolean {
         return this.parent === null;
     }
+
+    identicalTo(_other: ListItem) {
+        return true;
+    }
 }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -58,7 +58,11 @@ export class ListItem {
             return false;
         }
 
-        return this.originalMarkdown === other.originalMarkdown;
+        if (this.originalMarkdown !== other.originalMarkdown) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -63,13 +63,13 @@ export class ListItem {
 
     /**
      * Compare two lists of ListItem objects, and report whether their
-     * tasks are identical in the same order.
+     * contents, including any children, are identical and in the same order.
      *
      * This can be useful for optimising code if it is guaranteed that
      * there are no possible differences in the tasks in a file
      * after an edit, for example.
      *
-     * If any field is different in any task, it will return false.
+     * If any field is different in any task or list item, it will return false.
      *
      * @param list1
      * @param list2

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -50,6 +50,10 @@ export class ListItem {
     }
 
     identicalTo(other: ListItem) {
+        if (this.constructor.name !== other.constructor.name) {
+            return false;
+        }
+
         if (this.children.length !== other.children.length) {
             return false;
         }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -58,11 +58,7 @@ export class ListItem {
             return false;
         }
 
-        if (!ListItem.listsAreIdentical(this.children, other.children)) {
-            return false;
-        }
-
-        return true;
+        return ListItem.listsAreIdentical(this.children, other.children);
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -54,10 +54,6 @@ export class ListItem {
             return false;
         }
 
-        if (this.children.length !== other.children.length) {
-            return false;
-        }
-
         if (!ListItem.listsAreIdentical(this.children, other.children)) {
             return false;
         }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -49,6 +49,15 @@ export class ListItem {
         return this.parent === null;
     }
 
+    /**
+     * Compare all the fields in another ListItem, to detect any differences from this one.
+     *
+     * If any field is different in any way, it will return false.
+     *
+     * @note Use {@link Task.identicalTo} to compare {@link Task} objects.
+     *
+     * @param other - if this is in fact a {@link Task}, the result of false.
+     */
     identicalTo(other: ListItem) {
         if (this.constructor.name !== other.constructor.name) {
             return false;

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -49,7 +49,7 @@ export class ListItem {
         return this.parent === null;
     }
 
-    identicalTo(_other: ListItem) {
-        return true;
+    identicalTo(other: ListItem) {
+        return this.originalMarkdown === other.originalMarkdown;
     }
 }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -58,7 +58,7 @@ export class ListItem {
             return false;
         }
 
-        if (!ListItem.listItemListsIdentical(this.children, other.children)) {
+        if (!ListItem.listsAreIdentical(this.children, other.children)) {
             return false;
         }
 
@@ -78,7 +78,7 @@ export class ListItem {
      * @param list1
      * @param list2
      */
-    static listItemListsIdentical(list1: ListItem[], list2: ListItem[]) {
+    static listsAreIdentical(list1: ListItem[], list2: ListItem[]) {
         if (list1.length !== list2.length) {
             return false;
         }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -54,11 +54,11 @@ export class ListItem {
             return false;
         }
 
-        if (!ListItem.listsAreIdentical(this.children, other.children)) {
+        if (this.originalMarkdown !== other.originalMarkdown) {
             return false;
         }
 
-        if (this.originalMarkdown !== other.originalMarkdown) {
+        if (!ListItem.listsAreIdentical(this.children, other.children)) {
             return false;
         }
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -54,6 +54,10 @@ export class ListItem {
             return false;
         }
 
+        if (!ListItem.listItemListsIdentical(this.children, other.children)) {
+            return false;
+        }
+
         return this.originalMarkdown === other.originalMarkdown;
     }
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -50,6 +50,10 @@ export class ListItem {
     }
 
     identicalTo(other: ListItem) {
+        if (this.children.length !== other.children.length) {
+            return false;
+        }
+
         return this.originalMarkdown === other.originalMarkdown;
     }
 }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -78,7 +78,7 @@ export class ListItem {
      * @param list1
      * @param list2
      */
-    static listsAreIdentical(list1: ListItem[], list2: ListItem[]) {
+    static listsAreIdentical(list1: ListItem[], list2: ListItem[]): boolean {
         if (list1.length !== list2.length) {
             return false;
         }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -56,4 +56,25 @@ export class ListItem {
 
         return this.originalMarkdown === other.originalMarkdown;
     }
+
+    /**
+     * Compare two lists of ListItem objects, and report whether their
+     * tasks are identical in the same order.
+     *
+     * This can be useful for optimising code if it is guaranteed that
+     * there are no possible differences in the tasks in a file
+     * after an edit, for example.
+     *
+     * If any field is different in any task, it will return false.
+     *
+     * @param list1
+     * @param list2
+     */
+    static listItemListsIdentical(list1: ListItem[], list2: ListItem[]) {
+        if (list1.length !== list2.length) {
+            return false;
+        }
+
+        return list1.every((item, index) => item.identicalTo(list2[index]));
+    }
 }

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -798,7 +798,7 @@ export class Task extends ListItem {
      * @param newTasks
      */
     static tasksListsIdentical(oldTasks: Task[], newTasks: Task[]): boolean {
-        return ListItem.listItemListsIdentical(oldTasks, newTasks);
+        return ListItem.listsAreIdentical(oldTasks, newTasks);
     }
 
     /**

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -798,10 +798,7 @@ export class Task extends ListItem {
      * @param newTasks
      */
     static tasksListsIdentical(oldTasks: Task[], newTasks: Task[]): boolean {
-        if (oldTasks.length !== newTasks.length) {
-            return false;
-        }
-        return oldTasks.every((oldTask, index) => oldTask.identicalTo(newTasks[index]));
+        return ListItem.listItemListsIdentical(oldTasks, newTasks);
     }
 
     /**

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -859,10 +859,6 @@ export class Task extends ListItem {
             return false;
         }
 
-        if (this.children.length !== other.children.length) {
-            return false;
-        }
-
         return this.file.rawFrontmatterIdenticalTo(other.file);
     }
 

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -816,6 +816,10 @@ export class Task extends ListItem {
      * @param other
      */
     public identicalTo(other: Task) {
+        if (!super.identicalTo(other)) {
+            return false;
+        }
+
         // NEW_TASK_FIELD_EDIT_REQUIRED
 
         // Based on ideas from koala. AquaCat and javalent in Discord:

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -875,6 +875,10 @@ export class Task extends ListItem {
             return false;
         }
 
+        if (this.children.length !== other.children.length) {
+            return false;
+        }
+
         return this.file.rawFrontmatterIdenticalTo(other.file);
     }
 

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -785,23 +785,6 @@ export class Task extends ListItem {
     }
 
     /**
-     * Compare two lists of Task objects, and report whether their
-     * tasks are identical in the same order.
-     *
-     * This can be useful for optimising code if it is guaranteed that
-     * there are no possible differences in the tasks in a file
-     * after an edit, for example.
-     *
-     * If any field is different in any task, it will return false.
-     *
-     * @param oldTasks
-     * @param newTasks
-     */
-    static tasksListsIdentical(oldTasks: Task[], newTasks: Task[]): boolean {
-        return ListItem.listsAreIdentical(oldTasks, newTasks);
-    }
-
-    /**
      * Compare all the fields in another Task, to detect any differences from this one.
      *
      * If any field is different in any way, it will return false.

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -796,6 +796,7 @@ export class Task extends ListItem {
      * @param other
      */
     public identicalTo(other: Task) {
+        // First compare child Task and ListItem objects, and any other data in ListItem:
         if (!super.identicalTo(other)) {
             return false;
         }

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -119,3 +119,29 @@ describe('identicalTo', () => {
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 });
+
+describe('checking if list item lists are identical', () => {
+    it('should treat empty lists as identical', () => {
+        const list1: ListItem[] = [];
+        const list2: ListItem[] = [];
+        expect(ListItem.listItemListsIdentical(list1, list2)).toBe(true);
+    });
+
+    it('should treat different sized lists as different', () => {
+        const list1: ListItem[] = [];
+        const list2: ListItem[] = [new ListItem('- x', null)];
+        expect(ListItem.listItemListsIdentical(list1, list2)).toBe(false);
+    });
+
+    it('should detect matching tasks as same', () => {
+        const list1: ListItem[] = [new ListItem('- 1', null)];
+        const list2: ListItem[] = [new ListItem('- 1', null)];
+        expect(ListItem.listItemListsIdentical(list1, list2)).toBe(true);
+    });
+
+    it('- should detect non-matching tasks as different', () => {
+        const list1: ListItem[] = [new ListItem('- 1', null)];
+        const list2: ListItem[] = [new ListItem('- 2', null)];
+        expect(ListItem.listItemListsIdentical(list1, list2)).toBe(false);
+    });
+});

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -118,6 +118,16 @@ describe('identicalTo', () => {
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
+
+    it('should recognise list items with different children', () => {
+        const item1 = new ListItem('- item', null);
+        new ListItem('- child of item1', item1);
+
+        const item2 = new ListItem('- item', null);
+        new ListItem('- child of item2', item2);
+
+        expect(item2.identicalTo(item1)).toEqual(false);
+    });
 });
 
 describe('checking if list item lists are identical', () => {

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -142,24 +142,24 @@ describe('checking if list item lists are identical', () => {
     it('should treat empty lists as identical', () => {
         const list1: ListItem[] = [];
         const list2: ListItem[] = [];
-        expect(ListItem.listItemListsIdentical(list1, list2)).toBe(true);
+        expect(ListItem.listsAreIdentical(list1, list2)).toBe(true);
     });
 
     it('should treat different sized lists as different', () => {
         const list1: ListItem[] = [];
         const list2: ListItem[] = [new ListItem('- x', null)];
-        expect(ListItem.listItemListsIdentical(list1, list2)).toBe(false);
+        expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 
     it('should detect matching list items as same', () => {
         const list1: ListItem[] = [new ListItem('- 1', null)];
         const list2: ListItem[] = [new ListItem('- 1', null)];
-        expect(ListItem.listItemListsIdentical(list1, list2)).toBe(true);
+        expect(ListItem.listsAreIdentical(list1, list2)).toBe(true);
     });
 
     it('- should detect non-matching list items as different', () => {
         const list1: ListItem[] = [new ListItem('- 1', null)];
         const list2: ListItem[] = [new ListItem('- 2', null)];
-        expect(ListItem.listItemListsIdentical(list1, list2)).toBe(false);
+        expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -96,3 +96,11 @@ describe('list item tests', () => {
         }
     });
 });
+
+describe('identicalTo', () => {
+    it('should test the description', () => {
+        const listItem1 = new ListItem('same description', null);
+        const listItem2 = new ListItem('same description', null);
+        expect(listItem1.identicalTo(listItem2)).toEqual(true);
+    });
+});

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -6,6 +6,7 @@ import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Task } from '../../src/Task/Task';
 import { TaskLocation } from '../../src/Task/TaskLocation';
 import { ListItem } from '../../src/Task/ListItem';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { fromLine } from '../TestingTools/TestHelpers';
 
 window.moment = moment;
@@ -160,6 +161,32 @@ describe('checking if list item lists are identical', () => {
     it('- should detect non-matching list items as different', () => {
         const list1: ListItem[] = [new ListItem('- 1', null)];
         const list2: ListItem[] = [new ListItem('- 2', null)];
+        expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
+    });
+});
+
+describe('checking if task lists are identical', () => {
+    it('should treat empty lists as identical', () => {
+        const list1: Task[] = [];
+        const list2: Task[] = [];
+        expect(ListItem.listsAreIdentical(list1, list2)).toBe(true);
+    });
+
+    it('should treat different sized lists as different', () => {
+        const list1: Task[] = [];
+        const list2: Task[] = [new TaskBuilder().build()];
+        expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
+    });
+
+    it('should detect matching tasks as same', () => {
+        const list1: Task[] = [new TaskBuilder().description('1').build()];
+        const list2: Task[] = [new TaskBuilder().description('1').build()];
+        expect(ListItem.listsAreIdentical(list1, list2)).toBe(true);
+    });
+
+    it('should detect non-matching tasks as different', () => {
+        const list1: Task[] = [new TaskBuilder().description('1').build()];
+        const list2: Task[] = [new TaskBuilder().description('2').build()];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -115,7 +115,7 @@ describe('identicalTo', () => {
 
     it('should recognise list items with different number of children', () => {
         const item1 = new ListItem('- item', null);
-        new ListItem('- child of item1', item1);
+        createChildListItem('- child of item1', item1);
 
         const item2 = new ListItem('- item', null);
 
@@ -127,7 +127,7 @@ describe('identicalTo', () => {
         createChildListItem('- child of item1', item1);
 
         const item2 = new ListItem('- item', null);
-        new ListItem('- child of item2', item2);
+        createChildListItem('- child of item2', item2);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -6,6 +6,7 @@ import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Task } from '../../src/Task/Task';
 import { TaskLocation } from '../../src/Task/TaskLocation';
 import { ListItem } from '../../src/Task/ListItem';
+import { fromLine } from '../TestingTools/TestHelpers';
 
 window.moment = moment;
 
@@ -127,6 +128,13 @@ describe('identicalTo', () => {
         new ListItem('- child of item2', item2);
 
         expect(item2.identicalTo(item1)).toEqual(false);
+    });
+
+    it('should recognise ListItem and Task as different', () => {
+        const listItem = new ListItem('- [ ] description', null);
+        const task = fromLine({ line: '- [ ] description' });
+
+        expect(listItem.identicalTo(task)).toEqual(false);
     });
 });
 

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -143,13 +143,13 @@ describe('checking if list item lists are identical', () => {
         expect(ListItem.listItemListsIdentical(list1, list2)).toBe(false);
     });
 
-    it('should detect matching tasks as same', () => {
+    it('should detect matching list items as same', () => {
         const list1: ListItem[] = [new ListItem('- 1', null)];
         const list2: ListItem[] = [new ListItem('- 1', null)];
         expect(ListItem.listItemListsIdentical(list1, list2)).toBe(true);
     });
 
-    it('- should detect non-matching tasks as different', () => {
+    it('- should detect non-matching list items as different', () => {
         const list1: ListItem[] = [new ListItem('- 1', null)];
         const list2: ListItem[] = [new ListItem('- 2', null)];
         expect(ListItem.listItemListsIdentical(list1, list2)).toBe(false);

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -109,4 +109,13 @@ describe('identicalTo', () => {
         const listItem2 = new ListItem('- description two', null);
         expect(listItem1.identicalTo(listItem2)).toEqual(false);
     });
+
+    it('should recognise list items with different number of children', () => {
+        const item1 = new ListItem('- item', null);
+        new ListItem('- child of item1', item1);
+
+        const item2 = new ListItem('- item', null);
+
+        expect(item2.identicalTo(item1)).toEqual(false);
+    });
 });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -190,3 +190,15 @@ describe('checking if task lists are identical', () => {
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 });
+
+describe('checking if mixed lists are identical', () => {
+    it('should recognise mixed lists as unequal', () => {
+        const list1 = [new ListItem('- [ ] description', null)];
+        const list2 = [fromLine({ line: '- [ ] description' })];
+
+        expect(ListItem.listsAreIdentical(list1, list1)).toEqual(true);
+        expect(ListItem.listsAreIdentical(list1, list2)).toEqual(false);
+        expect(ListItem.listsAreIdentical(list2, list1)).toEqual(false);
+        expect(ListItem.listsAreIdentical(list2, list2)).toEqual(true);
+    });
+});

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -99,6 +99,12 @@ describe('list item tests', () => {
     });
 });
 
+function createChildListItem(originalMarkdown: string, item1: ListItem) {
+    // This exists purely to silence WebStorm about typescript:S1848
+    // See https://sonarcloud.io/organizations/obsidian-tasks-group/rules?open=typescript%3AS1848&rule_key=typescript%3AS1848
+    new ListItem(originalMarkdown, item1);
+}
+
 describe('identicalTo', () => {
     it('should test same markdown', () => {
         const listItem1 = new ListItem('- same description', null);
@@ -123,7 +129,7 @@ describe('identicalTo', () => {
 
     it('should recognise list items with different children', () => {
         const item1 = new ListItem('- item', null);
-        new ListItem('- child of item1', item1);
+        createChildListItem('- child of item1', item1);
 
         const item2 = new ListItem('- item', null);
         new ListItem('- child of item2', item2);

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -8,6 +8,7 @@ import { TaskLocation } from '../../src/Task/TaskLocation';
 import { ListItem } from '../../src/Task/ListItem';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { fromLine } from '../TestingTools/TestHelpers';
+import { createChildListItem } from './ListItemHelpers';
 
 window.moment = moment;
 
@@ -98,12 +99,6 @@ describe('list item tests', () => {
         }
     });
 });
-
-function createChildListItem(originalMarkdown: string, item1: ListItem) {
-    // This exists purely to silence WebStorm about typescript:S1848
-    // See https://sonarcloud.io/organizations/obsidian-tasks-group/rules?open=typescript%3AS1848&rule_key=typescript%3AS1848
-    new ListItem(originalMarkdown, item1);
-}
 
 describe('identicalTo', () => {
     it('should test same markdown', () => {

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -98,9 +98,15 @@ describe('list item tests', () => {
 });
 
 describe('identicalTo', () => {
-    it('should test the description', () => {
-        const listItem1 = new ListItem('same description', null);
-        const listItem2 = new ListItem('same description', null);
+    it('should test same markdown', () => {
+        const listItem1 = new ListItem('- same description', null);
+        const listItem2 = new ListItem('- same description', null);
         expect(listItem1.identicalTo(listItem2)).toEqual(true);
+    });
+
+    it('should test different markdown', () => {
+        const listItem1 = new ListItem('- description', null);
+        const listItem2 = new ListItem('- description two', null);
+        expect(listItem1.identicalTo(listItem2)).toEqual(false);
     });
 });

--- a/tests/Task/ListItemHelpers.ts
+++ b/tests/Task/ListItemHelpers.ts
@@ -1,0 +1,7 @@
+import { ListItem } from '../../src/Task/ListItem';
+
+export function createChildListItem(originalMarkdown: string, item1: ListItem) {
+    // This exists purely to silence WebStorm about typescript:S1848
+    // See https://sonarcloud.io/organizations/obsidian-tasks-group/rules?open=typescript%3AS1848&rule_key=typescript%3AS1848
+    new ListItem(originalMarkdown, item1);
+}

--- a/tests/Task/ListItemHelpers.ts
+++ b/tests/Task/ListItemHelpers.ts
@@ -1,7 +1,7 @@
 import { ListItem } from '../../src/Task/ListItem';
 
-export function createChildListItem(originalMarkdown: string, item1: ListItem) {
+export function createChildListItem(originalMarkdown: string, parent: ListItem) {
     // This exists purely to silence WebStorm about typescript:S1848
     // See https://sonarcloud.io/organizations/obsidian-tasks-group/rules?open=typescript%3AS1848&rule_key=typescript%3AS1848
-    new ListItem(originalMarkdown, item1);
+    new ListItem(originalMarkdown, parent);
 }

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -1748,7 +1748,4 @@ describe('identicalTo', () => {
 
         expect(task2.identicalTo(task1)).toEqual(false);
     });
-
-    // 2 list items differ both have children but...
-    // ...one has a child and one doesn't
 });

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -1752,29 +1752,3 @@ describe('identicalTo', () => {
     // 2 list items differ both have children but...
     // ...one has a child and one doesn't
 });
-
-describe('checking if task lists are identical', () => {
-    it('should treat empty lists as identical', () => {
-        const list1: Task[] = [];
-        const list2: Task[] = [];
-        expect(ListItem.listsAreIdentical(list1, list2)).toBe(true);
-    });
-
-    it('should treat different sized lists as different', () => {
-        const list1: Task[] = [];
-        const list2: Task[] = [new TaskBuilder().build()];
-        expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
-    });
-
-    it('should detect matching tasks as same', () => {
-        const list1: Task[] = [new TaskBuilder().description('1').build()];
-        const list2: Task[] = [new TaskBuilder().description('1').build()];
-        expect(ListItem.listsAreIdentical(list1, list2)).toBe(true);
-    });
-
-    it('should detect non-matching tasks as different', () => {
-        const list1: Task[] = [new TaskBuilder().description('1').build()];
-        const list2: Task[] = [new TaskBuilder().description('2').build()];
-        expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
-    });
-});

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -1740,14 +1740,13 @@ describe('identicalTo', () => {
         expect(task2.identicalTo(task1)).toEqual(false);
     });
 
-    it.failing('should recognise different description in child list items', () => {
+    it('should recognise different description in child list items', () => {
         const task1 = new TaskBuilder().build();
         const task2 = new TaskBuilder().build();
         new ListItem('- child of task1', task1);
         new ListItem('- child of task2', task2);
 
         expect(task2.identicalTo(task1)).toEqual(false);
-        expect(1).toEqual(2);
     });
 
     // 2 list items differ both have children but...

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -1739,6 +1739,19 @@ describe('identicalTo', () => {
 
         expect(task2.identicalTo(task1)).toEqual(false);
     });
+
+    it.failing('should recognise different description in child list items', () => {
+        const task1 = new TaskBuilder().build();
+        const task2 = new TaskBuilder().build();
+        new ListItem('- child of task1', task1);
+        new ListItem('- child of task2', task2);
+
+        expect(task2.identicalTo(task1)).toEqual(false);
+        expect(1).toEqual(2);
+    });
+
+    // 2 list items differ both have children but...
+    // ...one has a child and one doesn't
 });
 
 describe('checking if task lists are identical', () => {

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -5,6 +5,7 @@ import moment from 'moment';
 import { verifyAll } from 'approvals/lib/Providers/Jest/JestApprovals';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Status } from '../../src/Statuses/Status';
+import { ListItem } from '../../src/Task/ListItem';
 import { Task } from '../../src/Task/Task';
 import { resetSettings, updateSettings } from '../../src/Config/Settings';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
@@ -1729,6 +1730,14 @@ describe('identicalTo', () => {
 
         expect(task2.status.identicalTo(task1.status)).toEqual(true);
         expect(task2.identicalTo(task1)).toEqual(true);
+    });
+
+    it('should recognise different numbers of child items', () => {
+        const task1 = new TaskBuilder().build();
+        const task2 = new TaskBuilder().build();
+        new ListItem('- child of task2', task2);
+
+        expect(task2.identicalTo(task1)).toEqual(false);
     });
 });
 

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -5,7 +5,6 @@ import moment from 'moment';
 import { verifyAll } from 'approvals/lib/Providers/Jest/JestApprovals';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Status } from '../../src/Statuses/Status';
-import { ListItem } from '../../src/Task/ListItem';
 import { Task } from '../../src/Task/Task';
 import { resetSettings, updateSettings } from '../../src/Config/Settings';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
@@ -23,6 +22,7 @@ import type { TasksDate } from '../../src/DateTime/TasksDate';
 import { example_kanban } from '../Obsidian/__test_data__/example_kanban';
 import { jason_properties } from '../Obsidian/__test_data__/jason_properties';
 import { OnCompletion } from '../../src/Task/OnCompletion';
+import { createChildListItem } from './ListItemHelpers';
 
 window.moment = moment;
 
@@ -1735,7 +1735,7 @@ describe('identicalTo', () => {
     it('should recognise different numbers of child items', () => {
         const task1 = new TaskBuilder().build();
         const task2 = new TaskBuilder().build();
-        new ListItem('- child of task2', task2);
+        createChildListItem('- child of task2', task2);
 
         expect(task2.identicalTo(task1)).toEqual(false);
     });
@@ -1743,8 +1743,8 @@ describe('identicalTo', () => {
     it('should recognise different description in child list items', () => {
         const task1 = new TaskBuilder().build();
         const task2 = new TaskBuilder().build();
-        new ListItem('- child of task1', task1);
-        new ListItem('- child of task2', task2);
+        createChildListItem('- child of task1', task1);
+        createChildListItem('- child of task2', task2);
 
         expect(task2.identicalTo(task1)).toEqual(false);
     });

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -1757,24 +1757,24 @@ describe('checking if task lists are identical', () => {
     it('should treat empty lists as identical', () => {
         const list1: Task[] = [];
         const list2: Task[] = [];
-        expect(Task.tasksListsIdentical(list1, list2)).toBe(true);
+        expect(ListItem.listsAreIdentical(list1, list2)).toBe(true);
     });
 
     it('should treat different sized lists as different', () => {
         const list1: Task[] = [];
         const list2: Task[] = [new TaskBuilder().build()];
-        expect(Task.tasksListsIdentical(list1, list2)).toBe(false);
+        expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 
     it('should detect matching tasks as same', () => {
         const list1: Task[] = [new TaskBuilder().description('1').build()];
         const list2: Task[] = [new TaskBuilder().description('1').build()];
-        expect(Task.tasksListsIdentical(list1, list2)).toBe(true);
+        expect(ListItem.listsAreIdentical(list1, list2)).toBe(true);
     });
 
     it('should detect non-matching tasks as different', () => {
         const list1: Task[] = [new TaskBuilder().description('1').build()];
         const list2: Task[] = [new TaskBuilder().description('2').build()];
-        expect(Task.tasksListsIdentical(list1, list2)).toBe(false);
+        expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 });


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- make cache update when there are differences in child list items
- make Task check child list items

## Motivation and Context

- #60 

## How has this been tested?

- unit tests
- manual test in local vault

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
