### PR TITLE
fix: Handle any hidden VS16 character on all emojis

### DIFF
--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -60,7 +60,8 @@ function dateFieldRegex(symbols: string) {
 }
 
 function fieldRegex(symbols: string, valueRegexString: string) {
-    let source = symbols;
+    // \uFE0F? allows an optional Variant Selector 16 on emojis.
+    let source = symbols + '\uFE0F?';
     if (valueRegexString !== '') {
         source += ' *' + valueRegexString;
     }
@@ -95,8 +96,7 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
     TaskFormatRegularExpressions: {
         // The following regex's end with `$` because they will be matched and
         // removed from the end until none are left.
-        // \uFE0F? allows an optional Variant Selector 16 on emojis.
-        priorityRegex: fieldRegex('([🔺⏫🔼🔽⏬])\uFE0F?', ''),
+        priorityRegex: fieldRegex('([🔺⏫🔼🔽⏬])', ''),
         startDateRegex: dateFieldRegex('🛫'),
         createdDateRegex: dateFieldRegex('➕'),
         scheduledDateRegex: dateFieldRegex('[⏳⌛]'),
@@ -105,7 +105,7 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
         cancelledDateRegex: dateFieldRegex('❌'),
         recurrenceRegex: fieldRegex('🔁', '([a-zA-Z0-9, !]+)'),
         onCompletionRegex: fieldRegex('🏁', '([a-zA-Z]+)'),
-        dependsOnRegex: fieldRegex('⛔\uFE0F?', '(' + taskIdSequenceRegex.source + ')'),
+        dependsOnRegex: fieldRegex('⛔', '(' + taskIdSequenceRegex.source + ')'),
         idRegex: fieldRegex('🆔', '(' + taskIdRegex.source + ')'),
     },
 } as const;

--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -65,6 +65,8 @@ function fieldRegex(symbols: string, valueRegexString: string) {
     if (valueRegexString !== '') {
         source += ' *' + valueRegexString;
     }
+    // The regexes end with `$` because they will be matched and
+    // removed from the end until none are left.
     source += '$';
     return new RegExp(source, 'u');
 }
@@ -94,8 +96,6 @@ export const DEFAULT_SYMBOLS: DefaultTaskSerializerSymbols = {
     dependsOnSymbol: '⛔',
     idSymbol: '🆔',
     TaskFormatRegularExpressions: {
-        // The following regex's end with `$` because they will be matched and
-        // removed from the end until none are left.
         priorityRegex: fieldRegex('([🔺⏫🔼🔽⏬])', ''),
         startDateRegex: dateFieldRegex('🛫'),
         createdDateRegex: dateFieldRegex('➕'),

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -66,16 +66,16 @@ describe('validate emoji regular expressions', () => {
         expect(generateRegexApprovalTest()).toMatchInlineSnapshot(`
             "
             priorityRegex: /([🔺⏫🔼🔽⏬])\\ufe0f?$/u
-            startDateRegex: /🛫 *(\\d{4}-\\d{2}-\\d{2})$/u
-            createdDateRegex: /➕ *(\\d{4}-\\d{2}-\\d{2})$/u
-            scheduledDateRegex: /[⏳⌛] *(\\d{4}-\\d{2}-\\d{2})$/u
-            dueDateRegex: /[📅📆🗓] *(\\d{4}-\\d{2}-\\d{2})$/u
-            doneDateRegex: /✅ *(\\d{4}-\\d{2}-\\d{2})$/u
-            cancelledDateRegex: /❌ *(\\d{4}-\\d{2}-\\d{2})$/u
-            recurrenceRegex: /🔁 *([a-zA-Z0-9, !]+)$/u
-            onCompletionRegex: /🏁 *([a-zA-Z]+)$/u
+            startDateRegex: /🛫\\ufe0f? *(\\d{4}-\\d{2}-\\d{2})$/u
+            createdDateRegex: /➕\\ufe0f? *(\\d{4}-\\d{2}-\\d{2})$/u
+            scheduledDateRegex: /[⏳⌛]\\ufe0f? *(\\d{4}-\\d{2}-\\d{2})$/u
+            dueDateRegex: /[📅📆🗓]\\ufe0f? *(\\d{4}-\\d{2}-\\d{2})$/u
+            doneDateRegex: /✅\\ufe0f? *(\\d{4}-\\d{2}-\\d{2})$/u
+            cancelledDateRegex: /❌\\ufe0f? *(\\d{4}-\\d{2}-\\d{2})$/u
+            recurrenceRegex: /🔁\\ufe0f? *([a-zA-Z0-9, !]+)$/u
+            onCompletionRegex: /🏁\\ufe0f? *([a-zA-Z]+)$/u
             dependsOnRegex: /⛔\\ufe0f? *([a-zA-Z0-9-_]+( *, *[a-zA-Z0-9-_]+ *)*)$/u
-            idRegex: /🆔 *([a-zA-Z0-9-_]+)$/u
+            idRegex: /🆔\\ufe0f? *([a-zA-Z0-9-_]+)$/u
             "
         `);
     });
@@ -122,7 +122,7 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
                 expect(taskDetails).toMatchTaskDetails({ ['scheduledDate']: moment('2021-06-20', 'YYYY-MM-DD') });
             });
 
-            it.failing('should parse a scheduledDate - with Variation Selector', () => {
+            it('should parse a scheduledDate - with Variation Selector', () => {
                 // This test showed the existence of https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3179
                 const input = '⏳️ 2024-11-18';
                 expect(hasVariantSelector16(input)).toBe(true);

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -122,6 +122,15 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
                 expect(taskDetails).toMatchTaskDetails({ ['scheduledDate']: moment('2021-06-20', 'YYYY-MM-DD') });
             });
 
+            it.failing('should parse a scheduledDate - with Variation Selector', () => {
+                // This test showed the existence of https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3179
+                const input = '⏳️ 2024-11-18';
+                expect(hasVariantSelector16(input)).toBe(true);
+
+                const taskDetails = deserialize(input);
+                expect(taskDetails).toMatchTaskDetails({ ['scheduledDate']: moment('2024-11-18', 'YYYY-MM-DD') });
+            });
+
             it('should parse a dueDate - with non-standard emoji 1', () => {
                 const taskDetails = deserialize('📆 2021-06-20');
                 expect(taskDetails).toMatchTaskDetails({ ['dueDate']: moment('2021-06-20', 'YYYY-MM-DD') });


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3179

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Tasks can now cope with any emojis being followed by VS16 Variation Selectors, not just priorities and depends-on.

## Motivation and Context

Fix #3179

## How has this been tested?

- Automated tests
- Exploratory testing

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
