### PR TITLE
fix: '\' at end of last line in query no longer discards the instruction

### DIFF
--- a/src/Query/Scanner.ts
+++ b/src/Query/Scanner.ts
@@ -69,7 +69,15 @@ export function continueLines(input: string): Statement[] {
 
     let currentStatementRaw = '';
     let currentStatementProcessed = '';
-    for (const inputLine of input.split('\n')) {
+
+    // See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3137.
+    //      Issue #3137 revealed that if the last line of the query ended in
+    //      a backslash, this function returned without saved the final
+    //      instruction.
+    //      The simplest way to prevent this is to add an extra end-of-line
+    //      to the end of the query, which will get ignored when not needed:
+    const inputWithGuaranteedFinalEOL = input + '\n';
+    for (const inputLine of inputWithGuaranteedFinalEOL.split('\n')) {
         const adjustedLine = adjustLine(inputLine, continuePreviousLine);
         if (continuePreviousLine) {
             currentStatementRaw += '\n' + inputLine;

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -556,8 +556,7 @@ describe('Query parsing', () => {
         expect(new Query('short mode\nfull').queryLayoutOptions.shortMode).toEqual(false);
     });
 
-    it.failing('should cope with missing end-of-line character in query ending with continuation character', () => {
-        // See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3137
+    it('should cope with missing end-of-line character in query ending with continuation character - #3137', () => {
         const query = new Query('path includes query.md \\');
         expect(query.filters.length).toEqual(1);
         expect(query.filters[0].instruction).toEqual('path includes query.md');

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -556,6 +556,13 @@ describe('Query parsing', () => {
         expect(new Query('short mode\nfull').queryLayoutOptions.shortMode).toEqual(false);
     });
 
+    it.failing('should cope with missing end-of-line character in query ending with continuation character', () => {
+        // See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3137
+        const query = new Query('path includes query.md \\');
+        expect(query.filters.length).toEqual(1);
+        expect(query.filters[0].instruction).toEqual('path includes query.md');
+    });
+
     describe('should include instruction in parsing error messages', () => {
         function getQueryError(source: string) {
             return new Query(source, new TasksFile('Example Path.md')).error;

--- a/tests/Query/Scanner.test.ts
+++ b/tests/Query/Scanner.test.ts
@@ -150,6 +150,11 @@ describe('continue_lines', () => {
         expect(continueLinesFlattened(text)).toEqual('description includes one two three four five six');
     });
 
+    it('should preserve last instruction in query that ends in a continuation line = #3137', () => {
+        const text = 'due today \\';
+        expect(continueLinesFlattened(text)).toEqual('due today');
+    });
+
     it('visualise continue_lines', () => {
         const output = `
 input:


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
    - Fixes #3137

## Description

This works around an issue found with Obsidian 1.7.4, that in Live Preview, Obsidian eats the final end-of-line character in code blocks.

In the Tasks plugin, the line continuation code depended on there being a final end-of-line character at the end of the query text in order to allow users to place dangling `\` markers on the last line in the query.

That problem was logged in #3137.

This change ensures that there is always a last end-of-line character at the end of every query, regardless of its location. This will be useful if/when Tasks allows users to run searches via its API - as requested in #2459.

## Motivation and Context

Fixez #3137.

## How has this been tested?

- With new tests
- And exploratory testing

## Screenshots (if appropriate)

I used this test file:

~~~
# asdfasdf

- [ ] #task asdfasdfads

```tasks
limit 10
ignore global query
explain
( path includes {{ query.file.path }} )\
```
~~~

And arranged the views as:

**Source Mode | Live Preview | Reading Mode**

### Before the fix


![image](https://github.com/user-attachments/assets/d5023386-0999-4e4a-82dd-d523ff8353b3)

### After the fix

![image](https://github.com/user-attachments/assets/9836ad66-f36f-4e24-9d2f-84e6528e143b)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
