### PR TITLE
refactor: add `PriorityTools.priorityValue()`

### DIFF
--- a/src/TaskSerializer/DataviewTaskSerializer.ts
+++ b/src/TaskSerializer/DataviewTaskSerializer.ts
@@ -1,5 +1,6 @@
 import { TaskLayoutComponent } from '../Layout/TaskLayoutOptions';
-import { Priority } from '../Task/Priority';
+import { PriorityTools } from '../lib/PriorityTools';
+import type { Priority } from '../Task/Priority';
 import type { Task } from '../Task/Task';
 import { DefaultTaskSerializer, taskIdRegex, taskIdSequenceRegex } from './DefaultTaskSerializer';
 
@@ -103,20 +104,7 @@ export class DataviewTaskSerializer extends DefaultTaskSerializer {
     }
 
     protected parsePriority(p: string): Priority {
-        switch (p) {
-            case 'highest':
-                return Priority.Highest;
-            case 'high':
-                return Priority.High;
-            case 'medium':
-                return Priority.Medium;
-            case 'low':
-                return Priority.Low;
-            case 'lowest':
-                return Priority.Lowest;
-            default:
-                return Priority.None;
-        }
+        return PriorityTools.priorityValue(p);
     }
 
     public componentToString(task: Task, shortMode: boolean, component: TaskLayoutComponent) {

--- a/src/lib/PriorityTools.ts
+++ b/src/lib/PriorityTools.ts
@@ -1,4 +1,5 @@
 import { Priority } from '../Task/Priority';
+import { type EditableTaskPriority, appleSauce } from '../ui/EditableTask';
 
 export class PriorityTools {
     /**
@@ -38,5 +39,9 @@ export class PriorityTools {
      */
     public static priorityNameUsingNormal(priority: Priority) {
         return PriorityTools.priorityNameUsingNone(priority).replace('None', 'Normal');
+    }
+
+    public static priorityValue(priority: EditableTaskPriority) {
+        return appleSauce(priority);
     }
 }

--- a/src/lib/PriorityTools.ts
+++ b/src/lib/PriorityTools.ts
@@ -49,7 +49,7 @@ export class PriorityTools {
      * @see priorityNameUsingNormal
      */
     public static priorityValue(priority: string): Priority {
-        switch (priority) {
+        switch (priority.toLowerCase()) {
             case 'lowest':
                 return Priority.Lowest;
             case 'low':

--- a/src/lib/PriorityTools.ts
+++ b/src/lib/PriorityTools.ts
@@ -1,5 +1,4 @@
 import { Priority } from '../Task/Priority';
-import type { EditableTaskPriority } from '../ui/EditableTask';
 
 export class PriorityTools {
     /**
@@ -41,7 +40,7 @@ export class PriorityTools {
         return PriorityTools.priorityNameUsingNone(priority).replace('None', 'Normal');
     }
 
-    public static priorityValue(priority: EditableTaskPriority): Priority {
+    public static priorityValue(priority: string): Priority {
         switch (priority) {
             case 'lowest':
                 return Priority.Lowest;

--- a/src/lib/PriorityTools.ts
+++ b/src/lib/PriorityTools.ts
@@ -40,6 +40,14 @@ export class PriorityTools {
         return PriorityTools.priorityNameUsingNone(priority).replace('None', 'Normal');
     }
 
+    /**
+     * Get the {@link Priority} value from a string. A lower-case string is expected.
+     *
+     * In case the value was not recognised, {@link Priority.None} will be returned.
+     *
+     * @param priority
+     * @see priorityNameUsingNormal
+     */
     public static priorityValue(priority: string): Priority {
         switch (priority) {
             case 'lowest':

--- a/src/lib/PriorityTools.ts
+++ b/src/lib/PriorityTools.ts
@@ -41,7 +41,7 @@ export class PriorityTools {
         return PriorityTools.priorityNameUsingNone(priority).replace('None', 'Normal');
     }
 
-    public static priorityValue(priority: EditableTaskPriority) {
+    public static priorityValue(priority: EditableTaskPriority): Priority {
         switch (priority) {
             case 'lowest':
                 return Priority.Lowest;

--- a/src/lib/PriorityTools.ts
+++ b/src/lib/PriorityTools.ts
@@ -41,11 +41,12 @@ export class PriorityTools {
     }
 
     /**
-     * Get the {@link Priority} value from a string. The input string will be lower-cased.
+     * Get the {@link Priority} value from a string. The algorithm is case-insensitive.
      *
      * In case the value was not recognised, {@link Priority.None} will be returned.
      *
-     * @param priority
+     * @param priority - a string containing a name of one the supported {@link Priority} values.
+     *                   Capitalisation is ignored.
      * @see priorityNameUsingNormal
      */
     public static priorityValue(priority: string): Priority {

--- a/src/lib/PriorityTools.ts
+++ b/src/lib/PriorityTools.ts
@@ -41,7 +41,7 @@ export class PriorityTools {
     }
 
     /**
-     * Get the {@link Priority} value from a string. A lower-case string is expected.
+     * Get the {@link Priority} value from a string. The input string will be lower-cased.
      *
      * In case the value was not recognised, {@link Priority.None} will be returned.
      *

--- a/src/lib/PriorityTools.ts
+++ b/src/lib/PriorityTools.ts
@@ -1,5 +1,5 @@
 import { Priority } from '../Task/Priority';
-import { type EditableTaskPriority, appleSauce } from '../ui/EditableTask';
+import type { EditableTaskPriority } from '../ui/EditableTask';
 
 export class PriorityTools {
     /**
@@ -42,6 +42,19 @@ export class PriorityTools {
     }
 
     public static priorityValue(priority: EditableTaskPriority) {
-        return appleSauce(priority);
+        switch (priority) {
+            case 'lowest':
+                return Priority.Lowest;
+            case 'low':
+                return Priority.Low;
+            case 'medium':
+                return Priority.Medium;
+            case 'high':
+                return Priority.High;
+            case 'highest':
+                return Priority.Highest;
+            default:
+                return Priority.None;
+        }
     }
 }

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -185,8 +185,6 @@ export class EditableTask {
             });
         }
 
-        const parsedPriority = priorityValue(this.priority);
-
         const parsedOnCompletion: OnCompletion = this.onCompletion;
 
         const blockedByWithIds = [];
@@ -216,7 +214,7 @@ export class EditableTask {
             ...task,
             description,
             status: task.status,
-            priority: parsedPriority,
+            priority: priorityValue(this.priority),
             onCompletion: parsedOnCompletion,
             recurrence,
             startDate,

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -12,7 +12,7 @@ import { StatusType } from '../Statuses/StatusConfiguration';
 
 type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
 
-function priorityValue(priority: EditableTaskPriority) {
+function appleSauce(priority: EditableTaskPriority) {
     switch (priority) {
         case 'lowest':
             return Priority.Lowest;
@@ -27,6 +27,10 @@ function priorityValue(priority: EditableTaskPriority) {
         default:
             return Priority.None;
     }
+}
+
+function priorityValue(priority: EditableTaskPriority) {
+    return appleSauce(priority);
 }
 
 /**

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -1,18 +1,19 @@
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { parseTypedDateForSaving } from '../DateTime/DateTools';
+import { PriorityTools } from '../lib/PriorityTools';
 import { replaceTaskWithTasks } from '../Obsidian/File';
 import type { Status } from '../Statuses/Status';
-import { Occurrence } from '../Task/Occurrence';
 import type { OnCompletion } from '../Task/OnCompletion';
+import { Occurrence } from '../Task/Occurrence';
 import { Priority } from '../Task/Priority';
 import { Recurrence } from '../Task/Recurrence';
 import { Task } from '../Task/Task';
 import { addDependencyToParent, ensureTaskHasId, generateUniqueId, removeDependency } from '../Task/TaskDependency';
 import { StatusType } from '../Statuses/StatusConfiguration';
 
-type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
+export type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
 
-function appleSauce(priority: EditableTaskPriority) {
+export function appleSauce(priority: EditableTaskPriority) {
     switch (priority) {
         case 'lowest':
             return Priority.Lowest;
@@ -30,7 +31,7 @@ function appleSauce(priority: EditableTaskPriority) {
 }
 
 function priorityValue(priority: EditableTaskPriority) {
-    return appleSauce(priority);
+    return PriorityTools.priorityValue(priority);
 }
 
 /**

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -2,8 +2,8 @@ import { GlobalFilter } from '../Config/GlobalFilter';
 import { parseTypedDateForSaving } from '../DateTime/DateTools';
 import { replaceTaskWithTasks } from '../Obsidian/File';
 import type { Status } from '../Statuses/Status';
-import type { OnCompletion } from '../Task/OnCompletion';
 import { Occurrence } from '../Task/Occurrence';
+import type { OnCompletion } from '../Task/OnCompletion';
 import { Priority } from '../Task/Priority';
 import { Recurrence } from '../Task/Recurrence';
 import { Task } from '../Task/Task';
@@ -185,8 +185,7 @@ export class EditableTask {
             });
         }
 
-        const priority = this.priority;
-        const parsedPriority = priorityValue(priority);
+        const parsedPriority = priorityValue(this.priority);
 
         const parsedOnCompletion: OnCompletion = this.onCompletion;
 

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -13,27 +13,20 @@ import { StatusType } from '../Statuses/StatusConfiguration';
 type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
 
 function priorityValue(priority: 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest') {
-    let parsedPriority: Priority;
     switch (priority) {
         case 'lowest':
-            parsedPriority = Priority.Lowest;
-            break;
+            return Priority.Lowest;
         case 'low':
-            parsedPriority = Priority.Low;
-            break;
+            return Priority.Low;
         case 'medium':
-            parsedPriority = Priority.Medium;
-            break;
+            return Priority.Medium;
         case 'high':
-            parsedPriority = Priority.High;
-            break;
+            return Priority.High;
         case 'highest':
-            parsedPriority = Priority.Highest;
-            break;
+            return Priority.Highest;
         default:
             return Priority.None;
     }
-    return parsedPriority;
 }
 
 /**

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -12,7 +12,7 @@ import { StatusType } from '../Statuses/StatusConfiguration';
 
 type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
 
-function priorityValue(priority: 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest') {
+function priorityValue(priority: EditableTaskPriority) {
     switch (priority) {
         case 'lowest':
             return Priority.Lowest;

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -11,8 +11,6 @@ import { Task } from '../Task/Task';
 import { addDependencyToParent, ensureTaskHasId, generateUniqueId, removeDependency } from '../Task/TaskDependency';
 import { StatusType } from '../Statuses/StatusConfiguration';
 
-export type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
-
 /**
  * {@link Task} objects are immutable. This class allows to create a mutable object from a {@link Task}, apply the edits,
  * and get the resulting task(s).

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -13,23 +13,6 @@ import { StatusType } from '../Statuses/StatusConfiguration';
 
 export type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
 
-export function appleSauce(priority: EditableTaskPriority) {
-    switch (priority) {
-        case 'lowest':
-            return Priority.Lowest;
-        case 'low':
-            return Priority.Low;
-        case 'medium':
-            return Priority.Medium;
-        case 'high':
-            return Priority.High;
-        case 'highest':
-            return Priority.Highest;
-        default:
-            return Priority.None;
-    }
-}
-
 function priorityValue(priority: EditableTaskPriority) {
     return PriorityTools.priorityValue(priority);
 }

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -13,10 +13,6 @@ import { StatusType } from '../Statuses/StatusConfiguration';
 
 export type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
 
-function priorityValue(priority: EditableTaskPriority) {
-    return PriorityTools.priorityValue(priority);
-}
-
 /**
  * {@link Task} objects are immutable. This class allows to create a mutable object from a {@link Task}, apply the edits,
  * and get the resulting task(s).
@@ -202,7 +198,7 @@ export class EditableTask {
             ...task,
             description,
             status: task.status,
-            priority: priorityValue(this.priority),
+            priority: PriorityTools.priorityValue(this.priority),
             onCompletion: parsedOnCompletion,
             recurrence,
             startDate,

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -12,6 +12,30 @@ import { StatusType } from '../Statuses/StatusConfiguration';
 
 type EditableTaskPriority = 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest';
 
+function priorityValue(priority: 'none' | 'lowest' | 'low' | 'medium' | 'high' | 'highest') {
+    let parsedPriority: Priority;
+    switch (priority) {
+        case 'lowest':
+            parsedPriority = Priority.Lowest;
+            break;
+        case 'low':
+            parsedPriority = Priority.Low;
+            break;
+        case 'medium':
+            parsedPriority = Priority.Medium;
+            break;
+        case 'high':
+            parsedPriority = Priority.High;
+            break;
+        case 'highest':
+            parsedPriority = Priority.Highest;
+            break;
+        default:
+            return Priority.None;
+    }
+    return parsedPriority;
+}
+
 /**
  * {@link Task} objects are immutable. This class allows to create a mutable object from a {@link Task}, apply the edits,
  * and get the resulting task(s).
@@ -169,26 +193,7 @@ export class EditableTask {
         }
 
         const priority = this.priority;
-        let parsedPriority: Priority;
-        switch (priority) {
-            case 'lowest':
-                parsedPriority = Priority.Lowest;
-                break;
-            case 'low':
-                parsedPriority = Priority.Low;
-                break;
-            case 'medium':
-                parsedPriority = Priority.Medium;
-                break;
-            case 'high':
-                parsedPriority = Priority.High;
-                break;
-            case 'highest':
-                parsedPriority = Priority.Highest;
-                break;
-            default:
-                parsedPriority = Priority.None;
-        }
+        const parsedPriority = priorityValue(priority);
 
         const parsedOnCompletion: OnCompletion = this.onCompletion;
 

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -25,7 +25,7 @@ export class EditableTask {
     // NEW_TASK_FIELD_EDIT_REQUIRED
     description: string;
     status: Status;
-    priority: EditableTaskPriority;
+    priority: string;
     recurrenceRule: string;
     onCompletion: OnCompletion;
     createdDate: string;
@@ -45,7 +45,7 @@ export class EditableTask {
         // NEW_TASK_FIELD_EDIT_REQUIRED
         description: string;
         status: Status;
-        priority: EditableTaskPriority;
+        priority: string;
         onCompletion: OnCompletion;
         recurrenceRule: string;
         createdDate: string;
@@ -91,7 +91,7 @@ export class EditableTask {
         const addGlobalFilterOnSave =
             description != task.description || !GlobalFilter.getInstance().includedIn(task.description);
 
-        let priority: EditableTaskPriority = 'none';
+        let priority = 'none';
         if (task.priority === Priority.Lowest) {
             priority = 'lowest';
         } else if (task.priority === Priority.Low) {

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -168,8 +168,9 @@ export class EditableTask {
             });
         }
 
+        const priority = this.priority;
         let parsedPriority: Priority;
-        switch (this.priority) {
+        switch (priority) {
             case 'lowest':
                 parsedPriority = Priority.Lowest;
                 break;

--- a/tests/lib/PriorityTools.test.ts
+++ b/tests/lib/PriorityTools.test.ts
@@ -12,4 +12,23 @@ describe('priority naming', () => {
         expect(PriorityTools.priorityNameUsingNone(none)).toEqual('None');
         expect(PriorityTools.priorityNameUsingNormal(none)).toEqual('Normal');
     });
+
+    it.each([
+        // Normal cases
+        ['highest', Priority.Highest],
+        ['high', Priority.High],
+        ['none', Priority.None],
+        ['normal', Priority.None],
+        ['low', Priority.Low],
+        ['lowest', Priority.Lowest],
+
+        // Erroneous cases
+        ['', Priority.None],
+        ['invalid_priority_string!', Priority.None],
+
+        // Priority string has to be in lower case
+        ['Highest', Priority.None],
+    ])('should get priority value "%s"', (str, value) => {
+        expect(PriorityTools.priorityValue(str)).toEqual(value);
+    });
 });

--- a/tests/lib/PriorityTools.test.ts
+++ b/tests/lib/PriorityTools.test.ts
@@ -28,6 +28,7 @@ describe('priority naming', () => {
 
         // Priority string has to be in lower case
         ['Highest', Priority.None],
+        ['highEst', Priority.None],
     ])('should get priority value "%s"', (str, value) => {
         expect(PriorityTools.priorityValue(str)).toEqual(value);
     });

--- a/tests/lib/PriorityTools.test.ts
+++ b/tests/lib/PriorityTools.test.ts
@@ -17,6 +17,7 @@ describe('priority naming', () => {
         // Normal cases
         ['highest', Priority.Highest],
         ['high', Priority.High],
+        ['medium', Priority.Medium],
         ['none', Priority.None],
         ['normal', Priority.None],
         ['low', Priority.Low],
@@ -26,10 +27,10 @@ describe('priority naming', () => {
         ['', Priority.None],
         ['invalid_priority_string!', Priority.None],
 
-        // Priority string is lower-cased
+        // Priority search is case-insensitive
         ['Highest', Priority.Highest],
         ['highEst', Priority.Highest],
-    ])('should get priority value "%s"', (str, value) => {
+    ])('should get priority value for "%s"', (str, value) => {
         expect(PriorityTools.priorityValue(str)).toEqual(value);
     });
 });

--- a/tests/lib/PriorityTools.test.ts
+++ b/tests/lib/PriorityTools.test.ts
@@ -26,9 +26,9 @@ describe('priority naming', () => {
         ['', Priority.None],
         ['invalid_priority_string!', Priority.None],
 
-        // Priority string has to be in lower case
-        ['Highest', Priority.None],
-        ['highEst', Priority.None],
+        // Priority string is lower-cased
+        ['Highest', Priority.Highest],
+        ['highEst', Priority.Highest],
     ])('should get priority value "%s"', (str, value) => {
         expect(PriorityTools.priorityValue(str)).toEqual(value);
     });


### PR DESCRIPTION
# Types of changes

This is a 2 months old PR I forgot to submit =) If you find these changes unnecessary, feel free to reject the PR.

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- I noticed some repetitive code (string -> priority conversion) and an excessive types used around that (`EditableTaskPriority`) so I decided to refactor that

## Motivation and Context

- Less repetition in code

## How has this been tested?

- Unit tests added

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
