### PR TITLE
fix: - Allow multiple spaces after onCompletion emoji

### DIFF
--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -91,7 +91,7 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
         doneDateRegex: /✅ *(\d{4}-\d{2}-\d{2})$/u,
         cancelledDateRegex: /❌ *(\d{4}-\d{2}-\d{2})$/u,
         recurrenceRegex: /🔁 ?([a-zA-Z0-9, !]+)$/iu,
-        onCompletionRegex: /🏁 ?([a-zA-Z]+)$/iu,
+        onCompletionRegex: /🏁 *([a-zA-Z]+)$/iu,
         dependsOnRegex: new RegExp('⛔\uFE0F? *(' + taskIdSequenceRegex.source + ')$', 'iu'),
         idRegex: new RegExp('🆔 *(' + taskIdRegex.source + ')$', 'iu'),
     },

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -71,7 +71,7 @@ describe('validate emoji regular expressions', () => {
             doneDateRegex: /✅ *(\\d{4}-\\d{2}-\\d{2})$/u
             cancelledDateRegex: /❌ *(\\d{4}-\\d{2}-\\d{2})$/u
             recurrenceRegex: /🔁 ?([a-zA-Z0-9, !]+)$/iu
-            onCompletionRegex: /🏁 ?([a-zA-Z]+)$/iu
+            onCompletionRegex: /🏁 *([a-zA-Z]+)$/iu
             dependsOnRegex: /⛔️? *([a-zA-Z0-9-_]+( *, *[a-zA-Z0-9-_]+ *)*)$/iu
             idRegex: /🆔 *([a-zA-Z0-9-_]+)$/iu"
         `);
@@ -175,7 +175,7 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
                 expect(taskDetails).toMatchTaskDetails({ onCompletion: OnCompletion.Delete });
             });
 
-            it.failing('should allow multiple spaces', () => {
+            it('should allow multiple spaces', () => {
                 const onCompletion = `${onCompletionSymbol}  Keep`;
                 const taskDetails = deserialize(onCompletion);
                 expect(taskDetails).toMatchTaskDetails({ onCompletion: OnCompletion.Keep });

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -174,6 +174,12 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
                 const taskDetails = deserialize(onCompletion);
                 expect(taskDetails).toMatchTaskDetails({ onCompletion: OnCompletion.Delete });
             });
+
+            it.failing('should allow multiple spaces', () => {
+                const onCompletion = `${onCompletionSymbol}  Keep`;
+                const taskDetails = deserialize(onCompletion);
+                expect(taskDetails).toMatchTaskDetails({ onCompletion: OnCompletion.Keep });
+            });
         });
 
         describe('should parse depends on', () => {

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -170,7 +170,7 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
 
         describe('should parse onCompletion', () => {
             it('should parse delete action', () => {
-                const onCompletion = `${onCompletionSymbol} delete`;
+                const onCompletion = `${onCompletionSymbol} Delete`;
                 const taskDetails = deserialize(onCompletion);
                 expect(taskDetails).toMatchTaskDetails({ onCompletion: OnCompletion.Delete });
             });


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Multiple spaces are now allowed between `🏁` and its value.

I found this whilst doing preparatory refactoring to fix #3179.

Also, adjust test to confirm that parsing of `on completion` field is case-insensitive.

## Motivation and Context

Fix unreported bug that the Tasks Emoji format did not allow more than one space between the emoji and value.

- `🏁 delete` worked
- `🏁  delete` was not parsed, and was considered part of the task description 

## How has this been tested?

- Added failing test to show the problem
- Did exploratory testing to confirm it's fixed

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
