### PR TITLE
docs: Add the "Tasks extras" and other improvements to Styling docs

### DIFF
--- a/docs/Advanced/Styling.md
+++ b/docs/Advanced/Styling.md
@@ -71,135 +71,184 @@ The reason for this additional internal span is that it allows CSS styles that c
 
 ### Sample HTML: Full mode
 
-To help visualise the structure above, here is the HTML for a sample task shown in [[Layout#Full Mode|full mode]].
+To help visualise the structure above, here is the HTML for a sample Tasks search shown in [[Layout#Full Mode|full mode]].
 
 > [!Note]
-> The below does not (yet) show the "Task extras".
+> In Reading Mode:
+>
+> - all the classes and data inside the `li` are available,
+> - and none of the "Task extras" content is available.
 
-<!-- snippet: TaskLineRenderer.test.Visualise_HTML_Full_task_-_full_mode.approved.html -->
+<!-- snippet: QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task.approved.html -->
 ```html
 <!--
   - [ ] Do exercises #todo #health 🆔 abcdef ⛔ 123456,abc123 🔼 🔁 every day when done 🏁 delete ➕ 2023-07-01 🛫 2023-07-02 ⏳ 2023-07-03 📅 2023-07-04 ❌ 2023-07-06 ✅ 2023-07-05 ^dcf64c
 -->
 
-<li
-  class="task-list-item plugin-tasks-list-item"
-  data-task-priority="medium"
-  data-task-created="past-4d"
-  data-task-start="past-3d"
-  data-task-scheduled="past-2d"
-  data-task-due="past-1d"
-  data-task-cancelled="future-1d"
-  data-task-done="today"
-  data-task=""
-  data-line="0"
-  data-task-status-name="Todo"
-  data-task-status-type="TODO">
-  <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
-  <span class="tasks-list-text">
-    <span class="task-description"><span>Do exercises #todo #health</span></span>
-    <span class="task-id"><span>🆔 abcdef</span></span>
-    <span class="task-dependsOn"><span>⛔ 123456,abc123</span></span>
-    <span class="task-priority" data-task-priority="medium"><span>🔼</span></span>
-    <span class="task-recurring"><span>🔁 every day when done</span></span>
-    <span class="task-onCompletion"><span>🏁 delete</span></span>
-    <span
-      class="task-created"
+<div>
+  <ul class="contains-task-list plugin-tasks-query-result">
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="medium"
       data-task-created="past-4d"
-      title="Click to edit created date, Right-click for more options">
-      <span>➕ 2023-07-01</span>
-    </span>
-    <span class="task-start" data-task-start="past-3d" title="Click to edit start date, Right-click for more options">
-      <span>🛫 2023-07-02</span>
-    </span>
-    <span
-      class="task-scheduled"
+      data-task-start="past-3d"
       data-task-scheduled="past-2d"
-      title="Click to edit scheduled date, Right-click for more options">
-      <span>⏳ 2023-07-03</span>
-    </span>
-    <span class="task-due" data-task-due="past-1d" title="Click to edit due date, Right-click for more options">
-      <span>📅 2023-07-04</span>
-    </span>
-    <span
-      class="task-cancelled"
+      data-task-due="past-1d"
       data-task-cancelled="future-1d"
-      title="Click to edit cancelled date, Right-click for more options">
-      <span>❌ 2023-07-06</span>
-    </span>
-    <span class="task-done" data-task-done="today" title="Click to edit done date, Right-click for more options">
-      <span>✅ 2023-07-05</span>
-    </span>
-    <span class="task-block-link"><span>^dcf64c</span></span>
-  </span>
-</li>
+      data-task-done="today"
+      data-task=""
+      data-line="0"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>Do exercises #todo #health</span></span>
+        <span class="task-id"><span>🆔 abcdef</span></span>
+        <span class="task-dependsOn"><span>⛔ 123456,abc123</span></span>
+        <span class="task-priority" data-task-priority="medium"><span>🔼</span></span>
+        <span class="task-recurring"><span>🔁 every day when done</span></span>
+        <span class="task-onCompletion"><span>🏁 delete</span></span>
+        <span
+          class="task-created"
+          data-task-created="past-4d"
+          title="Click to edit created date, Right-click for more options">
+          <span>➕ 2023-07-01</span>
+        </span>
+        <span
+          class="task-start"
+          data-task-start="past-3d"
+          title="Click to edit start date, Right-click for more options">
+          <span>🛫 2023-07-02</span>
+        </span>
+        <span
+          class="task-scheduled"
+          data-task-scheduled="past-2d"
+          title="Click to edit scheduled date, Right-click for more options">
+          <span>⏳ 2023-07-03</span>
+        </span>
+        <span class="task-due" data-task-due="past-1d" title="Click to edit due date, Right-click for more options">
+          <span>📅 2023-07-04</span>
+        </span>
+        <span
+          class="task-cancelled"
+          data-task-cancelled="future-1d"
+          title="Click to edit cancelled date, Right-click for more options">
+          <span>❌ 2023-07-06</span>
+        </span>
+        <span class="task-done" data-task-done="today" title="Click to edit done date, Right-click for more options">
+          <span>✅ 2023-07-05</span>
+        </span>
+        <span class="task-block-link"><span>^dcf64c</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-urgency">18.157</span>
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">fileName &gt; My Header</a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+        <a class="tasks-postpone" title="ℹ️ Due tomorrow, on Thu 6th Jul (right-click for more options)"></a>
+      </span>
+    </li>
+  </ul>
+  <div class="task-count">1 task</div>
+</div>
 ```
 <!-- endSnippet -->
 
 ### Sample HTML: Short mode
 
-Here is the same task in [[Layout#Short Mode|short mode]]. The only difference is that any text values after Tasks emoji are omitted:
+Here is the same Tasks search in [[Layout#Short Mode|short mode]].
+
+The differences from full mode are:
+
+- the `ul` has an extra class `tasks-layout-short-mode`,
+- any text values after Tasks emoji are omitted,
+- the backlink is shorter and has an extra class `internal-link-short-mode`,
+- the postpone button has an extra class `tasks-postpone-short-mode`.
 
 > [!Note]
-> The below does not (yet) show the "Task extras".
+> In Reading Mode:
 >
-<!-- snippet: TaskLineRenderer.test.Visualise_HTML_Full_task_-_short_mode.approved.html -->
+> - all the classes and data inside the `li` are available,
+> - and none of the "Task extras" content is available.
+
+<!-- snippet: QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task_-_short_mode.approved.html -->
 ```html
 <!--
   - [ ] Do exercises #todo #health 🆔 abcdef ⛔ 123456,abc123 🔼 🔁 every day when done 🏁 delete ➕ 2023-07-01 🛫 2023-07-02 ⏳ 2023-07-03 📅 2023-07-04 ❌ 2023-07-06 ✅ 2023-07-05 ^dcf64c
 -->
 
-<li
-  class="task-list-item plugin-tasks-list-item"
-  data-task-priority="medium"
-  data-task-created="past-4d"
-  data-task-start="past-3d"
-  data-task-scheduled="past-2d"
-  data-task-due="past-1d"
-  data-task-cancelled="future-1d"
-  data-task-done="today"
-  data-task=""
-  data-line="0"
-  data-task-status-name="Todo"
-  data-task-status-type="TODO">
-  <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
-  <span class="tasks-list-text">
-    <span class="task-description"><span>Do exercises #todo #health</span></span>
-    <span class="task-id"><span>🆔</span></span>
-    <span class="task-dependsOn"><span>⛔</span></span>
-    <span class="task-priority" data-task-priority="medium"><span>🔼</span></span>
-    <span class="task-recurring"><span>🔁</span></span>
-    <span class="task-onCompletion"><span>🏁</span></span>
-    <span
-      class="task-created"
+<div>
+  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-short-mode">
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="medium"
       data-task-created="past-4d"
-      title="Click to edit created date, Right-click for more options">
-      <span>➕</span>
-    </span>
-    <span class="task-start" data-task-start="past-3d" title="Click to edit start date, Right-click for more options">
-      <span>🛫</span>
-    </span>
-    <span
-      class="task-scheduled"
+      data-task-start="past-3d"
       data-task-scheduled="past-2d"
-      title="Click to edit scheduled date, Right-click for more options">
-      <span>⏳</span>
-    </span>
-    <span class="task-due" data-task-due="past-1d" title="Click to edit due date, Right-click for more options">
-      <span>📅</span>
-    </span>
-    <span
-      class="task-cancelled"
+      data-task-due="past-1d"
       data-task-cancelled="future-1d"
-      title="Click to edit cancelled date, Right-click for more options">
-      <span>❌</span>
-    </span>
-    <span class="task-done" data-task-done="today" title="Click to edit done date, Right-click for more options">
-      <span>✅</span>
-    </span>
-    <span class="task-block-link"><span>^dcf64c</span></span>
-  </span>
-</li>
+      data-task-done="today"
+      data-task=""
+      data-line="0"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>Do exercises #todo #health</span></span>
+        <span class="task-id"><span>🆔</span></span>
+        <span class="task-dependsOn"><span>⛔</span></span>
+        <span class="task-priority" data-task-priority="medium"><span>🔼</span></span>
+        <span class="task-recurring"><span>🔁</span></span>
+        <span class="task-onCompletion"><span>🏁</span></span>
+        <span
+          class="task-created"
+          data-task-created="past-4d"
+          title="Click to edit created date, Right-click for more options">
+          <span>➕</span>
+        </span>
+        <span
+          class="task-start"
+          data-task-start="past-3d"
+          title="Click to edit start date, Right-click for more options">
+          <span>🛫</span>
+        </span>
+        <span
+          class="task-scheduled"
+          data-task-scheduled="past-2d"
+          title="Click to edit scheduled date, Right-click for more options">
+          <span>⏳</span>
+        </span>
+        <span class="task-due" data-task-due="past-1d" title="Click to edit due date, Right-click for more options">
+          <span>📅</span>
+        </span>
+        <span
+          class="task-cancelled"
+          data-task-cancelled="future-1d"
+          title="Click to edit cancelled date, Right-click for more options">
+          <span>❌</span>
+        </span>
+        <span class="task-done" data-task-done="today" title="Click to edit done date, Right-click for more options">
+          <span>✅</span>
+        </span>
+        <span class="task-block-link"><span>^dcf64c</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-urgency">18.157</span>
+        <span class="tasks-backlink">
+          <a rel="noopener" target="_blank" class="internal-link internal-link-short-mode">🔗</a>
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+        <a
+          class="tasks-postpone tasks-postpone-short-mode"
+          title="ℹ️ Due tomorrow, on Thu 6th Jul (right-click for more options)"></a>
+      </span>
+    </li>
+  </ul>
+  <div class="task-count">1 task</div>
+</div>
 ```
 <!-- endSnippet -->
 

--- a/docs/Advanced/Styling.md
+++ b/docs/Advanced/Styling.md
@@ -44,9 +44,15 @@ The Tasks plugin renders a task in the following structure (this refers to query
         - Task description and tags (span class="task-description")
           - Internal span
             - Each tag in the description is wrapped in <a href class="tag" data-tag-name="[tag-name]">
+        - Task ID (span class="task-id")
+          - Internal span
+        - Task 'depends on' (span class="task-dependsOn")
+          - Internal span
         - Task priority (span class="task-priority" + data-task-priority attribute)
           - Internal span
         - Task recurrence rule (span class="task-recurring")
+          - Internal span
+        - Task 'on completion' (span class="onCompletion")
           - Internal span
         - Task created date (span class="task-created" + data-task-created attribute)
           - Internal span
@@ -216,8 +222,10 @@ The generic classes are:
 - `task-cancelled`
 - `task-done`
 - `task-recurring`
+- `task-onCompletion`
 - `task-id`
 - `task-dependsOn`
+- `task-block-link`
 
 In addition to the generic classes, there are [**data attributes**](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) that represent the content of the various task components.
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -409,7 +409,9 @@ export class QueryResultsRenderer {
 
     private addUrgency(listItem: HTMLElement, task: Task) {
         const text = new Intl.NumberFormat().format(task.urgency);
-        listItem.createSpan({ text, cls: 'tasks-urgency' });
+        const span = createAndAppendElement('span', listItem);
+        span.textContent = text;
+        span.classList.add('tasks-urgency');
     }
 
     /**

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task.approved.html
@@ -1,3 +1,7 @@
+<!--
+  - [ ] Do exercises #todo #health 🆔 abcdef ⛔ 123456,abc123 🔼 🔁 every day when done 🏁 delete ➕ 2023-07-01 🛫 2023-07-02 ⏳ 2023-07-03 📅 2023-07-04 ❌ 2023-07-06 ✅ 2023-07-05 ^dcf64c
+-->
+
 <div>
   <ul class="contains-task-list plugin-tasks-query-result">
     <li

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task.approved.html
@@ -1,5 +1,5 @@
 <div>
-  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+  <ul class="contains-task-list plugin-tasks-query-result">
     <li
       class="task-list-item plugin-tasks-list-item"
       data-task-priority="medium"
@@ -54,6 +54,7 @@
         <span class="task-block-link"><span>^dcf64c</span></span>
       </span>
       <span class="task-extras">
+        <span class="tasks-urgency">18.157</span>
         <span class="tasks-backlink">
           (
           <a rel="noopener" target="_blank" class="internal-link">fileName &gt; My Header</a>

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task.approved.html
@@ -3,12 +3,12 @@
     <li
       class="task-list-item plugin-tasks-list-item"
       data-task-priority="medium"
-      data-task-created="past-far"
-      data-task-start="past-far"
-      data-task-scheduled="past-far"
-      data-task-due="past-far"
-      data-task-cancelled="past-far"
-      data-task-done="past-far"
+      data-task-created="past-4d"
+      data-task-start="past-3d"
+      data-task-scheduled="past-2d"
+      data-task-due="past-1d"
+      data-task-cancelled="future-1d"
+      data-task-done="today"
       data-task=""
       data-line="0"
       data-task-status-name="Todo"
@@ -23,32 +23,32 @@
         <span class="task-onCompletion"><span>🏁 delete</span></span>
         <span
           class="task-created"
-          data-task-created="past-far"
+          data-task-created="past-4d"
           title="Click to edit created date, Right-click for more options">
           <span>➕ 2023-07-01</span>
         </span>
         <span
           class="task-start"
-          data-task-start="past-far"
+          data-task-start="past-3d"
           title="Click to edit start date, Right-click for more options">
           <span>🛫 2023-07-02</span>
         </span>
         <span
           class="task-scheduled"
-          data-task-scheduled="past-far"
+          data-task-scheduled="past-2d"
           title="Click to edit scheduled date, Right-click for more options">
           <span>⏳ 2023-07-03</span>
         </span>
-        <span class="task-due" data-task-due="past-far" title="Click to edit due date, Right-click for more options">
+        <span class="task-due" data-task-due="past-1d" title="Click to edit due date, Right-click for more options">
           <span>📅 2023-07-04</span>
         </span>
         <span
           class="task-cancelled"
-          data-task-cancelled="past-far"
+          data-task-cancelled="future-1d"
           title="Click to edit cancelled date, Right-click for more options">
           <span>❌ 2023-07-06</span>
         </span>
-        <span class="task-done" data-task-done="past-far" title="Click to edit done date, Right-click for more options">
+        <span class="task-done" data-task-done="today" title="Click to edit done date, Right-click for more options">
           <span>✅ 2023-07-05</span>
         </span>
         <span class="task-block-link"><span>^dcf64c</span></span>
@@ -60,7 +60,7 @@
           )
         </span>
         <a class="tasks-edit" title="Edit task" href="#"></a>
-        <a class="tasks-postpone" title="ℹ️ Due tomorrow, on Tue 20th Aug (right-click for more options)"></a>
+        <a class="tasks-postpone" title="ℹ️ Due tomorrow, on Thu 6th Jul (right-click for more options)"></a>
       </span>
     </li>
   </ul>

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task_-_short_mode.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task_-_short_mode.approved.html
@@ -1,0 +1,69 @@
+<div>
+  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-short-mode">
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="medium"
+      data-task-created="past-4d"
+      data-task-start="past-3d"
+      data-task-scheduled="past-2d"
+      data-task-due="past-1d"
+      data-task-cancelled="future-1d"
+      data-task-done="today"
+      data-task=""
+      data-line="0"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>Do exercises #todo #health</span></span>
+        <span class="task-id"><span>🆔</span></span>
+        <span class="task-dependsOn"><span>⛔</span></span>
+        <span class="task-priority" data-task-priority="medium"><span>🔼</span></span>
+        <span class="task-recurring"><span>🔁</span></span>
+        <span class="task-onCompletion"><span>🏁</span></span>
+        <span
+          class="task-created"
+          data-task-created="past-4d"
+          title="Click to edit created date, Right-click for more options">
+          <span>➕</span>
+        </span>
+        <span
+          class="task-start"
+          data-task-start="past-3d"
+          title="Click to edit start date, Right-click for more options">
+          <span>🛫</span>
+        </span>
+        <span
+          class="task-scheduled"
+          data-task-scheduled="past-2d"
+          title="Click to edit scheduled date, Right-click for more options">
+          <span>⏳</span>
+        </span>
+        <span class="task-due" data-task-due="past-1d" title="Click to edit due date, Right-click for more options">
+          <span>📅</span>
+        </span>
+        <span
+          class="task-cancelled"
+          data-task-cancelled="future-1d"
+          title="Click to edit cancelled date, Right-click for more options">
+          <span>❌</span>
+        </span>
+        <span class="task-done" data-task-done="today" title="Click to edit done date, Right-click for more options">
+          <span>✅</span>
+        </span>
+        <span class="task-block-link"><span>^dcf64c</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-urgency">18.157</span>
+        <span class="tasks-backlink">
+          <a rel="noopener" target="_blank" class="internal-link internal-link-short-mode">🔗</a>
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+        <a
+          class="tasks-postpone tasks-postpone-short-mode"
+          title="ℹ️ Due tomorrow, on Thu 6th Jul (right-click for more options)"></a>
+      </span>
+    </li>
+  </ul>
+  <div class="task-count">1 task</div>
+</div>

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task_-_short_mode.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_fully_populated_task_-_short_mode.approved.html
@@ -1,3 +1,7 @@
+<!--
+  - [ ] Do exercises #todo #health 🆔 abcdef ⛔ 123456,abc123 🔼 🔁 every day when done 🏁 delete ➕ 2023-07-01 🛫 2023-07-02 ⏳ 2023-07-03 📅 2023-07-04 ❌ 2023-07-06 ✅ 2023-07-05 ^dcf64c
+-->
+
 <div>
   <ul class="contains-task-list plugin-tasks-query-result tasks-layout-short-mode">
     <li

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items.approved.html
@@ -1,3 +1,12 @@
+<!--
+    - [ ] parent 1
+        - [ ] child 1
+            - [ ] grandchild 1
+        - [ ] child 2
+                - [ ] grand grand child
+    - [ ] parent 2
+-->
+
 <div>
   <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
     <li

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items_hidden.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items_hidden.approved.html
@@ -1,3 +1,12 @@
+<!--
+    - [ ] parent 1
+        - [ ] child 1
+            - [ ] grandchild 1
+        - [ ] child 2
+                - [ ] grand grand child
+    - [ ] parent 2
+-->
+
 <div>
   <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
     <li

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items_reverse_sorted.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_parent-child_items_reverse_sorted.approved.html
@@ -1,3 +1,12 @@
+<!--
+    - [ ] parent 2
+                - [ ] grand grand child
+        - [ ] child 2
+            - [ ] grandchild 1
+        - [ ] child 1
+    - [ ] parent 1
+-->
+
 <div>
   <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
     <li

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_should_render_tasks_without_their_parents.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_should_render_tasks_without_their_parents.approved.html
@@ -1,3 +1,10 @@
+<!--
+- [ ] parent task
+        - [ ] grandchild task 1
+        - [ ] grandchild task 2
+        - [ ] grandchild task 3
+-->
+
 <div>
   <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
     <li

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -52,7 +52,7 @@ describe('QueryResultsRenderer tests', () => {
 
     it('fully populated task', async () => {
         const allTasks = [TaskBuilder.createFullyPopulatedTask()];
-        await verifyRenderedTasksHTML(allTasks);
+        await verifyRenderedTasksHTML(allTasks, 'show urgency');
     });
 
     const showTree = 'show tree\n';

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -18,7 +18,7 @@ window.moment = moment;
 
 beforeEach(() => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2024-08-19'));
+    jest.setSystemTime(new Date('2023-07-05'));
 });
 
 afterEach(() => {

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -55,6 +55,11 @@ describe('QueryResultsRenderer tests', () => {
         await verifyRenderedTasksHTML(allTasks, 'show urgency');
     });
 
+    it('fully populated task - short mode', async () => {
+        const allTasks = [TaskBuilder.createFullyPopulatedTask()];
+        await verifyRenderedTasksHTML(allTasks, 'show urgency\nshort mode');
+    });
+
     const showTree = 'show tree\n';
     const hideTree = 'hide tree\n';
 

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -12,6 +12,7 @@ import { readTasksFromSimulatedFile } from '../Obsidian/SimulatedFile';
 import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
 import { prettifyHTML } from '../TestingTools/HTMLHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { toMarkdown } from '../TestingTools/TestHelpers';
 import { mockHTMLRenderer } from './RenderingTestHelpers';
 
 window.moment = moment;
@@ -46,8 +47,12 @@ describe('QueryResultsRenderer tests', () => {
 
         await renderer.render(State.Warm, allTasks, container, queryRendererParameters);
 
+        const taskAsMarkdown = `<!--
+${toMarkdown(allTasks)}
+-->\n\n`;
+
         const prettyHTML = prettifyHTML(container.outerHTML);
-        verifyWithFileExtension(prettyHTML, 'html');
+        verifyWithFileExtension(taskAsMarkdown + prettyHTML, 'html');
     }
 
     it('fully populated task', async () => {


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Improve `Styling` docs:

- Add some missing recent fields to the documentation (`id`, `dependsOn` and `onCompletion`).
- Show the HTML for a full Tasks query block, instead of just for a single task.
- It shows the classes added to the `ul` in the Sample HTML in Styling doc
- It also adds the "Tasks extras" to the Sample HTML in Styling docs:
    - Urgency
    - Backlink
    - Edit button
    - Postpone button

## Motivation and Context

I had to look some of this up for a user support query, so I thought I might as well save it.

Though it turned out to be a larger task than I had expected!

## How has this been tested?

- Automated tests
- Exploratory testing

## Screenshots

The bits marked in red are the new bits:

<img width="1139" alt="image" src="https://github.com/user-attachments/assets/a9f93644-02f4-4a51-9867-6f33ca58ca97">


## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
