### PR TITLE
refactor: Introduce FileParser class

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/Test Data/multiple_headings.md
+++ b/resources/sample_vaults/Tasks-Demo/Test Data/multiple_headings.md
@@ -1,7 +1,17 @@
 # multiple_headings
 
+## Level 2 heading with no taks
+
 ## Level 2 heading
+
+- [ ] #task Task 1 in Level 2 heading - in 'multiple_headings' - list 1
+- [ ] #task task 2 in Level 2 heading - in 'multiple_headings' - list 1
+
+Divider to create a new section
+
+- [ ] #task task 3 in Level 2 heading - in 'multiple_headings' - list 2
 
 ### Level 3 heading
 
-- [ ] #task Task in 'multiple_headings'
+- [ ] #task Task 4 in 'multiple_headings' - in 'multiple_headings' - list 3
+- [ ] #task Task 5 in 'multiple_headings' - in 'multiple_headings' - list 3

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -10,7 +10,7 @@ import { getSettings } from '../Config/Settings';
 import { Lazy } from '../lib/Lazy';
 import { Logger, logging } from '../lib/logging';
 import type { TasksEvents } from './TasksEvents';
-import { parseFileContent } from './FileParser';
+import { FileParser } from './FileParser';
 
 export enum State {
     Cold = 'Cold',
@@ -307,7 +307,8 @@ export class Cache {
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
         logger: Logger,
     ): Task[] {
-        return parseFileContent(filePath, fileContent, listItems, logger, fileCache, errorReporter);
+        const fileParser = new FileParser();
+        return fileParser.parseFileContent(filePath, fileContent, listItems, logger, fileCache, errorReporter);
     }
 
     private reportTaskParsingErrorToUser(e: any, filePath: string, listItem: ListItemCache, line: string) {

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -308,7 +308,7 @@ export class Cache {
         logger: Logger,
     ): Task[] {
         const fileParser = new FileParser(filePath, fileContent, listItems, logger, fileCache, errorReporter);
-        return fileParser.parseFileContent(filePath, fileContent, listItems, logger, fileCache, errorReporter);
+        return fileParser.parseFileContent();
     }
 
     private reportTaskParsingErrorToUser(e: any, filePath: string, listItem: ListItemCache, line: string) {

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -307,7 +307,7 @@ export class Cache {
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
         logger: Logger,
     ): Task[] {
-        const fileParser = new FileParser(filePath);
+        const fileParser = new FileParser(filePath, fileContent, listItems, logger, fileCache, errorReporter);
         return fileParser.parseFileContent(filePath, fileContent, listItems, logger, fileCache, errorReporter);
     }
 

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -307,7 +307,7 @@ export class Cache {
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
         logger: Logger,
     ): Task[] {
-        const fileParser = new FileParser();
+        const fileParser = new FileParser(filePath);
         return fileParser.parseFileContent(filePath, fileContent, listItems, logger, fileCache, errorReporter);
     }
 

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -43,8 +43,7 @@ export class FileParser {
         }
 
         const tasksFile = new TasksFile(this.filePath, this.fileCache);
-        const fileLines = this.fileLines;
-        const linesInFile = fileLines.length;
+        const linesInFile = this.fileLines.length;
 
         // Lazily store date extracted from filename to avoid parsing more than needed
         // this.logger.debug(`getTasksFromFileContent() reading ${file.path}`);
@@ -87,7 +86,7 @@ export class FileParser {
                 continue;
             }
 
-            const line = fileLines[lineNumber];
+            const line = this.fileLines[lineNumber];
             if (line === undefined) {
                 this.logger.debug(`${this.filePath}: line ${lineNumber} - ignoring 'undefined' line.`);
                 continue;
@@ -136,7 +135,7 @@ export class FileParser {
 
                 const parentListItem: ListItem | null = line2ListItem.get(listItem.parent) ?? null;
 
-                line2ListItem.set(lineNumber, new ListItem(fileLines[lineNumber], parentListItem));
+                line2ListItem.set(lineNumber, new ListItem(this.fileLines[lineNumber], parentListItem));
             }
         }
 

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -58,7 +58,6 @@ export class FileParser {
         // rendered lists.
         let currentSection: SectionCache | null = null;
         let sectionIndex = 0;
-        const line2ListItem: Map<number, ListItem> = this.line2ListItem;
         for (const listItem of this.listItems) {
             const lineNumber = listItem.position.start.line;
             if (lineNumber >= linesInFile) {
@@ -115,7 +114,7 @@ export class FileParser {
                     if (task !== null) {
                         // listItem.parent could be negative if the parent is not found (in other words, it is a root task).
                         // That is not a problem, as we never put a negative number in line2ListItem map, so parent will be null.
-                        const parentListItem: ListItem | null = line2ListItem.get(listItem.parent) ?? null;
+                        const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
                         if (parentListItem !== null) {
                             task = new Task({
                                 ...task,
@@ -123,7 +122,7 @@ export class FileParser {
                             });
                         }
 
-                        line2ListItem.set(lineNumber, task);
+                        this.line2ListItem.set(lineNumber, task);
                     }
                 } catch (e) {
                     this.errorReporter(e, this.filePath, listItem, line);
@@ -135,8 +134,8 @@ export class FileParser {
                     this.tasks.push(task);
                 }
             } else {
-                const parentListItem: ListItem | null = line2ListItem.get(listItem.parent) ?? null;
-                line2ListItem.set(lineNumber, new ListItem(this.fileLines[lineNumber], parentListItem));
+                const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
+                this.line2ListItem.set(lineNumber, new ListItem(this.fileLines[lineNumber], parentListItem));
             }
         }
 

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -39,129 +39,111 @@ export class FileParser {
         const thisDotlogger = this.logger;
         const thisDotfileCache = this.fileCache;
         const thisDoterrorReporter = this.errorReporter;
-        return parseFileContent(
-            thisDotfilePath,
-            thisDotfileContent,
-            thisDotlistItems,
-            thisDotlogger,
-            thisDotfileCache,
-            thisDoterrorReporter,
-        );
-    }
-}
-
-export function parseFileContent(
-    thisDotfilePath: string,
-    thisDotfileContent: string,
-    thisDotlistItems: ListItemCache[] | undefined,
-    thisDotlogger: Logger,
-    thisDotfileCache: CachedMetadata,
-    thisDoterrorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
-) {
-    const tasks: Task[] = [];
-    if (thisDotlistItems === undefined) {
-        // When called via Cache, this function would never be called or files without list items.
-        // It is useful for tests to be act gracefully on sample Markdown files with no list items, however.
-        return tasks;
-    }
-
-    const tasksFile = new TasksFile(thisDotfilePath, thisDotfileCache);
-    const fileLines = thisDotfileContent.split('\n');
-    const linesInFile = fileLines.length;
-
-    // Lazily store date extracted from filename to avoid parsing more than needed
-    // this.logger.debug(`getTasksFromFileContent() reading ${file.path}`);
-    const dateFromFileName = new Lazy(() => DateFallback.fromPath(thisDotfilePath));
-
-    // We want to store section information with every task so
-    // that we can use that when we post process the markdown
-    // rendered lists.
-    let currentSection: SectionCache | null = null;
-    let sectionIndex = 0;
-    const line2ListItem: Map<number, ListItem> = new Map();
-    for (const listItem of thisDotlistItems) {
-        const lineNumber = listItem.position.start.line;
-        if (lineNumber >= linesInFile) {
-            /*
-                Obsidian CachedMetadata has told us that there is a task on lineNumber, but there are
-                not that many lines in the file.
-
-                This was the underlying cause of all the 'Stuck on "Loading Tasks..."' messages,
-                as it resulted in the line 'undefined' being parsed.
-
-                Somehow the file had been shortened whilst Obsidian was closed, meaning that
-                when Obsidian started up, it got the new file content, but still had the old cached
-                data about locations of list items in the file.
-             */
-            thisDotlogger.debug(
-                `${thisDotfilePath} Obsidian gave us a line number ${lineNumber} past the end of the file. ${linesInFile}.`,
-            );
+        const tasks: Task[] = [];
+        if (thisDotlistItems === undefined) {
+            // When called via Cache, this function would never be called or files without list items.
+            // It is useful for tests to be act gracefully on sample Markdown files with no list items, however.
             return tasks;
         }
-        if (currentSection === null || currentSection.position.end.line < lineNumber) {
-            // We went past the current section (or this is the first task).
-            // Find the section that is relevant for this task and the following of the same section.
-            currentSection = Cache.getSection(lineNumber, thisDotfileCache.sections);
-            sectionIndex = 0;
-        }
 
-        if (currentSection === null) {
-            // Cannot process a task without a section.
-            continue;
-        }
+        const tasksFile = new TasksFile(thisDotfilePath, thisDotfileCache);
+        const fileLines = thisDotfileContent.split('\n');
+        const linesInFile = fileLines.length;
 
-        const line = fileLines[lineNumber];
-        if (line === undefined) {
-            thisDotlogger.debug(`${thisDotfilePath}: line ${lineNumber} - ignoring 'undefined' line.`);
-            continue;
-        }
+        // Lazily store date extracted from filename to avoid parsing more than needed
+        // this.logger.debug(`getTasksFromFileContent() reading ${file.path}`);
+        const dateFromFileName = new Lazy(() => DateFallback.fromPath(thisDotfilePath));
 
-        const taskLocation = new TaskLocation(
-            tasksFile,
-            lineNumber,
-            currentSection.position.start.line,
-            sectionIndex,
-            Cache.getPrecedingHeader(lineNumber, thisDotfileCache.headings),
-        );
-        if (listItem.task !== undefined) {
-            let task;
-            try {
-                task = Task.fromLine({
-                    line,
-                    taskLocation: taskLocation,
-                    fallbackDate: dateFromFileName.value,
-                });
+        // We want to store section information with every task so
+        // that we can use that when we post process the markdown
+        // rendered lists.
+        let currentSection: SectionCache | null = null;
+        let sectionIndex = 0;
+        const line2ListItem: Map<number, ListItem> = new Map();
+        for (const listItem of thisDotlistItems) {
+            const lineNumber = listItem.position.start.line;
+            if (lineNumber >= linesInFile) {
+                /*
+                    Obsidian CachedMetadata has told us that there is a task on lineNumber, but there are
+                    not that many lines in the file.
 
-                if (task !== null) {
-                    // listItem.parent could be negative if the parent is not found (in other words, it is a root task).
-                    // That is not a problem, as we never put a negative number in line2ListItem map, so parent will be null.
-                    const parentListItem: ListItem | null = line2ListItem.get(listItem.parent) ?? null;
-                    if (parentListItem !== null) {
-                        task = new Task({
-                            ...task,
-                            parent: parentListItem,
-                        });
-                    }
+                    This was the underlying cause of all the 'Stuck on "Loading Tasks..."' messages,
+                    as it resulted in the line 'undefined' being parsed.
 
-                    line2ListItem.set(lineNumber, task);
-                }
-            } catch (e) {
-                thisDoterrorReporter(e, thisDotfilePath, listItem, line);
+                    Somehow the file had been shortened whilst Obsidian was closed, meaning that
+                    when Obsidian started up, it got the new file content, but still had the old cached
+                    data about locations of list items in the file.
+                 */
+                thisDotlogger.debug(
+                    `${thisDotfilePath} Obsidian gave us a line number ${lineNumber} past the end of the file. ${linesInFile}.`,
+                );
+                return tasks;
+            }
+            if (currentSection === null || currentSection.position.end.line < lineNumber) {
+                // We went past the current section (or this is the first task).
+                // Find the section that is relevant for this task and the following of the same section.
+                currentSection = Cache.getSection(lineNumber, thisDotfileCache.sections);
+                sectionIndex = 0;
+            }
+
+            if (currentSection === null) {
+                // Cannot process a task without a section.
                 continue;
             }
 
-            if (task !== null) {
-                sectionIndex++;
-                tasks.push(task);
+            const line = fileLines[lineNumber];
+            if (line === undefined) {
+                thisDotlogger.debug(`${thisDotfilePath}: line ${lineNumber} - ignoring 'undefined' line.`);
+                continue;
             }
-        } else {
-            const lineNumber = listItem.position.start.line;
 
-            const parentListItem: ListItem | null = line2ListItem.get(listItem.parent) ?? null;
+            const taskLocation = new TaskLocation(
+                tasksFile,
+                lineNumber,
+                currentSection.position.start.line,
+                sectionIndex,
+                Cache.getPrecedingHeader(lineNumber, thisDotfileCache.headings),
+            );
+            if (listItem.task !== undefined) {
+                let task;
+                try {
+                    task = Task.fromLine({
+                        line,
+                        taskLocation: taskLocation,
+                        fallbackDate: dateFromFileName.value,
+                    });
 
-            line2ListItem.set(lineNumber, new ListItem(fileLines[lineNumber], parentListItem));
+                    if (task !== null) {
+                        // listItem.parent could be negative if the parent is not found (in other words, it is a root task).
+                        // That is not a problem, as we never put a negative number in line2ListItem map, so parent will be null.
+                        const parentListItem: ListItem | null = line2ListItem.get(listItem.parent) ?? null;
+                        if (parentListItem !== null) {
+                            task = new Task({
+                                ...task,
+                                parent: parentListItem,
+                            });
+                        }
+
+                        line2ListItem.set(lineNumber, task);
+                    }
+                } catch (e) {
+                    thisDoterrorReporter(e, thisDotfilePath, listItem, line);
+                    continue;
+                }
+
+                if (task !== null) {
+                    sectionIndex++;
+                    tasks.push(task);
+                }
+            } else {
+                const lineNumber = listItem.position.start.line;
+
+                const parentListItem: ListItem | null = line2ListItem.get(listItem.parent) ?? null;
+
+                line2ListItem.set(lineNumber, new ListItem(fileLines[lineNumber], parentListItem));
+            }
         }
-    }
 
-    return tasks;
+        return tasks;
+    }
 }

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -8,6 +8,19 @@ import { ListItem } from '../Task/ListItem';
 import { TaskLocation } from '../Task/TaskLocation';
 import { Cache } from './Cache';
 
+export class FileParser {
+    public parseFileContent(
+        filePath: string,
+        fileContent: string,
+        listItems: ListItemCache[] | undefined,
+        logger: Logger,
+        fileCache: CachedMetadata,
+        errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
+    ) {
+        return parseFileContent(filePath, fileContent, listItems, logger, fileCache, errorReporter);
+    }
+}
+
 export function parseFileContent(
     filePath: string,
     fileContent: string,

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -9,15 +9,21 @@ import { TaskLocation } from '../Task/TaskLocation';
 import { Cache } from './Cache';
 
 export class FileParser {
+    private readonly filePath: string;
+
+    constructor(filePath: string) {
+        this.filePath = filePath;
+    }
+
     public parseFileContent(
-        filePath: string,
+        _filePath: string,
         fileContent: string,
         listItems: ListItemCache[] | undefined,
         logger: Logger,
         fileCache: CachedMetadata,
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
     ) {
-        return parseFileContent(filePath, fileContent, listItems, logger, fileCache, errorReporter);
+        return parseFileContent(this.filePath, fileContent, listItems, logger, fileCache, errorReporter);
     }
 }
 

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -32,14 +32,7 @@ export class FileParser {
         this.errorReporter = errorReporter;
     }
 
-    public parseFileContent(
-        _filePath: string,
-        _fileContent: string,
-        _listItems: ListItemCache[] | undefined,
-        _logger: Logger,
-        _fileCache: CachedMetadata,
-        _errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
-    ) {
+    public parseFileContent() {
         return parseFileContent(
             this.filePath,
             this.fileContent,

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -17,6 +17,7 @@ export class FileParser {
     private readonly errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void;
 
     private readonly fileLines: string[];
+    private line2ListItem: Map<number, ListItem> = new Map();
     private readonly tasks: Task[] = [];
     private readonly dateFromFileName: Lazy<moment.Moment | null>;
 
@@ -57,7 +58,7 @@ export class FileParser {
         // rendered lists.
         let currentSection: SectionCache | null = null;
         let sectionIndex = 0;
-        const line2ListItem: Map<number, ListItem> = new Map();
+        const line2ListItem: Map<number, ListItem> = this.line2ListItem;
         for (const listItem of this.listItems) {
             const lineNumber = listItem.position.start.line;
             if (lineNumber >= linesInFile) {

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -10,27 +10,44 @@ import { Cache } from './Cache';
 
 export class FileParser {
     private readonly filePath: string;
+    private readonly fileContent: string;
+    private readonly listItems: ListItemCache[];
+    private readonly logger: Logger;
+    private readonly fileCache: CachedMetadata;
+    private readonly errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void;
 
     constructor(
         filePath: string,
-        _fileContent: string,
-        _listItems: ListItemCache[],
-        _logger: Logger,
-        _fileCache: CachedMetadata,
-        _errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
-    ) {
-        this.filePath = filePath;
-    }
-
-    public parseFileContent(
-        _filePath: string,
         fileContent: string,
-        listItems: ListItemCache[] | undefined,
+        listItems: ListItemCache[],
         logger: Logger,
         fileCache: CachedMetadata,
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
     ) {
-        return parseFileContent(this.filePath, fileContent, listItems, logger, fileCache, errorReporter);
+        this.filePath = filePath;
+        this.fileContent = fileContent;
+        this.listItems = listItems;
+        this.logger = logger;
+        this.fileCache = fileCache;
+        this.errorReporter = errorReporter;
+    }
+
+    public parseFileContent(
+        _filePath: string,
+        _fileContent: string,
+        _listItems: ListItemCache[] | undefined,
+        _logger: Logger,
+        _fileCache: CachedMetadata,
+        _errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
+    ) {
+        return parseFileContent(
+            this.filePath,
+            this.fileContent,
+            this.listItems,
+            this.logger,
+            this.fileCache,
+            this.errorReporter,
+        );
     }
 }
 

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -11,7 +11,14 @@ import { Cache } from './Cache';
 export class FileParser {
     private readonly filePath: string;
 
-    constructor(filePath: string) {
+    constructor(
+        filePath: string,
+        _fileContent: string,
+        _listItems: ListItemCache[],
+        _logger: Logger,
+        _fileCache: CachedMetadata,
+        _errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
+    ) {
         this.filePath = filePath;
     }
 

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -33,13 +33,19 @@ export class FileParser {
     }
 
     public parseFileContent() {
+        const thisDotfilePath = this.filePath;
+        const thisDotfileContent = this.fileContent;
+        const thisDotlistItems = this.listItems;
+        const thisDotlogger = this.logger;
+        const thisDotfileCache = this.fileCache;
+        const thisDoterrorReporter = this.errorReporter;
         return parseFileContent(
-            this.filePath,
-            this.fileContent,
-            this.listItems,
-            this.logger,
-            this.fileCache,
-            this.errorReporter,
+            thisDotfilePath,
+            thisDotfileContent,
+            thisDotlistItems,
+            thisDotlogger,
+            thisDotfileCache,
+            thisDoterrorReporter,
         );
     }
 }

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -47,7 +47,7 @@ export class FileParser {
         const linesInFile = this.fileLines.length;
 
         // Lazily store date extracted from filename to avoid parsing more than needed
-        // this.logger.debug(`getTasksFromFileContent() reading ${file.path}`);
+        // this.logger.debug(`FileParser.parseFileContent() reading ${this.filePath}`);
         const dateFromFileName = new Lazy(() => DateFallback.fromPath(this.filePath));
 
         // We want to store section information with every task so

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -35,6 +35,8 @@ export class FileParser {
         this.fileCache = fileCache;
         this.errorReporter = errorReporter;
         this.fileLines = this.fileContent.split('\n');
+
+        // Lazily store date extracted from filename to avoid parsing more than needed
         this.dateFromFileName = new Lazy(() => DateFallback.fromPath(this.filePath));
     }
 
@@ -48,9 +50,7 @@ export class FileParser {
         const tasksFile = new TasksFile(this.filePath, this.fileCache);
         const linesInFile = this.fileLines.length;
 
-        // Lazily store date extracted from filename to avoid parsing more than needed
         // this.logger.debug(`FileParser.parseFileContent() reading ${this.filePath}`);
-        const dateFromFileName = this.dateFromFileName;
 
         // We want to store section information with every task so
         // that we can use that when we post process the markdown
@@ -108,7 +108,7 @@ export class FileParser {
                     task = Task.fromLine({
                         line,
                         taskLocation: taskLocation,
-                        fallbackDate: dateFromFileName.value,
+                        fallbackDate: this.dateFromFileName.value,
                     });
 
                     if (task !== null) {

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -17,7 +17,7 @@ export class FileParser {
     private readonly errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void;
 
     private readonly fileLines: string[];
-    private line2ListItem: Map<number, ListItem> = new Map();
+    private readonly line2ListItem: Map<number, ListItem> = new Map();
     private readonly tasks: Task[] = [];
     private readonly dateFromFileName: Lazy<moment.Moment | null>;
 

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -37,11 +37,10 @@ export class FileParser {
     }
 
     public parseFileContent() {
-        const tasks: Task[] = this.tasks;
         if (this.listItems === undefined) {
             // When called via Cache, this function would never be called or files without list items.
             // It is useful for tests to be act gracefully on sample Markdown files with no list items, however.
-            return tasks;
+            return this.tasks;
         }
 
         const tasksFile = new TasksFile(this.filePath, this.fileCache);
@@ -74,7 +73,7 @@ export class FileParser {
                 this.logger.debug(
                     `${this.filePath} Obsidian gave us a line number ${lineNumber} past the end of the file. ${linesInFile}.`,
                 );
-                return tasks;
+                return this.tasks;
             }
             if (currentSection === null || currentSection.position.end.line < lineNumber) {
                 // We went past the current section (or this is the first task).
@@ -130,7 +129,7 @@ export class FileParser {
 
                 if (task !== null) {
                     sectionIndex++;
-                    tasks.push(task);
+                    this.tasks.push(task);
                 }
             } else {
                 const parentListItem: ListItem | null = line2ListItem.get(listItem.parent) ?? null;
@@ -138,6 +137,6 @@ export class FileParser {
             }
         }
 
-        return tasks;
+        return this.tasks;
     }
 }

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -131,10 +131,7 @@ export class FileParser {
                     tasks.push(task);
                 }
             } else {
-                const lineNumber = listItem.position.start.line;
-
                 const parentListItem: ListItem | null = line2ListItem.get(listItem.parent) ?? null;
-
                 line2ListItem.set(lineNumber, new ListItem(this.fileLines[lineNumber], parentListItem));
             }
         }

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -15,6 +15,7 @@ export class FileParser {
     private readonly logger: Logger;
     private readonly fileCache: CachedMetadata;
     private readonly errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void;
+    private readonly fileLines: string[];
 
     constructor(
         filePath: string,
@@ -30,6 +31,7 @@ export class FileParser {
         this.logger = logger;
         this.fileCache = fileCache;
         this.errorReporter = errorReporter;
+        this.fileLines = this.fileContent.split('\n');
     }
 
     public parseFileContent() {
@@ -41,7 +43,7 @@ export class FileParser {
         }
 
         const tasksFile = new TasksFile(this.filePath, this.fileCache);
-        const fileLines = this.fileContent.split('\n');
+        const fileLines = this.fileLines;
         const linesInFile = fileLines.length;
 
         // Lazily store date extracted from filename to avoid parsing more than needed

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -33,26 +33,20 @@ export class FileParser {
     }
 
     public parseFileContent() {
-        const thisDotfilePath = this.filePath;
-        const thisDotfileContent = this.fileContent;
-        const thisDotlistItems = this.listItems;
-        const thisDotlogger = this.logger;
-        const thisDotfileCache = this.fileCache;
-        const thisDoterrorReporter = this.errorReporter;
         const tasks: Task[] = [];
-        if (thisDotlistItems === undefined) {
+        if (this.listItems === undefined) {
             // When called via Cache, this function would never be called or files without list items.
             // It is useful for tests to be act gracefully on sample Markdown files with no list items, however.
             return tasks;
         }
 
-        const tasksFile = new TasksFile(thisDotfilePath, thisDotfileCache);
-        const fileLines = thisDotfileContent.split('\n');
+        const tasksFile = new TasksFile(this.filePath, this.fileCache);
+        const fileLines = this.fileContent.split('\n');
         const linesInFile = fileLines.length;
 
         // Lazily store date extracted from filename to avoid parsing more than needed
         // this.logger.debug(`getTasksFromFileContent() reading ${file.path}`);
-        const dateFromFileName = new Lazy(() => DateFallback.fromPath(thisDotfilePath));
+        const dateFromFileName = new Lazy(() => DateFallback.fromPath(this.filePath));
 
         // We want to store section information with every task so
         // that we can use that when we post process the markdown
@@ -60,7 +54,7 @@ export class FileParser {
         let currentSection: SectionCache | null = null;
         let sectionIndex = 0;
         const line2ListItem: Map<number, ListItem> = new Map();
-        for (const listItem of thisDotlistItems) {
+        for (const listItem of this.listItems) {
             const lineNumber = listItem.position.start.line;
             if (lineNumber >= linesInFile) {
                 /*
@@ -74,15 +68,15 @@ export class FileParser {
                     when Obsidian started up, it got the new file content, but still had the old cached
                     data about locations of list items in the file.
                  */
-                thisDotlogger.debug(
-                    `${thisDotfilePath} Obsidian gave us a line number ${lineNumber} past the end of the file. ${linesInFile}.`,
+                this.logger.debug(
+                    `${this.filePath} Obsidian gave us a line number ${lineNumber} past the end of the file. ${linesInFile}.`,
                 );
                 return tasks;
             }
             if (currentSection === null || currentSection.position.end.line < lineNumber) {
                 // We went past the current section (or this is the first task).
                 // Find the section that is relevant for this task and the following of the same section.
-                currentSection = Cache.getSection(lineNumber, thisDotfileCache.sections);
+                currentSection = Cache.getSection(lineNumber, this.fileCache.sections);
                 sectionIndex = 0;
             }
 
@@ -93,7 +87,7 @@ export class FileParser {
 
             const line = fileLines[lineNumber];
             if (line === undefined) {
-                thisDotlogger.debug(`${thisDotfilePath}: line ${lineNumber} - ignoring 'undefined' line.`);
+                this.logger.debug(`${this.filePath}: line ${lineNumber} - ignoring 'undefined' line.`);
                 continue;
             }
 
@@ -102,7 +96,7 @@ export class FileParser {
                 lineNumber,
                 currentSection.position.start.line,
                 sectionIndex,
-                Cache.getPrecedingHeader(lineNumber, thisDotfileCache.headings),
+                Cache.getPrecedingHeader(lineNumber, this.fileCache.headings),
             );
             if (listItem.task !== undefined) {
                 let task;
@@ -127,7 +121,7 @@ export class FileParser {
                         line2ListItem.set(lineNumber, task);
                     }
                 } catch (e) {
-                    thisDoterrorReporter(e, thisDotfilePath, listItem, line);
+                    this.errorReporter(e, this.filePath, listItem, line);
                     continue;
                 }
 

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -18,6 +18,7 @@ export class FileParser {
 
     private readonly fileLines: string[];
     private readonly tasks: Task[] = [];
+    private readonly dateFromFileName: Lazy<moment.Moment | null>;
 
     constructor(
         filePath: string,
@@ -34,6 +35,7 @@ export class FileParser {
         this.fileCache = fileCache;
         this.errorReporter = errorReporter;
         this.fileLines = this.fileContent.split('\n');
+        this.dateFromFileName = new Lazy(() => DateFallback.fromPath(this.filePath));
     }
 
     public parseFileContent() {
@@ -48,7 +50,7 @@ export class FileParser {
 
         // Lazily store date extracted from filename to avoid parsing more than needed
         // this.logger.debug(`FileParser.parseFileContent() reading ${this.filePath}`);
-        const dateFromFileName = new Lazy(() => DateFallback.fromPath(this.filePath));
+        const dateFromFileName = this.dateFromFileName;
 
         // We want to store section information with every task so
         // that we can use that when we post process the markdown

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -41,6 +41,9 @@ export class FileParser {
         this.dateFromFileName = new Lazy(() => DateFallback.fromPath(this.filePath));
     }
 
+    /**
+     * **Warning**: This is designed to only be called **once per {@link FileParser} instance**.
+     */
     public parseFileContent() {
         if (this.listItems === undefined) {
             // When called via Cache, this function would never be called or files without list items.

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -15,7 +15,9 @@ export class FileParser {
     private readonly logger: Logger;
     private readonly fileCache: CachedMetadata;
     private readonly errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void;
+
     private readonly fileLines: string[];
+    private readonly tasks: Task[] = [];
 
     constructor(
         filePath: string,
@@ -35,7 +37,7 @@ export class FileParser {
     }
 
     public parseFileContent() {
-        const tasks: Task[] = [];
+        const tasks: Task[] = this.tasks;
         if (this.listItems === undefined) {
             // When called via Cache, this function would never be called or files without list items.
             // It is useful for tests to be act gracefully on sample Markdown files with no list items, however.

--- a/src/Task/TaskLocation.ts
+++ b/src/Task/TaskLocation.ts
@@ -87,7 +87,7 @@ export class TaskLocation {
     }
 
     public allFieldsExceptTasksFileForTesting() {
-        const { _tasksFile, ...rest } = Object.assign({}, this);
+        const { _tasksFile, ...rest } = { ...this };
         return rest;
     }
 }

--- a/src/Task/TaskLocation.ts
+++ b/src/Task/TaskLocation.ts
@@ -85,4 +85,9 @@ export class TaskLocation {
     public get hasKnownPath(): boolean {
         return this.path !== '';
     }
+
+    public allFieldsExceptTasksFileForTesting() {
+        const { _tasksFile, ...rest } = Object.assign({}, this);
+        return rest;
+    }
 }

--- a/tests/Obsidian/FileParser.test.ts
+++ b/tests/Obsidian/FileParser.test.ts
@@ -1,0 +1,47 @@
+import { readTasksFromSimulatedFile } from './SimulatedFile';
+import multiple_headings from './__test_data__/multiple_headings.json';
+
+describe('FileParser', () => {
+    it('should set all non-TasksFile data in TaskLocation', () => {
+        // This test exists to detect accidental changes to the task-reading code.
+        // I found that intentionally breaking the setting of _sectionIndex was
+        // not caught by any other tests.
+
+        const tasks = readTasksFromSimulatedFile(multiple_headings);
+        const locationDataExceptTasksFile = tasks.map((task) => task.taskLocation.allFieldsExceptTasksFileForTesting());
+        expect(locationDataExceptTasksFile).toMatchInlineSnapshot(`
+            [
+              {
+                "_lineNumber": 6,
+                "_precedingHeader": "Level 2 heading",
+                "_sectionIndex": 0,
+                "_sectionStart": 6,
+              },
+              {
+                "_lineNumber": 7,
+                "_precedingHeader": "Level 2 heading",
+                "_sectionIndex": 1,
+                "_sectionStart": 6,
+              },
+              {
+                "_lineNumber": 11,
+                "_precedingHeader": "Level 2 heading",
+                "_sectionIndex": 0,
+                "_sectionStart": 11,
+              },
+              {
+                "_lineNumber": 15,
+                "_precedingHeader": "Level 3 heading",
+                "_sectionIndex": 0,
+                "_sectionStart": 15,
+              },
+              {
+                "_lineNumber": 16,
+                "_precedingHeader": "Level 3 heading",
+                "_sectionIndex": 1,
+                "_sectionStart": 15,
+              },
+            ]
+        `);
+    });
+});

--- a/tests/Obsidian/SimulatedFile.ts
+++ b/tests/Obsidian/SimulatedFile.ts
@@ -1,6 +1,6 @@
 import type { CachedMetadata } from 'obsidian';
 import { logging } from '../../src/lib/logging';
-import { parseFileContent } from '../../src/Obsidian/FileParser';
+import { FileParser } from '../../src/Obsidian/FileParser';
 import { setCurrentCacheFile } from '../__mocks__/obsidian';
 
 export interface SimulatedFile {
@@ -18,7 +18,8 @@ export interface SimulatedFile {
 export function readTasksFromSimulatedFile(testData: SimulatedFile) {
     const logger = logging.getLogger('testCache');
     setCurrentCacheFile(testData);
-    return parseFileContent(
+    const fileParser = new FileParser();
+    return fileParser.parseFileContent(
         testData.filePath,
         testData.fileContents,
         testData.cachedMetadata.listItems!,

--- a/tests/Obsidian/SimulatedFile.ts
+++ b/tests/Obsidian/SimulatedFile.ts
@@ -18,7 +18,7 @@ export interface SimulatedFile {
 export function readTasksFromSimulatedFile(testData: SimulatedFile) {
     const logger = logging.getLogger('testCache');
     setCurrentCacheFile(testData);
-    const fileParser = new FileParser();
+    const fileParser = new FileParser(testData.filePath);
     return fileParser.parseFileContent(
         testData.filePath,
         testData.fileContents,

--- a/tests/Obsidian/SimulatedFile.ts
+++ b/tests/Obsidian/SimulatedFile.ts
@@ -26,14 +26,7 @@ export function readTasksFromSimulatedFile(testData: SimulatedFile) {
         testData.cachedMetadata,
         errorReporter,
     );
-    return fileParser.parseFileContent(
-        testData.filePath,
-        testData.fileContents,
-        testData.cachedMetadata.listItems!,
-        logger,
-        testData.cachedMetadata,
-        errorReporter,
-    );
+    return fileParser.parseFileContent();
 }
 
 function errorReporter() {

--- a/tests/Obsidian/SimulatedFile.ts
+++ b/tests/Obsidian/SimulatedFile.ts
@@ -18,7 +18,14 @@ export interface SimulatedFile {
 export function readTasksFromSimulatedFile(testData: SimulatedFile) {
     const logger = logging.getLogger('testCache');
     setCurrentCacheFile(testData);
-    const fileParser = new FileParser(testData.filePath);
+    const fileParser = new FileParser(
+        testData.filePath,
+        testData.fileContents,
+        testData.cachedMetadata.listItems!,
+        logger,
+        testData.cachedMetadata,
+        errorReporter,
+    );
     return fileParser.parseFileContent(
         testData.filePath,
         testData.fileContents,

--- a/tests/Obsidian/__test_data__/multiple_headings.json
+++ b/tests/Obsidian/__test_data__/multiple_headings.json
@@ -18,13 +18,13 @@
         }
       },
       {
-        "heading": "Level 2 heading",
+        "heading": "Level 2 heading with no taks",
         "level": 2,
         "position": {
           "end": {
-            "col": 18,
+            "col": 31,
             "line": 2,
-            "offset": 39
+            "offset": 52
           },
           "start": {
             "col": 0,
@@ -34,18 +34,34 @@
         }
       },
       {
+        "heading": "Level 2 heading",
+        "level": 2,
+        "position": {
+          "end": {
+            "col": 18,
+            "line": 4,
+            "offset": 72
+          },
+          "start": {
+            "col": 0,
+            "line": 4,
+            "offset": 54
+          }
+        }
+      },
+      {
         "heading": "Level 3 heading",
         "level": 3,
         "position": {
           "end": {
             "col": 19,
-            "line": 4,
-            "offset": 60
+            "line": 13,
+            "offset": 344
           },
           "start": {
             "col": 0,
-            "line": 4,
-            "offset": 41
+            "line": 13,
+            "offset": 325
           }
         }
       }
@@ -55,14 +71,78 @@
         "parent": -6,
         "position": {
           "end": {
-            "col": 39,
+            "col": 71,
             "line": 6,
-            "offset": 101
+            "offset": 145
           },
           "start": {
             "col": 0,
             "line": 6,
-            "offset": 62
+            "offset": 74
+          }
+        },
+        "task": " "
+      },
+      {
+        "parent": -6,
+        "position": {
+          "end": {
+            "col": 71,
+            "line": 7,
+            "offset": 217
+          },
+          "start": {
+            "col": 0,
+            "line": 7,
+            "offset": 146
+          }
+        },
+        "task": " "
+      },
+      {
+        "parent": -11,
+        "position": {
+          "end": {
+            "col": 71,
+            "line": 11,
+            "offset": 323
+          },
+          "start": {
+            "col": 0,
+            "line": 11,
+            "offset": 252
+          }
+        },
+        "task": " "
+      },
+      {
+        "parent": -15,
+        "position": {
+          "end": {
+            "col": 75,
+            "line": 15,
+            "offset": 421
+          },
+          "start": {
+            "col": 0,
+            "line": 15,
+            "offset": 346
+          }
+        },
+        "task": " "
+      },
+      {
+        "parent": -15,
+        "position": {
+          "end": {
+            "col": 75,
+            "line": 16,
+            "offset": 497
+          },
+          "start": {
+            "col": 0,
+            "line": 16,
+            "offset": 422
           }
         },
         "task": " "
@@ -87,9 +167,9 @@
       {
         "position": {
           "end": {
-            "col": 18,
+            "col": 31,
             "line": 2,
-            "offset": 39
+            "offset": 52
           },
           "start": {
             "col": 0,
@@ -102,14 +182,14 @@
       {
         "position": {
           "end": {
-            "col": 19,
+            "col": 18,
             "line": 4,
-            "offset": 60
+            "offset": 72
           },
           "start": {
             "col": 0,
             "line": 4,
-            "offset": 41
+            "offset": 54
           }
         },
         "type": "heading"
@@ -117,14 +197,74 @@
       {
         "position": {
           "end": {
-            "col": 39,
-            "line": 6,
-            "offset": 101
+            "col": 71,
+            "line": 7,
+            "offset": 217
           },
           "start": {
             "col": 0,
             "line": 6,
-            "offset": 62
+            "offset": 74
+          }
+        },
+        "type": "list"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 31,
+            "line": 9,
+            "offset": 250
+          },
+          "start": {
+            "col": 0,
+            "line": 9,
+            "offset": 219
+          }
+        },
+        "type": "paragraph"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 71,
+            "line": 11,
+            "offset": 323
+          },
+          "start": {
+            "col": 0,
+            "line": 11,
+            "offset": 252
+          }
+        },
+        "type": "list"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 19,
+            "line": 13,
+            "offset": 344
+          },
+          "start": {
+            "col": 0,
+            "line": 13,
+            "offset": 325
+          }
+        },
+        "type": "heading"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 75,
+            "line": 16,
+            "offset": 497
+          },
+          "start": {
+            "col": 0,
+            "line": 15,
+            "offset": 346
           }
         },
         "type": "list"
@@ -136,22 +276,85 @@
           "end": {
             "col": 11,
             "line": 6,
-            "offset": 73
+            "offset": 85
           },
           "start": {
             "col": 6,
             "line": 6,
-            "offset": 68
+            "offset": 80
+          }
+        },
+        "tag": "#task"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 11,
+            "line": 7,
+            "offset": 157
+          },
+          "start": {
+            "col": 6,
+            "line": 7,
+            "offset": 152
+          }
+        },
+        "tag": "#task"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 11,
+            "line": 11,
+            "offset": 263
+          },
+          "start": {
+            "col": 6,
+            "line": 11,
+            "offset": 258
+          }
+        },
+        "tag": "#task"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 11,
+            "line": 15,
+            "offset": 357
+          },
+          "start": {
+            "col": 6,
+            "line": 15,
+            "offset": 352
+          }
+        },
+        "tag": "#task"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 11,
+            "line": 16,
+            "offset": 433
+          },
+          "start": {
+            "col": 6,
+            "line": 16,
+            "offset": 428
           }
         },
         "tag": "#task"
       }
-    ],
-    "v": 1
+    ]
   },
-  "fileContents": "# multiple_headings\n\n## Level 2 heading\n\n### Level 3 heading\n\n- [ ] #task Task in 'multiple_headings'\n",
+  "fileContents": "# multiple_headings\n\n## Level 2 heading with no taks\n\n## Level 2 heading\n\n- [ ] #task Task 1 in Level 2 heading - in 'multiple_headings' - list 1\n- [ ] #task task 2 in Level 2 heading - in 'multiple_headings' - list 1\n\nDivider to create a new section\n\n- [ ] #task task 3 in Level 2 heading - in 'multiple_headings' - list 2\n\n### Level 3 heading\n\n- [ ] #task Task 4 in 'multiple_headings' - in 'multiple_headings' - list 3\n- [ ] #task Task 5 in 'multiple_headings' - in 'multiple_headings' - list 3\n",
   "filePath": "Test Data/multiple_headings.md",
   "getAllTags": [
+    "#task",
+    "#task",
+    "#task",
+    "#task",
     "#task"
   ],
   "obsidianApiVersion": "1.7.7",


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- Convert `parseFileContent()` in to a class `FileParser`.
-  By making some parameters fields, I can start extracting methods that have a reasonable number of parameters themselves.
- Initially, the big win is the extraction of `FileParser.parseFileContent()`, which greatly reduced the complexity of `FileParser.parseLine()`

Note that some of the new fields may turn out to be redundant - but I wanted to merge progress so far, why the diffs are still moderately readable.

Note that because of a change in indentation in some of this code, the diffs are easier to read in this Web UI if enabling GitHub's **'Hide whitespace'** option:

<img width="450" alt="image" src="https://github.com/user-attachments/assets/b1e35428-0256-4824-8116-e334856c87a2">


## Motivation and Context

Preparing to fix:

- https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3170

## How has this been tested?

- Automated tests
- Exploratory testing

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
