### PR TITLE
docs: Document Obsidian 1.7.2 Live Preview line continuation bug

### DIFF
--- a/docs/Queries/Line Continuations.md
+++ b/docs/Queries/Line Continuations.md
@@ -115,3 +115,19 @@ Points to note:
 > | `description includes something\` | `description includes something\\` |
 >
 > For details, see [[Line Continuations#Searches needing a trailing backslash|Searches needing a trailing backslash]] in [[Line Continuations]].
+
+## Appendix: Avoid trailing backslashes at the very end of a search code block
+
+> [!Warning]
+> Since Obsidian 1.7.2, placing a **final backslash (`\`) character** just before the end of a code block may cause the query to return all tasks in the vault in the Live Preview mode instead of performing the intended query. The query will still work as intended in Reading Mode. For vaults with many tasks, this may manifest as unusually slow query processing times in Live Preview mode. Before updating from an earlier version of Obsidian to Obsidian 1.7.2 or later, remove final backslashes at the very end of tasks code block queries:
+> 
+> For example:
+>
+> | Old instruction       | Use this instruction instead |
+> | --------------------  | ---------------------------- |
+> | ```` ```tasks ````    | ```` ```tasks ````           |
+> | `{start of query}\\`  | `{start of query}\\`         |
+> | `{continued query}\\` | `{continued query}\\`        |
+> | `{end of query}\\`    | `{end of query}`             |
+> | ```` ``` ````         | ```` ``` ````                |
+> 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
  - **WARNING: If the link is absent, the PR may be closed without review**, due to the workload that such reviews usually require.
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

See #3137. From that discussion, I added an appendix entry to this indicating the Live Preview behavior change since (I believe) Obsidian 1.7.2 that leads to malformed queries *only in Live Preview mode*. This upstream Obsidian bug ([reported here](https://forum.obsidian.md/t/bug-report-markdowncodeblockprocessor-adds-extra-newline-when-in-reading-mode/90197)) affects Obsidian Tasks code blocks and can manifest as surprisingly slow queries running to return all tasks in the vault.

The culprit may be  [Obsidian 1.7.2](https://obsidian.md/changelog/2024-09-19-desktop-v1.7.2/), judging by the changelog entry `Live preview now only escapes special characters (not letters and numbers).`.

See [my comment](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3137#issuecomment-2450608678) and [this comment](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3137#issuecomment-2448586854) for more detail.

## Motivation and Context

In #3137 it was determined that this is an upstream bug, but Tasks users using line continuations will be affected in surprising ways nonetheless, so perhaps it's worth documenting.

## How has this been tested?

Just a documentation change. Not tested.

## Screenshots (if appropriate)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
- [ ] Before merging this documentation change, verify that Obsidian v1.7.2 really is the culprit here, but it does seem to be the case

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
