### PR TITLE
feat: Add date-picker to Reading Mode and Tasks query results

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke Testing the Tasks Plugin.md
@@ -149,13 +149,13 @@ heading includes Rendering of Task Blocks
 
 - View this file in **Reading mode**...
 - On the task line above:
-  - [ ] #task ~~**left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.~~
-  - [ ] #task ~~**left**-click on a date value, and click outside the date picker, to confirm that the picker closes.~~
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+  - [ ] #task **left**-click on a date value, and click outside the date picker, to confirm that the picker closes.
   - [ ] #task **right**-click on a date value, and use the context menu to select and save a different date. Check that the date is updated.
   - [ ] #task **right**-click on a date value, and click outside the context menu, to confirm that the menu closes.
 - In the tasks search block below:
-  - [ ] #task ~~**left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.~~
-  - [ ] #task ~~**left**-click on a date value, and click outside the date picker, to confirm that the picker closes.~~
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+  - [ ] #task **left**-click on a date value, and click outside the date picker, to confirm that the picker closes.
   - [ ] #task **right**-click on a date value, and use the context menu to select and save a different date. Check that the date is updated.
   - [ ] #task **right**-click on a date value, and click outside the context menu, to confirm that the menu closes.
 - [ ] #task **check**: Checked all above steps for **editing dates** worked
@@ -177,8 +177,8 @@ hide postpone button
     2. **Check** that the text in the list item is copied in to the Description field
     3. Type some values in to the fields
     4. In one of the date fields, type `tm` (including the space afterwards) and **Check** it is expanded in to `tomorrow`
-    5. ~~In one of the date fields, left-click the calendar button, and use the context menu to select and save a date. Check that the date is saved.~~
-    6. ~~In one of the date fields, left-click the calendar button, and click outside the date picker, to confirm that the picker closes and the modal is still usable.~~
+    5. In one of the date fields, left-click the calendar button, and use the context menu to select and save a date. Check that the date is saved.
+    6. In one of the date fields, left-click the calendar button, and click outside the date picker, to confirm that the picker closes and the modal is still usable.
     7. Hit Return or click **Apply**
     8. **Check** that the list item above is converted in to a task
     9. **Check** that values you entered in the modal have been copied in to the list item above

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -11,6 +11,7 @@ import { TaskRegularExpressions } from '../Task/TaskRegularExpressions';
 import { StatusMenu } from '../ui/Menus/StatusMenu';
 import type { AllTaskDateFields } from '../DateTime/DateFieldTypes';
 import { defaultTaskSaver } from '../ui/Menus/TaskEditingMenu';
+import { promptForDate } from '../ui/Menus/DatePicker';
 import { splitDateText } from '../DateTime/Postponer';
 import { DateMenu } from '../ui/Menus/DateMenu';
 import { TaskFieldRenderer } from './TaskFieldRenderer';
@@ -215,11 +216,11 @@ export class TaskLineRenderer {
                     const componentDateField = component as AllTaskDateFields;
 
                     // Note: The more convenient span.onClickEvent() doesn't work here, as it is not available when tests are run.
-                    // span.addEventListener('click', (ev: MouseEvent) => {
-                    //     ev.preventDefault(); // suppress the default click behavior
-                    //     ev.stopPropagation(); // suppress further event propagation
-                    //     promptForDate(span, task, componentDateField, defaultTaskSaver);
-                    // });
+                    span.addEventListener('click', (ev: MouseEvent) => {
+                        ev.preventDefault(); // suppress the default click behavior
+                        ev.stopPropagation(); // suppress further event propagation
+                        promptForDate(span, task, componentDateField, defaultTaskSaver);
+                    });
 
                     span.addEventListener('contextmenu', (ev: MouseEvent) => {
                         ev.preventDefault(); // suppress the default context menu
@@ -229,8 +230,7 @@ export class TaskLineRenderer {
                     });
                     span.setAttribute(
                         'title',
-                        // `Click to edit ${splitDateText(componentDateField)}, Right-click for more options`,
-                        `Right-click to edit ${splitDateText(componentDateField)}`,
+                        `Click to edit ${splitDateText(componentDateField)}, Right-click for more options`,
                     );
                 }
             }

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -1,6 +1,6 @@
 import flatpickr from 'flatpickr';
 import type { Task } from '../../Task/Task';
-import { SetTaskDate } from '../EditInstructions/DateInstructions';
+import { RemoveTaskDate, SetTaskDate } from '../EditInstructions/DateInstructions';
 import type { AllTaskDateFields } from '../../DateTime/DateFieldTypes';
 
 /**
@@ -37,6 +37,25 @@ export function promptForDate(
                 await taskSaver(task, newTask);
             }
             instance.destroy(); // Proper cleanup
+        },
+        onReady: (_selectedDates, _dateStr, instance) => {
+            // Add a "Clear" button dynamically
+            const clearButton = document.createElement('button');
+            clearButton.type = 'button';
+            clearButton.textContent = 'Clear';
+            clearButton.classList.add('flatpickr-clear-button'); // Add a custom class for styling
+            clearButton.style.margin = '10px'; // Optional styling
+
+            // Append the button to the Flatpickr calendar container
+            const calendarContainer = instance.calendarContainer;
+            calendarContainer.appendChild(clearButton);
+
+            // Add click event to clear the date
+            clearButton.addEventListener('click', async () => {
+                const newTask = new RemoveTaskDate(dateFieldToEdit, task).apply(task); // Clear the date
+                await taskSaver(task, newTask);
+                instance.clear(); // Clear the Flatpickr selection
+            });
         },
     });
 

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -55,6 +55,7 @@ export function promptForDate(
                 const newTask = new RemoveTaskDate(dateFieldToEdit, task).apply(task); // Clear the date
                 await taskSaver(task, newTask);
                 instance.clear(); // Clear the Flatpickr selection
+                instance.close(); // Close the Flatpickr picker
             });
         },
     });

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -54,8 +54,7 @@ export function promptForDate(
             clearButton.addEventListener('click', async () => {
                 const newTask = new RemoveTaskDate(dateFieldToEdit, task).apply(task); // Clear the date
                 await taskSaver(task, newTask);
-                instance.clear(); // Clear the Flatpickr selection
-                instance.close(); // Close the Flatpickr picker
+                instance.destroy(); // Proper cleanup
             });
 
             // Create "Today" button
@@ -68,8 +67,7 @@ export function promptForDate(
                 const today = new Date();
                 const newTask = new SetTaskDate(dateFieldToEdit, today).apply(task); // Set today's date
                 await taskSaver(task, newTask);
-                instance.setDate(today); // Set the Flatpickr picker to today
-                instance.close(); // Close the Flatpickr picker
+                instance.destroy(); // Proper cleanup
             });
 
             // Append buttons to the container

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -24,6 +24,7 @@ export function promptForDate(
     //      running overnight, the flatpickr modal shows the previous day as Today.
     const fp = flatpickr(parentElement, {
         defaultDate: currentValue ? currentValue.format('YYYY-MM-DD') : new Date(),
+        disableMobile: true,
         enableTime: false, // Optional: Enable time picker
         dateFormat: 'Y-m-d', // Adjust the date and time format as needed
         locale: {

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -39,24 +39,46 @@ export function promptForDate(
             instance.destroy(); // Proper cleanup
         },
         onReady: (_selectedDates, _dateStr, instance) => {
-            // Add a "Clear" button dynamically
+            // Add custom buttons dynamically
+            const buttonContainer = document.createElement('div');
+            buttonContainer.style.display = 'flex';
+            buttonContainer.style.justifyContent = 'space-between';
+            buttonContainer.style.marginTop = '10px';
+
+            // Create "Clear" button
             const clearButton = document.createElement('button');
             clearButton.type = 'button';
             clearButton.textContent = 'Clear';
             clearButton.classList.add('flatpickr-clear-button'); // Add a custom class for styling
-            clearButton.style.margin = '10px'; // Optional styling
 
-            // Append the button to the Flatpickr calendar container
-            const calendarContainer = instance.calendarContainer;
-            calendarContainer.appendChild(clearButton);
-
-            // Add click event to clear the date
             clearButton.addEventListener('click', async () => {
                 const newTask = new RemoveTaskDate(dateFieldToEdit, task).apply(task); // Clear the date
                 await taskSaver(task, newTask);
                 instance.clear(); // Clear the Flatpickr selection
                 instance.close(); // Close the Flatpickr picker
             });
+
+            // Create "Today" button
+            const todayButton = document.createElement('button');
+            todayButton.type = 'button';
+            todayButton.textContent = 'Today';
+            todayButton.classList.add('flatpickr-today-button'); // Add a custom class for styling
+
+            todayButton.addEventListener('click', async () => {
+                const today = new Date();
+                const newTask = new SetTaskDate(dateFieldToEdit, today).apply(task); // Set today's date
+                await taskSaver(task, newTask);
+                instance.setDate(today); // Set the Flatpickr picker to today
+                instance.close(); // Close the Flatpickr picker
+            });
+
+            // Append buttons to the container
+            buttonContainer.appendChild(clearButton);
+            buttonContainer.appendChild(todayButton);
+
+            // Append the button container to the Flatpickr calendar container
+            const calendarContainer = instance.calendarContainer;
+            calendarContainer.appendChild(buttonContainer);
         },
     });
 

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -56,6 +56,7 @@ export function promptForDate(
                 await taskSaver(task, newTask);
                 instance.destroy(); // Proper cleanup
             });
+            buttonContainer.appendChild(clearButton);
 
             // Create "Today" button
             const setDateToToday = () => {
@@ -64,9 +65,6 @@ export function promptForDate(
                 return new SetTaskDate(dateFieldToEdit, today).apply(task);
             };
             addButton(buttonContainer, instance, task, taskSaver, 'Today', setDateToToday);
-
-            // Append buttons to the container
-            buttonContainer.appendChild(clearButton);
 
             // Append the button container to the Flatpickr calendar container
             const calendarContainer = instance.calendarContainer;

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -36,7 +36,7 @@ export function promptForDate(
                 const newTask = new SetTaskDate(dateFieldToEdit, date).apply(task);
                 await taskSaver(task, newTask);
             }
-            instance.destroy(); // Proper cleanup
+            instance.destroy();
         },
         onReady: (_selectedDates, _dateStr, instance) => {
             // Add custom buttons dynamically
@@ -77,12 +77,12 @@ function addButton(
     const button = document.createElement('button');
     button.type = 'button';
     button.textContent = buttonName;
-    button.classList.add('flatpickr-button'); // Add a custom class for styling
+    button.classList.add('flatpickr-button');
 
     button.addEventListener('click', async () => {
         const newTask = applyDate();
         await taskSaver(task, newTask);
-        instance.destroy(); // Proper cleanup
+        instance.destroy();
     });
     buttonContainer.appendChild(button);
 }

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -49,7 +49,7 @@ export function promptForDate(
             const clearButton = document.createElement('button');
             clearButton.type = 'button';
             clearButton.textContent = 'Clear';
-            clearButton.classList.add('flatpickr-clear-button'); // Add a custom class for styling
+            clearButton.classList.add('flatpickr-button'); // Add a custom class for styling
 
             clearButton.addEventListener('click', async () => {
                 const newTask = new RemoveTaskDate(dateFieldToEdit, task).apply(task); // Clear the date
@@ -61,7 +61,7 @@ export function promptForDate(
             const todayButton = document.createElement('button');
             todayButton.type = 'button';
             todayButton.textContent = 'Today';
-            todayButton.classList.add('flatpickr-today-button'); // Add a custom class for styling
+            todayButton.classList.add('flatpickr-button'); // Add a custom class for styling
 
             todayButton.addEventListener('click', async () => {
                 const today = new Date();

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -64,7 +64,7 @@ export function promptForDate(
                 const today = new Date();
                 return new SetTaskDate(dateFieldToEdit, today).apply(task);
             };
-            addButton(buttonName, applyDate, taskSaver, task, instance, buttonContainer);
+            addButton(buttonContainer, instance, task, taskSaver, buttonName, applyDate);
 
             // Append buttons to the container
             buttonContainer.appendChild(clearButton);
@@ -80,12 +80,12 @@ export function promptForDate(
 }
 
 function addButton(
+    buttonContainer: HTMLDivElement,
+    instance: flatpickr.Instance,
+    task: Task,
+    taskSaver: (originalTask: Task, newTasks: Task | Task[]) => Promise<void>,
     buttonName: string,
     applyDate: () => Task[],
-    taskSaver: (originalTask: Task, newTasks: Task | Task[]) => Promise<void>,
-    task: Task,
-    instance: flatpickr.Instance,
-    buttonContainer: HTMLDivElement,
 ) {
     const button = document.createElement('button');
     button.type = 'button';

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -51,12 +51,10 @@ export function promptForDate(
             });
 
             // Create "Today" button
-            const setDateToToday = () => {
-                // Set today's date
+            addButton(buttonContainer, instance, task, taskSaver, 'Today', () => {
                 const today = new Date();
                 return new SetTaskDate(dateFieldToEdit, today).apply(task);
-            };
-            addButton(buttonContainer, instance, task, taskSaver, 'Today', setDateToToday);
+            });
 
             // Append the button container to the Flatpickr calendar container
             const calendarContainer = instance.calendarContainer;

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -58,12 +58,12 @@ export function promptForDate(
             });
 
             // Create "Today" button
-            const applyDate = () => {
+            const setDateToToday = () => {
                 // Set today's date
                 const today = new Date();
                 return new SetTaskDate(dateFieldToEdit, today).apply(task);
             };
-            addButton(buttonContainer, instance, task, taskSaver, 'Today', applyDate);
+            addButton(buttonContainer, instance, task, taskSaver, 'Today', setDateToToday);
 
             // Append buttons to the container
             buttonContainer.appendChild(clearButton);

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -74,10 +74,10 @@ export function promptForDate(
                 await taskSaver(task, newTask);
                 instance.destroy(); // Proper cleanup
             });
+            buttonContainer.appendChild(todayButton);
 
             // Append buttons to the container
             buttonContainer.appendChild(clearButton);
-            buttonContainer.appendChild(todayButton);
 
             // Append the button container to the Flatpickr calendar container
             const calendarContainer = instance.calendarContainer;

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -51,10 +51,10 @@ export function promptForDate(
             clearButton.textContent = 'Clear';
             clearButton.classList.add('flatpickr-button'); // Add a custom class for styling
 
-            function clearDate() {
+            const clearDate = () => {
                 // Clear the date
                 return new RemoveTaskDate(dateFieldToEdit, task).apply(task);
-            }
+            };
             clearButton.addEventListener('click', async () => {
                 const newTask = clearDate();
                 await taskSaver(task, newTask);

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -58,9 +58,10 @@ export function promptForDate(
             });
 
             // Create "Today" button
+            const buttonName = 'Today';
             const todayButton = document.createElement('button');
             todayButton.type = 'button';
-            todayButton.textContent = 'Today';
+            todayButton.textContent = buttonName;
             todayButton.classList.add('flatpickr-button'); // Add a custom class for styling
 
             todayButton.addEventListener('click', async () => {

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -64,11 +64,11 @@ export function promptForDate(
             todayButton.textContent = buttonName;
             todayButton.classList.add('flatpickr-button'); // Add a custom class for styling
 
-            function applyDate() {
+            const applyDate = () => {
                 // Set today's date
                 const today = new Date();
                 return new SetTaskDate(dateFieldToEdit, today).apply(task);
-            }
+            };
 
             todayButton.addEventListener('click', async () => {
                 const newTask = applyDate();

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -46,11 +46,9 @@ export function promptForDate(
             buttonContainer.style.marginTop = '10px';
 
             // Create "Clear" button
-            const clearDate = () => {
-                // Clear the date
+            addButton(buttonContainer, instance, task, taskSaver, 'Clear', () => {
                 return new RemoveTaskDate(dateFieldToEdit, task).apply(task);
-            };
-            addButton(buttonContainer, instance, task, taskSaver, 'Clear', clearDate);
+            });
 
             // Create "Today" button
             const setDateToToday = () => {

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -46,21 +46,11 @@ export function promptForDate(
             buttonContainer.style.marginTop = '10px';
 
             // Create "Clear" button
-            const clearButton = document.createElement('button');
-            clearButton.type = 'button';
-            clearButton.textContent = 'Clear';
-            clearButton.classList.add('flatpickr-button'); // Add a custom class for styling
-
             const clearDate = () => {
                 // Clear the date
                 return new RemoveTaskDate(dateFieldToEdit, task).apply(task);
             };
-            clearButton.addEventListener('click', async () => {
-                const newTask = clearDate();
-                await taskSaver(task, newTask);
-                instance.destroy(); // Proper cleanup
-            });
-            buttonContainer.appendChild(clearButton);
+            addButton(buttonContainer, instance, task, taskSaver, 'Clear', clearDate);
 
             // Create "Today" button
             const setDateToToday = () => {

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -65,9 +65,9 @@ export function promptForDate(
             todayButton.classList.add('flatpickr-button'); // Add a custom class for styling
 
             function applyDate() {
+                // Set today's date
                 const today = new Date();
-                const newTask = new SetTaskDate(dateFieldToEdit, today).apply(task); // Set today's date
-                return newTask;
+                return new SetTaskDate(dateFieldToEdit, today).apply(task);
             }
 
             todayButton.addEventListener('click', async () => {

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -58,13 +58,12 @@ export function promptForDate(
             });
 
             // Create "Today" button
-            const buttonName = 'Today';
             const applyDate = () => {
                 // Set today's date
                 const today = new Date();
                 return new SetTaskDate(dateFieldToEdit, today).apply(task);
             };
-            addButton(buttonContainer, instance, task, taskSaver, buttonName, applyDate);
+            addButton(buttonContainer, instance, task, taskSaver, 'Today', applyDate);
 
             // Append buttons to the container
             buttonContainer.appendChild(clearButton);

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -64,17 +64,7 @@ export function promptForDate(
                 const today = new Date();
                 return new SetTaskDate(dateFieldToEdit, today).apply(task);
             };
-            const todayButton = document.createElement('button');
-            todayButton.type = 'button';
-            todayButton.textContent = buttonName;
-            todayButton.classList.add('flatpickr-button'); // Add a custom class for styling
-
-            todayButton.addEventListener('click', async () => {
-                const newTask = applyDate();
-                await taskSaver(task, newTask);
-                instance.destroy(); // Proper cleanup
-            });
-            buttonContainer.appendChild(todayButton);
+            addButton(buttonName, applyDate, taskSaver, task, instance, buttonContainer);
 
             // Append buttons to the container
             buttonContainer.appendChild(clearButton);
@@ -87,4 +77,25 @@ export function promptForDate(
 
     // Open the calendar programmatically
     fp.open();
+}
+
+function addButton(
+    buttonName: string,
+    applyDate: () => Task[],
+    taskSaver: (originalTask: Task, newTasks: Task | Task[]) => Promise<void>,
+    task: Task,
+    instance: flatpickr.Instance,
+    buttonContainer: HTMLDivElement,
+) {
+    const todayButton = document.createElement('button');
+    todayButton.type = 'button';
+    todayButton.textContent = buttonName;
+    todayButton.classList.add('flatpickr-button'); // Add a custom class for styling
+
+    todayButton.addEventListener('click', async () => {
+        const newTask = applyDate();
+        await taskSaver(task, newTask);
+        instance.destroy(); // Proper cleanup
+    });
+    buttonContainer.appendChild(todayButton);
 }

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -51,8 +51,12 @@ export function promptForDate(
             clearButton.textContent = 'Clear';
             clearButton.classList.add('flatpickr-button'); // Add a custom class for styling
 
+            function clearDate() {
+                // Clear the date
+                return new RemoveTaskDate(dateFieldToEdit, task).apply(task);
+            }
             clearButton.addEventListener('click', async () => {
-                const newTask = new RemoveTaskDate(dateFieldToEdit, task).apply(task); // Clear the date
+                const newTask = clearDate();
                 await taskSaver(task, newTask);
                 instance.destroy(); // Proper cleanup
             });

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -2,6 +2,7 @@ import flatpickr from 'flatpickr';
 import type { Task } from '../../Task/Task';
 import { RemoveTaskDate, SetTaskDate } from '../EditInstructions/DateInstructions';
 import type { AllTaskDateFields } from '../../DateTime/DateFieldTypes';
+import type { TaskSaver } from './TaskEditingMenu';
 
 /**
  * A calendar date picker which edits a date value in a {@link Task} object.
@@ -14,7 +15,7 @@ export function promptForDate(
     parentElement: HTMLElement,
     task: Task,
     dateFieldToEdit: AllTaskDateFields,
-    taskSaver: (originalTask: Task, newTasks: Task | Task[]) => Promise<void>,
+    taskSaver: TaskSaver,
 ) {
     const currentValue = task[dateFieldToEdit];
     // TODO figure out how Today's date is determined: if Obsidian is left
@@ -67,7 +68,7 @@ function addButton(
     buttonContainer: HTMLDivElement,
     instance: flatpickr.Instance,
     task: Task,
-    taskSaver: (originalTask: Task, newTasks: Task | Task[]) => Promise<void>,
+    taskSaver: TaskSaver,
     buttonName: string,
     applyDate: () => Task[],
 ) {

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -64,9 +64,14 @@ export function promptForDate(
             todayButton.textContent = buttonName;
             todayButton.classList.add('flatpickr-button'); // Add a custom class for styling
 
-            todayButton.addEventListener('click', async () => {
+            function applyDate() {
                 const today = new Date();
                 const newTask = new SetTaskDate(dateFieldToEdit, today).apply(task); // Set today's date
+                return newTask;
+            }
+
+            todayButton.addEventListener('click', async () => {
+                const newTask = applyDate();
                 await taskSaver(task, newTask);
                 instance.destroy(); // Proper cleanup
             });

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -59,16 +59,15 @@ export function promptForDate(
 
             // Create "Today" button
             const buttonName = 'Today';
-            const todayButton = document.createElement('button');
-            todayButton.type = 'button';
-            todayButton.textContent = buttonName;
-            todayButton.classList.add('flatpickr-button'); // Add a custom class for styling
-
             const applyDate = () => {
                 // Set today's date
                 const today = new Date();
                 return new SetTaskDate(dateFieldToEdit, today).apply(task);
             };
+            const todayButton = document.createElement('button');
+            todayButton.type = 'button';
+            todayButton.textContent = buttonName;
+            todayButton.classList.add('flatpickr-button'); // Add a custom class for styling
 
             todayButton.addEventListener('click', async () => {
                 const newTask = applyDate();

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -5,13 +5,10 @@ import type { AllTaskDateFields } from '../../DateTime/DateFieldTypes';
 
 /**
  * A calendar date picker which edits a date value in a {@link Task} object.
- * See also {@link openDatePicker}
  * @param parentElement
  * @param task
  * @param dateFieldToEdit
  * @param taskSaver
- *
- * See also {@link openDatePicker}
  */
 export function promptForDate(
     parentElement: HTMLElement,

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -87,15 +87,15 @@ function addButton(
     instance: flatpickr.Instance,
     buttonContainer: HTMLDivElement,
 ) {
-    const todayButton = document.createElement('button');
-    todayButton.type = 'button';
-    todayButton.textContent = buttonName;
-    todayButton.classList.add('flatpickr-button'); // Add a custom class for styling
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = buttonName;
+    button.classList.add('flatpickr-button'); // Add a custom class for styling
 
-    todayButton.addEventListener('click', async () => {
+    button.addEventListener('click', async () => {
         const newTask = applyDate();
         await taskSaver(task, newTask);
         instance.destroy(); // Proper cleanup
     });
-    buttonContainer.appendChild(todayButton);
+    buttonContainer.appendChild(button);
 }

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task.approved.html
@@ -21,22 +21,34 @@
         <span class="task-priority" data-task-priority="medium"><span>🔼</span></span>
         <span class="task-recurring"><span>🔁 every day when done</span></span>
         <span class="task-onCompletion"><span>🏁 delete</span></span>
-        <span class="task-created" data-task-created="past-far" title="Right-click to edit created date">
+        <span
+          class="task-created"
+          data-task-created="past-far"
+          title="Click to edit created date, Right-click for more options">
           <span>➕ 2023-07-01</span>
         </span>
-        <span class="task-start" data-task-start="past-far" title="Right-click to edit start date">
+        <span
+          class="task-start"
+          data-task-start="past-far"
+          title="Click to edit start date, Right-click for more options">
           <span>🛫 2023-07-02</span>
         </span>
-        <span class="task-scheduled" data-task-scheduled="past-far" title="Right-click to edit scheduled date">
+        <span
+          class="task-scheduled"
+          data-task-scheduled="past-far"
+          title="Click to edit scheduled date, Right-click for more options">
           <span>⏳ 2023-07-03</span>
         </span>
-        <span class="task-due" data-task-due="past-far" title="Right-click to edit due date">
+        <span class="task-due" data-task-due="past-far" title="Click to edit due date, Right-click for more options">
           <span>📅 2023-07-04</span>
         </span>
-        <span class="task-cancelled" data-task-cancelled="past-far" title="Right-click to edit cancelled date">
+        <span
+          class="task-cancelled"
+          data-task-cancelled="past-far"
+          title="Click to edit cancelled date, Right-click for more options">
           <span>❌ 2023-07-06</span>
         </span>
-        <span class="task-done" data-task-done="past-far" title="Right-click to edit done date">
+        <span class="task-done" data-task-done="past-far" title="Click to edit done date, Right-click for more options">
           <span>✅ 2023-07-05</span>
         </span>
         <span class="task-block-link"><span>^dcf64c</span></span>

--- a/tests/Renderer/TaskLineRenderer.test.Visualise_HTML_Full_task_-_full_mode.approved.html
+++ b/tests/Renderer/TaskLineRenderer.test.Visualise_HTML_Full_task_-_full_mode.approved.html
@@ -23,22 +23,31 @@
     <span class="task-priority" data-task-priority="medium"><span>🔼</span></span>
     <span class="task-recurring"><span>🔁 every day when done</span></span>
     <span class="task-onCompletion"><span>🏁 delete</span></span>
-    <span class="task-created" data-task-created="past-4d" title="Right-click to edit created date">
+    <span
+      class="task-created"
+      data-task-created="past-4d"
+      title="Click to edit created date, Right-click for more options">
       <span>➕ 2023-07-01</span>
     </span>
-    <span class="task-start" data-task-start="past-3d" title="Right-click to edit start date">
+    <span class="task-start" data-task-start="past-3d" title="Click to edit start date, Right-click for more options">
       <span>🛫 2023-07-02</span>
     </span>
-    <span class="task-scheduled" data-task-scheduled="past-2d" title="Right-click to edit scheduled date">
+    <span
+      class="task-scheduled"
+      data-task-scheduled="past-2d"
+      title="Click to edit scheduled date, Right-click for more options">
       <span>⏳ 2023-07-03</span>
     </span>
-    <span class="task-due" data-task-due="past-1d" title="Right-click to edit due date">
+    <span class="task-due" data-task-due="past-1d" title="Click to edit due date, Right-click for more options">
       <span>📅 2023-07-04</span>
     </span>
-    <span class="task-cancelled" data-task-cancelled="future-1d" title="Right-click to edit cancelled date">
+    <span
+      class="task-cancelled"
+      data-task-cancelled="future-1d"
+      title="Click to edit cancelled date, Right-click for more options">
       <span>❌ 2023-07-06</span>
     </span>
-    <span class="task-done" data-task-done="today" title="Right-click to edit done date">
+    <span class="task-done" data-task-done="today" title="Click to edit done date, Right-click for more options">
       <span>✅ 2023-07-05</span>
     </span>
     <span class="task-block-link"><span>^dcf64c</span></span>

--- a/tests/Renderer/TaskLineRenderer.test.Visualise_HTML_Full_task_-_short_mode.approved.html
+++ b/tests/Renderer/TaskLineRenderer.test.Visualise_HTML_Full_task_-_short_mode.approved.html
@@ -23,18 +23,33 @@
     <span class="task-priority" data-task-priority="medium"><span>🔼</span></span>
     <span class="task-recurring"><span>🔁</span></span>
     <span class="task-onCompletion"><span>🏁</span></span>
-    <span class="task-created" data-task-created="past-4d" title="Right-click to edit created date">
+    <span
+      class="task-created"
+      data-task-created="past-4d"
+      title="Click to edit created date, Right-click for more options">
       <span>➕</span>
     </span>
-    <span class="task-start" data-task-start="past-3d" title="Right-click to edit start date"><span>🛫</span></span>
-    <span class="task-scheduled" data-task-scheduled="past-2d" title="Right-click to edit scheduled date">
+    <span class="task-start" data-task-start="past-3d" title="Click to edit start date, Right-click for more options">
+      <span>🛫</span>
+    </span>
+    <span
+      class="task-scheduled"
+      data-task-scheduled="past-2d"
+      title="Click to edit scheduled date, Right-click for more options">
       <span>⏳</span>
     </span>
-    <span class="task-due" data-task-due="past-1d" title="Right-click to edit due date"><span>📅</span></span>
-    <span class="task-cancelled" data-task-cancelled="future-1d" title="Right-click to edit cancelled date">
+    <span class="task-due" data-task-due="past-1d" title="Click to edit due date, Right-click for more options">
+      <span>📅</span>
+    </span>
+    <span
+      class="task-cancelled"
+      data-task-cancelled="future-1d"
+      title="Click to edit cancelled date, Right-click for more options">
       <span>❌</span>
     </span>
-    <span class="task-done" data-task-done="today" title="Right-click to edit done date"><span>✅</span></span>
+    <span class="task-done" data-task-done="today" title="Click to edit done date, Right-click for more options">
+      <span>✅</span>
+    </span>
     <span class="task-block-link"><span>^dcf64c</span></span>
   </span>
 </li>


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: #2649
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

## Description

Add a **calendar date-picker** when user left-clicks on date values in **Reading Mode** and **Tasks search results**.
<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

## Motivation and Context

Fix #2649.

## How has this been tested?

- Exploratory testing
- Running the newly reinstated smoke tests for editing of dates
- I've been using virtually identical code in my own vault for months. This code differs in having new Clear and Today buttons, and working correctly on mobile.

## Screenshots (if appropriate)

Demo:

https://github.com/user-attachments/assets/0e386af5-8db5-40c7-87ff-466608855753

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
