### PR TITLE
fix: align status column with other dates

### DIFF
--- a/src/ui/EditTask.scss
+++ b/src/ui/EditTask.scss
@@ -67,7 +67,7 @@
 
 .tasks-modal-dates-section {
     display: grid;
-    grid-template-columns: 6.0em auto;
+    grid-template-columns: 6.0em 13em auto;
     column-gap: .5em;
     row-gap: 5px;
     align-items: center;


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

## Description

- align status column with other dates

## Motivation and Context

- better UI

## How has this been tested?

- manual test in demo vault

## Screenshots

Before
<img width="512" alt="Снимок экрана 2024-11-19 в 19 45 26" src="https://github.com/user-attachments/assets/55c65987-d035-4853-9e1b-cc4306ab86ca">

After
<img width="510" alt="Снимок экрана 2024-11-19 в 19 45 54" src="https://github.com/user-attachments/assets/cc819a9c-a7d9-4951-9be3-c27042bb616f">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
