### PR TITLE
fix: 'on completion' delete now renders correctly in Live Preview

### DIFF
--- a/src/Obsidian/LivePreviewExtension.ts
+++ b/src/Obsidian/LivePreviewExtension.ts
@@ -90,19 +90,6 @@ class LivePreviewExtension implements PluginValue {
         });
         this.view.dispatch(transaction);
 
-        // Dirty workaround.
-        // While the code in this method properly updates the `checked` state
-        // of the target checkbox, some Obsidian internals revert the state.
-        // This means that the checkbox would remain in its original `checked`
-        // state (`true` or `false`), even though the underlying document
-        // updates correctly.
-        // As a "fix", we set the checkbox's `checked` state *again* after a
-        // timeout to revert Obsidian's wrongful reversal.
-        const desiredCheckedStatus = target.checked;
-        setTimeout(() => {
-            target.checked = desiredCheckedStatus;
-        }, 1);
-
         return true;
     }
 }


### PR DESCRIPTION


# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3043

## Description

This fixes #3043 by removing some code which appears no longer to be necessary, and which caused '🏁 delete' in Live Preview to render the new task as DONE, even though in the markdown it was correctly TODO.

This is a revert of the behaviour added in 73d910490e1882dfb2d22ea0f53bfec42b357c96

## Motivation and Context

- #3043

## How has this been tested?

In the test vault:

- By running through the smoke tests in Live Preview to make sure they still work
- By running through the reproduction I added in https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3043#issuecomment-2393969888

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
