### PR TITLE
refactor: Add ListItem methods findClosestParentTask() and isTask()

### DIFF
--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -12,7 +12,7 @@ import type { GroupDisplayHeading } from '../Query/Group/GroupDisplayHeading';
 import type { TaskGroups } from '../Query/Group/TaskGroups';
 import type { QueryResult } from '../Query/QueryResult';
 import type { TasksFile } from '../Scripting/TasksFile';
-import { type ListItem, findClosestParentTask } from '../Task/ListItem';
+import type { ListItem } from '../Task/ListItem';
 import { Task } from '../Task/Task';
 import { PostponeMenu } from '../ui/Menus/PostponeMenu';
 import { TaskLineRenderer, type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
@@ -257,7 +257,7 @@ export class QueryResultsRenderer {
     }
 
     private willBeRenderedLater(listItem: ListItem, renderedListItems: Set<ListItem>, listItems: ListItem[]) {
-        const closestParentTask = findClosestParentTask(listItem);
+        const closestParentTask = listItem.findClosestParentTask();
         if (!closestParentTask) {
             return false;
         }
@@ -332,7 +332,7 @@ export class QueryResultsRenderer {
         await this.textRenderer(
             listItem.description,
             span,
-            findClosestParentTask(listItem)?.path ?? '',
+            listItem.findClosestParentTask()?.path ?? '',
             this.obsidianComponent,
         );
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -39,12 +39,14 @@ export interface QueryRendererParameters {
 export function findClosestParentTask(listItem: ListItem): Task | null {
     // Try to find the closest parent that is a task
     let closestParentTask = listItem.parent;
+
     while (closestParentTask !== null) {
         if (closestParentTask instanceof Task) {
             return closestParentTask as Task;
         }
         closestParentTask = closestParentTask.parent;
     }
+
     return null;
 }
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -12,7 +12,7 @@ import type { GroupDisplayHeading } from '../Query/Group/GroupDisplayHeading';
 import type { TaskGroups } from '../Query/Group/TaskGroups';
 import type { QueryResult } from '../Query/QueryResult';
 import type { TasksFile } from '../Scripting/TasksFile';
-import type { ListItem } from '../Task/ListItem';
+import { type ListItem, findClosestParentTask } from '../Task/ListItem';
 import { Task } from '../Task/Task';
 import { PostponeMenu } from '../ui/Menus/PostponeMenu';
 import { TaskLineRenderer, type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
@@ -26,28 +26,6 @@ export interface QueryRendererParameters {
     backlinksClickHandler: BacklinksEventHandler;
     backlinksMousedownHandler: BacklinksEventHandler;
     editTaskPencilClickHandler: EditButtonClickHandler;
-}
-
-/**
- * We want this function to be a method of ListItem but that causes a circular dependency
- * which makes the plugin fail to load in Obsidian.
- *
- * Note: the tests are in ListItem.test.ts
- *
- * @param listItem
- */
-export function findClosestParentTask(listItem: ListItem): Task | null {
-    // Try to find the closest parent that is a task
-    let closestParentTask = listItem.parent;
-
-    while (closestParentTask !== null) {
-        if (closestParentTask instanceof Task) {
-            return closestParentTask as Task;
-        }
-        closestParentTask = closestParentTask.parent;
-    }
-
-    return null;
 }
 
 export class QueryResultsRenderer {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -41,7 +41,7 @@ export function findClosestParentTask(listItem: ListItem) {
     let closestParentTask = listItem.parent;
     while (closestParentTask !== null) {
         if (closestParentTask instanceof Task) {
-            break; // Exit the loop when the Task is found
+            return closestParentTask as Task;
         }
         closestParentTask = closestParentTask.parent;
     }

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -45,7 +45,7 @@ export function findClosestParentTask(listItem: ListItem) {
         }
         closestParentTask = closestParentTask.parent;
     }
-    return closestParentTask;
+    return null;
 }
 
 export class QueryResultsRenderer {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -39,7 +39,10 @@ export interface QueryRendererParameters {
 export function findClosestParentTask(listItem: ListItem) {
     // Try to find the closest parent that is a task
     let closestParentTask = listItem.parent;
-    while (closestParentTask !== null && !(closestParentTask instanceof Task)) {
+    while (closestParentTask !== null) {
+        if (closestParentTask instanceof Task) {
+            break; // Exit the loop when the Task is found
+        }
         closestParentTask = closestParentTask.parent;
     }
     return closestParentTask;

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -36,7 +36,7 @@ export interface QueryRendererParameters {
  *
  * @param listItem
  */
-export function findClosestParentTask(listItem: ListItem) {
+export function findClosestParentTask(listItem: ListItem): Task | null {
     // Try to find the closest parent that is a task
     let closestParentTask = listItem.parent;
     while (closestParentTask !== null) {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -1,4 +1,5 @@
 import { TaskRegularExpressions } from './TaskRegularExpressions';
+import { Task } from './Task';
 
 export class ListItem {
     // The original line read from file.
@@ -91,4 +92,26 @@ export class ListItem {
 
         return list1.every((item, index) => item.identicalTo(list2[index]));
     }
+}
+
+/**
+ * We want this function to be a method of ListItem but that causes a circular dependency
+ * which makes the plugin fail to load in Obsidian.
+ *
+ * Note: the tests are in ListItem.test.ts
+ *
+ * @param listItem
+ */
+export function findClosestParentTask(listItem: ListItem): Task | null {
+    // Try to find the closest parent that is a task
+    let closestParentTask = listItem.parent;
+
+    while (closestParentTask !== null) {
+        if (closestParentTask instanceof Task) {
+            return closestParentTask as Task;
+        }
+        closestParentTask = closestParentTask.parent;
+    }
+
+    return null;
 }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -46,6 +46,10 @@ export class ListItem {
         return this.parent === null;
     }
 
+    get isTask() {
+        return false;
+    }
+
     /**
      * Compare all the fields in another ListItem, to detect any differences from this one.
      *

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -47,8 +47,22 @@ export class ListItem {
         return this.parent === null;
     }
 
+    /**
+     * Find to find the closest parent that is a {@link Task}
+     */
     public findClosestParentTask(): Task | null {
-        return findClosestParentTask(this);
+        let closestParentTask = this.parent;
+
+        while (closestParentTask !== null) {
+            // Lazy load the Task class to avoid circular dependencies
+            const { Task } = require('./Task');
+            if (closestParentTask instanceof Task) {
+                return closestParentTask as Task;
+            }
+            closestParentTask = closestParentTask.parent;
+        }
+
+        return null;
     }
 
     get isTask() {
@@ -96,28 +110,4 @@ export class ListItem {
 
         return list1.every((item, index) => item.identicalTo(list2[index]));
     }
-}
-
-/**
- * We want this function to be a method of ListItem but that causes a circular dependency
- * which makes the plugin fail to load in Obsidian.
- *
- * Note: the tests are in ListItem.test.ts
- *
- * @param listItem
- */
-export function findClosestParentTask(listItem: ListItem): Task | null {
-    // Try to find the closest parent that is a task
-    let closestParentTask = listItem.parent;
-
-    while (closestParentTask !== null) {
-        // Lazy load the Task class to avoid circular dependencies
-        const { Task } = require('./Task');
-        if (closestParentTask instanceof Task) {
-            return closestParentTask as Task;
-        }
-        closestParentTask = closestParentTask.parent;
-    }
-
-    return null;
 }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -47,6 +47,10 @@ export class ListItem {
         return this.parent === null;
     }
 
+    public findClosestParentTask(): Task | null {
+        return findClosestParentTask(this);
+    }
+
     get isTask() {
         return false;
     }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -1,5 +1,5 @@
 import { TaskRegularExpressions } from './TaskRegularExpressions';
-import { Task } from './Task';
+import type { Task } from './Task';
 
 export class ListItem {
     // The original line read from file.
@@ -107,6 +107,8 @@ export function findClosestParentTask(listItem: ListItem): Task | null {
     let closestParentTask = listItem.parent;
 
     while (closestParentTask !== null) {
+        // Lazy load the Task class to avoid circular dependencies
+        const { Task } = require('./Task');
         if (closestParentTask instanceof Task) {
             return closestParentTask as Task;
         }

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -493,6 +493,15 @@ export class Task extends ListItem {
     }
 
     /**
+     * Return whether this object is a {@link Task}.
+     *
+     * This is useful at run-time to discover whether a {@link ListItem} reference is in fact a {@link Task}.
+     */
+    get isTask() {
+        return true;
+    }
+
+    /**
      * Return whether the task is considered done.
      * @returns true if the status type is {@link StatusType.DONE}, {@link StatusType.CANCELLED} or {@link StatusType.NON_TASK}, and false otherwise.
      */

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -5,7 +5,7 @@ import moment from 'moment/moment';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Task } from '../../src/Task/Task';
 import { TaskLocation } from '../../src/Task/TaskLocation';
-import { ListItem, findClosestParentTask } from '../../src/Task/ListItem';
+import { ListItem } from '../../src/Task/ListItem';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { fromLine } from '../TestingTools/TestHelpers';
 import { createChildListItem } from './ListItemHelpers';
@@ -111,9 +111,9 @@ describe('related items', () => {
         const item = new ListItem('- item', null);
         const childOfItem = new ListItem('- child of item', item);
 
-        expect(findClosestParentTask(task)).toEqual(null);
-        expect(findClosestParentTask(item)).toEqual(null);
-        expect(findClosestParentTask(childOfItem)).toEqual(null);
+        expect(task.findClosestParentTask()).toEqual(null);
+        expect(item.findClosestParentTask()).toEqual(null);
+        expect(childOfItem.findClosestParentTask()).toEqual(null);
     });
 
     it('should find the closest parent task', () => {
@@ -121,9 +121,9 @@ describe('related items', () => {
         const child = new ListItem('- item', parentTask);
         const grandChild = new ListItem('- item', child);
 
-        expect(findClosestParentTask(parentTask)).toEqual(null);
-        expect(findClosestParentTask(child)).toEqual(parentTask);
-        expect(findClosestParentTask(grandChild)).toEqual(parentTask);
+        expect(parentTask.findClosestParentTask()).toEqual(null);
+        expect(child.findClosestParentTask()).toEqual(parentTask);
+        expect(grandChild.findClosestParentTask()).toEqual(parentTask);
     });
 });
 

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -5,10 +5,9 @@ import moment from 'moment/moment';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Task } from '../../src/Task/Task';
 import { TaskLocation } from '../../src/Task/TaskLocation';
-import { ListItem } from '../../src/Task/ListItem';
+import { ListItem, findClosestParentTask } from '../../src/Task/ListItem';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { fromLine } from '../TestingTools/TestHelpers';
-import { findClosestParentTask } from '../../src/Renderer/QueryResultsRenderer';
 import { createChildListItem } from './ListItemHelpers';
 
 window.moment = moment;

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -80,6 +80,11 @@ describe('list item tests', () => {
         expect(child.isRoot).toEqual(false);
     });
 
+    it('should not be a task', () => {
+        const listItem = new ListItem('- list item', null);
+        expect(listItem.isTask).toBe(false);
+    });
+
     it.each([
         ['- ', true],
         ['* ', true],

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -67,6 +67,13 @@ describe('immutability', () => {
     });
 });
 
+describe('list item-related tests', () => {
+    it('should be a task', () => {
+        const task = fromLine({ line: '- [ ] A Task' });
+        expect(task.isTask).toBe(true);
+    });
+});
+
 describe('parsing', () => {
     it('parses a task from a line starting with hyphen', () => {
         // Arrange


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

This fixes a problem that @ilandikov and I had, where we wanted to move `findClosestParentTask()` from `QueryResultsRenderer.ts` to `ListItem.ts`, but when we did so, the Tasks plugin crashed on start-up.

It is more convenient to be able to to write `listItem.findClosestParentTask()` and that now works.

I thought that the `isTask` accessor would be needed to make this work, but in fact it wasn't needed. However, it may still be useful eventually in custom filters and groups.

## Motivation and Context

Move code to a more logical place.

## How has this been tested?

- Running the tests
- Running the plugin and confirming that Tasks renderers `Parent-Child relationships - Searches - Tasks.md` correctly


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
