### PR TITLE
refactor: Reduce repetition of parsing of show/hide options

### DIFF
--- a/src/Layout/QueryLayoutOptions.ts
+++ b/src/Layout/QueryLayoutOptions.ts
@@ -23,29 +23,20 @@ export class QueryLayoutOptions {
  * @see parseTaskShowHideOptions
  */
 export function parseQueryShowHideOptions(queryLayoutOptions: QueryLayoutOptions, option: string, hide: boolean) {
-    if (option.startsWith('tree')) {
-        queryLayoutOptions.hideTree = hide;
-        return true;
-    }
-    if (option.startsWith('task count')) {
-        queryLayoutOptions.hideTaskCount = hide;
-        return true;
-    }
-    if (option.startsWith('backlink')) {
-        queryLayoutOptions.hideBacklinks = hide;
-        return true;
-    }
-    if (option.startsWith('postpone button')) {
-        queryLayoutOptions.hidePostponeButton = hide;
-        return true;
-    }
-    if (option.startsWith('edit button')) {
-        queryLayoutOptions.hideEditButton = hide;
-        return true;
-    }
-    if (option.startsWith('urgency')) {
-        queryLayoutOptions.hideUrgency = hide;
-        return true;
+    const optionMap = new Map<string, keyof QueryLayoutOptions>([
+        ['tree', 'hideTree'],
+        ['task count', 'hideTaskCount'],
+        ['backlink', 'hideBacklinks'],
+        ['postpone button', 'hidePostponeButton'],
+        ['edit button', 'hideEditButton'],
+        ['urgency', 'hideUrgency'],
+    ]);
+
+    for (const [key, property] of optionMap.entries()) {
+        if (option.startsWith(key)) {
+            queryLayoutOptions[property] = hide;
+            return true;
+        }
     }
     return false;
 }

--- a/src/Layout/QueryLayoutOptions.ts
+++ b/src/Layout/QueryLayoutOptions.ts
@@ -24,11 +24,12 @@ export class QueryLayoutOptions {
  */
 export function parseQueryShowHideOptions(queryLayoutOptions: QueryLayoutOptions, option: string, hide: boolean) {
     const optionMap = new Map<string, keyof QueryLayoutOptions>([
-        ['tree', 'hideTree'],
-        ['task count', 'hideTaskCount'],
+        // Alphabetical order
         ['backlink', 'hideBacklinks'],
-        ['postpone button', 'hidePostponeButton'],
         ['edit button', 'hideEditButton'],
+        ['postpone button', 'hidePostponeButton'],
+        ['task count', 'hideTaskCount'],
+        ['tree', 'hideTree'],
         ['urgency', 'hideUrgency'],
     ]);
 

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -135,10 +135,6 @@ export function parseTaskShowHideOptions(taskLayoutOptions: TaskLayoutOptions, o
         taskLayoutOptions.setVisibility(TaskLayoutComponent.RecurrenceRule, visible);
         return true;
     }
-    if (option.startsWith('tags')) {
-        taskLayoutOptions.setTagsVisibility(visible);
-        return true;
-    }
     if (option.startsWith('id')) {
         taskLayoutOptions.setVisibility(TaskLayoutComponent.Id, visible);
         return true;
@@ -151,5 +147,11 @@ export function parseTaskShowHideOptions(taskLayoutOptions: TaskLayoutOptions, o
         taskLayoutOptions.setVisibility(TaskLayoutComponent.OnCompletion, visible);
         return true;
     }
+
+    if (option.startsWith('tags')) {
+        taskLayoutOptions.setTagsVisibility(visible);
+        return true;
+    }
+
     return false;
 }

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -104,17 +104,18 @@ export class TaskLayoutOptions {
  */
 export function parseTaskShowHideOptions(taskLayoutOptions: TaskLayoutOptions, option: string, visible: boolean) {
     const optionMap = new Map<string, TaskLayoutComponent>([
-        ['priority', TaskLayoutComponent.Priority],
+        // Alphabetical order
         ['cancelled date', TaskLayoutComponent.CancelledDate],
         ['created date', TaskLayoutComponent.CreatedDate],
-        ['start date', TaskLayoutComponent.StartDate],
-        ['scheduled date', TaskLayoutComponent.ScheduledDate],
-        ['due date', TaskLayoutComponent.DueDate],
-        ['done date', TaskLayoutComponent.DoneDate],
-        ['recurrence rule', TaskLayoutComponent.RecurrenceRule],
-        ['id', TaskLayoutComponent.Id],
         ['depends on', TaskLayoutComponent.DependsOn],
+        ['done date', TaskLayoutComponent.DoneDate],
+        ['due date', TaskLayoutComponent.DueDate],
+        ['id', TaskLayoutComponent.Id],
         ['on completion', TaskLayoutComponent.OnCompletion],
+        ['priority', TaskLayoutComponent.Priority],
+        ['recurrence rule', TaskLayoutComponent.RecurrenceRule],
+        ['scheduled date', TaskLayoutComponent.ScheduledDate],
+        ['start date', TaskLayoutComponent.StartDate],
     ]);
 
     for (const [key, component] of optionMap.entries()) {

--- a/src/Layout/TaskLayoutOptions.ts
+++ b/src/Layout/TaskLayoutOptions.ts
@@ -103,49 +103,25 @@ export class TaskLayoutOptions {
  * @see parseQueryShowHideOptions
  */
 export function parseTaskShowHideOptions(taskLayoutOptions: TaskLayoutOptions, option: string, visible: boolean) {
-    if (option.startsWith('priority')) {
-        taskLayoutOptions.setVisibility(TaskLayoutComponent.Priority, visible);
-        return true;
-    }
-    if (option.startsWith('cancelled date')) {
-        taskLayoutOptions.setVisibility(TaskLayoutComponent.CancelledDate, visible);
-        return true;
-    }
-    if (option.startsWith('created date')) {
-        taskLayoutOptions.setVisibility(TaskLayoutComponent.CreatedDate, visible);
-        return true;
-    }
-    if (option.startsWith('start date')) {
-        taskLayoutOptions.setVisibility(TaskLayoutComponent.StartDate, visible);
-        return true;
-    }
-    if (option.startsWith('scheduled date')) {
-        taskLayoutOptions.setVisibility(TaskLayoutComponent.ScheduledDate, visible);
-        return true;
-    }
-    if (option.startsWith('due date')) {
-        taskLayoutOptions.setVisibility(TaskLayoutComponent.DueDate, visible);
-        return true;
-    }
-    if (option.startsWith('done date')) {
-        taskLayoutOptions.setVisibility(TaskLayoutComponent.DoneDate, visible);
-        return true;
-    }
-    if (option.startsWith('recurrence rule')) {
-        taskLayoutOptions.setVisibility(TaskLayoutComponent.RecurrenceRule, visible);
-        return true;
-    }
-    if (option.startsWith('id')) {
-        taskLayoutOptions.setVisibility(TaskLayoutComponent.Id, visible);
-        return true;
-    }
-    if (option.startsWith('depends on')) {
-        taskLayoutOptions.setVisibility(TaskLayoutComponent.DependsOn, visible);
-        return true;
-    }
-    if (option.startsWith('on completion')) {
-        taskLayoutOptions.setVisibility(TaskLayoutComponent.OnCompletion, visible);
-        return true;
+    const optionMap = new Map<string, TaskLayoutComponent>([
+        ['priority', TaskLayoutComponent.Priority],
+        ['cancelled date', TaskLayoutComponent.CancelledDate],
+        ['created date', TaskLayoutComponent.CreatedDate],
+        ['start date', TaskLayoutComponent.StartDate],
+        ['scheduled date', TaskLayoutComponent.ScheduledDate],
+        ['due date', TaskLayoutComponent.DueDate],
+        ['done date', TaskLayoutComponent.DoneDate],
+        ['recurrence rule', TaskLayoutComponent.RecurrenceRule],
+        ['id', TaskLayoutComponent.Id],
+        ['depends on', TaskLayoutComponent.DependsOn],
+        ['on completion', TaskLayoutComponent.OnCompletion],
+    ]);
+
+    for (const [key, component] of optionMap.entries()) {
+        if (option.startsWith(key)) {
+            taskLayoutOptions.setVisibility(component, visible);
+            return true;
+        }
     }
 
     if (option.startsWith('tags')) {

--- a/tests/Layout/QueryLayoutOptions.test.ts
+++ b/tests/Layout/QueryLayoutOptions.test.ts
@@ -19,4 +19,18 @@ describe('parsing query show/hide layout options', () => {
         parseOptionAndCheck(options, option, hiddenByDefault);
         expect(options.hideTree).toEqual(hiddenByDefault);
     });
+
+    it('should parse "task count" option', () => {
+        const option = 'task count';
+        const hiddenByDefault = false;
+
+        const options = new QueryLayoutOptions();
+        expect(options.hideTaskCount).toBe(hiddenByDefault);
+
+        parseOptionAndCheck(options, option, !hiddenByDefault);
+        expect(options.hideTaskCount).toEqual(!hiddenByDefault);
+
+        parseOptionAndCheck(options, option, hiddenByDefault);
+        expect(options.hideTaskCount).toEqual(hiddenByDefault);
+    });
 });

--- a/tests/Layout/QueryLayoutOptions.test.ts
+++ b/tests/Layout/QueryLayoutOptions.test.ts
@@ -6,31 +6,23 @@ describe('parsing query show/hide layout options', () => {
         expect(success).toEqual(true);
     }
 
-    it('should parse "tree" option', () => {
-        const option = 'tree';
-        const hiddenByDefault = true;
+    const testCases: [string, keyof QueryLayoutOptions, boolean][] = [
+        ['tree', 'hideTree', true],
+        ['task count', 'hideTaskCount', false],
+        ['backlink', 'hideBacklinks', false],
+        ['postpone button', 'hidePostponeButton', false],
+        ['edit button', 'hideEditButton', false],
+        ['urgency', 'hideUrgency', true],
+    ];
 
+    it.each(testCases)('should parse "%s" option', (option, property, hiddenByDefault) => {
         const options = new QueryLayoutOptions();
-        expect(options.hideTree).toBe(hiddenByDefault);
+        expect(options[property]).toBe(hiddenByDefault);
 
         parseOptionAndCheck(options, option, !hiddenByDefault);
-        expect(options.hideTree).toEqual(!hiddenByDefault);
+        expect(options[property]).toEqual(!hiddenByDefault);
 
         parseOptionAndCheck(options, option, hiddenByDefault);
-        expect(options.hideTree).toEqual(hiddenByDefault);
-    });
-
-    it('should parse "task count" option', () => {
-        const option = 'task count';
-        const hiddenByDefault = false;
-
-        const options = new QueryLayoutOptions();
-        expect(options.hideTaskCount).toBe(hiddenByDefault);
-
-        parseOptionAndCheck(options, option, !hiddenByDefault);
-        expect(options.hideTaskCount).toEqual(!hiddenByDefault);
-
-        parseOptionAndCheck(options, option, hiddenByDefault);
-        expect(options.hideTaskCount).toEqual(hiddenByDefault);
+        expect(options[property]).toEqual(hiddenByDefault);
     });
 });

--- a/tests/Layout/QueryLayoutOptions.test.ts
+++ b/tests/Layout/QueryLayoutOptions.test.ts
@@ -7,11 +7,12 @@ describe('parsing query show/hide layout options', () => {
     }
 
     const testCases: [string, keyof QueryLayoutOptions, boolean][] = [
-        ['tree', 'hideTree', true],
-        ['task count', 'hideTaskCount', false],
+        // Alphabetical order
         ['backlink', 'hideBacklinks', false],
-        ['postpone button', 'hidePostponeButton', false],
         ['edit button', 'hideEditButton', false],
+        ['postpone button', 'hidePostponeButton', false],
+        ['task count', 'hideTaskCount', false],
+        ['tree', 'hideTree', true],
         ['urgency', 'hideUrgency', true],
     ];
 

--- a/tests/Layout/QueryLayoutOptions.test.ts
+++ b/tests/Layout/QueryLayoutOptions.test.ts
@@ -1,0 +1,22 @@
+import { QueryLayoutOptions, parseQueryShowHideOptions } from '../../src/Layout/QueryLayoutOptions';
+
+describe('parsing query show/hide layout options', () => {
+    function parseOptionAndCheck(options: QueryLayoutOptions, option: string, hide: boolean) {
+        const success = parseQueryShowHideOptions(options, option, hide);
+        expect(success).toEqual(true);
+    }
+
+    it('should parse "tree" option', () => {
+        const option = 'tree';
+        const hiddenByDefault = true;
+
+        const options = new QueryLayoutOptions();
+        expect(options.hideTree).toBe(hiddenByDefault);
+
+        parseOptionAndCheck(options, option, !hiddenByDefault);
+        expect(options.hideTree).toEqual(!hiddenByDefault);
+
+        parseOptionAndCheck(options, option, hiddenByDefault);
+        expect(options.hideTree).toEqual(hiddenByDefault);
+    });
+});

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -1,4 +1,4 @@
-import { TaskLayoutComponent, TaskLayoutOptions } from '../../src/Layout/TaskLayoutOptions';
+import { TaskLayoutComponent, TaskLayoutOptions, parseTaskShowHideOptions } from '../../src/Layout/TaskLayoutOptions';
 
 describe('TaskLayoutOptions', () => {
     it('should be constructable', () => {
@@ -149,5 +149,20 @@ describe('TaskLayoutOptions', () => {
             cancelledDate
             doneDate"
         `);
+    });
+});
+
+describe('parsing task show/hide layout options', () => {
+    it('should parse priority', () => {
+        const option = 'priority';
+        const component = TaskLayoutComponent.Priority;
+
+        const options = new TaskLayoutOptions();
+
+        parseTaskShowHideOptions(options, option, false);
+        expect(options.isShown(component)).toEqual(false);
+
+        parseTaskShowHideOptions(options, option, true);
+        expect(options.isShown(component)).toEqual(true);
     });
 });

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -153,16 +153,26 @@ describe('TaskLayoutOptions', () => {
 });
 
 describe('parsing task show/hide layout options', () => {
-    it.each([['priority', TaskLayoutComponent.Priority]])(
-        'should parse option: %s',
-        (option: string, component: TaskLayoutComponent) => {
-            const options = new TaskLayoutOptions();
+    it.each([
+        // Alphabetical order
+        ['cancelled date', TaskLayoutComponent.CancelledDate],
+        ['created date', TaskLayoutComponent.CreatedDate],
+        ['depends on', TaskLayoutComponent.DependsOn],
+        ['done date', TaskLayoutComponent.DoneDate],
+        ['due date', TaskLayoutComponent.DueDate],
+        ['id', TaskLayoutComponent.Id],
+        ['on completion', TaskLayoutComponent.OnCompletion],
+        ['priority', TaskLayoutComponent.Priority],
+        ['recurrence rule', TaskLayoutComponent.RecurrenceRule],
+        ['scheduled date', TaskLayoutComponent.ScheduledDate],
+        ['start date', TaskLayoutComponent.StartDate],
+    ])('should parse option: %s', (option: string, component: TaskLayoutComponent) => {
+        const options = new TaskLayoutOptions();
 
-            parseTaskShowHideOptions(options, option, false);
-            expect(options.isShown(component)).toEqual(false);
+        parseTaskShowHideOptions(options, option, false);
+        expect(options.isShown(component)).toEqual(false);
 
-            parseTaskShowHideOptions(options, option, true);
-            expect(options.isShown(component)).toEqual(true);
-        },
-    );
+        parseTaskShowHideOptions(options, option, true);
+        expect(options.isShown(component)).toEqual(true);
+    });
 });

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -175,4 +175,14 @@ describe('parsing task show/hide layout options', () => {
         parseTaskShowHideOptions(options, option, true);
         expect(options.isShown(component)).toEqual(true);
     });
+
+    it('should parse tags option', () => {
+        const options = new TaskLayoutOptions();
+
+        parseTaskShowHideOptions(options, 'tags', false);
+        expect(options.areTagsShown()).toEqual(false);
+
+        parseTaskShowHideOptions(options, 'tags', true);
+        expect(options.areTagsShown()).toEqual(true);
+    });
 });

--- a/tests/Layout/TaskLayoutOptions.test.ts
+++ b/tests/Layout/TaskLayoutOptions.test.ts
@@ -153,16 +153,16 @@ describe('TaskLayoutOptions', () => {
 });
 
 describe('parsing task show/hide layout options', () => {
-    it('should parse priority', () => {
-        const option = 'priority';
-        const component = TaskLayoutComponent.Priority;
+    it.each([['priority', TaskLayoutComponent.Priority]])(
+        'should parse option: %s',
+        (option: string, component: TaskLayoutComponent) => {
+            const options = new TaskLayoutOptions();
 
-        const options = new TaskLayoutOptions();
+            parseTaskShowHideOptions(options, option, false);
+            expect(options.isShown(component)).toEqual(false);
 
-        parseTaskShowHideOptions(options, option, false);
-        expect(options.isShown(component)).toEqual(false);
-
-        parseTaskShowHideOptions(options, option, true);
-        expect(options.isShown(component)).toEqual(true);
-    });
+            parseTaskShowHideOptions(options, option, true);
+            expect(options.isShown(component)).toEqual(true);
+        },
+    );
 });


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Refactor to reduce repetition in `QueryLayoutOptions` and `TaskLayoutComponent`.

## Motivation and Context

To make the code easier to read and to modify.

## How has this been tested?

- Automated tests

Specifically, I added full tests of the existing code first, and then refactored the original code.

I am conscious that there is now some similarity between code in the tests and the implementation - but the tests came first, to ensure I didn't break the code during refactoring.

## Screenshots (if appropriate)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
