### PR TITLE
refactor: test `DateEditor` svelte component

### DIFF
--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -10,7 +10,8 @@
     export let forwardOnly: boolean;
     export let accesskey: string | null;
 
-    let parsedDate: string;
+    // Use this for testing purposes only
+    export let parsedDate: string = '';
     // let inputElement: HTMLInputElement;
     // let flatpickrInstance: any;
     //

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -110,21 +110,11 @@ describe('date editor wrapper tests', () => {
     });
 
     it('should replace an empty date field with typed abbreviation', async () => {
-        const { container } = renderDateEditorWrapper();
-        const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
-        const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(
-            container,
-            'dueDateFromDateEditor',
-        );
-        const parsedDateFromDateEditor = getAndCheckRenderedElement<HTMLInputElement>(
-            container,
-            'parsedDateFromDateEditor',
-        );
-
-        await fireEvent.input(dueDateInput, { target: { value: 'tm ' } });
-
-        expect(dueDateInput.value).toEqual('tomorrow');
-        expect(dueDateFromDateEditorInput.value).toEqual('tomorrow');
-        expect(parsedDateFromDateEditor.value).toEqual('2024-04-21');
+        await testTypingInput({
+            userTyped: 'tm ',
+            expectedLeftText: 'tomorrow',
+            expectedRightText: '2024-04-21',
+            expectedReturnedDate: 'tomorrow',
+        });
     });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -45,7 +45,7 @@ function renderDateEditorWrapper(componentOptions: { forwardOnly: boolean }) {
 
     expect(() => container).toBeTruthy();
 
-    return { result, container };
+    return { container };
 }
 
 beforeEach(() => {

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -47,6 +47,15 @@ function renderDateEditorWrapper() {
     return { result, container };
 }
 
+beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-04-20'));
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
+
 describe('date editor wrapper tests', () => {
     it('should replace an empty date field with typed date value', async () => {
         const { container } = renderDateEditorWrapper();
@@ -63,5 +72,22 @@ describe('date editor wrapper tests', () => {
 
         expect(dueDateInput.value).toEqual('2024-10-01');
         expect(dueDateFromDateEditorInput.value).toEqual('2024-10-01');
+    });
+
+    it('should replace an empty date field with typed abbreviation', async () => {
+        const { container } = renderDateEditorWrapper();
+        const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
+        const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(
+            container,
+            'dueDateFromDateEditor',
+        );
+
+        expect(dueDateInput.value).toEqual('');
+        expect(dueDateFromDateEditorInput.value).toEqual('');
+
+        await fireEvent.input(dueDateInput, { target: { value: 'tm ' } });
+
+        expect(dueDateInput.value).toEqual('tomorrow');
+        expect(dueDateFromDateEditorInput.value).toEqual('tomorrow');
     });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -39,8 +39,8 @@ describe('date editor tests', () => {
     });
 });
 
-function renderDateEditorWrapper() {
-    const result: RenderResult<DateEditorWrapper> = render(DateEditorWrapper, { forwardOnly: true });
+function renderDateEditorWrapper(componentOptions: { forwardOnly: boolean }) {
+    const result: RenderResult<DateEditorWrapper> = render(DateEditorWrapper, componentOptions);
 
     const { container } = result;
     expect(() => container).toBeTruthy();
@@ -61,18 +61,21 @@ function testInputValue(container: HTMLElement, inputId: string, expectedText: s
     expect(input.value).toEqual(expectedText);
 }
 
-async function testTypingInput({
-    userTyped,
-    expectedLeftText,
-    expectedRightText,
-    expectedReturnedDate,
-}: {
-    userTyped: string;
-    expectedLeftText: string;
-    expectedRightText: string;
-    expectedReturnedDate: string;
-}) {
-    const { container } = renderDateEditorWrapper();
+async function testTypingInput(
+    {
+        userTyped,
+        expectedLeftText,
+        expectedRightText,
+        expectedReturnedDate,
+    }: {
+        userTyped: string;
+        expectedLeftText: string;
+        expectedRightText: string;
+        expectedReturnedDate: string;
+    },
+    { forwardOnly }: { forwardOnly: boolean } = { forwardOnly: true },
+) {
+    const { container } = renderDateEditorWrapper({ forwardOnly });
 
     const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
     await fireEvent.input(dueDateInput, { target: { value: userTyped } });
@@ -84,7 +87,7 @@ async function testTypingInput({
 
 describe('date editor wrapper tests', () => {
     it('should initialise fields correctly', () => {
-        const { container } = renderDateEditorWrapper();
+        const { container } = renderDateEditorWrapper({ forwardOnly: true });
 
         testInputValue(container, 'due', '');
         testInputValue(container, 'parsedDateFromDateEditor', '<i>no due date</i>');
@@ -125,5 +128,17 @@ describe('date editor wrapper tests', () => {
             expectedRightText: '2024-04-26',
             expectedReturnedDate: 'friday',
         });
+    });
+
+    it('should select a backward/earlier date', async () => {
+        await testTypingInput(
+            {
+                userTyped: 'friday',
+                expectedLeftText: 'friday',
+                expectedRightText: '2024-04-19',
+                expectedReturnedDate: 'friday',
+            },
+            { forwardOnly: false },
+        );
     });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -122,12 +122,15 @@ describe('date editor wrapper tests', () => {
     });
 
     it('should select a forward date', async () => {
-        await testTypingInput({
-            userTyped: 'friday',
-            expectedLeftText: 'friday',
-            expectedRightText: '2024-04-26',
-            expectedReturnedDate: 'friday',
-        });
+        await testTypingInput(
+            {
+                userTyped: 'friday',
+                expectedLeftText: 'friday',
+                expectedRightText: '2024-04-26',
+                expectedReturnedDate: 'friday',
+            },
+            { forwardOnly: true },
+        );
     });
 
     it('should select a backward/earlier date', async () => {

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -78,8 +78,8 @@ async function testTypingInput({
     await fireEvent.input(dueDateInput, { target: { value: userTyped } });
 
     expect(dueDateInput.value).toEqual(expectedLeftText);
-    expect(dueDateFromDateEditorInput.value).toEqual(expectedReturnedDate);
     expect(parsedDateFromDateEditor.value).toEqual(expectedRightText);
+    expect(dueDateFromDateEditorInput.value).toEqual(expectedReturnedDate);
 }
 
 describe('date editor wrapper tests', () => {

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+import { type RenderResult, render } from '@testing-library/svelte';
+import moment from 'moment/moment';
+import { TASK_FORMATS } from '../../src/Config/Settings';
+import DateEditor from '../../src/ui/DateEditor.svelte';
+
+import { getAndCheckRenderedElement } from './RenderingTestHelpers';
+
+window.moment = moment;
+
+function renderDateEditor() {
+    const result: RenderResult<DateEditor> = render(DateEditor, {
+        id: 'due',
+        dateSymbol: TASK_FORMATS.tasksPluginEmoji.taskSerializer.symbols.dueDateSymbol,
+        date: '',
+        isDateValid: true,
+        forwardOnly: true,
+        accesskey: 'D',
+    });
+
+    const { container } = result;
+    expect(() => container).toBeTruthy();
+    return { result, container };
+}
+
+describe('date editor tests', () => {
+    it('should render and read input value', () => {
+        const { container } = renderDateEditor();
+        const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
+
+        expect(dueDateInput.value).toEqual('');
+    });
+});

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -56,6 +56,11 @@ afterEach(() => {
     jest.useRealTimers();
 });
 
+function testInputValue(container: HTMLElement, inputId: string, expectedText: string) {
+    const input = getAndCheckRenderedElement<HTMLInputElement>(container, inputId);
+    expect(input.value).toEqual(expectedText);
+}
+
 async function testTypingInput({
     userTyped,
     expectedLeftText,
@@ -74,11 +79,7 @@ async function testTypingInput({
 
     expect(dueDateInput.value).toEqual(expectedLeftText);
 
-    const parsedDateFromDateEditor = getAndCheckRenderedElement<HTMLInputElement>(
-        container,
-        'parsedDateFromDateEditor',
-    );
-    expect(parsedDateFromDateEditor.value).toEqual(expectedRightText);
+    testInputValue(container, 'parsedDateFromDateEditor', expectedRightText);
 
     const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'dueDateFromDateEditor');
     expect(dueDateFromDateEditorInput.value).toEqual(expectedReturnedDate);

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -56,12 +56,17 @@ afterEach(() => {
     jest.useRealTimers();
 });
 
-async function testTypingInput(
-    userTyped: string,
-    expectedLeftText: string,
-    expectedRightText: string,
-    expectedReturnedDate: string,
-) {
+async function testTypingInput({
+    userTyped,
+    expectedLeftText,
+    expectedRightText,
+    expectedReturnedDate,
+}: {
+    userTyped: string;
+    expectedLeftText: string;
+    expectedRightText: string;
+    expectedReturnedDate: string;
+}) {
     const { container } = renderDateEditorWrapper();
     const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
     const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'dueDateFromDateEditor');
@@ -96,12 +101,12 @@ describe('date editor wrapper tests', () => {
     });
 
     it('should replace an empty date field with typed date value', async () => {
-        const userTyped = '2024-10-01';
-        const expectedLeftText = '2024-10-01';
-        const expectedRightText = '2024-10-01';
-        const expectedReturnedDate = '2024-10-01';
-
-        await testTypingInput(userTyped, expectedLeftText, expectedRightText, expectedReturnedDate);
+        await testTypingInput({
+            userTyped: '2024-10-01',
+            expectedLeftText: '2024-10-01',
+            expectedRightText: '2024-10-01',
+            expectedReturnedDate: '2024-10-01',
+        });
     });
 
     it('should replace an empty date field with typed abbreviation', async () => {

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -41,9 +41,10 @@ describe('date editor tests', () => {
 
 function renderDateEditorWrapper(componentOptions: { forwardOnly: boolean }) {
     const result: RenderResult<DateEditorWrapper> = render(DateEditorWrapper, componentOptions);
-
     const { container } = result;
+
     expect(() => container).toBeTruthy();
+
     return { result, container };
 }
 

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -44,7 +44,7 @@ function renderDateEditorWrapper(componentOptions: { forwardOnly: boolean }) {
 
     expect(() => container).toBeTruthy();
 
-    return { container };
+    return container;
 }
 
 beforeEach(() => {
@@ -75,7 +75,7 @@ async function testTypingInput(
     },
     { forwardOnly }: { forwardOnly: boolean } = { forwardOnly: true },
 ) {
-    const { container } = renderDateEditorWrapper({ forwardOnly });
+    const container = renderDateEditorWrapper({ forwardOnly });
 
     const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
     await fireEvent.input(dueDateInput, { target: { value: userTyped } });
@@ -87,7 +87,7 @@ async function testTypingInput(
 
 describe('date editor wrapper tests', () => {
     it('should initialise fields correctly', () => {
-        const { container } = renderDateEditorWrapper({ forwardOnly: true });
+        const container = renderDateEditorWrapper({ forwardOnly: true });
 
         testInputValue(container, 'due', '');
         testInputValue(container, 'parsedDateFromDateEditor', '<i>no due date</i>');

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -68,17 +68,19 @@ async function testTypingInput({
     expectedReturnedDate: string;
 }) {
     const { container } = renderDateEditorWrapper();
+
     const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
-    const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'dueDateFromDateEditor');
+    await fireEvent.input(dueDateInput, { target: { value: userTyped } });
+
+    expect(dueDateInput.value).toEqual(expectedLeftText);
+
     const parsedDateFromDateEditor = getAndCheckRenderedElement<HTMLInputElement>(
         container,
         'parsedDateFromDateEditor',
     );
-
-    await fireEvent.input(dueDateInput, { target: { value: userTyped } });
-
-    expect(dueDateInput.value).toEqual(expectedLeftText);
     expect(parsedDateFromDateEditor.value).toEqual(expectedRightText);
+
+    const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'dueDateFromDateEditor');
     expect(dueDateFromDateEditorInput.value).toEqual(expectedReturnedDate);
 }
 

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -17,15 +17,6 @@ function renderDateEditorWrapper(componentOptions: { forwardOnly: boolean }) {
     return container;
 }
 
-beforeEach(() => {
-    jest.useFakeTimers();
-    jest.setSystemTime(new Date('2024-04-20'));
-});
-
-afterEach(() => {
-    jest.useRealTimers();
-});
-
 function testInputValue(container: HTMLElement, inputId: string, expectedText: string) {
     const input = getAndCheckRenderedElement<HTMLInputElement>(container, inputId);
     expect(input.value).toEqual(expectedText);
@@ -54,6 +45,15 @@ async function testTypingInput(
     testInputValue(container, 'parsedDateFromDateEditor', expectedRightText);
     testInputValue(container, 'dueDateFromDateEditor', expectedReturnedDate);
 }
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-04-20'));
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
 
 describe('date editor wrapper tests', () => {
     it('should initialise fields correctly', () => {

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { type RenderResult, render } from '@testing-library/svelte';
+import { type RenderResult, fireEvent, render } from '@testing-library/svelte';
 import moment from 'moment/moment';
 import { TASK_FORMATS } from '../../src/Config/Settings';
 import DateEditor from '../../src/ui/DateEditor.svelte';
@@ -26,10 +26,14 @@ function renderDateEditor() {
 }
 
 describe('date editor tests', () => {
-    it('should render and read input value', () => {
+    it('should render and read input value', async () => {
         const { container } = renderDateEditor();
         const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
 
         expect(dueDateInput.value).toEqual('');
+
+        await fireEvent.input(dueDateInput, { target: { value: '2024-10-01' } });
+
+        expect(dueDateInput.value).toEqual('2024-10-01');
     });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -57,7 +57,7 @@ afterEach(() => {
 });
 
 describe('date editor wrapper tests', () => {
-    it('should replace an empty date field with typed date value', async () => {
+    it('should initialise fields correctly', () => {
         const { container } = renderDateEditorWrapper();
         const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
         const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(
@@ -72,6 +72,19 @@ describe('date editor wrapper tests', () => {
         expect(dueDateInput.value).toEqual('');
         expect(dueDateFromDateEditorInput.value).toEqual('');
         expect(parsedDateFromDateEditor.value).toEqual('<i>no due date</i>');
+    });
+
+    it('should replace an empty date field with typed date value', async () => {
+        const { container } = renderDateEditorWrapper();
+        const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
+        const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(
+            container,
+            'dueDateFromDateEditor',
+        );
+        const parsedDateFromDateEditor = getAndCheckRenderedElement<HTMLInputElement>(
+            container,
+            'parsedDateFromDateEditor',
+        );
 
         await fireEvent.input(dueDateInput, { target: { value: '2024-10-01' } });
 
@@ -91,10 +104,6 @@ describe('date editor wrapper tests', () => {
             container,
             'parsedDateFromDateEditor',
         );
-
-        expect(dueDateInput.value).toEqual('');
-        expect(dueDateFromDateEditorInput.value).toEqual('');
-        expect(parsedDateFromDateEditor.value).toEqual('<i>no due date</i>');
 
         await fireEvent.input(dueDateInput, { target: { value: 'tm ' } });
 

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -117,4 +117,13 @@ describe('date editor wrapper tests', () => {
             expectedReturnedDate: 'tomorrow',
         });
     });
+
+    it('should show an error message for invalid date', async () => {
+        await testTypingInput({
+            userTyped: 'blah',
+            expectedLeftText: 'blah',
+            expectedRightText: '<i>invalid due date</i>',
+            expectedReturnedDate: 'blah',
+        });
+    });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -1,43 +1,13 @@
 /**
  * @jest-environment jsdom
  */
-import { type RenderResult, fireEvent, render } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
 import moment from 'moment/moment';
-import { TASK_FORMATS } from '../../src/Config/Settings';
-import DateEditor from '../../src/ui/DateEditor.svelte';
 import DateEditorWrapper from './DateEditorWrapper.svelte';
 
 import { getAndCheckRenderedElement } from './RenderingTestHelpers';
 
 window.moment = moment;
-
-function renderDateEditor() {
-    const result: RenderResult<DateEditor> = render(DateEditor, {
-        id: 'due',
-        dateSymbol: TASK_FORMATS.tasksPluginEmoji.taskSerializer.symbols.dueDateSymbol,
-        date: '',
-        isDateValid: true,
-        forwardOnly: true,
-        accesskey: 'D',
-    });
-
-    const { container } = result;
-    expect(() => container).toBeTruthy();
-    return { result, container };
-}
-
-describe('date editor tests', () => {
-    it('should render and read input value', async () => {
-        const { container } = renderDateEditor();
-        const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
-
-        expect(dueDateInput.value).toEqual('');
-
-        await fireEvent.input(dueDateInput, { target: { value: '2024-10-01' } });
-
-        expect(dueDateInput.value).toEqual('2024-10-01');
-    });
-});
 
 function renderDateEditorWrapper(componentOptions: { forwardOnly: boolean }) {
     const { container } = render(DateEditorWrapper, componentOptions);

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -77,7 +77,7 @@ async function testTypingInput({
     const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
     await fireEvent.input(dueDateInput, { target: { value: userTyped } });
 
-    expect(dueDateInput.value).toEqual(expectedLeftText);
+    testInputValue(container, 'due', expectedLeftText);
     testInputValue(container, 'parsedDateFromDateEditor', expectedRightText);
     testInputValue(container, 'dueDateFromDateEditor', expectedReturnedDate);
 }

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -117,4 +117,13 @@ describe('date editor wrapper tests', () => {
             expectedReturnedDate: 'blah',
         });
     });
+
+    it('should select a forward date', async () => {
+        await testTypingInput({
+            userTyped: 'friday',
+            expectedLeftText: 'friday',
+            expectedRightText: '2024-04-26',
+            expectedReturnedDate: 'friday',
+        });
+    });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -64,14 +64,20 @@ describe('date editor wrapper tests', () => {
             container,
             'dueDateFromDateEditor',
         );
+        const parsedDateFromDateEditor = getAndCheckRenderedElement<HTMLInputElement>(
+            container,
+            'parsedDateFromDateEditor',
+        );
 
         expect(dueDateInput.value).toEqual('');
         expect(dueDateFromDateEditorInput.value).toEqual('');
+        expect(parsedDateFromDateEditor.value).toEqual('<i>no due date</i>');
 
         await fireEvent.input(dueDateInput, { target: { value: '2024-10-01' } });
 
         expect(dueDateInput.value).toEqual('2024-10-01');
         expect(dueDateFromDateEditorInput.value).toEqual('2024-10-01');
+        expect(parsedDateFromDateEditor.value).toEqual('2024-10-01');
     });
 
     it('should replace an empty date field with typed abbreviation', async () => {
@@ -81,13 +87,19 @@ describe('date editor wrapper tests', () => {
             container,
             'dueDateFromDateEditor',
         );
+        const parsedDateFromDateEditor = getAndCheckRenderedElement<HTMLInputElement>(
+            container,
+            'parsedDateFromDateEditor',
+        );
 
         expect(dueDateInput.value).toEqual('');
         expect(dueDateFromDateEditorInput.value).toEqual('');
+        expect(parsedDateFromDateEditor.value).toEqual('<i>no due date</i>');
 
         await fireEvent.input(dueDateInput, { target: { value: 'tm ' } });
 
         expect(dueDateInput.value).toEqual('tomorrow');
         expect(dueDateFromDateEditorInput.value).toEqual('tomorrow');
+        expect(parsedDateFromDateEditor.value).toEqual('2024-04-21');
     });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -40,7 +40,7 @@ describe('date editor tests', () => {
 });
 
 function renderDateEditorWrapper() {
-    const result: RenderResult<DateEditorWrapper> = render(DateEditorWrapper, {});
+    const result: RenderResult<DateEditorWrapper> = render(DateEditorWrapper, { forwardOnly: true });
 
     const { container } = result;
     expect(() => container).toBeTruthy();

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -86,11 +86,16 @@ describe('date editor wrapper tests', () => {
             'parsedDateFromDateEditor',
         );
 
-        await fireEvent.input(dueDateInput, { target: { value: '2024-10-01' } });
+        const userTyped = '2024-10-01';
+        const expectedLeftText = '2024-10-01';
+        const expectedRightText = '2024-10-01';
+        const expectedReturnedDate = '2024-10-01';
 
-        expect(dueDateInput.value).toEqual('2024-10-01');
-        expect(dueDateFromDateEditorInput.value).toEqual('2024-10-01');
-        expect(parsedDateFromDateEditor.value).toEqual('2024-10-01');
+        await fireEvent.input(dueDateInput, { target: { value: userTyped } });
+
+        expect(dueDateInput.value).toEqual(expectedLeftText);
+        expect(dueDateFromDateEditorInput.value).toEqual(expectedReturnedDate);
+        expect(parsedDateFromDateEditor.value).toEqual(expectedRightText);
     });
 
     it('should replace an empty date field with typed abbreviation', async () => {

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -40,8 +40,7 @@ describe('date editor tests', () => {
 });
 
 function renderDateEditorWrapper(componentOptions: { forwardOnly: boolean }) {
-    const result: RenderResult<DateEditorWrapper> = render(DateEditorWrapper, componentOptions);
-    const { container } = result;
+    const { container } = render(DateEditorWrapper, componentOptions);
 
     expect(() => container).toBeTruthy();
 

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -85,19 +85,10 @@ async function testTypingInput({
 describe('date editor wrapper tests', () => {
     it('should initialise fields correctly', () => {
         const { container } = renderDateEditorWrapper();
-        const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
-        const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(
-            container,
-            'dueDateFromDateEditor',
-        );
-        const parsedDateFromDateEditor = getAndCheckRenderedElement<HTMLInputElement>(
-            container,
-            'parsedDateFromDateEditor',
-        );
 
-        expect(dueDateInput.value).toEqual('');
-        expect(dueDateFromDateEditorInput.value).toEqual('');
-        expect(parsedDateFromDateEditor.value).toEqual('<i>no due date</i>');
+        testInputValue(container, 'due', '');
+        testInputValue(container, 'parsedDateFromDateEditor', '<i>no due date</i>');
+        testInputValue(container, 'dueDateFromDateEditor', '');
     });
 
     it('should replace an empty date field with typed date value', async () => {

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -5,6 +5,7 @@ import { type RenderResult, fireEvent, render } from '@testing-library/svelte';
 import moment from 'moment/moment';
 import { TASK_FORMATS } from '../../src/Config/Settings';
 import DateEditor from '../../src/ui/DateEditor.svelte';
+import DateEditorWrapper from './DateEditorWrapper.svelte';
 
 import { getAndCheckRenderedElement } from './RenderingTestHelpers';
 
@@ -35,5 +36,32 @@ describe('date editor tests', () => {
         await fireEvent.input(dueDateInput, { target: { value: '2024-10-01' } });
 
         expect(dueDateInput.value).toEqual('2024-10-01');
+    });
+});
+
+function renderDateEditorWrapper() {
+    const result: RenderResult<DateEditorWrapper> = render(DateEditorWrapper, {});
+
+    const { container } = result;
+    expect(() => container).toBeTruthy();
+    return { result, container };
+}
+
+describe('date editor wrapper tests', () => {
+    it('should replace an empty date field with typed date value', async () => {
+        const { container } = renderDateEditorWrapper();
+        const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
+        const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(
+            container,
+            'dueDateFromDateEditor',
+        );
+
+        expect(dueDateInput.value).toEqual('');
+        expect(dueDateFromDateEditorInput.value).toEqual('');
+
+        await fireEvent.input(dueDateInput, { target: { value: '2024-10-01' } });
+
+        expect(dueDateInput.value).toEqual('2024-10-01');
+        expect(dueDateFromDateEditorInput.value).toEqual('2024-10-01');
     });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -78,11 +78,8 @@ async function testTypingInput({
     await fireEvent.input(dueDateInput, { target: { value: userTyped } });
 
     expect(dueDateInput.value).toEqual(expectedLeftText);
-
     testInputValue(container, 'parsedDateFromDateEditor', expectedRightText);
-
-    const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'dueDateFromDateEditor');
-    expect(dueDateFromDateEditorInput.value).toEqual(expectedReturnedDate);
+    testInputValue(container, 'dueDateFromDateEditor', expectedReturnedDate);
 }
 
 describe('date editor wrapper tests', () => {

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -56,6 +56,27 @@ afterEach(() => {
     jest.useRealTimers();
 });
 
+async function testTypingInput(
+    userTyped: string,
+    expectedLeftText: string,
+    expectedRightText: string,
+    expectedReturnedDate: string,
+) {
+    const { container } = renderDateEditorWrapper();
+    const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
+    const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'dueDateFromDateEditor');
+    const parsedDateFromDateEditor = getAndCheckRenderedElement<HTMLInputElement>(
+        container,
+        'parsedDateFromDateEditor',
+    );
+
+    await fireEvent.input(dueDateInput, { target: { value: userTyped } });
+
+    expect(dueDateInput.value).toEqual(expectedLeftText);
+    expect(dueDateFromDateEditorInput.value).toEqual(expectedReturnedDate);
+    expect(parsedDateFromDateEditor.value).toEqual(expectedRightText);
+}
+
 describe('date editor wrapper tests', () => {
     it('should initialise fields correctly', () => {
         const { container } = renderDateEditorWrapper();
@@ -75,27 +96,12 @@ describe('date editor wrapper tests', () => {
     });
 
     it('should replace an empty date field with typed date value', async () => {
-        const { container } = renderDateEditorWrapper();
-        const dueDateInput = getAndCheckRenderedElement<HTMLInputElement>(container, 'due');
-        const dueDateFromDateEditorInput = getAndCheckRenderedElement<HTMLInputElement>(
-            container,
-            'dueDateFromDateEditor',
-        );
-        const parsedDateFromDateEditor = getAndCheckRenderedElement<HTMLInputElement>(
-            container,
-            'parsedDateFromDateEditor',
-        );
-
         const userTyped = '2024-10-01';
         const expectedLeftText = '2024-10-01';
         const expectedRightText = '2024-10-01';
         const expectedReturnedDate = '2024-10-01';
 
-        await fireEvent.input(dueDateInput, { target: { value: userTyped } });
-
-        expect(dueDateInput.value).toEqual(expectedLeftText);
-        expect(dueDateFromDateEditorInput.value).toEqual(expectedReturnedDate);
-        expect(parsedDateFromDateEditor.value).toEqual(expectedRightText);
+        await testTypingInput(userTyped, expectedLeftText, expectedRightText, expectedReturnedDate);
     });
 
     it('should replace an empty date field with typed abbreviation', async () => {

--- a/tests/ui/DateEditorWrapper.svelte
+++ b/tests/ui/DateEditorWrapper.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    import { TASK_FORMATS } from '../../src/Config/Settings';
+    import DateEditor from '../../src/ui/DateEditor.svelte';
+
+    let dateFromDateEditor: string = '';
+    let isDueDateValid = true;
+</script>
+
+<DateEditor
+    id="due"
+    dateSymbol={TASK_FORMATS.tasksPluginEmoji.taskSerializer.symbols.dueDateSymbol}
+    bind:date={dateFromDateEditor}
+    bind:isDateValid={isDueDateValid}
+    forwardOnly={true}
+    accesskey={null}
+    on:open={() => {}}
+    on:close={() => {}}
+/>
+<input bind:value={dateFromDateEditor} id="dueDateFromDateEditor" />
+
+<style>
+</style>

--- a/tests/ui/DateEditorWrapper.svelte
+++ b/tests/ui/DateEditorWrapper.svelte
@@ -3,6 +3,7 @@
     import DateEditor from '../../src/ui/DateEditor.svelte';
 
     let dateFromDateEditor: string = '';
+    let parsedDateFromDateEditor: string = '';
     let isDueDateValid = true;
 </script>
 
@@ -15,8 +16,10 @@
     accesskey={null}
     on:open={() => {}}
     on:close={() => {}}
+    bind:parsedDate={parsedDateFromDateEditor}
 />
 <input bind:value={dateFromDateEditor} id="dueDateFromDateEditor" />
+<input bind:value={parsedDateFromDateEditor} id="parsedDateFromDateEditor" />
 
 <style>
 </style>

--- a/tests/ui/DateEditorWrapper.svelte
+++ b/tests/ui/DateEditorWrapper.svelte
@@ -2,6 +2,8 @@
     import { TASK_FORMATS } from '../../src/Config/Settings';
     import DateEditor from '../../src/ui/DateEditor.svelte';
 
+    export let forwardOnly: boolean;
+
     let dateFromDateEditor: string = '';
     let parsedDateFromDateEditor: string = '';
     let isDueDateValid = true;
@@ -12,7 +14,7 @@
     dateSymbol={TASK_FORMATS.tasksPluginEmoji.taskSerializer.symbols.dueDateSymbol}
     bind:date={dateFromDateEditor}
     bind:isDateValid={isDueDateValid}
-    forwardOnly={true}
+    {forwardOnly}
     accesskey={null}
     on:open={() => {}}
     on:close={() => {}}

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -14,6 +14,11 @@ import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
 import { verifyAllCombinations3Async } from '../TestingTools/CombinationApprovalsAsync';
 import { prettifyHTML } from '../TestingTools/HTMLHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import {
+    getAndCheckApplyButton,
+    getAndCheckRenderedDescriptionElement,
+    getAndCheckRenderedElement,
+} from './RenderingTestHelpers';
 
 window.moment = moment;
 /**
@@ -48,28 +53,6 @@ function renderAndCheckModal(task: Task, onSubmit: (updatedTasks: Task[]) => voi
     const { container } = result;
     expect(() => container).toBeTruthy();
     return { result, container };
-}
-
-/**
- * Find the element with the given id.
- * Template type T might be, for example, HTMLInputElement or HTMLSelectElement
- * @param container
- * @param elementId
- */
-function getAndCheckRenderedElement<T>(container: HTMLElement, elementId: string) {
-    const element = container.ownerDocument.getElementById(elementId) as T;
-    expect(() => element).toBeTruthy();
-    return element;
-}
-
-function getAndCheckRenderedDescriptionElement(container: HTMLElement): HTMLInputElement {
-    return getAndCheckRenderedElement<HTMLInputElement>(container, 'description');
-}
-
-function getAndCheckApplyButton(result: RenderResult<EditTask>): HTMLButtonElement {
-    const submit = result.getByText('Apply') as HTMLButtonElement;
-    expect(submit).toBeTruthy();
-    return submit;
 }
 
 async function editInputElement(inputElement: HTMLInputElement, newValue: string) {

--- a/tests/ui/RenderingTestHelpers.ts
+++ b/tests/ui/RenderingTestHelpers.ts
@@ -1,0 +1,24 @@
+import type { RenderResult } from '@testing-library/svelte';
+import type EditTask from '../../src/ui/EditTask.svelte';
+
+/**
+ * Find the element with the given id.
+ * Template type T might be, for example, HTMLInputElement or HTMLSelectElement
+ * @param container
+ * @param elementId
+ */
+export function getAndCheckRenderedElement<T>(container: HTMLElement, elementId: string) {
+    const element = container.ownerDocument.getElementById(elementId) as T;
+    expect(() => element).toBeTruthy();
+    return element;
+}
+
+export function getAndCheckRenderedDescriptionElement(container: HTMLElement): HTMLInputElement {
+    return getAndCheckRenderedElement<HTMLInputElement>(container, 'description');
+}
+
+export function getAndCheckApplyButton(result: RenderResult<EditTask>): HTMLButtonElement {
+    const submit = result.getByText('Apply') as HTMLButtonElement;
+    expect(submit).toBeTruthy();
+    return submit;
+}


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- Make `DateEditor.parsedDate` available for testing
- Create `DateEditorWrapper` component to test the `DateEditor`
- Add tests showing current behaviour

## Motivation and Context

- Prepare to TDD date picker's behaviour

## How has this been tested?

- Unit tests

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
