### PR TITLE
fix: Allow multi-line properties in {{query.file.property('...')}}

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/Test Data/query_using_properties.md
+++ b/resources/sample_vaults/Tasks-Demo/Test Data/query_using_properties.md
@@ -12,6 +12,7 @@ task_instructions: |
 task_instructions_with_continuation_line: |
   path \
     includes query_using_properties
+task_instruction_with_spaces: "  path includes query_using_properties  "
 ---
 
 # query_using_properties
@@ -26,6 +27,17 @@ Read a Tasks instruction from a property in this file, and embed it in to any nu
 explain
 ignore global query
 {{query.file.property('task_instruction')}}
+limit 10
+```
+
+## Use a one-line property: task_instruction_with_spaces
+
+Read a Tasks instruction **that is surrounded by extra spaces** from a property in this file, and embed it in to any number of queries in the file:
+
+```tasks
+explain
+ignore global query
+{{query.file.property('task_instruction_with_spaces')}}
 limit 10
 ```
 

--- a/resources/sample_vaults/Tasks-Demo/Test Data/query_using_properties.md
+++ b/resources/sample_vaults/Tasks-Demo/Test Data/query_using_properties.md
@@ -26,13 +26,14 @@ limit 10
 
 ## Use a multi-line property: task_instructions
 
-This fails as the `task_instructions` contains multiple lines , and placeholders are applied after the query is split at line-endings...
+Read multiple Tasks instructions from a property in this file, and embed them in to any number of queries in the file:
 
 ```tasks
 ignore global query
 folder includes Test Data
 explain
 {{query.file.property('task_instructions')}}
+limit 10
 ```
 
 ## Use a list property in a custom filter: root_dirs_to_search

--- a/resources/sample_vaults/Tasks-Demo/Test Data/query_using_properties.md
+++ b/resources/sample_vaults/Tasks-Demo/Test Data/query_using_properties.md
@@ -9,6 +9,9 @@ task_instructions: |
     group by filename
   # a comment
     # an indented comment
+task_instructions_with_continuation_line: |
+  path \
+    includes query_using_properties
 ---
 
 # query_using_properties
@@ -35,6 +38,20 @@ ignore global query
 folder includes Test Data
 explain
 {{query.file.property('task_instructions')}}
+limit 10
+```
+
+## Use a multi-line property: task_instructions_with_continuation_line
+
+Read multiple Tasks instructions with a continuation line from a property in this file, and embed them in to any number of queries in the file.
+
+Continuation lines are currently unsupported in placeholders.
+
+```tasks
+ignore global query
+folder includes Test Data
+explain
+{{query.file.property('task_instructions_with_continuation_line')}}
 limit 10
 ```
 

--- a/resources/sample_vaults/Tasks-Demo/Test Data/query_using_properties.md
+++ b/resources/sample_vaults/Tasks-Demo/Test Data/query_using_properties.md
@@ -6,7 +6,7 @@ task_instruction: group by filename
 task_instructions: |
   group by root
   group by folder
-  group by filename
+    group by filename
   # a comment
 ---
 

--- a/resources/sample_vaults/Tasks-Demo/Test Data/query_using_properties.md
+++ b/resources/sample_vaults/Tasks-Demo/Test Data/query_using_properties.md
@@ -7,6 +7,7 @@ task_instructions: |
   group by root
   group by folder
   group by filename
+  # a comment
 ---
 
 # query_using_properties

--- a/resources/sample_vaults/Tasks-Demo/Test Data/query_using_properties.md
+++ b/resources/sample_vaults/Tasks-Demo/Test Data/query_using_properties.md
@@ -8,6 +8,7 @@ task_instructions: |
   group by folder
     group by filename
   # a comment
+    # an indented comment
 ---
 
 # query_using_properties

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -59,14 +59,14 @@ export class Query implements IQuery {
 
         const anyContinuationLinesRemoved = continueLines(source);
         anyContinuationLinesRemoved.forEach((statement: Statement) => {
-            const line = this.expandPlaceholders(statement, tasksFile);
+            this.expandPlaceholders(statement, tasksFile);
             if (this.error !== undefined) {
                 // There was an error expanding placeholders.
                 return;
             }
 
             try {
-                this.parseLine(line, statement);
+                this.parseLine(statement);
             } catch (e) {
                 let message;
                 if (e instanceof Error) {
@@ -89,7 +89,7 @@ export class Query implements IQuery {
         return this._queryId;
     }
 
-    private parseLine(_line: string, statement: Statement) {
+    private parseLine(statement: Statement) {
         const line = statement.anyPlaceholdersExpanded;
         switch (true) {
             case this.shortModeRegexp.test(line):

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -172,7 +172,7 @@ ${source}`;
         const expandedSourceLines = expandedSource.split('\n').map((line) => line.trim());
         if (expandedSourceLines.length === 1) {
             // Save any expanded text back in to the statement:
-            statement.recordExpandedPlaceholders(expandedSource.trim());
+            statement.recordExpandedPlaceholders(expandedSourceLines[0]);
             return [statement];
         }
 

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -174,12 +174,12 @@ ${source}`;
         // The expanded source is more than one line, so we will need to create multiple statements
         const newStatements: Statement[] = [];
         for (const expandedSourceLine of expandedSourceLines) {
-            if (expandedSourceLine.length > 0) {
-                const newStatement = new Statement(statement.rawInstruction, statement.anyContinuationLinesRemoved);
-                // Save any expanded text back in to the statement:
-                newStatement.recordExpandedPlaceholders(expandedSourceLine);
-                newStatements.push(newStatement);
+            if (expandedSourceLine.length <= 0) {
+                continue;
             }
+            const newStatement = new Statement(statement.rawInstruction, statement.anyContinuationLinesRemoved);
+            newStatement.recordExpandedPlaceholders(expandedSourceLine);
+            newStatements.push(newStatement);
         }
         return newStatements;
     }

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -66,7 +66,10 @@ export class Query implements IQuery {
                 // There was an error expanding placeholders.
                 return;
             }
-            anyPlaceholdersExpanded.push(statement);
+            const expandedStatements = [statement];
+            for (const expandedStatement of expandedStatements) {
+                anyPlaceholdersExpanded.push(expandedStatement);
+            }
         }
 
         for (const statement of anyPlaceholdersExpanded) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -184,9 +184,6 @@ ${source}`;
         const newStatements: Statement[] = [];
         let countOfValidStatements = 0;
         for (const expandedSourceLine of expandedSourceLines) {
-            if (expandedSourceLine.length <= 0) {
-                continue;
-            }
             countOfValidStatements += 1;
             const counter = `: statement ${countOfValidStatements} after expansion of placeholder`;
             const newStatement = new Statement(

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -176,7 +176,8 @@ ${source}`;
             return [statement];
         }
 
-        // The expanded source is more than one line, so we will need to create multiple statements
+        // The expanded source is more than one line, so we will need to create multiple statements.
+        // This only happens if the placeholder was a multiple-line property from the query file.
         const newStatements: Statement[] = [];
         let countOfValidStatements = 0;
         for (const expandedSourceLine of expandedSourceLines) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -89,7 +89,8 @@ export class Query implements IQuery {
         return this._queryId;
     }
 
-    private parseLine(line: string, statement: Statement) {
+    private parseLine(_line: string, statement: Statement) {
+        const line = statement.anyPlaceholdersExpanded;
         switch (true) {
             case this.shortModeRegexp.test(line):
                 this._queryLayoutOptions.shortMode = true;

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -182,10 +182,8 @@ ${source}`;
         // The expanded source is more than one line, so we will need to create multiple statements.
         // This only happens if the placeholder was a multiple-line property from the query file.
         const newStatements: Statement[] = [];
-        let countOfValidStatements = 0;
-        expandedSourceLines.forEach((expandedSourceLine) => {
-            countOfValidStatements += 1;
-            const counter = `: statement ${countOfValidStatements} after expansion of placeholder`;
+        expandedSourceLines.forEach((expandedSourceLine, index) => {
+            const counter = `: statement ${index + 1} after expansion of placeholder`;
             const newStatement = new Statement(
                 statement.rawInstruction + counter,
                 statement.anyContinuationLinesRemoved + counter,

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -58,7 +58,7 @@ export class Query implements IQuery {
         this.debug(`Creating query: ${this.formatQueryForLogging()}`);
 
         const anyContinuationLinesRemoved = continueLines(source);
-        anyContinuationLinesRemoved.forEach((statement: Statement) => {
+        for (const statement of anyContinuationLinesRemoved) {
             this.expandPlaceholders(statement, tasksFile);
             if (this.error !== undefined) {
                 // There was an error expanding placeholders.
@@ -78,7 +78,7 @@ export class Query implements IQuery {
                 this.setError(message, statement);
                 return;
             }
-        });
+        }
     }
 
     public get filePath(): string | undefined {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -174,11 +174,12 @@ ${source}`;
         // The expanded source is more than one line, so we will need to create multiple statements
         const newStatements: Statement[] = [];
         for (const expandedSourceLine of expandedSourceLines) {
-            if (expandedSourceLine.length <= 0) {
+            const trimmedExpandedSourceLine = expandedSourceLine.trim();
+            if (trimmedExpandedSourceLine.length <= 0) {
                 continue;
             }
             const newStatement = new Statement(statement.rawInstruction, statement.anyContinuationLinesRemoved);
-            newStatement.recordExpandedPlaceholders(expandedSourceLine);
+            newStatement.recordExpandedPlaceholders(trimmedExpandedSourceLine);
             newStatements.push(newStatement);
         }
         return newStatements;

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -181,17 +181,15 @@ ${source}`;
 
         // The expanded source is more than one line, so we will need to create multiple statements.
         // This only happens if the placeholder was a multiple-line property from the query file.
-        const newStatements: Statement[] = [];
-        expandedSourceLines.forEach((expandedSourceLine, index) => {
+        return expandedSourceLines.map((expandedSourceLine, index) => {
             const counter = `: statement ${index + 1} after expansion of placeholder`;
             const newStatement = new Statement(
                 statement.rawInstruction + counter,
                 statement.anyContinuationLinesRemoved + counter,
             );
             newStatement.recordExpandedPlaceholders(expandedSourceLine);
-            newStatements.push(newStatement);
+            return newStatement;
         });
-        return newStatements;
     }
 
     /**

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -139,7 +139,6 @@ ${source}`;
         }
 
         // TODO Do not complain about any placeholder errors in comment lines
-        // TODO Show the original and expanded text in explanations
         // TODO Give user error info if they try and put a string in a regex search
         let expandedSource: string = source;
         if (tasksFile) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -74,6 +74,9 @@ export class Query implements IQuery {
         for (const statement of anyPlaceholdersExpanded) {
             try {
                 this.parseLine(statement);
+                if (this.error !== undefined) {
+                    return;
+                }
             } catch (e) {
                 let message;
                 if (e instanceof Error) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -61,12 +61,11 @@ export class Query implements IQuery {
 
         const anyPlaceholdersExpanded: Statement[] = [];
         for (const statement of anyContinuationLinesRemoved) {
-            this.expandPlaceholders(statement, tasksFile);
+            const expandedStatements = this.expandPlaceholders(statement, tasksFile);
             if (this.error !== undefined) {
                 // There was an error expanding placeholders.
                 return;
             }
-            const expandedStatements = [statement];
             for (const expandedStatement of expandedStatements) {
                 anyPlaceholdersExpanded.push(expandedStatement);
             }
@@ -136,7 +135,7 @@ export class Query implements IQuery {
         return `[${this.source.split('\n').join(' ; ')}]`;
     }
 
-    private expandPlaceholders(statement: Statement, tasksFile: OptionalTasksFile) {
+    private expandPlaceholders(statement: Statement, tasksFile: OptionalTasksFile): Statement[] {
         const source = statement.anyContinuationLinesRemoved;
         if (source.includes('{{') && source.includes('}}')) {
             if (this.tasksFile === undefined) {
@@ -144,7 +143,7 @@ export class Query implements IQuery {
 but no file path has been supplied, so cannot expand placeholder values.
 The query is:
 ${source}`;
-                return source;
+                return [statement];
             }
         }
 
@@ -161,13 +160,13 @@ ${source}`;
                 } else {
                     this._error = 'Internal error. expandPlaceholders() threw something other than Error.';
                 }
-                return source;
+                return [statement];
             }
         }
 
         // Save any expanded text back in to the statement:
         statement.recordExpandedPlaceholders(expandedSource);
-        return expandedSource;
+        return [statement];
     }
 
     /**

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -169,7 +169,7 @@ ${source}`;
     }
 
     private createStatementsFromExpandedPlaceholders(expandedSource: string, statement: Statement) {
-        const expandedSourceLines = expandedSource.split('\n');
+        const expandedSourceLines = expandedSource.split('\n').map((line) => line.trim());
         if (expandedSourceLines.length === 1) {
             // Save any expanded text back in to the statement:
             statement.recordExpandedPlaceholders(expandedSource.trim());

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -169,7 +169,10 @@ ${source}`;
     }
 
     private createStatementsFromExpandedPlaceholders(expandedSource: string, statement: Statement) {
-        const expandedSourceLines = expandedSource.split('\n').map((line) => line.trim());
+        const expandedSourceLines = expandedSource
+            .split('\n')
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0);
         if (expandedSourceLines.length === 1) {
             // Save any expanded text back in to the statement:
             statement.recordExpandedPlaceholders(expandedSourceLines[0]);

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -57,7 +57,8 @@ export class Query implements IQuery {
 
         this.debug(`Creating query: ${this.formatQueryForLogging()}`);
 
-        continueLines(source).forEach((statement: Statement) => {
+        const anyContinuationLinesRemoved = continueLines(source);
+        anyContinuationLinesRemoved.forEach((statement: Statement) => {
             const line = this.expandPlaceholders(statement, tasksFile);
             if (this.error !== undefined) {
                 // There was an error expanding placeholders.

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -169,18 +169,19 @@ ${source}`;
     }
 
     private createStatementsFromExpandedPlaceholders(expandedSource: string, statement: Statement) {
+        // Trim and filter empty lines in one step.
         const expandedSourceLines = expandedSource
             .split('\n')
             .map((line) => line.trim())
             .filter((line) => line.length > 0);
+
         if (expandedSourceLines.length === 1) {
-            // Save any expanded text back in to the statement:
+            // Save the single expanded line back into the statement.
             statement.recordExpandedPlaceholders(expandedSourceLines[0]);
             return [statement];
         }
 
-        // The expanded source is more than one line, so we will need to create multiple statements.
-        // This only happens if the placeholder was a multiple-line property from the query file.
+        // Handle multiple-line placeholders.
         return expandedSourceLines.map((expandedSourceLine, index) => {
             const counter = `: statement ${index + 1} after expansion of placeholder`;
             const newStatement = new Statement(

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -172,7 +172,7 @@ ${source}`;
         const expandedSourceLines = expandedSource.split('\n');
         if (expandedSourceLines.length === 1) {
             // Save any expanded text back in to the statement:
-            statement.recordExpandedPlaceholders(expandedSource);
+            statement.recordExpandedPlaceholders(expandedSource.trim());
             return [statement];
         }
 

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -165,6 +165,10 @@ ${source}`;
             }
         }
 
+        return this.createStatementsFromExpandedPlaceholders(expandedSource, statement);
+    }
+
+    private createStatementsFromExpandedPlaceholders(expandedSource: string, statement: Statement) {
         const expandedSourceLines = expandedSource.split('\n');
         if (expandedSourceLines.length === 1) {
             // Save any expanded text back in to the statement:

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -64,7 +64,9 @@ export class Query implements IQuery {
                 // There was an error expanding placeholders.
                 return;
             }
+        }
 
+        for (const statement of anyContinuationLinesRemoved) {
             try {
                 this.parseLine(statement);
             } catch (e) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -164,9 +164,24 @@ ${source}`;
             }
         }
 
-        // Save any expanded text back in to the statement:
-        statement.recordExpandedPlaceholders(expandedSource);
-        return [statement];
+        const expandedSourceLines = expandedSource.split('\n');
+        if (expandedSourceLines.length === 1) {
+            // Save any expanded text back in to the statement:
+            statement.recordExpandedPlaceholders(expandedSource);
+            return [statement];
+        }
+
+        // The expanded source is more than one line, so we will need to create multiple statements
+        const newStatements: Statement[] = [];
+        for (const expandedSourceLine of expandedSourceLines) {
+            if (expandedSourceLine.length > 0) {
+                const newStatement = new Statement(statement.rawInstruction, statement.anyContinuationLinesRemoved);
+                // Save any expanded text back in to the statement:
+                newStatement.recordExpandedPlaceholders(expandedSourceLine);
+                newStatements.push(newStatement);
+            }
+        }
+        return newStatements;
     }
 
     /**

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -66,9 +66,7 @@ export class Query implements IQuery {
                 // There was an error expanding placeholders.
                 return;
             }
-            for (const expandedStatement of expandedStatements) {
-                anyPlaceholdersExpanded.push(expandedStatement);
-            }
+            anyPlaceholdersExpanded.push(...expandedStatements);
         }
 
         for (const statement of anyPlaceholdersExpanded) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -58,15 +58,18 @@ export class Query implements IQuery {
         this.debug(`Creating query: ${this.formatQueryForLogging()}`);
 
         const anyContinuationLinesRemoved = continueLines(source);
+
+        const anyPlaceholdersExpanded: Statement[] = [];
         for (const statement of anyContinuationLinesRemoved) {
             this.expandPlaceholders(statement, tasksFile);
             if (this.error !== undefined) {
                 // There was an error expanding placeholders.
                 return;
             }
+            anyPlaceholdersExpanded.push(statement);
         }
 
-        for (const statement of anyContinuationLinesRemoved) {
+        for (const statement of anyPlaceholdersExpanded) {
             try {
                 this.parseLine(statement);
             } catch (e) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -183,7 +183,7 @@ ${source}`;
         // This only happens if the placeholder was a multiple-line property from the query file.
         const newStatements: Statement[] = [];
         let countOfValidStatements = 0;
-        for (const expandedSourceLine of expandedSourceLines) {
+        expandedSourceLines.forEach((expandedSourceLine) => {
             countOfValidStatements += 1;
             const counter = `: statement ${countOfValidStatements} after expansion of placeholder`;
             const newStatement = new Statement(
@@ -192,7 +192,7 @@ ${source}`;
             );
             newStatement.recordExpandedPlaceholders(expandedSourceLine);
             newStatements.push(newStatement);
-        }
+        });
         return newStatements;
     }
 

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -181,8 +181,7 @@ ${source}`;
         const newStatements: Statement[] = [];
         let countOfValidStatements = 0;
         for (const expandedSourceLine of expandedSourceLines) {
-            const trimmedExpandedSourceLine = expandedSourceLine.trim();
-            if (trimmedExpandedSourceLine.length <= 0) {
+            if (expandedSourceLine.length <= 0) {
                 continue;
             }
             countOfValidStatements += 1;
@@ -191,7 +190,7 @@ ${source}`;
                 statement.rawInstruction + counter,
                 statement.anyContinuationLinesRemoved + counter,
             );
-            newStatement.recordExpandedPlaceholders(trimmedExpandedSourceLine);
+            newStatement.recordExpandedPlaceholders(expandedSourceLine);
             newStatements.push(newStatement);
         }
         return newStatements;

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -176,12 +176,18 @@ ${source}`;
 
         // The expanded source is more than one line, so we will need to create multiple statements
         const newStatements: Statement[] = [];
+        let countOfValidStatements = 0;
         for (const expandedSourceLine of expandedSourceLines) {
             const trimmedExpandedSourceLine = expandedSourceLine.trim();
             if (trimmedExpandedSourceLine.length <= 0) {
                 continue;
             }
-            const newStatement = new Statement(statement.rawInstruction, statement.anyContinuationLinesRemoved);
+            countOfValidStatements += 1;
+            const counter = `: statement ${countOfValidStatements} after expansion of placeholder`;
+            const newStatement = new Statement(
+                statement.rawInstruction + counter,
+                statement.anyContinuationLinesRemoved + counter,
+            );
             newStatement.recordExpandedPlaceholders(trimmedExpandedSourceLine);
             newStatements.push(newStatement);
         }

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -41,6 +41,8 @@ export class QueryRenderer {
         //    not yet available, so empty.
         //  - It does not listen out for edits the properties, so if a property is edited,
         //    the user needs to close and re-open the file.
+        //  - Multi-line properties are supported, but they cannot contain
+        //    continuation lines.
         const app = this.app;
         const filePath = context.sourcePath;
         const tFile = app.vault.getAbstractFileByPath(filePath);

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -41,8 +41,6 @@ export class QueryRenderer {
         //    not yet available, so empty.
         //  - It does not listen out for edits the properties, so if a property is edited,
         //    the user needs to close and re-open the file.
-        //  - Only single-line properties work. Multiple-line properties give an error message
-        //    'do not understand query'.
         const app = this.app;
         const filePath = context.sourcePath;
         const tFile = app.vault.getAbstractFileByPath(filePath);

--- a/tests/Obsidian/__test_data__/query_using_properties.json
+++ b/tests/Obsidian/__test_data__/query_using_properties.json
@@ -6,14 +6,14 @@
         "Filters/"
       ],
       "task_instruction": "group by filename",
-      "task_instructions": "group by root\ngroup by folder\ngroup by filename\n# a comment\n"
+      "task_instructions": "group by root\ngroup by folder\n  group by filename\n# a comment\n"
     },
     "frontmatterLinks": [],
     "frontmatterPosition": {
       "end": {
         "col": 3,
         "line": 10,
-        "offset": 179
+        "offset": 181
       },
       "start": {
         "col": 0,
@@ -29,12 +29,12 @@
           "end": {
             "col": 24,
             "line": 12,
-            "offset": 205
+            "offset": 207
           },
           "start": {
             "col": 0,
             "line": 12,
-            "offset": 181
+            "offset": 183
           }
         }
       },
@@ -45,12 +45,12 @@
           "end": {
             "col": 44,
             "line": 16,
-            "offset": 297
+            "offset": 299
           },
           "start": {
             "col": 0,
             "line": 16,
-            "offset": 253
+            "offset": 255
           }
         }
       },
@@ -61,12 +61,12 @@
           "end": {
             "col": 47,
             "line": 27,
-            "offset": 551
+            "offset": 553
           },
           "start": {
             "col": 0,
             "line": 27,
-            "offset": 504
+            "offset": 506
           }
         }
       },
@@ -77,12 +77,12 @@
           "end": {
             "col": 62,
             "line": 39,
-            "offset": 857
+            "offset": 859
           },
           "start": {
             "col": 0,
             "line": 39,
-            "offset": 795
+            "offset": 797
           }
         }
       }
@@ -94,12 +94,12 @@
           "end": {
             "col": 44,
             "line": 14,
-            "offset": 251
+            "offset": 253
           },
           "start": {
             "col": 0,
             "line": 14,
-            "offset": 207
+            "offset": 209
           }
         },
         "task": " "
@@ -111,7 +111,7 @@
           "end": {
             "col": 3,
             "line": 10,
-            "offset": 179
+            "offset": 181
           },
           "start": {
             "col": 0,
@@ -126,12 +126,12 @@
           "end": {
             "col": 24,
             "line": 12,
-            "offset": 205
+            "offset": 207
           },
           "start": {
             "col": 0,
             "line": 12,
-            "offset": 181
+            "offset": 183
           }
         },
         "type": "heading"
@@ -141,12 +141,12 @@
           "end": {
             "col": 44,
             "line": 14,
-            "offset": 251
+            "offset": 253
           },
           "start": {
             "col": 0,
             "line": 14,
-            "offset": 207
+            "offset": 209
           }
         },
         "type": "list"
@@ -156,12 +156,12 @@
           "end": {
             "col": 44,
             "line": 16,
-            "offset": 297
+            "offset": 299
           },
           "start": {
             "col": 0,
             "line": 16,
-            "offset": 253
+            "offset": 255
           }
         },
         "type": "heading"
@@ -171,12 +171,12 @@
           "end": {
             "col": 108,
             "line": 18,
-            "offset": 407
+            "offset": 409
           },
           "start": {
             "col": 0,
             "line": 18,
-            "offset": 299
+            "offset": 301
           }
         },
         "type": "paragraph"
@@ -186,12 +186,12 @@
           "end": {
             "col": 3,
             "line": 25,
-            "offset": 502
+            "offset": 504
           },
           "start": {
             "col": 0,
             "line": 20,
-            "offset": 409
+            "offset": 411
           }
         },
         "type": "code"
@@ -201,12 +201,12 @@
           "end": {
             "col": 47,
             "line": 27,
-            "offset": 551
+            "offset": 553
           },
           "start": {
             "col": 0,
             "line": 27,
-            "offset": 504
+            "offset": 506
           }
         },
         "type": "heading"
@@ -216,12 +216,12 @@
           "end": {
             "col": 118,
             "line": 29,
-            "offset": 671
+            "offset": 673
           },
           "start": {
             "col": 0,
             "line": 29,
-            "offset": 553
+            "offset": 555
           }
         },
         "type": "paragraph"
@@ -231,12 +231,12 @@
           "end": {
             "col": 3,
             "line": 37,
-            "offset": 793
+            "offset": 795
           },
           "start": {
             "col": 0,
             "line": 31,
-            "offset": 673
+            "offset": 675
           }
         },
         "type": "code"
@@ -246,12 +246,12 @@
           "end": {
             "col": 62,
             "line": 39,
-            "offset": 857
+            "offset": 859
           },
           "start": {
             "col": 0,
             "line": 39,
-            "offset": 795
+            "offset": 797
           }
         },
         "type": "heading"
@@ -261,12 +261,12 @@
           "end": {
             "col": 3,
             "line": 54,
-            "offset": 1245
+            "offset": 1247
           },
           "start": {
             "col": 0,
             "line": 41,
-            "offset": 859
+            "offset": 861
           }
         },
         "type": "code"
@@ -278,19 +278,19 @@
           "end": {
             "col": 11,
             "line": 14,
-            "offset": 218
+            "offset": 220
           },
           "start": {
             "col": 6,
             "line": 14,
-            "offset": 213
+            "offset": 215
           }
         },
         "tag": "#task"
       }
     ]
   },
-  "fileContents": "---\nroot_dirs_to_search:\n  - Formats/\n  - Filters/\ntask_instruction: group by filename\ntask_instructions: |\n  group by root\n  group by folder\n  group by filename\n  # a comment\n---\n\n# query_using_properties\n\n- [ ] #task Task in 'query_using_properties'\n\n## Use a one-line property: task_instruction\n\nRead a Tasks instruction from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions\n\nRead multiple Tasks instructions from a property in this file, and embed them in to any number of queries in the file:\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions')}}\nlimit 10\n```\n\n## Use a list property in a custom filter: root_dirs_to_search\n\n```tasks\nignore global query\nexplain\n\nfilter by function \\\n    if (!query.file.hasProperty('root_dirs_to_search')) { \\\n        throw Error('Please set the \"root_dirs_to_search\" list property, with each value ending in a backslash...'); \\\n    } \\\n    const roots = query.file.property('root_dirs_to_search'); \\\n    return roots.includes(task.file.root);\n\nlimit groups 5\ngroup by root\n```\n",
+  "fileContents": "---\nroot_dirs_to_search:\n  - Formats/\n  - Filters/\ntask_instruction: group by filename\ntask_instructions: |\n  group by root\n  group by folder\n    group by filename\n  # a comment\n---\n\n# query_using_properties\n\n- [ ] #task Task in 'query_using_properties'\n\n## Use a one-line property: task_instruction\n\nRead a Tasks instruction from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions\n\nRead multiple Tasks instructions from a property in this file, and embed them in to any number of queries in the file:\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions')}}\nlimit 10\n```\n\n## Use a list property in a custom filter: root_dirs_to_search\n\n```tasks\nignore global query\nexplain\n\nfilter by function \\\n    if (!query.file.hasProperty('root_dirs_to_search')) { \\\n        throw Error('Please set the \"root_dirs_to_search\" list property, with each value ending in a backslash...'); \\\n    } \\\n    const roots = query.file.property('root_dirs_to_search'); \\\n    return roots.includes(task.file.root);\n\nlimit groups 5\ngroup by root\n```\n",
   "filePath": "Test Data/query_using_properties.md",
   "getAllTags": [
     "#task"

--- a/tests/Obsidian/__test_data__/query_using_properties.json
+++ b/tests/Obsidian/__test_data__/query_using_properties.json
@@ -76,13 +76,13 @@
         "position": {
           "end": {
             "col": 62,
-            "line": 37,
-            "offset": 852
+            "line": 38,
+            "offset": 843
           },
           "start": {
             "col": 0,
-            "line": 37,
-            "offset": 790
+            "line": 38,
+            "offset": 781
           }
         }
       }
@@ -214,9 +214,9 @@
       {
         "position": {
           "end": {
-            "col": 136,
+            "col": 118,
             "line": 28,
-            "offset": 675
+            "offset": 657
           },
           "start": {
             "col": 0,
@@ -230,13 +230,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 35,
-            "offset": 788
+            "line": 36,
+            "offset": 779
           },
           "start": {
             "col": 0,
             "line": 30,
-            "offset": 677
+            "offset": 659
           }
         },
         "type": "code"
@@ -245,13 +245,13 @@
         "position": {
           "end": {
             "col": 62,
-            "line": 37,
-            "offset": 852
+            "line": 38,
+            "offset": 843
           },
           "start": {
             "col": 0,
-            "line": 37,
-            "offset": 790
+            "line": 38,
+            "offset": 781
           }
         },
         "type": "heading"
@@ -260,13 +260,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 52,
-            "offset": 1240
+            "line": 53,
+            "offset": 1231
           },
           "start": {
             "col": 0,
-            "line": 39,
-            "offset": 854
+            "line": 40,
+            "offset": 845
           }
         },
         "type": "code"
@@ -290,7 +290,7 @@
       }
     ]
   },
-  "fileContents": "---\nroot_dirs_to_search:\n  - Formats/\n  - Filters/\ntask_instruction: group by filename\ntask_instructions: |\n  group by root\n  group by folder\n  group by filename\n---\n\n# query_using_properties\n\n- [ ] #task Task in 'query_using_properties'\n\n## Use a one-line property: task_instruction\n\nRead a Tasks instruction from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions\n\nThis fails as the `task_instructions` contains multiple lines , and placeholders are applied after the query is split at line-endings...\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions')}}\n```\n\n## Use a list property in a custom filter: root_dirs_to_search\n\n```tasks\nignore global query\nexplain\n\nfilter by function \\\n    if (!query.file.hasProperty('root_dirs_to_search')) { \\\n        throw Error('Please set the \"root_dirs_to_search\" list property, with each value ending in a backslash...'); \\\n    } \\\n    const roots = query.file.property('root_dirs_to_search'); \\\n    return roots.includes(task.file.root);\n\nlimit groups 5\ngroup by root\n```\n",
+  "fileContents": "---\nroot_dirs_to_search:\n  - Formats/\n  - Filters/\ntask_instruction: group by filename\ntask_instructions: |\n  group by root\n  group by folder\n  group by filename\n---\n\n# query_using_properties\n\n- [ ] #task Task in 'query_using_properties'\n\n## Use a one-line property: task_instruction\n\nRead a Tasks instruction from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions\n\nRead multiple Tasks instructions from a property in this file, and embed them in to any number of queries in the file:\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions')}}\nlimit 10\n```\n\n## Use a list property in a custom filter: root_dirs_to_search\n\n```tasks\nignore global query\nexplain\n\nfilter by function \\\n    if (!query.file.hasProperty('root_dirs_to_search')) { \\\n        throw Error('Please set the \"root_dirs_to_search\" list property, with each value ending in a backslash...'); \\\n    } \\\n    const roots = query.file.property('root_dirs_to_search'); \\\n    return roots.includes(task.file.root);\n\nlimit groups 5\ngroup by root\n```\n",
   "filePath": "Test Data/query_using_properties.md",
   "getAllTags": [
     "#task"

--- a/tests/Obsidian/__test_data__/query_using_properties.json
+++ b/tests/Obsidian/__test_data__/query_using_properties.json
@@ -6,14 +6,14 @@
         "Filters/"
       ],
       "task_instruction": "group by filename",
-      "task_instructions": "group by root\ngroup by folder\n  group by filename\n# a comment\n"
+      "task_instructions": "group by root\ngroup by folder\n  group by filename\n# a comment\n  # an indented comment\n"
     },
     "frontmatterLinks": [],
     "frontmatterPosition": {
       "end": {
         "col": 3,
-        "line": 10,
-        "offset": 181
+        "line": 11,
+        "offset": 207
       },
       "start": {
         "col": 0,
@@ -28,13 +28,13 @@
         "position": {
           "end": {
             "col": 24,
-            "line": 12,
-            "offset": 207
+            "line": 13,
+            "offset": 233
           },
           "start": {
             "col": 0,
-            "line": 12,
-            "offset": 183
+            "line": 13,
+            "offset": 209
           }
         }
       },
@@ -44,13 +44,13 @@
         "position": {
           "end": {
             "col": 44,
-            "line": 16,
-            "offset": 299
+            "line": 17,
+            "offset": 325
           },
           "start": {
             "col": 0,
-            "line": 16,
-            "offset": 255
+            "line": 17,
+            "offset": 281
           }
         }
       },
@@ -60,13 +60,13 @@
         "position": {
           "end": {
             "col": 47,
-            "line": 27,
-            "offset": 553
+            "line": 28,
+            "offset": 579
           },
           "start": {
             "col": 0,
-            "line": 27,
-            "offset": 506
+            "line": 28,
+            "offset": 532
           }
         }
       },
@@ -76,30 +76,30 @@
         "position": {
           "end": {
             "col": 62,
-            "line": 39,
-            "offset": 859
+            "line": 40,
+            "offset": 885
           },
           "start": {
             "col": 0,
-            "line": 39,
-            "offset": 797
+            "line": 40,
+            "offset": 823
           }
         }
       }
     ],
     "listItems": [
       {
-        "parent": -14,
+        "parent": -15,
         "position": {
           "end": {
             "col": 44,
-            "line": 14,
-            "offset": 253
+            "line": 15,
+            "offset": 279
           },
           "start": {
             "col": 0,
-            "line": 14,
-            "offset": 209
+            "line": 15,
+            "offset": 235
           }
         },
         "task": " "
@@ -110,8 +110,8 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 10,
-            "offset": 181
+            "line": 11,
+            "offset": 207
           },
           "start": {
             "col": 0,
@@ -125,13 +125,13 @@
         "position": {
           "end": {
             "col": 24,
-            "line": 12,
-            "offset": 207
+            "line": 13,
+            "offset": 233
           },
           "start": {
             "col": 0,
-            "line": 12,
-            "offset": 183
+            "line": 13,
+            "offset": 209
           }
         },
         "type": "heading"
@@ -140,13 +140,13 @@
         "position": {
           "end": {
             "col": 44,
-            "line": 14,
-            "offset": 253
+            "line": 15,
+            "offset": 279
           },
           "start": {
             "col": 0,
-            "line": 14,
-            "offset": 209
+            "line": 15,
+            "offset": 235
           }
         },
         "type": "list"
@@ -155,13 +155,13 @@
         "position": {
           "end": {
             "col": 44,
-            "line": 16,
-            "offset": 299
+            "line": 17,
+            "offset": 325
           },
           "start": {
             "col": 0,
-            "line": 16,
-            "offset": 255
+            "line": 17,
+            "offset": 281
           }
         },
         "type": "heading"
@@ -170,13 +170,13 @@
         "position": {
           "end": {
             "col": 108,
-            "line": 18,
-            "offset": 409
+            "line": 19,
+            "offset": 435
           },
           "start": {
             "col": 0,
-            "line": 18,
-            "offset": 301
+            "line": 19,
+            "offset": 327
           }
         },
         "type": "paragraph"
@@ -185,13 +185,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 25,
-            "offset": 504
+            "line": 26,
+            "offset": 530
           },
           "start": {
             "col": 0,
-            "line": 20,
-            "offset": 411
+            "line": 21,
+            "offset": 437
           }
         },
         "type": "code"
@@ -200,13 +200,13 @@
         "position": {
           "end": {
             "col": 47,
-            "line": 27,
-            "offset": 553
+            "line": 28,
+            "offset": 579
           },
           "start": {
             "col": 0,
-            "line": 27,
-            "offset": 506
+            "line": 28,
+            "offset": 532
           }
         },
         "type": "heading"
@@ -215,13 +215,13 @@
         "position": {
           "end": {
             "col": 118,
-            "line": 29,
-            "offset": 673
+            "line": 30,
+            "offset": 699
           },
           "start": {
             "col": 0,
-            "line": 29,
-            "offset": 555
+            "line": 30,
+            "offset": 581
           }
         },
         "type": "paragraph"
@@ -230,13 +230,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 37,
-            "offset": 795
+            "line": 38,
+            "offset": 821
           },
           "start": {
             "col": 0,
-            "line": 31,
-            "offset": 675
+            "line": 32,
+            "offset": 701
           }
         },
         "type": "code"
@@ -245,13 +245,13 @@
         "position": {
           "end": {
             "col": 62,
-            "line": 39,
-            "offset": 859
+            "line": 40,
+            "offset": 885
           },
           "start": {
             "col": 0,
-            "line": 39,
-            "offset": 797
+            "line": 40,
+            "offset": 823
           }
         },
         "type": "heading"
@@ -260,13 +260,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 54,
-            "offset": 1247
+            "line": 55,
+            "offset": 1273
           },
           "start": {
             "col": 0,
-            "line": 41,
-            "offset": 861
+            "line": 42,
+            "offset": 887
           }
         },
         "type": "code"
@@ -277,20 +277,20 @@
         "position": {
           "end": {
             "col": 11,
-            "line": 14,
-            "offset": 220
+            "line": 15,
+            "offset": 246
           },
           "start": {
             "col": 6,
-            "line": 14,
-            "offset": 215
+            "line": 15,
+            "offset": 241
           }
         },
         "tag": "#task"
       }
     ]
   },
-  "fileContents": "---\nroot_dirs_to_search:\n  - Formats/\n  - Filters/\ntask_instruction: group by filename\ntask_instructions: |\n  group by root\n  group by folder\n    group by filename\n  # a comment\n---\n\n# query_using_properties\n\n- [ ] #task Task in 'query_using_properties'\n\n## Use a one-line property: task_instruction\n\nRead a Tasks instruction from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions\n\nRead multiple Tasks instructions from a property in this file, and embed them in to any number of queries in the file:\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions')}}\nlimit 10\n```\n\n## Use a list property in a custom filter: root_dirs_to_search\n\n```tasks\nignore global query\nexplain\n\nfilter by function \\\n    if (!query.file.hasProperty('root_dirs_to_search')) { \\\n        throw Error('Please set the \"root_dirs_to_search\" list property, with each value ending in a backslash...'); \\\n    } \\\n    const roots = query.file.property('root_dirs_to_search'); \\\n    return roots.includes(task.file.root);\n\nlimit groups 5\ngroup by root\n```\n",
+  "fileContents": "---\nroot_dirs_to_search:\n  - Formats/\n  - Filters/\ntask_instruction: group by filename\ntask_instructions: |\n  group by root\n  group by folder\n    group by filename\n  # a comment\n    # an indented comment\n---\n\n# query_using_properties\n\n- [ ] #task Task in 'query_using_properties'\n\n## Use a one-line property: task_instruction\n\nRead a Tasks instruction from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions\n\nRead multiple Tasks instructions from a property in this file, and embed them in to any number of queries in the file:\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions')}}\nlimit 10\n```\n\n## Use a list property in a custom filter: root_dirs_to_search\n\n```tasks\nignore global query\nexplain\n\nfilter by function \\\n    if (!query.file.hasProperty('root_dirs_to_search')) { \\\n        throw Error('Please set the \"root_dirs_to_search\" list property, with each value ending in a backslash...'); \\\n    } \\\n    const roots = query.file.property('root_dirs_to_search'); \\\n    return roots.includes(task.file.root);\n\nlimit groups 5\ngroup by root\n```\n",
   "filePath": "Test Data/query_using_properties.md",
   "getAllTags": [
     "#task"

--- a/tests/Obsidian/__test_data__/query_using_properties.json
+++ b/tests/Obsidian/__test_data__/query_using_properties.json
@@ -6,6 +6,7 @@
         "Filters/"
       ],
       "task_instruction": "group by filename",
+      "task_instruction_with_spaces": "  path includes query_using_properties  ",
       "task_instructions": "group by root\ngroup by folder\n  group by filename\n# a comment\n  # an indented comment\n",
       "task_instructions_with_continuation_line": "path \\\n  includes query_using_properties\n"
     },
@@ -13,8 +14,8 @@
     "frontmatterPosition": {
       "end": {
         "col": 3,
-        "line": 14,
-        "offset": 296
+        "line": 15,
+        "offset": 369
       },
       "start": {
         "col": 0,
@@ -29,13 +30,13 @@
         "position": {
           "end": {
             "col": 24,
-            "line": 16,
-            "offset": 322
+            "line": 17,
+            "offset": 395
           },
           "start": {
             "col": 0,
-            "line": 16,
-            "offset": 298
+            "line": 17,
+            "offset": 371
           }
         }
       },
@@ -45,13 +46,29 @@
         "position": {
           "end": {
             "col": 44,
-            "line": 20,
-            "offset": 414
+            "line": 21,
+            "offset": 487
           },
           "start": {
             "col": 0,
-            "line": 20,
-            "offset": 370
+            "line": 21,
+            "offset": 443
+          }
+        }
+      },
+      {
+        "heading": "Use a one-line property: task_instruction_with_spaces",
+        "level": 2,
+        "position": {
+          "end": {
+            "col": 56,
+            "line": 32,
+            "offset": 750
+          },
+          "start": {
+            "col": 0,
+            "line": 32,
+            "offset": 694
           }
         }
       },
@@ -61,13 +78,13 @@
         "position": {
           "end": {
             "col": 47,
-            "line": 31,
-            "offset": 668
+            "line": 43,
+            "offset": 1055
           },
           "start": {
             "col": 0,
-            "line": 31,
-            "offset": 621
+            "line": 43,
+            "offset": 1008
           }
         }
       },
@@ -77,13 +94,13 @@
         "position": {
           "end": {
             "col": 70,
-            "line": 43,
-            "offset": 982
+            "line": 55,
+            "offset": 1369
           },
           "start": {
             "col": 0,
-            "line": 43,
-            "offset": 912
+            "line": 55,
+            "offset": 1299
           }
         }
       },
@@ -93,30 +110,30 @@
         "position": {
           "end": {
             "col": 62,
-            "line": 57,
-            "offset": 1399
+            "line": 69,
+            "offset": 1786
           },
           "start": {
             "col": 0,
-            "line": 57,
-            "offset": 1337
+            "line": 69,
+            "offset": 1724
           }
         }
       }
     ],
     "listItems": [
       {
-        "parent": -18,
+        "parent": -19,
         "position": {
           "end": {
             "col": 44,
-            "line": 18,
-            "offset": 368
+            "line": 19,
+            "offset": 441
           },
           "start": {
             "col": 0,
-            "line": 18,
-            "offset": 324
+            "line": 19,
+            "offset": 397
           }
         },
         "task": " "
@@ -127,8 +144,8 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 14,
-            "offset": 296
+            "line": 15,
+            "offset": 369
           },
           "start": {
             "col": 0,
@@ -142,13 +159,13 @@
         "position": {
           "end": {
             "col": 24,
-            "line": 16,
-            "offset": 322
+            "line": 17,
+            "offset": 395
           },
           "start": {
             "col": 0,
-            "line": 16,
-            "offset": 298
+            "line": 17,
+            "offset": 371
           }
         },
         "type": "heading"
@@ -157,13 +174,13 @@
         "position": {
           "end": {
             "col": 44,
-            "line": 18,
-            "offset": 368
+            "line": 19,
+            "offset": 441
           },
           "start": {
             "col": 0,
-            "line": 18,
-            "offset": 324
+            "line": 19,
+            "offset": 397
           }
         },
         "type": "list"
@@ -172,13 +189,13 @@
         "position": {
           "end": {
             "col": 44,
-            "line": 20,
-            "offset": 414
+            "line": 21,
+            "offset": 487
           },
           "start": {
             "col": 0,
-            "line": 20,
-            "offset": 370
+            "line": 21,
+            "offset": 443
           }
         },
         "type": "heading"
@@ -187,13 +204,13 @@
         "position": {
           "end": {
             "col": 108,
-            "line": 22,
-            "offset": 524
+            "line": 23,
+            "offset": 597
           },
           "start": {
             "col": 0,
-            "line": 22,
-            "offset": 416
+            "line": 23,
+            "offset": 489
           }
         },
         "type": "paragraph"
@@ -202,13 +219,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 29,
-            "offset": 619
+            "line": 30,
+            "offset": 692
           },
           "start": {
             "col": 0,
-            "line": 24,
-            "offset": 526
+            "line": 25,
+            "offset": 599
           }
         },
         "type": "code"
@@ -216,14 +233,14 @@
       {
         "position": {
           "end": {
-            "col": 47,
-            "line": 31,
-            "offset": 668
+            "col": 56,
+            "line": 32,
+            "offset": 750
           },
           "start": {
             "col": 0,
-            "line": 31,
-            "offset": 621
+            "line": 32,
+            "offset": 694
           }
         },
         "type": "heading"
@@ -231,14 +248,14 @@
       {
         "position": {
           "end": {
-            "col": 118,
-            "line": 33,
-            "offset": 788
+            "col": 147,
+            "line": 34,
+            "offset": 899
           },
           "start": {
             "col": 0,
-            "line": 33,
-            "offset": 670
+            "line": 34,
+            "offset": 752
           }
         },
         "type": "paragraph"
@@ -248,12 +265,57 @@
           "end": {
             "col": 3,
             "line": 41,
-            "offset": 910
+            "offset": 1006
           },
           "start": {
             "col": 0,
-            "line": 35,
-            "offset": 790
+            "line": 36,
+            "offset": 901
+          }
+        },
+        "type": "code"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 47,
+            "line": 43,
+            "offset": 1055
+          },
+          "start": {
+            "col": 0,
+            "line": 43,
+            "offset": 1008
+          }
+        },
+        "type": "heading"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 118,
+            "line": 45,
+            "offset": 1175
+          },
+          "start": {
+            "col": 0,
+            "line": 45,
+            "offset": 1057
+          }
+        },
+        "type": "paragraph"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 3,
+            "line": 53,
+            "offset": 1297
+          },
+          "start": {
+            "col": 0,
+            "line": 47,
+            "offset": 1177
           }
         },
         "type": "code"
@@ -262,13 +324,13 @@
         "position": {
           "end": {
             "col": 70,
-            "line": 43,
-            "offset": 982
+            "line": 55,
+            "offset": 1369
           },
           "start": {
             "col": 0,
-            "line": 43,
-            "offset": 912
+            "line": 55,
+            "offset": 1299
           }
         },
         "type": "heading"
@@ -277,13 +339,13 @@
         "position": {
           "end": {
             "col": 143,
-            "line": 45,
-            "offset": 1127
+            "line": 57,
+            "offset": 1514
           },
           "start": {
             "col": 0,
-            "line": 45,
-            "offset": 984
+            "line": 57,
+            "offset": 1371
           }
         },
         "type": "paragraph"
@@ -292,13 +354,13 @@
         "position": {
           "end": {
             "col": 61,
-            "line": 47,
-            "offset": 1190
+            "line": 59,
+            "offset": 1577
           },
           "start": {
             "col": 0,
-            "line": 47,
-            "offset": 1129
+            "line": 59,
+            "offset": 1516
           }
         },
         "type": "paragraph"
@@ -307,13 +369,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 55,
-            "offset": 1335
+            "line": 67,
+            "offset": 1722
           },
           "start": {
             "col": 0,
-            "line": 49,
-            "offset": 1192
+            "line": 61,
+            "offset": 1579
           }
         },
         "type": "code"
@@ -322,13 +384,13 @@
         "position": {
           "end": {
             "col": 62,
-            "line": 57,
-            "offset": 1399
+            "line": 69,
+            "offset": 1786
           },
           "start": {
             "col": 0,
-            "line": 57,
-            "offset": 1337
+            "line": 69,
+            "offset": 1724
           }
         },
         "type": "heading"
@@ -337,13 +399,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 72,
-            "offset": 1787
+            "line": 84,
+            "offset": 2174
           },
           "start": {
             "col": 0,
-            "line": 59,
-            "offset": 1401
+            "line": 71,
+            "offset": 1788
           }
         },
         "type": "code"
@@ -354,20 +416,20 @@
         "position": {
           "end": {
             "col": 11,
-            "line": 18,
-            "offset": 335
+            "line": 19,
+            "offset": 408
           },
           "start": {
             "col": 6,
-            "line": 18,
-            "offset": 330
+            "line": 19,
+            "offset": 403
           }
         },
         "tag": "#task"
       }
     ]
   },
-  "fileContents": "---\nroot_dirs_to_search:\n  - Formats/\n  - Filters/\ntask_instruction: group by filename\ntask_instructions: |\n  group by root\n  group by folder\n    group by filename\n  # a comment\n    # an indented comment\ntask_instructions_with_continuation_line: |\n  path \\\n    includes query_using_properties\n---\n\n# query_using_properties\n\n- [ ] #task Task in 'query_using_properties'\n\n## Use a one-line property: task_instruction\n\nRead a Tasks instruction from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions\n\nRead multiple Tasks instructions from a property in this file, and embed them in to any number of queries in the file:\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions_with_continuation_line\n\nRead multiple Tasks instructions with a continuation line from a property in this file, and embed them in to any number of queries in the file.\n\nContinuation lines are currently unsupported in placeholders.\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions_with_continuation_line')}}\nlimit 10\n```\n\n## Use a list property in a custom filter: root_dirs_to_search\n\n```tasks\nignore global query\nexplain\n\nfilter by function \\\n    if (!query.file.hasProperty('root_dirs_to_search')) { \\\n        throw Error('Please set the \"root_dirs_to_search\" list property, with each value ending in a backslash...'); \\\n    } \\\n    const roots = query.file.property('root_dirs_to_search'); \\\n    return roots.includes(task.file.root);\n\nlimit groups 5\ngroup by root\n```\n",
+  "fileContents": "---\nroot_dirs_to_search:\n  - Formats/\n  - Filters/\ntask_instruction: group by filename\ntask_instructions: |\n  group by root\n  group by folder\n    group by filename\n  # a comment\n    # an indented comment\ntask_instructions_with_continuation_line: |\n  path \\\n    includes query_using_properties\ntask_instruction_with_spaces: \"  path includes query_using_properties  \"\n---\n\n# query_using_properties\n\n- [ ] #task Task in 'query_using_properties'\n\n## Use a one-line property: task_instruction\n\nRead a Tasks instruction from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction')}}\nlimit 10\n```\n\n## Use a one-line property: task_instruction_with_spaces\n\nRead a Tasks instruction **that is surrounded by extra spaces** from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction_with_spaces')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions\n\nRead multiple Tasks instructions from a property in this file, and embed them in to any number of queries in the file:\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions_with_continuation_line\n\nRead multiple Tasks instructions with a continuation line from a property in this file, and embed them in to any number of queries in the file.\n\nContinuation lines are currently unsupported in placeholders.\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions_with_continuation_line')}}\nlimit 10\n```\n\n## Use a list property in a custom filter: root_dirs_to_search\n\n```tasks\nignore global query\nexplain\n\nfilter by function \\\n    if (!query.file.hasProperty('root_dirs_to_search')) { \\\n        throw Error('Please set the \"root_dirs_to_search\" list property, with each value ending in a backslash...'); \\\n    } \\\n    const roots = query.file.property('root_dirs_to_search'); \\\n    return roots.includes(task.file.root);\n\nlimit groups 5\ngroup by root\n```\n",
   "filePath": "Test Data/query_using_properties.md",
   "getAllTags": [
     "#task"

--- a/tests/Obsidian/__test_data__/query_using_properties.json
+++ b/tests/Obsidian/__test_data__/query_using_properties.json
@@ -6,14 +6,15 @@
         "Filters/"
       ],
       "task_instruction": "group by filename",
-      "task_instructions": "group by root\ngroup by folder\n  group by filename\n# a comment\n  # an indented comment\n"
+      "task_instructions": "group by root\ngroup by folder\n  group by filename\n# a comment\n  # an indented comment\n",
+      "task_instructions_with_continuation_line": "path \\\n  includes query_using_properties\n"
     },
     "frontmatterLinks": [],
     "frontmatterPosition": {
       "end": {
         "col": 3,
-        "line": 11,
-        "offset": 207
+        "line": 14,
+        "offset": 296
       },
       "start": {
         "col": 0,
@@ -28,13 +29,13 @@
         "position": {
           "end": {
             "col": 24,
-            "line": 13,
-            "offset": 233
+            "line": 16,
+            "offset": 322
           },
           "start": {
             "col": 0,
-            "line": 13,
-            "offset": 209
+            "line": 16,
+            "offset": 298
           }
         }
       },
@@ -44,13 +45,13 @@
         "position": {
           "end": {
             "col": 44,
-            "line": 17,
-            "offset": 325
+            "line": 20,
+            "offset": 414
           },
           "start": {
             "col": 0,
-            "line": 17,
-            "offset": 281
+            "line": 20,
+            "offset": 370
           }
         }
       },
@@ -60,13 +61,29 @@
         "position": {
           "end": {
             "col": 47,
-            "line": 28,
-            "offset": 579
+            "line": 31,
+            "offset": 668
           },
           "start": {
             "col": 0,
-            "line": 28,
-            "offset": 532
+            "line": 31,
+            "offset": 621
+          }
+        }
+      },
+      {
+        "heading": "Use a multi-line property: task_instructions_with_continuation_line",
+        "level": 2,
+        "position": {
+          "end": {
+            "col": 70,
+            "line": 43,
+            "offset": 982
+          },
+          "start": {
+            "col": 0,
+            "line": 43,
+            "offset": 912
           }
         }
       },
@@ -76,30 +93,30 @@
         "position": {
           "end": {
             "col": 62,
-            "line": 40,
-            "offset": 885
+            "line": 57,
+            "offset": 1399
           },
           "start": {
             "col": 0,
-            "line": 40,
-            "offset": 823
+            "line": 57,
+            "offset": 1337
           }
         }
       }
     ],
     "listItems": [
       {
-        "parent": -15,
+        "parent": -18,
         "position": {
           "end": {
             "col": 44,
-            "line": 15,
-            "offset": 279
+            "line": 18,
+            "offset": 368
           },
           "start": {
             "col": 0,
-            "line": 15,
-            "offset": 235
+            "line": 18,
+            "offset": 324
           }
         },
         "task": " "
@@ -110,8 +127,8 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 11,
-            "offset": 207
+            "line": 14,
+            "offset": 296
           },
           "start": {
             "col": 0,
@@ -125,13 +142,13 @@
         "position": {
           "end": {
             "col": 24,
-            "line": 13,
-            "offset": 233
+            "line": 16,
+            "offset": 322
           },
           "start": {
             "col": 0,
-            "line": 13,
-            "offset": 209
+            "line": 16,
+            "offset": 298
           }
         },
         "type": "heading"
@@ -140,13 +157,13 @@
         "position": {
           "end": {
             "col": 44,
-            "line": 15,
-            "offset": 279
+            "line": 18,
+            "offset": 368
           },
           "start": {
             "col": 0,
-            "line": 15,
-            "offset": 235
+            "line": 18,
+            "offset": 324
           }
         },
         "type": "list"
@@ -155,13 +172,13 @@
         "position": {
           "end": {
             "col": 44,
-            "line": 17,
-            "offset": 325
+            "line": 20,
+            "offset": 414
           },
           "start": {
             "col": 0,
-            "line": 17,
-            "offset": 281
+            "line": 20,
+            "offset": 370
           }
         },
         "type": "heading"
@@ -170,13 +187,13 @@
         "position": {
           "end": {
             "col": 108,
-            "line": 19,
-            "offset": 435
+            "line": 22,
+            "offset": 524
           },
           "start": {
             "col": 0,
-            "line": 19,
-            "offset": 327
+            "line": 22,
+            "offset": 416
           }
         },
         "type": "paragraph"
@@ -185,13 +202,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 26,
-            "offset": 530
+            "line": 29,
+            "offset": 619
           },
           "start": {
             "col": 0,
-            "line": 21,
-            "offset": 437
+            "line": 24,
+            "offset": 526
           }
         },
         "type": "code"
@@ -200,13 +217,13 @@
         "position": {
           "end": {
             "col": 47,
-            "line": 28,
-            "offset": 579
+            "line": 31,
+            "offset": 668
           },
           "start": {
             "col": 0,
-            "line": 28,
-            "offset": 532
+            "line": 31,
+            "offset": 621
           }
         },
         "type": "heading"
@@ -215,13 +232,13 @@
         "position": {
           "end": {
             "col": 118,
-            "line": 30,
-            "offset": 699
+            "line": 33,
+            "offset": 788
           },
           "start": {
             "col": 0,
-            "line": 30,
-            "offset": 581
+            "line": 33,
+            "offset": 670
           }
         },
         "type": "paragraph"
@@ -230,13 +247,73 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 38,
-            "offset": 821
+            "line": 41,
+            "offset": 910
           },
           "start": {
             "col": 0,
-            "line": 32,
-            "offset": 701
+            "line": 35,
+            "offset": 790
+          }
+        },
+        "type": "code"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 70,
+            "line": 43,
+            "offset": 982
+          },
+          "start": {
+            "col": 0,
+            "line": 43,
+            "offset": 912
+          }
+        },
+        "type": "heading"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 143,
+            "line": 45,
+            "offset": 1127
+          },
+          "start": {
+            "col": 0,
+            "line": 45,
+            "offset": 984
+          }
+        },
+        "type": "paragraph"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 61,
+            "line": 47,
+            "offset": 1190
+          },
+          "start": {
+            "col": 0,
+            "line": 47,
+            "offset": 1129
+          }
+        },
+        "type": "paragraph"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 3,
+            "line": 55,
+            "offset": 1335
+          },
+          "start": {
+            "col": 0,
+            "line": 49,
+            "offset": 1192
           }
         },
         "type": "code"
@@ -245,13 +322,13 @@
         "position": {
           "end": {
             "col": 62,
-            "line": 40,
-            "offset": 885
+            "line": 57,
+            "offset": 1399
           },
           "start": {
             "col": 0,
-            "line": 40,
-            "offset": 823
+            "line": 57,
+            "offset": 1337
           }
         },
         "type": "heading"
@@ -260,13 +337,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 55,
-            "offset": 1273
+            "line": 72,
+            "offset": 1787
           },
           "start": {
             "col": 0,
-            "line": 42,
-            "offset": 887
+            "line": 59,
+            "offset": 1401
           }
         },
         "type": "code"
@@ -277,20 +354,20 @@
         "position": {
           "end": {
             "col": 11,
-            "line": 15,
-            "offset": 246
+            "line": 18,
+            "offset": 335
           },
           "start": {
             "col": 6,
-            "line": 15,
-            "offset": 241
+            "line": 18,
+            "offset": 330
           }
         },
         "tag": "#task"
       }
     ]
   },
-  "fileContents": "---\nroot_dirs_to_search:\n  - Formats/\n  - Filters/\ntask_instruction: group by filename\ntask_instructions: |\n  group by root\n  group by folder\n    group by filename\n  # a comment\n    # an indented comment\n---\n\n# query_using_properties\n\n- [ ] #task Task in 'query_using_properties'\n\n## Use a one-line property: task_instruction\n\nRead a Tasks instruction from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions\n\nRead multiple Tasks instructions from a property in this file, and embed them in to any number of queries in the file:\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions')}}\nlimit 10\n```\n\n## Use a list property in a custom filter: root_dirs_to_search\n\n```tasks\nignore global query\nexplain\n\nfilter by function \\\n    if (!query.file.hasProperty('root_dirs_to_search')) { \\\n        throw Error('Please set the \"root_dirs_to_search\" list property, with each value ending in a backslash...'); \\\n    } \\\n    const roots = query.file.property('root_dirs_to_search'); \\\n    return roots.includes(task.file.root);\n\nlimit groups 5\ngroup by root\n```\n",
+  "fileContents": "---\nroot_dirs_to_search:\n  - Formats/\n  - Filters/\ntask_instruction: group by filename\ntask_instructions: |\n  group by root\n  group by folder\n    group by filename\n  # a comment\n    # an indented comment\ntask_instructions_with_continuation_line: |\n  path \\\n    includes query_using_properties\n---\n\n# query_using_properties\n\n- [ ] #task Task in 'query_using_properties'\n\n## Use a one-line property: task_instruction\n\nRead a Tasks instruction from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions\n\nRead multiple Tasks instructions from a property in this file, and embed them in to any number of queries in the file:\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions_with_continuation_line\n\nRead multiple Tasks instructions with a continuation line from a property in this file, and embed them in to any number of queries in the file.\n\nContinuation lines are currently unsupported in placeholders.\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions_with_continuation_line')}}\nlimit 10\n```\n\n## Use a list property in a custom filter: root_dirs_to_search\n\n```tasks\nignore global query\nexplain\n\nfilter by function \\\n    if (!query.file.hasProperty('root_dirs_to_search')) { \\\n        throw Error('Please set the \"root_dirs_to_search\" list property, with each value ending in a backslash...'); \\\n    } \\\n    const roots = query.file.property('root_dirs_to_search'); \\\n    return roots.includes(task.file.root);\n\nlimit groups 5\ngroup by root\n```\n",
   "filePath": "Test Data/query_using_properties.md",
   "getAllTags": [
     "#task"

--- a/tests/Obsidian/__test_data__/query_using_properties.json
+++ b/tests/Obsidian/__test_data__/query_using_properties.json
@@ -6,14 +6,14 @@
         "Filters/"
       ],
       "task_instruction": "group by filename",
-      "task_instructions": "group by root\ngroup by folder\ngroup by filename\n"
+      "task_instructions": "group by root\ngroup by folder\ngroup by filename\n# a comment\n"
     },
     "frontmatterLinks": [],
     "frontmatterPosition": {
       "end": {
         "col": 3,
-        "line": 9,
-        "offset": 165
+        "line": 10,
+        "offset": 179
       },
       "start": {
         "col": 0,
@@ -28,13 +28,13 @@
         "position": {
           "end": {
             "col": 24,
-            "line": 11,
-            "offset": 191
+            "line": 12,
+            "offset": 205
           },
           "start": {
             "col": 0,
-            "line": 11,
-            "offset": 167
+            "line": 12,
+            "offset": 181
           }
         }
       },
@@ -44,13 +44,13 @@
         "position": {
           "end": {
             "col": 44,
-            "line": 15,
-            "offset": 283
+            "line": 16,
+            "offset": 297
           },
           "start": {
             "col": 0,
-            "line": 15,
-            "offset": 239
+            "line": 16,
+            "offset": 253
           }
         }
       },
@@ -60,13 +60,13 @@
         "position": {
           "end": {
             "col": 47,
-            "line": 26,
-            "offset": 537
+            "line": 27,
+            "offset": 551
           },
           "start": {
             "col": 0,
-            "line": 26,
-            "offset": 490
+            "line": 27,
+            "offset": 504
           }
         }
       },
@@ -76,30 +76,30 @@
         "position": {
           "end": {
             "col": 62,
-            "line": 38,
-            "offset": 843
+            "line": 39,
+            "offset": 857
           },
           "start": {
             "col": 0,
-            "line": 38,
-            "offset": 781
+            "line": 39,
+            "offset": 795
           }
         }
       }
     ],
     "listItems": [
       {
-        "parent": -13,
+        "parent": -14,
         "position": {
           "end": {
             "col": 44,
-            "line": 13,
-            "offset": 237
+            "line": 14,
+            "offset": 251
           },
           "start": {
             "col": 0,
-            "line": 13,
-            "offset": 193
+            "line": 14,
+            "offset": 207
           }
         },
         "task": " "
@@ -110,8 +110,8 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 9,
-            "offset": 165
+            "line": 10,
+            "offset": 179
           },
           "start": {
             "col": 0,
@@ -125,13 +125,13 @@
         "position": {
           "end": {
             "col": 24,
-            "line": 11,
-            "offset": 191
+            "line": 12,
+            "offset": 205
           },
           "start": {
             "col": 0,
-            "line": 11,
-            "offset": 167
+            "line": 12,
+            "offset": 181
           }
         },
         "type": "heading"
@@ -140,13 +140,13 @@
         "position": {
           "end": {
             "col": 44,
-            "line": 13,
-            "offset": 237
+            "line": 14,
+            "offset": 251
           },
           "start": {
             "col": 0,
-            "line": 13,
-            "offset": 193
+            "line": 14,
+            "offset": 207
           }
         },
         "type": "list"
@@ -155,13 +155,13 @@
         "position": {
           "end": {
             "col": 44,
-            "line": 15,
-            "offset": 283
+            "line": 16,
+            "offset": 297
           },
           "start": {
             "col": 0,
-            "line": 15,
-            "offset": 239
+            "line": 16,
+            "offset": 253
           }
         },
         "type": "heading"
@@ -170,13 +170,13 @@
         "position": {
           "end": {
             "col": 108,
-            "line": 17,
-            "offset": 393
+            "line": 18,
+            "offset": 407
           },
           "start": {
             "col": 0,
-            "line": 17,
-            "offset": 285
+            "line": 18,
+            "offset": 299
           }
         },
         "type": "paragraph"
@@ -185,13 +185,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 24,
-            "offset": 488
+            "line": 25,
+            "offset": 502
           },
           "start": {
             "col": 0,
-            "line": 19,
-            "offset": 395
+            "line": 20,
+            "offset": 409
           }
         },
         "type": "code"
@@ -200,13 +200,13 @@
         "position": {
           "end": {
             "col": 47,
-            "line": 26,
-            "offset": 537
+            "line": 27,
+            "offset": 551
           },
           "start": {
             "col": 0,
-            "line": 26,
-            "offset": 490
+            "line": 27,
+            "offset": 504
           }
         },
         "type": "heading"
@@ -215,13 +215,13 @@
         "position": {
           "end": {
             "col": 118,
-            "line": 28,
-            "offset": 657
+            "line": 29,
+            "offset": 671
           },
           "start": {
             "col": 0,
-            "line": 28,
-            "offset": 539
+            "line": 29,
+            "offset": 553
           }
         },
         "type": "paragraph"
@@ -230,13 +230,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 36,
-            "offset": 779
+            "line": 37,
+            "offset": 793
           },
           "start": {
             "col": 0,
-            "line": 30,
-            "offset": 659
+            "line": 31,
+            "offset": 673
           }
         },
         "type": "code"
@@ -245,13 +245,13 @@
         "position": {
           "end": {
             "col": 62,
-            "line": 38,
-            "offset": 843
+            "line": 39,
+            "offset": 857
           },
           "start": {
             "col": 0,
-            "line": 38,
-            "offset": 781
+            "line": 39,
+            "offset": 795
           }
         },
         "type": "heading"
@@ -260,13 +260,13 @@
         "position": {
           "end": {
             "col": 3,
-            "line": 53,
-            "offset": 1231
+            "line": 54,
+            "offset": 1245
           },
           "start": {
             "col": 0,
-            "line": 40,
-            "offset": 845
+            "line": 41,
+            "offset": 859
           }
         },
         "type": "code"
@@ -277,20 +277,20 @@
         "position": {
           "end": {
             "col": 11,
-            "line": 13,
-            "offset": 204
+            "line": 14,
+            "offset": 218
           },
           "start": {
             "col": 6,
-            "line": 13,
-            "offset": 199
+            "line": 14,
+            "offset": 213
           }
         },
         "tag": "#task"
       }
     ]
   },
-  "fileContents": "---\nroot_dirs_to_search:\n  - Formats/\n  - Filters/\ntask_instruction: group by filename\ntask_instructions: |\n  group by root\n  group by folder\n  group by filename\n---\n\n# query_using_properties\n\n- [ ] #task Task in 'query_using_properties'\n\n## Use a one-line property: task_instruction\n\nRead a Tasks instruction from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions\n\nRead multiple Tasks instructions from a property in this file, and embed them in to any number of queries in the file:\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions')}}\nlimit 10\n```\n\n## Use a list property in a custom filter: root_dirs_to_search\n\n```tasks\nignore global query\nexplain\n\nfilter by function \\\n    if (!query.file.hasProperty('root_dirs_to_search')) { \\\n        throw Error('Please set the \"root_dirs_to_search\" list property, with each value ending in a backslash...'); \\\n    } \\\n    const roots = query.file.property('root_dirs_to_search'); \\\n    return roots.includes(task.file.root);\n\nlimit groups 5\ngroup by root\n```\n",
+  "fileContents": "---\nroot_dirs_to_search:\n  - Formats/\n  - Filters/\ntask_instruction: group by filename\ntask_instructions: |\n  group by root\n  group by folder\n  group by filename\n  # a comment\n---\n\n# query_using_properties\n\n- [ ] #task Task in 'query_using_properties'\n\n## Use a one-line property: task_instruction\n\nRead a Tasks instruction from a property in this file, and embed it in to any number of queries in the file:\n\n```tasks\nexplain\nignore global query\n{{query.file.property('task_instruction')}}\nlimit 10\n```\n\n## Use a multi-line property: task_instructions\n\nRead multiple Tasks instructions from a property in this file, and embed them in to any number of queries in the file:\n\n```tasks\nignore global query\nfolder includes Test Data\nexplain\n{{query.file.property('task_instructions')}}\nlimit 10\n```\n\n## Use a list property in a custom filter: root_dirs_to_search\n\n```tasks\nignore global query\nexplain\n\nfilter by function \\\n    if (!query.file.hasProperty('root_dirs_to_search')) { \\\n        throw Error('Please set the \"root_dirs_to_search\" list property, with each value ending in a backslash...'); \\\n    } \\\n    const roots = query.file.property('root_dirs_to_search'); \\\n    return roots.includes(task.file.root);\n\nlimit groups 5\ngroup by root\n```\n",
   "filePath": "Test Data/query_using_properties.md",
   "getAllTags": [
     "#task"

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_placeholders.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_placeholders.approved.explanation.text
@@ -13,7 +13,7 @@ Explanation of this Tasks code block query:
   filename includes file path.md
 
   description includes Some Cryptic String {{! Inline comments are removed before search }} =>
-  description includes Some Cryptic String 
+  description includes Some Cryptic String
 
   No grouping instructions supplied.
 

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -830,11 +830,12 @@ Problem statement:
 
             it('should access multi-line property with query.file.property via placeholder', () => {
                 // Act
+                const propertyName = 'task_instructions';
                 const source = '{{query.file.property("task_instructions")}}';
                 const query = new Query(source, file);
 
                 // Assert
-                expect(file.property('task_instructions')).toEqual(`group by root
+                expect(file.property(propertyName)).toEqual(`group by root
 group by folder
   group by filename
 # a comment

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -828,7 +828,7 @@ Problem statement:
                 const query = new Query(source, file);
 
                 // Assert
-                expect(file.frontmatter.task_instructions).toEqual(`group by root
+                expect(file.property('task_instructions')).toEqual(`group by root
 group by folder
   group by filename
 # a comment
@@ -859,7 +859,7 @@ group by folder
                 const query = new Query(source, file);
 
                 // Assert
-                expect(file.frontmatter.task_instructions_with_continuation_line).toEqual(
+                expect(file.property('task_instructions_with_continuation_line')).toEqual(
                     `path \\
   includes query_using_properties
 `,

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -837,11 +837,7 @@ group by folder
 # a comment
   # an indented comment
 `;
-                const source = "{{query.file.property('task_instructions')}}";
-                const query = new Query(source, file);
-
-                // Assert
-                expect(file.property(propertyName)).toEqual(propertyValue);
+                const query = createQueryFromObsidianPropertyWithValue(propertyName, propertyValue);
 
                 expect(query.error).toBeUndefined();
                 expect(query.explainQuery()).toMatchInlineSnapshot(`

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -863,11 +863,7 @@ group by folder
                 const propertyValue = `path \\
   includes query_using_properties
 `;
-                const source = "{{query.file.property('task_instructions_with_continuation_line')}}";
-                const query = new Query(source, file);
-
-                // Assert
-                expect(file.property(propertyName)).toEqual(propertyValue);
+                const query = createQueryFromObsidianPropertyWithValue(propertyName, propertyValue);
 
                 expect(query.error).not.toBeUndefined();
                 expect(query.error).toMatchInlineSnapshot(`

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -812,9 +812,6 @@ Problem statement:
                 const query = makeQueryFromPropertyWithValue('task_instruction', propertyValue);
 
                 expect(query.error).toBeUndefined();
-                expect(query.grouping.length).toEqual(1);
-                expect(query.grouping[0].instruction).toEqual('group by filename');
-
                 expect(query.explainQuery()).toMatchInlineSnapshot(`
                     "No filters supplied. All tasks will match the query.
 

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -831,6 +831,7 @@ Problem statement:
                 expect(file.frontmatter.task_instructions).toEqual(`group by root
 group by folder
 group by filename
+# a comment
 `);
 
                 expect(query.error).toBeUndefined();

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -801,7 +801,8 @@ Problem statement:
         describe('via placeholders', () => {
             it('should use query.file.property() via placeholder', () => {
                 // Act
-                const source = "{{query.file.property('task_instruction')}}";
+                const propertyName = 'task_instruction';
+                const source = "{{query.file.property('" + propertyName + "')}}";
                 const query = new Query(source, file);
 
                 // Assert

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -808,7 +808,6 @@ Problem statement:
 
         describe('via placeholders', () => {
             it('should use query.file.property() via placeholder', () => {
-                // Act
                 const propertyValue = 'group by filename';
                 const query = makeQueryFromPropertyWithValue('task_instruction', propertyValue);
 
@@ -828,7 +827,6 @@ Problem statement:
             });
 
             it('should access multi-line property with query.file.property via placeholder', () => {
-                // Act
                 const propertyValue = `group by root
 group by folder
   group by filename
@@ -856,7 +854,6 @@ group by folder
             });
 
             it('does not work with continuation lines in multi-line property with query.file.property via placeholder', () => {
-                // Act
                 const propertyValue = `path \\
   includes query_using_properties
 `;

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -806,7 +806,7 @@ Problem statement:
                 const query = new Query(source, file);
 
                 // Assert
-                expect(file.property('task_instruction')).toEqual('group by filename');
+                expect(file.property(propertyName)).toEqual('group by filename');
 
                 expect(query.error).toBeUndefined();
                 expect(query.grouping.length).toEqual(1);

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -822,14 +822,10 @@ Problem statement:
                 `);
             });
 
-            it('cannot yet access multi-line property with query.file.property via placeholder', () => {
+            it('should access multi-line property with query.file.property via placeholder', () => {
                 // Act
                 const source = '{{query.file.property("task_instructions")}}';
                 const query = new Query(source, file);
-
-                // This fails because the placeholder is replaced by multiple lines.
-                // And currently, the parsing of lines in Query assumes that placeholders
-                // do not increase the number of lines in the query.
 
                 // Assert
                 expect(file.frontmatter.task_instructions).toEqual(`group by root
@@ -837,28 +833,20 @@ group by folder
 group by filename
 `);
 
-                expect(query.error).not.toBeUndefined();
-                expect(query.error).toMatchInlineSnapshot(`
-                    "do not understand query
-                    Problem statement:
-                        {{query.file.property("task_instructions")}} =>
-                        group by root
-                    group by folder
-                    group by filename
-
-                    "
-                `);
-
+                expect(query.error).toBeUndefined();
                 expect(query.explainQuery()).toMatchInlineSnapshot(`
-                    "Query has an error:
-                    do not understand query
-                    Problem statement:
-                        {{query.file.property("task_instructions")}} =>
-                        group by root
+                    "No filters supplied. All tasks will match the query.
+
+                    {{query.file.property("task_instructions")}} =>
+                    group by root
+
+                    {{query.file.property("task_instructions")}} =>
                     group by folder
+
+                    {{query.file.property("task_instructions")}} =>
                     group by filename
 
-
+                    No sorting instructions supplied.
                     "
                 `);
             });

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -868,13 +868,11 @@ group by folder
                 );
 
                 expect(query.error).not.toBeUndefined();
-                // Note: The first problem line is actually the incomplete 'path' line.
-                //       Currently, the last error is shown, rather than the first one.
                 expect(query.error).toMatchInlineSnapshot(`
                     "do not understand query
                     Problem statement:
                         {{query.file.property("task_instructions_with_continuation_line")}} =>
-                        includes query_using_properties
+                        path \\
                     "
                 `);
             });

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -864,15 +864,14 @@ group by folder
             it('does not work with continuation lines in multi-line property with query.file.property via placeholder', () => {
                 // Act
                 const propertyName = 'task_instructions_with_continuation_line';
+                const propertyValue = `path \\
+  includes query_using_properties
+`;
                 const source = '{{query.file.property("task_instructions_with_continuation_line")}}';
                 const query = new Query(source, file);
 
                 // Assert
-                expect(file.property(propertyName)).toEqual(
-                    `path \\
-  includes query_using_properties
-`,
-                );
+                expect(file.property(propertyName)).toEqual(propertyValue);
 
                 expect(query.error).not.toBeUndefined();
                 expect(query.error).toMatchInlineSnapshot(`

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -837,7 +837,7 @@ group by folder
 # a comment
   # an indented comment
 `;
-                const source = '{{query.file.property("task_instructions")}}';
+                const source = "{{query.file.property('task_instructions')}}";
                 const query = new Query(source, file);
 
                 // Assert
@@ -847,13 +847,13 @@ group by folder
                 expect(query.explainQuery()).toMatchInlineSnapshot(`
                     "No filters supplied. All tasks will match the query.
 
-                    {{query.file.property("task_instructions")}}: statement 1 after expansion of placeholder =>
+                    {{query.file.property('task_instructions')}}: statement 1 after expansion of placeholder =>
                     group by root
 
-                    {{query.file.property("task_instructions")}}: statement 2 after expansion of placeholder =>
+                    {{query.file.property('task_instructions')}}: statement 2 after expansion of placeholder =>
                     group by folder
 
-                    {{query.file.property("task_instructions")}}: statement 3 after expansion of placeholder =>
+                    {{query.file.property('task_instructions')}}: statement 3 after expansion of placeholder =>
                     group by filename
 
                     No sorting instructions supplied.

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -854,6 +854,30 @@ group by folder
                     "
                 `);
             });
+
+            it('does not work with continuation lines in multi-line property with query.file.property via placeholder', () => {
+                // Act
+                const source = '{{query.file.property("task_instructions_with_continuation_line")}}';
+                const query = new Query(source, file);
+
+                // Assert
+                expect(file.frontmatter.task_instructions_with_continuation_line).toEqual(
+                    `path \\
+  includes query_using_properties
+`,
+                );
+
+                expect(query.error).not.toBeUndefined();
+                // Note: The first problem line is actually the incomplete 'path' line.
+                //       Currently, the last error is shown, rather than the first one.
+                expect(query.error).toMatchInlineSnapshot(`
+                    "do not understand query
+                    Problem statement:
+                        {{query.file.property("task_instructions_with_continuation_line")}} =>
+                        includes query_using_properties
+                    "
+                `);
+            });
         });
 
         describe('via "filter by function"', () => {

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -798,7 +798,7 @@ Problem statement:
     describe('properties in the query file', () => {
         const file = getTasksFileFromMockData(query_using_properties);
 
-        function createQueryFromObsidianPropertyWithValue(propertyName: string, propertyValue: string) {
+        function makeQueryFromPropertyWithValue(propertyName: string, propertyValue: string) {
             const source = "{{query.file.property('" + propertyName + "')}}";
             const query = new Query(source, file);
 
@@ -811,7 +811,7 @@ Problem statement:
                 // Act
                 const propertyName = 'task_instruction';
                 const propertyValue = 'group by filename';
-                const query = createQueryFromObsidianPropertyWithValue(propertyName, propertyValue);
+                const query = makeQueryFromPropertyWithValue(propertyName, propertyValue);
 
                 expect(query.error).toBeUndefined();
                 expect(query.grouping.length).toEqual(1);
@@ -837,7 +837,7 @@ group by folder
 # a comment
   # an indented comment
 `;
-                const query = createQueryFromObsidianPropertyWithValue(propertyName, propertyValue);
+                const query = makeQueryFromPropertyWithValue(propertyName, propertyValue);
 
                 expect(query.error).toBeUndefined();
                 expect(query.explainQuery()).toMatchInlineSnapshot(`
@@ -863,7 +863,7 @@ group by folder
                 const propertyValue = `path \\
   includes query_using_properties
 `;
-                const query = createQueryFromObsidianPropertyWithValue(propertyName, propertyValue);
+                const query = makeQueryFromPropertyWithValue(propertyName, propertyValue);
 
                 expect(query.error).not.toBeUndefined();
                 expect(query.error).toMatchInlineSnapshot(`

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -867,7 +867,7 @@ group by folder
                 const propertyValue = `path \\
   includes query_using_properties
 `;
-                const source = '{{query.file.property("task_instructions_with_continuation_line")}}';
+                const source = "{{query.file.property('task_instructions_with_continuation_line')}}";
                 const query = new Query(source, file);
 
                 // Assert
@@ -877,7 +877,7 @@ group by folder
                 expect(query.error).toMatchInlineSnapshot(`
                     "do not understand query
                     Problem statement:
-                        {{query.file.property("task_instructions_with_continuation_line")}}: statement 1 after expansion of placeholder =>
+                        {{query.file.property('task_instructions_with_continuation_line')}}: statement 1 after expansion of placeholder =>
                         path \\
                     "
                 `);

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -862,11 +862,12 @@ group by folder
 
             it('does not work with continuation lines in multi-line property with query.file.property via placeholder', () => {
                 // Act
+                const propertyName = 'task_instructions_with_continuation_line';
                 const source = '{{query.file.property("task_instructions_with_continuation_line")}}';
                 const query = new Query(source, file);
 
                 // Assert
-                expect(file.property('task_instructions_with_continuation_line')).toEqual(
+                expect(file.property(propertyName)).toEqual(
                     `path \\
   includes query_using_properties
 `,

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -798,16 +798,20 @@ Problem statement:
     describe('properties in the query file', () => {
         const file = getTasksFileFromMockData(query_using_properties);
 
+        function createQueryFromObsidianPropertyWithValue(propertyName: string, propertyValue: string) {
+            const source = "{{query.file.property('" + propertyName + "')}}";
+            const query = new Query(source, file);
+
+            expect(file.property(propertyName)).toEqual(propertyValue);
+            return query;
+        }
+
         describe('via placeholders', () => {
             it('should use query.file.property() via placeholder', () => {
                 // Act
                 const propertyName = 'task_instruction';
                 const propertyValue = 'group by filename';
-                const source = "{{query.file.property('" + propertyName + "')}}";
-                const query = new Query(source, file);
-
-                // Assert
-                expect(file.property(propertyName)).toEqual(propertyValue);
+                const query = createQueryFromObsidianPropertyWithValue(propertyName, propertyValue);
 
                 expect(query.error).toBeUndefined();
                 expect(query.grouping.length).toEqual(1);

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -832,6 +832,7 @@ Problem statement:
 group by folder
   group by filename
 # a comment
+  # an indented comment
 `);
 
                 expect(query.error).toBeUndefined();

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -831,16 +831,17 @@ Problem statement:
             it('should access multi-line property with query.file.property via placeholder', () => {
                 // Act
                 const propertyName = 'task_instructions';
-                const source = '{{query.file.property("task_instructions")}}';
-                const query = new Query(source, file);
-
-                // Assert
-                expect(file.property(propertyName)).toEqual(`group by root
+                const propertyValue = `group by root
 group by folder
   group by filename
 # a comment
   # an indented comment
-`);
+`;
+                const source = '{{query.file.property("task_instructions")}}';
+                const query = new Query(source, file);
+
+                // Assert
+                expect(file.property(propertyName)).toEqual(propertyValue);
 
                 expect(query.error).toBeUndefined();
                 expect(query.explainQuery()).toMatchInlineSnapshot(`

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -823,6 +823,22 @@ Problem statement:
                 `);
             });
 
+            it.failing('should use query.file.property() via placeholder that has spaces around value', () => {
+                const propertyValue = '  path includes query_using_properties  ';
+                const query = makeQueryFromPropertyWithValue('task_instruction_with_spaces', propertyValue);
+
+                expect(query.error).toBeUndefined();
+                expect(query.explainQuery()).toMatchInlineSnapshot(`
+                    "{{query.file.property('task_instruction_with_spaces')}} =>
+                    path includes query_using_properties
+
+                    No grouping instructions supplied.
+
+                    No sorting instructions supplied.
+                    "
+                `);
+            });
+
             it('should access multi-line property with query.file.property via placeholder', () => {
                 const propertyValue = `group by root
 group by folder

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -809,9 +809,8 @@ Problem statement:
         describe('via placeholders', () => {
             it('should use query.file.property() via placeholder', () => {
                 // Act
-                const propertyName = 'task_instruction';
                 const propertyValue = 'group by filename';
-                const query = makeQueryFromPropertyWithValue(propertyName, propertyValue);
+                const query = makeQueryFromPropertyWithValue('task_instruction', propertyValue);
 
                 expect(query.error).toBeUndefined();
                 expect(query.grouping.length).toEqual(1);
@@ -830,14 +829,13 @@ Problem statement:
 
             it('should access multi-line property with query.file.property via placeholder', () => {
                 // Act
-                const propertyName = 'task_instructions';
                 const propertyValue = `group by root
 group by folder
   group by filename
 # a comment
   # an indented comment
 `;
-                const query = makeQueryFromPropertyWithValue(propertyName, propertyValue);
+                const query = makeQueryFromPropertyWithValue('task_instructions', propertyValue);
 
                 expect(query.error).toBeUndefined();
                 expect(query.explainQuery()).toMatchInlineSnapshot(`
@@ -859,11 +857,10 @@ group by folder
 
             it('does not work with continuation lines in multi-line property with query.file.property via placeholder', () => {
                 // Act
-                const propertyName = 'task_instructions_with_continuation_line';
                 const propertyValue = `path \\
   includes query_using_properties
 `;
-                const query = makeQueryFromPropertyWithValue(propertyName, propertyValue);
+                const query = makeQueryFromPropertyWithValue('task_instructions_with_continuation_line', propertyValue);
 
                 expect(query.error).not.toBeUndefined();
                 expect(query.error).toMatchInlineSnapshot(`

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -770,7 +770,7 @@ Problem statement:
             expect(query.filters.length).toEqual(0);
         });
 
-        it.failing('should report first error if non-existent placeholder used', () => {
+        it('should report first error if non-existent placeholder used', () => {
             // Arrange
             const source = `{{error 1}}
 {{error 2}}
@@ -782,7 +782,6 @@ Problem statement:
 
             // Assert
             expect(query).not.toBeValid();
-            // TODO This currently shows 'error 3', not 'error 1'
             expect(query.error).toEqual(
                 'There was an error expanding one or more placeholders.\n' +
                     '\n' +

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -823,7 +823,7 @@ Problem statement:
                 `);
             });
 
-            it.failing('should use query.file.property() via placeholder that has spaces around value', () => {
+            it('should use query.file.property() via placeholder that has spaces around value', () => {
                 const propertyValue = '  path includes query_using_properties  ';
                 const query = makeQueryFromPropertyWithValue('task_instruction_with_spaces', propertyValue);
 

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -836,18 +836,16 @@ group by folder
 `);
 
                 expect(query.error).toBeUndefined();
-                // It is not clear that this is a multi-line property that has been expanded.
-                // Might it be worth adding line numbers after the placeholdert?
                 expect(query.explainQuery()).toMatchInlineSnapshot(`
                     "No filters supplied. All tasks will match the query.
 
-                    {{query.file.property("task_instructions")}} =>
+                    {{query.file.property("task_instructions")}}: statement 1 after expansion of placeholder =>
                     group by root
 
-                    {{query.file.property("task_instructions")}} =>
+                    {{query.file.property("task_instructions")}}: statement 2 after expansion of placeholder =>
                     group by folder
 
-                    {{query.file.property("task_instructions")}} =>
+                    {{query.file.property("task_instructions")}}: statement 3 after expansion of placeholder =>
                     group by filename
 
                     No sorting instructions supplied.
@@ -871,7 +869,7 @@ group by folder
                 expect(query.error).toMatchInlineSnapshot(`
                     "do not understand query
                     Problem statement:
-                        {{query.file.property("task_instructions_with_continuation_line")}} =>
+                        {{query.file.property("task_instructions_with_continuation_line")}}: statement 1 after expansion of placeholder =>
                         path \\
                     "
                 `);

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -769,6 +769,31 @@ Problem statement:
             );
             expect(query.filters.length).toEqual(0);
         });
+
+        it.failing('should report first error if non-existent placeholder used', () => {
+            // Arrange
+            const source = `{{error 1}}
+{{error 2}}
+{{error 3}}`;
+            const tasksFile = new TasksFile('a/b/path with space.md');
+
+            // Act
+            const query = new Query(source, tasksFile);
+
+            // Assert
+            expect(query).not.toBeValid();
+            // TODO This currently shows 'error 3', not 'error 1'
+            expect(query.error).toEqual(
+                'There was an error expanding one or more placeholders.\n' +
+                    '\n' +
+                    'The error message was:\n' +
+                    '    Unknown property: error 1\n' +
+                    '\n' +
+                    'The problem is in:\n' +
+                    '    {{error 1}}',
+            );
+            expect(query.filters.length).toEqual(0);
+        });
     });
 
     describe('properties in the query file', () => {

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -830,7 +830,7 @@ Problem statement:
                 // Assert
                 expect(file.frontmatter.task_instructions).toEqual(`group by root
 group by folder
-group by filename
+  group by filename
 # a comment
 `);
 

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -802,11 +802,12 @@ Problem statement:
             it('should use query.file.property() via placeholder', () => {
                 // Act
                 const propertyName = 'task_instruction';
+                const propertyValue = 'group by filename';
                 const source = "{{query.file.property('" + propertyName + "')}}";
                 const query = new Query(source, file);
 
                 // Assert
-                expect(file.property(propertyName)).toEqual('group by filename');
+                expect(file.property(propertyName)).toEqual(propertyValue);
 
                 expect(query.error).toBeUndefined();
                 expect(query.grouping.length).toEqual(1);

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -836,6 +836,8 @@ group by folder
 `);
 
                 expect(query.error).toBeUndefined();
+                // It is not clear that this is a multi-line property that has been expanded.
+                // Might it be worth adding line numbers after the placeholdert?
                 expect(query.explainQuery()).toMatchInlineSnapshot(`
                     "No filters supplied. All tasks will match the query.
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

This fixes one of the limitations from PR #3242 - the following now works:

> Only single-line properties work. Multiple-line properties give an error message 'do not understand query'.


Note that continuation lines are not supported in multi-line properties, when they are used in placeholders.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Getting closer to releasing access to `query.file.property()` and `query.file.hasProperty()` to users...

See:

- #3083
- #3154

## How has this been tested?

- Extra automated tests
- Exploratory testing

## Screenshots (if appropriate)

Consider the following demo sample markdown note.

I have 3 Tasks searches, and they differ only in the `happens` date filter: I have a bunch of standard instructions that I want to use in all 3 searches.

Now, I can put all my standard instructions in a multi-line `common_instructions` property value, and embed its value as a placeholder in each of the 3 searches 🎉 :

~~~
---
common_instructions: |
  tags include #my/lovely/project
  short mode
  show tree
  show urgency
  group by due
---

- [ ] #task Do stuff - ==overdue== #my/lovely/project 📅 2024-12-21
- [ ] #task Do stuff - ==today== #my/lovely/project 📅 2024-12-22
- [ ] #task Do stuff - ==future== #my/lovely/project 📅 2024-12-23

## Overdue tasks

```tasks
{{query.file.property('common_instructions')}}
happens before today
```

## Tasks for today

```tasks
{{query.file.property('common_instructions')}}
happens today
```

## Future tasks

```tasks
{{query.file.property('common_instructions')}}
happens after today
```
~~~

Here are the search results:

![image](https://github.com/user-attachments/assets/9fd0b600-0006-4973-a1a0-d43608e651c9)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
