### PR TITLE
docs: Fix URL in the help message for unexpanded template text

### DIFF
--- a/docs/Advanced/Daily Agenda.md
+++ b/docs/Advanced/Daily Agenda.md
@@ -87,7 +87,7 @@ Possible causes:
 - Some sample template text was accidentally pasted in to a tasks query,
   instead of in to a template file.
 
-See: https://publish.obsidian.md/tasks/Advanced/Instruction+contains+unexpanded+template+text
+See: https://publish.obsidian.md/tasks/Advanced/Daily+Agenda#Instruction+contains+unexpanded+template+text
 ```
 <!-- endSnippet -->
 

--- a/src/lib/TemplatingPluginTools.ts
+++ b/src/lib/TemplatingPluginTools.ts
@@ -24,7 +24,7 @@ Possible causes:
 - Some sample template text was accidentally pasted in to a tasks query,
   instead of in to a template file.
 
-See: https://publish.obsidian.md/tasks/Advanced/Instruction+contains+unexpanded+template+text
+See: https://publish.obsidian.md/tasks/Advanced/Daily+Agenda#Instruction+contains+unexpanded+template+text
 `;
     }
 }

--- a/tests/lib/TemplatingPluginTools.test.TemplatingPluginTools_date_templating_error_sample_for_docs.approved.text
+++ b/tests/lib/TemplatingPluginTools.test.TemplatingPluginTools_date_templating_error_sample_for_docs.approved.text
@@ -8,4 +8,4 @@ Possible causes:
 - Some sample template text was accidentally pasted in to a tasks query,
   instead of in to a template file.
 
-See: https://publish.obsidian.md/tasks/Advanced/Instruction+contains+unexpanded+template+text
+See: https://publish.obsidian.md/tasks/Advanced/Daily+Agenda#Instruction+contains+unexpanded+template+text


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

## Description

I just discovered that the URL in some help text was wrong...

The URL in this Tasks error message gave a 404:

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/50aaa67e-9f5d-48d5-b551-69cce64fca05">

The file name was ommitted.

The correct URL is:

https://publish.obsidian.md/tasks/Advanced/Daily+Agenda#Instruction+contains+unexpanded+template+text

## Motivation and Context

Prevent a 404...

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

By checking the new URL...


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
