### PR TITLE
fix: ! Prevent Tasks getting stuck 'Loading Tasks...' (again)

### DIFF
--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -43,43 +43,43 @@ export function getTasksFromFileContent2(
     let sectionIndex = 0;
     const line2ListItem: Map<number, ListItem> = new Map();
     for (const listItem of listItems) {
+        const lineNumber = listItem.position.start.line;
+        if (lineNumber >= linesInFile) {
+            /*
+                Obsidian CachedMetadata has told us that there is a task on lineNumber, but there are
+                not that many lines in the file.
+
+                This was the underlying cause of all the 'Stuck on "Loading Tasks..."' messages,
+                as it resulted in the line 'undefined' being parsed.
+
+                Somehow the file had been shortened whilst Obsidian was closed, meaning that
+                when Obsidian started up, it got the new file content, but still had the old cached
+                data about locations of list items in the file.
+             */
+            logger.debug(
+                `${filePath} Obsidian gave us a line number ${lineNumber} past the end of the file. ${linesInFile}.`,
+            );
+            return tasks;
+        }
+        if (currentSection === null || currentSection.position.end.line < lineNumber) {
+            // We went past the current section (or this is the first task).
+            // Find the section that is relevant for this task and the following of the same section.
+            currentSection = Cache.getSection(lineNumber, fileCache.sections);
+            sectionIndex = 0;
+        }
+
+        if (currentSection === null) {
+            // Cannot process a task without a section.
+            continue;
+        }
+
+        const line = fileLines[lineNumber];
+        if (line === undefined) {
+            logger.debug(`${filePath}: line ${lineNumber} - ignoring 'undefined' line.`);
+            continue;
+        }
+
         if (listItem.task !== undefined) {
-            const lineNumber = listItem.position.start.line;
-            if (lineNumber >= linesInFile) {
-                /*
-                    Obsidian CachedMetadata has told us that there is a task on lineNumber, but there are
-                    not that many lines in the file.
-
-                    This was the underlying cause of all the 'Stuck on "Loading Tasks..."' messages,
-                    as it resulted in the line 'undefined' being parsed.
-
-                    Somehow the file had been shortened whilst Obsidian was closed, meaning that
-                    when Obsidian started up, it got the new file content, but still had the old cached
-                    data about locations of list items in the file.
-                 */
-                logger.debug(
-                    `${filePath} Obsidian gave us a line number ${lineNumber} past the end of the file. ${linesInFile}.`,
-                );
-                return tasks;
-            }
-            if (currentSection === null || currentSection.position.end.line < lineNumber) {
-                // We went past the current section (or this is the first task).
-                // Find the section that is relevant for this task and the following of the same section.
-                currentSection = Cache.getSection(lineNumber, fileCache.sections);
-                sectionIndex = 0;
-            }
-
-            if (currentSection === null) {
-                // Cannot process a task without a section.
-                continue;
-            }
-
-            const line = fileLines[lineNumber];
-            if (line === undefined) {
-                logger.debug(`${filePath}: line ${lineNumber} - ignoring 'undefined' line.`);
-                continue;
-            }
-
             let task;
             try {
                 task = Task.fromLine({


### PR DESCRIPTION

This essentially moves the code from PR #1524 to an outer scope, so that it is also applied in the new parsing code for creating ListItem objects.

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
    - See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3156

## Description

### The problem

I discovered previously that, at startup, Obsidian's cached data could sometimes refer to no-longer-existent lines, which previously resulted in Tasks trying to create a task object from invalid data.

The same issue has occurred with creating `ListItem` objects - reported by 3 users here in GitHub, and 2 in Discord (which may or may not be the same people).

I've logged reproduction steps in https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3156#issuecomment-2444696600

### The fix

This fix essentially moves the code from PR #1524 to an outer scope, so that it is also applied in the new parsing code for creating `ListItem` objects.

## Motivation and Context

- Fixes #3156
- Fixes #3153
- Fixes #3157

## How has this been tested?

- By ensuring the steps described in https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3156#issuecomment-2444696600 now work, in the test vault
- By running the smoke tests

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
