### PR TITLE
feat: Add date-picker to the Edit Task modal

### DIFF
--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -106,8 +106,14 @@
 <!--    aria-label="Open date picker"-->
 <!--    style="background: none; border: none; padding: 0; cursor: pointer;"-->
 <!--/>-->
-
-<code class="tasks-modal-parsed-date">{dateSymbol} {@html parsedDate}</code>
+<code class="tasks-modal-parsed-date"
+    >{dateSymbol}
+    {#if isDateValid}
+        <input type="date" bind:value={date} />
+    {:else}
+        {@html parsedDate}
+    {/if}
+</code>
 
 <style>
 </style>

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -23,10 +23,15 @@
     //     setIcon(node, 'calendar-days');
     // };
 
+    let pickedDate = '';
+
     $: {
         date = doAutocomplete(date);
         parsedDate = parseTypedDateForDisplayUsingFutureDate(id, date, forwardOnly);
         isDateValid = !parsedDate.includes('invalid');
+        if (isDateValid) {
+            pickedDate = parsedDate;
+        }
     }
 
     // 'weekend' abbreviation omitted due to lack of space.
@@ -109,7 +114,7 @@
 <code class="tasks-modal-parsed-date"
     >{dateSymbol}
     {#if isDateValid}
-        <input type="date" bind:value={date} id="date-editor-picker" />
+        <input type="date" bind:value={pickedDate} id="date-editor-picker" />
     {:else}
         {@html parsedDate}
     {/if}

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -118,14 +118,20 @@
 <!--    aria-label="Open date picker"-->
 <!--    style="background: none; border: none; padding: 0; cursor: pointer;"-->
 <!--/>-->
-<code class="tasks-modal-parsed-date"
-    >{dateSymbol}
-    {#if isDateValid}
-        <input type="date" bind:value={pickedDate} id="date-editor-picker" on:input={onDatePicked} tabindex="-1" />
-    {:else}
-        {@html parsedDate}
-    {/if}
-</code>
+{#if isDateValid}
+    <div class="tasks-modal-parsed-date">
+        {dateSymbol}<input
+            class="tasks-modal-date-editor-picker"
+            type="date"
+            bind:value={pickedDate}
+            id="date-editor-picker"
+            on:input={onDatePicked}
+            tabindex="-1"
+        />
+    </div>
+{:else}
+    <code class="tasks-modal-parsed-date">{dateSymbol} {@html parsedDate}</code>
+{/if}
 
 <style>
 </style>

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -109,7 +109,7 @@
 <code class="tasks-modal-parsed-date"
     >{dateSymbol}
     {#if isDateValid}
-        <input type="date" bind:value={date} />
+        <input type="date" bind:value={date} id="date-editor-picker" />
     {:else}
         {@html parsedDate}
     {/if}

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -121,7 +121,7 @@
 <code class="tasks-modal-parsed-date"
     >{dateSymbol}
     {#if isDateValid}
-        <input type="date" bind:value={pickedDate} id="date-editor-picker" on:input={onDatePicked} />
+        <input type="date" bind:value={pickedDate} id="date-editor-picker" on:input={onDatePicked} tabindex="-1" />
     {:else}
         {@html parsedDate}
     {/if}

--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -34,6 +34,13 @@
         }
     }
 
+    function onDatePicked(e: Event) {
+        if (e.target === null) {
+            return;
+        }
+        date = pickedDate;
+    }
+
     // 'weekend' abbreviation omitted due to lack of space.
     const datePlaceholder = "Try 'Mon' or 'tm' then space";
 
@@ -114,7 +121,7 @@
 <code class="tasks-modal-parsed-date"
     >{dateSymbol}
     {#if isDateValid}
-        <input type="date" bind:value={pickedDate} id="date-editor-picker" />
+        <input type="date" bind:value={pickedDate} id="date-editor-picker" on:input={onDatePicked} />
     {:else}
         {@html parsedDate}
     {/if}

--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -81,6 +81,10 @@
         min-width: 15em;
     }
 
+    .tasks-modal-date-editor-picker {
+        margin-left: .5em;
+    }
+
     //.tasks-modal-calendar-button {
     //    grid-column: 3;
     //    color: var(--text-muted);

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -138,5 +138,11 @@ describe('date editor wrapper tests', () => {
 
         const datePicker = getAndCheckRenderedElement<HTMLInputElement>(container, 'date-editor-picker');
         expect(datePicker.value).toEqual('');
+
+        await fireEvent.input(datePicker, { target: { value: '2024-11-03' } });
+
+        expect(datePicker.value).toEqual('2024-11-03');
+
+        testInputValue(container, 'due', '2024-11-03');
     });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -65,6 +65,9 @@ describe('date editor wrapper tests', () => {
         testInputValue(container, 'due', '');
         testInputValue(container, 'parsedDateFromDateEditor', '<i>no due date</i>');
         testInputValue(container, 'dueDateFromDateEditor', '');
+
+        const datePicker = getAndCheckRenderedElement<HTMLInputElement>(container, 'date-editor-picker');
+        expect(datePicker.value).toEqual('');
     });
 
     it('should replace an empty date field with typed date value', async () => {

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -144,5 +144,8 @@ describe('date editor wrapper tests', () => {
         expect(datePicker.value).toEqual('2024-11-03');
 
         testInputValue(container, 'due', '2024-11-03');
+        testInputValue(container, 'parsedDateFromDateEditor', '2024-11-03');
+        testInputValue(container, 'dueDateFromDateEditor', '2024-11-03');
+        testInputValue(container, 'parsedDateValidFromDateEditor', 'true');
     });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -55,6 +55,9 @@ async function testTypingInput(
 
     if (expectedReturnedDateValidity === 'true') {
         testDatePickerValue(container, expectedRightText);
+    } else {
+        const datePicker = container.ownerDocument.getElementById('date-editor-picker') as HTMLInputElement;
+        expect(datePicker).toBeNull();
     }
 }
 

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -22,6 +22,11 @@ function testInputValue(container: HTMLElement, inputId: string, expectedText: s
     expect(input.value).toEqual(expectedText);
 }
 
+function testDatePickerValue(container: HTMLElement, expectedValue: string) {
+    const datePicker = getAndCheckRenderedElement<HTMLInputElement>(container, 'date-editor-picker');
+    expect(datePicker.value).toEqual(expectedValue);
+}
+
 async function testTypingInput(
     {
         userTyped,
@@ -66,8 +71,7 @@ describe('date editor wrapper tests', () => {
         testInputValue(container, 'parsedDateFromDateEditor', '<i>no due date</i>');
         testInputValue(container, 'dueDateFromDateEditor', '');
 
-        const datePicker = getAndCheckRenderedElement<HTMLInputElement>(container, 'date-editor-picker');
-        expect(datePicker.value).toEqual('');
+        testDatePickerValue(container, '');
     });
 
     it('should replace an empty date field with typed date value', async () => {

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -28,11 +28,13 @@ async function testTypingInput(
         expectedLeftText,
         expectedRightText,
         expectedReturnedDate,
+        expectedReturnedDateValidity = 'true',
     }: {
         userTyped: string;
         expectedLeftText: string;
         expectedRightText: string;
         expectedReturnedDate: string;
+        expectedReturnedDateValidity?: 'true' | 'false';
     },
     { forwardOnly }: { forwardOnly: boolean } = { forwardOnly: true },
 ) {
@@ -44,6 +46,7 @@ async function testTypingInput(
     testInputValue(container, 'due', expectedLeftText);
     testInputValue(container, 'parsedDateFromDateEditor', expectedRightText);
     testInputValue(container, 'dueDateFromDateEditor', expectedReturnedDate);
+    testInputValue(container, 'parsedDateValidFromDateEditor', expectedReturnedDateValidity);
 }
 
 beforeEach(() => {
@@ -88,6 +91,7 @@ describe('date editor wrapper tests', () => {
             expectedLeftText: 'blah',
             expectedRightText: '<i>invalid due date</i>',
             expectedReturnedDate: 'blah',
+            expectedReturnedDateValidity: 'false',
         });
     });
 

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -122,7 +122,6 @@ describe('date editor wrapper tests', () => {
     it('should pick a date', async () => {
         const container = renderDateEditorWrapper({ forwardOnly: false });
 
-        const element = container.ownerDocument.getElementById('date-editor-picker');
-        expect(element).not.toBeNull();
+        getAndCheckRenderedElement<HTMLInputElement>(container, 'date-editor-picker');
     });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -122,6 +122,7 @@ describe('date editor wrapper tests', () => {
     it('should pick a date', async () => {
         const container = renderDateEditorWrapper({ forwardOnly: false });
 
-        getAndCheckRenderedElement<HTMLInputElement>(container, 'date-editor-picker');
+        const datePicker = getAndCheckRenderedElement<HTMLInputElement>(container, 'date-editor-picker');
+        expect(datePicker.value).toEqual('');
     });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -52,6 +52,10 @@ async function testTypingInput(
     testInputValue(container, 'parsedDateFromDateEditor', expectedRightText);
     testInputValue(container, 'dueDateFromDateEditor', expectedReturnedDate);
     testInputValue(container, 'parsedDateValidFromDateEditor', expectedReturnedDateValidity);
+
+    if (expectedReturnedDateValidity === 'true') {
+        testDatePickerValue(container, expectedRightText);
+    }
 }
 
 beforeEach(() => {

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -135,9 +135,7 @@ describe('date editor wrapper tests', () => {
 
     it('should pick a date', async () => {
         const container = renderDateEditorWrapper({ forwardOnly: false });
-
         const datePicker = getAndCheckRenderedElement<HTMLInputElement>(container, 'date-editor-picker');
-        expect(datePicker.value).toEqual('');
 
         await fireEvent.input(datePicker, { target: { value: '2024-11-03' } });
 

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -123,6 +123,6 @@ describe('date editor wrapper tests', () => {
         const container = renderDateEditorWrapper({ forwardOnly: false });
 
         const element = container.ownerDocument.getElementById('date-editor-picker');
-        expect(element).toBeNull();
+        expect(element).not.toBeNull();
     });
 });

--- a/tests/ui/DateEditor.test.ts
+++ b/tests/ui/DateEditor.test.ts
@@ -118,4 +118,11 @@ describe('date editor wrapper tests', () => {
             { forwardOnly: false },
         );
     });
+
+    it('should pick a date', async () => {
+        const container = renderDateEditorWrapper({ forwardOnly: false });
+
+        const element = container.ownerDocument.getElementById('date-editor-picker');
+        expect(element).toBeNull();
+    });
 });

--- a/tests/ui/DateEditorWrapper.svelte
+++ b/tests/ui/DateEditorWrapper.svelte
@@ -22,6 +22,7 @@
 />
 <input bind:value={dateFromDateEditor} id="dueDateFromDateEditor" />
 <input bind:value={parsedDateFromDateEditor} id="parsedDateFromDateEditor" />
+<input bind:value={isDueDateValid} id="parsedDateValidFromDateEditor" />
 
 <style>
 </style>

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
@@ -96,7 +96,7 @@
         accesskey="d" />
       <code class="tasks-modal-parsed-date">
         📅
-        <i>no due date</i>
+        <input type="date" />
       </code>
       <label for="scheduled">
         <span class="accesskey">S</span>
@@ -110,7 +110,7 @@
         accesskey="s" />
       <code class="tasks-modal-parsed-date">
         ⏳
-        <i>no scheduled date</i>
+        <input type="date" />
       </code>
       <label for="start">
         St
@@ -125,7 +125,7 @@
         accesskey="a" />
       <code class="tasks-modal-parsed-date">
         🛫
-        <i>no start date</i>
+        <input type="date" />
       </code>
       <div class="future-dates-only">
         <label for="forwardOnly">
@@ -223,7 +223,7 @@
         accesskey="c" />
       <code class="tasks-modal-parsed-date">
         ➕
-        <i>no created date</i>
+        <input type="date" />
       </code>
       <label for="done">
         Done (
@@ -238,7 +238,7 @@
         accesskey="x" />
       <code class="tasks-modal-parsed-date">
         ✅
-        <i>no done date</i>
+        <input type="date" />
       </code>
       <label for="cancelled">
         Cancelled (
@@ -253,7 +253,7 @@
         accesskey="-" />
       <code class="tasks-modal-parsed-date">
         ❌
-        <i>no cancelled date</i>
+        <input type="date" />
       </code>
     </section>
     <section class="tasks-modal-button-section">

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
@@ -96,7 +96,7 @@
         accesskey="d" />
       <code class="tasks-modal-parsed-date">
         📅
-        <input type="date" id="date-editor-picker" />
+        <input type="date" id="date-editor-picker" tabindex="-1" />
       </code>
       <label for="scheduled">
         <span class="accesskey">S</span>
@@ -110,7 +110,7 @@
         accesskey="s" />
       <code class="tasks-modal-parsed-date">
         ⏳
-        <input type="date" id="date-editor-picker" />
+        <input type="date" id="date-editor-picker" tabindex="-1" />
       </code>
       <label for="start">
         St
@@ -125,7 +125,7 @@
         accesskey="a" />
       <code class="tasks-modal-parsed-date">
         🛫
-        <input type="date" id="date-editor-picker" />
+        <input type="date" id="date-editor-picker" tabindex="-1" />
       </code>
       <div class="future-dates-only">
         <label for="forwardOnly">
@@ -223,7 +223,7 @@
         accesskey="c" />
       <code class="tasks-modal-parsed-date">
         ➕
-        <input type="date" id="date-editor-picker" />
+        <input type="date" id="date-editor-picker" tabindex="-1" />
       </code>
       <label for="done">
         Done (
@@ -238,7 +238,7 @@
         accesskey="x" />
       <code class="tasks-modal-parsed-date">
         ✅
-        <input type="date" id="date-editor-picker" />
+        <input type="date" id="date-editor-picker" tabindex="-1" />
       </code>
       <label for="cancelled">
         Cancelled (
@@ -253,7 +253,7 @@
         accesskey="-" />
       <code class="tasks-modal-parsed-date">
         ❌
-        <input type="date" id="date-editor-picker" />
+        <input type="date" id="date-editor-picker" tabindex="-1" />
       </code>
     </section>
     <section class="tasks-modal-button-section">

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
@@ -94,10 +94,10 @@
         class="tasks-modal-date-input"
         placeholder="Try 'Mon' or 'tm' then space"
         accesskey="d" />
-      <code class="tasks-modal-parsed-date">
+      <div class="tasks-modal-parsed-date">
         📅
-        <input type="date" id="date-editor-picker" tabindex="-1" />
-      </code>
+        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
+      </div>
       <label for="scheduled">
         <span class="accesskey">S</span>
         cheduled
@@ -108,10 +108,10 @@
         class="tasks-modal-date-input"
         placeholder="Try 'Mon' or 'tm' then space"
         accesskey="s" />
-      <code class="tasks-modal-parsed-date">
+      <div class="tasks-modal-parsed-date">
         ⏳
-        <input type="date" id="date-editor-picker" tabindex="-1" />
-      </code>
+        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
+      </div>
       <label for="start">
         St
         <span class="accesskey">a</span>
@@ -123,10 +123,10 @@
         class="tasks-modal-date-input"
         placeholder="Try 'Mon' or 'tm' then space"
         accesskey="a" />
-      <code class="tasks-modal-parsed-date">
+      <div class="tasks-modal-parsed-date">
         🛫
-        <input type="date" id="date-editor-picker" tabindex="-1" />
-      </code>
+        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
+      </div>
       <div class="future-dates-only">
         <label for="forwardOnly">
           Only
@@ -221,10 +221,10 @@
         class="tasks-modal-date-input"
         placeholder="Try 'Mon' or 'tm' then space"
         accesskey="c" />
-      <code class="tasks-modal-parsed-date">
+      <div class="tasks-modal-parsed-date">
         ➕
-        <input type="date" id="date-editor-picker" tabindex="-1" />
-      </code>
+        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
+      </div>
       <label for="done">
         Done (
         <span class="accesskey">x</span>
@@ -236,10 +236,10 @@
         class="tasks-modal-date-input"
         placeholder="Try 'Mon' or 'tm' then space"
         accesskey="x" />
-      <code class="tasks-modal-parsed-date">
+      <div class="tasks-modal-parsed-date">
         ✅
-        <input type="date" id="date-editor-picker" tabindex="-1" />
-      </code>
+        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
+      </div>
       <label for="cancelled">
         Cancelled (
         <span class="accesskey">-</span>
@@ -251,10 +251,10 @@
         class="tasks-modal-date-input"
         placeholder="Try 'Mon' or 'tm' then space"
         accesskey="-" />
-      <code class="tasks-modal-parsed-date">
+      <div class="tasks-modal-parsed-date">
         ❌
-        <input type="date" id="date-editor-picker" tabindex="-1" />
-      </code>
+        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
+      </div>
     </section>
     <section class="tasks-modal-button-section">
       <button type="submit" class="mod-cta">Apply</button>

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
@@ -105,13 +105,13 @@
       <input
         id="scheduled"
         type="text"
-        class="tasks-modal-date-input"
+        class="tasks-modal-date-input tasks-modal-error"
         placeholder="Try 'Mon' or 'tm' then space"
         accesskey="s" />
-      <div class="tasks-modal-parsed-date">
+      <code class="tasks-modal-parsed-date">
         ⏳
-        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
-      </div>
+        <i>invalid scheduled date</i>
+      </code>
       <label for="start">
         St
         <span class="accesskey">a</span>
@@ -257,7 +257,7 @@
       </div>
     </section>
     <section class="tasks-modal-button-section">
-      <button type="submit" class="mod-cta">Apply</button>
+      <button type="submit" class="mod-cta" disabled="">Apply</button>
       <button type="button">Cancel</button>
     </section>
   </form>

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot.approved.html
@@ -96,7 +96,7 @@
         accesskey="d" />
       <code class="tasks-modal-parsed-date">
         📅
-        <input type="date" />
+        <input type="date" id="date-editor-picker" />
       </code>
       <label for="scheduled">
         <span class="accesskey">S</span>
@@ -110,7 +110,7 @@
         accesskey="s" />
       <code class="tasks-modal-parsed-date">
         ⏳
-        <input type="date" />
+        <input type="date" id="date-editor-picker" />
       </code>
       <label for="start">
         St
@@ -125,7 +125,7 @@
         accesskey="a" />
       <code class="tasks-modal-parsed-date">
         🛫
-        <input type="date" />
+        <input type="date" id="date-editor-picker" />
       </code>
       <div class="future-dates-only">
         <label for="forwardOnly">
@@ -223,7 +223,7 @@
         accesskey="c" />
       <code class="tasks-modal-parsed-date">
         ➕
-        <input type="date" />
+        <input type="date" id="date-editor-picker" />
       </code>
       <label for="done">
         Done (
@@ -238,7 +238,7 @@
         accesskey="x" />
       <code class="tasks-modal-parsed-date">
         ✅
-        <input type="date" />
+        <input type="date" id="date-editor-picker" />
       </code>
       <label for="cancelled">
         Cancelled (
@@ -253,7 +253,7 @@
         accesskey="-" />
       <code class="tasks-modal-parsed-date">
         ❌
-        <input type="date" />
+        <input type="date" id="date-editor-picker" />
       </code>
     </section>
     <section class="tasks-modal-button-section">

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
@@ -58,19 +58,19 @@
       <input id="due" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         📅
-        <i>no due date</i>
+        <input type="date" />
       </code>
       <label for="scheduled">Scheduled</label>
       <input id="scheduled" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ⏳
-        <i>no scheduled date</i>
+        <input type="date" />
       </code>
       <label for="start">Start</label>
       <input id="start" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         🛫
-        <i>no start date</i>
+        <input type="date" />
       </code>
       <div class="future-dates-only">
         <label for="forwardOnly">Only future dates:</label>
@@ -143,19 +143,19 @@
       <input id="created" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ➕
-        <i>no created date</i>
+        <input type="date" />
       </code>
       <label for="done">Done</label>
       <input id="done" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ✅
-        <i>no done date</i>
+        <input type="date" />
       </code>
       <label for="cancelled">Cancelled</label>
       <input id="cancelled" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ❌
-        <i>no cancelled date</i>
+        <input type="date" />
       </code>
     </section>
     <section class="tasks-modal-button-section">

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
@@ -58,19 +58,19 @@
       <input id="due" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         📅
-        <input type="date" />
+        <input type="date" id="date-editor-picker" />
       </code>
       <label for="scheduled">Scheduled</label>
       <input id="scheduled" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ⏳
-        <input type="date" />
+        <input type="date" id="date-editor-picker" />
       </code>
       <label for="start">Start</label>
       <input id="start" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         🛫
-        <input type="date" />
+        <input type="date" id="date-editor-picker" />
       </code>
       <div class="future-dates-only">
         <label for="forwardOnly">Only future dates:</label>
@@ -143,19 +143,19 @@
       <input id="created" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ➕
-        <input type="date" />
+        <input type="date" id="date-editor-picker" />
       </code>
       <label for="done">Done</label>
       <input id="done" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ✅
-        <input type="date" />
+        <input type="date" id="date-editor-picker" />
       </code>
       <label for="cancelled">Cancelled</label>
       <input id="cancelled" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ❌
-        <input type="date" />
+        <input type="date" id="date-editor-picker" />
       </code>
     </section>
     <section class="tasks-modal-button-section">

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
@@ -61,11 +61,15 @@
         <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
       </div>
       <label for="scheduled">Scheduled</label>
-      <input id="scheduled" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
-      <div class="tasks-modal-parsed-date">
+      <input
+        id="scheduled"
+        type="text"
+        class="tasks-modal-date-input tasks-modal-error"
+        placeholder="Try 'Mon' or 'tm' then space" />
+      <code class="tasks-modal-parsed-date">
         ⏳
-        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
-      </div>
+        <i>invalid scheduled date</i>
+      </code>
       <label for="start">Start</label>
       <input id="start" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <div class="tasks-modal-parsed-date">
@@ -159,7 +163,7 @@
       </div>
     </section>
     <section class="tasks-modal-button-section">
-      <button type="submit" class="mod-cta">Apply</button>
+      <button type="submit" class="mod-cta" disabled="">Apply</button>
       <button type="button">Cancel</button>
     </section>
   </form>

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
@@ -58,19 +58,19 @@
       <input id="due" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         📅
-        <input type="date" id="date-editor-picker" />
+        <input type="date" id="date-editor-picker" tabindex="-1" />
       </code>
       <label for="scheduled">Scheduled</label>
       <input id="scheduled" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ⏳
-        <input type="date" id="date-editor-picker" />
+        <input type="date" id="date-editor-picker" tabindex="-1" />
       </code>
       <label for="start">Start</label>
       <input id="start" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         🛫
-        <input type="date" id="date-editor-picker" />
+        <input type="date" id="date-editor-picker" tabindex="-1" />
       </code>
       <div class="future-dates-only">
         <label for="forwardOnly">Only future dates:</label>
@@ -143,19 +143,19 @@
       <input id="created" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ➕
-        <input type="date" id="date-editor-picker" />
+        <input type="date" id="date-editor-picker" tabindex="-1" />
       </code>
       <label for="done">Done</label>
       <input id="done" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ✅
-        <input type="date" id="date-editor-picker" />
+        <input type="date" id="date-editor-picker" tabindex="-1" />
       </code>
       <label for="cancelled">Cancelled</label>
       <input id="cancelled" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
       <code class="tasks-modal-parsed-date">
         ❌
-        <input type="date" id="date-editor-picker" />
+        <input type="date" id="date-editor-picker" tabindex="-1" />
       </code>
     </section>
     <section class="tasks-modal-button-section">

--- a/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
+++ b/tests/ui/EditTask.test.Edit_Modal_HTML_snapshot_tests_should_match_snapshot_-_without_access_keys.approved.html
@@ -56,22 +56,22 @@
       </code>
       <label for="due">Due</label>
       <input id="due" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
-      <code class="tasks-modal-parsed-date">
+      <div class="tasks-modal-parsed-date">
         📅
-        <input type="date" id="date-editor-picker" tabindex="-1" />
-      </code>
+        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
+      </div>
       <label for="scheduled">Scheduled</label>
       <input id="scheduled" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
-      <code class="tasks-modal-parsed-date">
+      <div class="tasks-modal-parsed-date">
         ⏳
-        <input type="date" id="date-editor-picker" tabindex="-1" />
-      </code>
+        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
+      </div>
       <label for="start">Start</label>
       <input id="start" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
-      <code class="tasks-modal-parsed-date">
+      <div class="tasks-modal-parsed-date">
         🛫
-        <input type="date" id="date-editor-picker" tabindex="-1" />
-      </code>
+        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
+      </div>
       <div class="future-dates-only">
         <label for="forwardOnly">Only future dates:</label>
         <input id="forwardOnly" type="checkbox" class="task-list-item-checkbox tasks-modal-checkbox" />
@@ -141,22 +141,22 @@
       </select>
       <label for="created">Created</label>
       <input id="created" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
-      <code class="tasks-modal-parsed-date">
+      <div class="tasks-modal-parsed-date">
         ➕
-        <input type="date" id="date-editor-picker" tabindex="-1" />
-      </code>
+        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
+      </div>
       <label for="done">Done</label>
       <input id="done" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
-      <code class="tasks-modal-parsed-date">
+      <div class="tasks-modal-parsed-date">
         ✅
-        <input type="date" id="date-editor-picker" tabindex="-1" />
-      </code>
+        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
+      </div>
       <label for="cancelled">Cancelled</label>
       <input id="cancelled" type="text" class="tasks-modal-date-input" placeholder="Try 'Mon' or 'tm' then space" />
-      <code class="tasks-modal-parsed-date">
+      <div class="tasks-modal-parsed-date">
         ❌
-        <input type="date" id="date-editor-picker" tabindex="-1" />
-      </code>
+        <input class="tasks-modal-date-editor-picker" type="date" id="date-editor-picker" tabindex="-1" />
+      </div>
     </section>
     <section class="tasks-modal-button-section">
       <button type="submit" class="mod-cta">Apply</button>

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -658,7 +658,9 @@ describe('Edit Modal HTML snapshot tests', () => {
     });
 
     function verifyModalHTML() {
-        const task = taskFromLine({ line: '- [ ] absolutely to do', path: '' });
+        // Populate task a valid and an invalid date. Note that the valid date value
+        // is not visible in the HTML output.
+        const task = taskFromLine({ line: '- [ ] absolutely to do 🛫 2024-01-01 ⏳ 2024-02-33', path: '' });
         const onSubmit = () => {};
         const allTasks = [task];
         const { container } = renderAndCheckModal(task, onSubmit, allTasks);

--- a/tests/ui/RenderingTestHelpers.ts
+++ b/tests/ui/RenderingTestHelpers.ts
@@ -9,7 +9,7 @@ import type EditTask from '../../src/ui/EditTask.svelte';
  */
 export function getAndCheckRenderedElement<T>(container: HTMLElement, elementId: string) {
     const element = container.ownerDocument.getElementById(elementId) as T;
-    expect(() => element).toBeTruthy();
+    expect(element).not.toBeNull();
     return element;
 }
 


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion:
    - #2649
    - #2190 

## Description

- add date picker for the dates in the Edit Task modal
- fix helper function testing that an element has been rendered (`getAndCheckRenderedElement()`)

## Motivation and Context

- Quicker way to select dates in the Edit Task modal

## How has this been tested?

- Unit tests
- Exploratory testing 

## Screenshots (if appropriate)


https://github.com/user-attachments/assets/94921f53-5e3f-49b9-aa94-9926402277b6



## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
