### PR TITLE
fix: Correct the direct toggling of non-recurring tasks in Live Preview

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
@@ -58,25 +58,27 @@ Work through all the tasks below, until zero tasks remain in this query:
 
 ## The Smoke Tests
 
-### Completion of tasks
+### Toggling tasks
+
+#### Completion of tasks
 
 - [ ] #task Mark this task complete in **Source view** using **Tasks: Toggle task done** command
 - [ ] #task Mark this task complete by clicking on it in **Reading view**
-- [ ] #task Mark this task complete by clicking on it in **Live Preview**
+- [ ] #task Mark this task complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly==
 - [ ] #task **check**: Checked all above methods for **completing tasks** - and they worked
 
-### Un-completion of tasks
+#### Un-completion of tasks
 
 <!-- markdownlint-disable ul-style -->
 
 * [x] #task Mark this task not complete in **Source view** using **Tasks: Toggle task done** command ✅ 2022-07-05
 * [x] #task Mark this task not complete by clicking on it in **Reading view** ✅ 2022-07-05
-* [x] #task Mark this task not complete by clicking on it in **Live Preview** ✅ 2022-07-05
+* [x] #task Mark this task not complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== ✅ 2022-07-05
 * [ ] #task **check**: Checked all above methods for **un-completing tasks** - and they worked
 
 <!-- markdownlint-enable ul-style -->
 
-### Recurring Tasks
+#### Recurring Tasks
 
 Confirm that when a recurring task is completed, a new task is created, all the date fields are incremented, and the indentation is unchanged.
 
@@ -84,11 +86,31 @@ Confirm that when a recurring task is completed, a new task is created, all the 
 >
 > - [ ] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19
 >
-> > - [ ] #task Complete this recurring task in **Reading view**🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19
+> > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19
 
-- [ ] #task Complete this recurring task in **Live Preview**🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19
+- [ ] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19
 
 > - [ ] #task **check**: Checked all above steps for **recurring tasks** worked
+
+### On Completion
+
+#### On Completion Delete: Non-recurring tasks
+
+Confirm that the **task line is deleted**.
+
+- [ ] #task Complete this auto-deleting non-recurring task in **Source view** using **Tasks: Toggle task done** command 🏁 delete 📅 2024-10-27
+- [ ] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27
+- [ ] #task Complete this auto-deleting non-recurring task in **Live Preview** 🏁 delete 📅 2024-10-27
+- [ ] #task **check**: Checked all above steps for **auto-deleting non-recurring tasks** worked
+
+#### On Completion Delete: Recurring Tasks
+
+Confirm that when an auto-deleting recurring task is completed, a **new task is created replacing the old task**, and the checkbox remains not-done.
+
+- [ ] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-27
+- [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27
+- [ ] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-27
+- [ ] #task **check**: Checked all above steps for **auto-deleting recurring tasks** worked
 
 ### Rendering of Task Blocks
 

--- a/src/Obsidian/LivePreviewExtension.ts
+++ b/src/Obsidian/LivePreviewExtension.ts
@@ -90,6 +90,19 @@ class LivePreviewExtension implements PluginValue {
         });
         this.view.dispatch(transaction);
 
+        // Dirty workaround.
+        // While the code in this method properly updates the `checked` state
+        // of the target checkbox, some Obsidian internals revert the state.
+        // This means that the checkbox would remain in its original `checked`
+        // state (`true` or `false`), even though the underlying document
+        // updates correctly.
+        // As a "fix", we set the checkbox's `checked` state *again* after a
+        // timeout to revert Obsidian's wrongful reversal.
+        const desiredCheckedStatus = target.checked;
+        setTimeout(() => {
+            target.checked = desiredCheckedStatus;
+        }, 1);
+
         return true;
     }
 }

--- a/src/Obsidian/LivePreviewExtension.ts
+++ b/src/Obsidian/LivePreviewExtension.ts
@@ -98,7 +98,8 @@ class LivePreviewExtension implements PluginValue {
         // updates correctly.
         // As a "fix", we set the checkbox's `checked` state *explicitly* after a
         // timeout in case we need to revert Obsidian's possibly wrongful reversal.
-        if (toggled.length === 1) {
+        const needToForceCheckedProperty = toggled.length === 1;
+        if (needToForceCheckedProperty) {
             // The smoke tests show the workaround is only needed when the event replaces
             // a single task line.
             // (When one task line becomes two because of recurrence, both the

--- a/src/Obsidian/LivePreviewExtension.ts
+++ b/src/Obsidian/LivePreviewExtension.ts
@@ -96,12 +96,21 @@ class LivePreviewExtension implements PluginValue {
         // This means that the checkbox would remain in its original `checked`
         // state (`true` or `false`), even though the underlying document
         // updates correctly.
-        // As a "fix", we set the checkbox's `checked` state *again* after a
-        // timeout to revert Obsidian's wrongful reversal.
-        const desiredCheckedStatus = target.checked;
-        setTimeout(() => {
-            target.checked = desiredCheckedStatus;
-        }, 1);
+        // As a "fix", we set the checkbox's `checked` state *explicitly* after a
+        // timeout in case we need to revert Obsidian's possibly wrongful reversal.
+        if (toggled.length === 1) {
+            // The smoke tests show the workaround is only needed when the event replaces
+            // a single task line.
+            // (When one task line becomes two because of recurrence, both the
+            // edited task lines are rendered correctly by this code)
+            // Since the advent of 'on completion: delete', we cannot rely on the
+            // event target's opinion of the new status, as that facility means
+            // that the new status *may* be different from that in the event.
+            const desiredCheckedStatus = toggled[0].status.symbol !== ' ';
+            setTimeout(() => {
+                target.checked = desiredCheckedStatus;
+            }, 1);
+        }
 
         return true;
     }


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3148
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

## Description

My fix for #3043 - in #3145 - inadvertently broke the more common case of toggling non-recurring tasks in Live Preview mode.

This change:
 
- Reverts #3145
- And then refines the logic in the original code for the addition of 'on completion: delete', to fix the check-box state after direct toggling of non-recurring tasks in Live Preview
- Adds some smoke tests to ensure that the behaviour in Live Preview is tested and remains working.

## Motivation and Context

Fixes #3148.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- New smoke tests
    - Tested with values of the  'Recurring tasks' order setting
    - Tested with a 3-state status set - TODO -> IN_PROGRESS -> DONE
- Exploratory testing in the test vault


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
