### PR TITLE
chore(dev): bump Obsidian API version from 1.1.1 to 1.4.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "obsidian-tasks-plugin",
   "name": "Tasks",
   "version": "7.14.0",
-  "minAppVersion": "1.1.1",
+  "minAppVersion": "1.4.0",
   "description": "Track tasks across your vault. Supports due dates, recurring tasks, done dates, sub-set of checklist items, and filtering.",
   "helpUrl": "https://publish.obsidian.md/tasks/",
   "author": "Clare Macrae and Ilyas Landikov (created by Martin Schenck)",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "madge": "^8.0.0",
     "markdownlint-cli2": "^0.13.0",
     "moment": "^2.29.4",
-    "obsidian": "^1.1.1",
+    "obsidian": "^1.4.0",
     "prettier": "^2.8.8",
     "prettier-plugin-svelte": "^2.10.1",
     "svelte": "^3.59.1",

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Console Logs/obsidian.md-1735685320026 - Tasks using Obsidian 1.4.0 - Cannot find task to edit after date picker.log
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Console Logs/obsidian.md-1735685320026 - Tasks using Obsidian 1.4.0 - Cannot find task to edit after date picker.log
@@ -1,0 +1,518 @@
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:09.738][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:09.738][debug][tasks.Task] toggle() original: - [ ] #task Mark this task complete in **Source view** using **Tasks: Toggle task done** command 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:09.739][debug][tasks.Task] toggle() ==> 1   : - [x] #task Mark this task complete in **Source view** using **Tasks: Toggle task done** command ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:11.764][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:11.766][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:11.766][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:11.766][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:12.560][debug][tasks.Task] toggle(): task line number: 65. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:12.561][debug][tasks.Task] toggle() original: - [ ] #task Mark this task complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:12.561][debug][tasks.Task] toggle() ==> 1   : - [x] #task Mark this task complete by clicking on it in **Reading view** ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:12.562][debug][tasks.File] replaceTaskWithTasks(): task line number: 65. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:12.562][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Mark this task complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:12.562][debug][tasks.File] replaceTaskWithTasks() ==> 1   : - [x] #task Mark this task complete by clicking on it in **Reading view** ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:12.562][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:12.566][debug][tasks.File] Found original markdown at original line number 65 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:12.607][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:12.609][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:12.609][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:12.609][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:14.498][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:14.498][debug][tasks.Task] toggle() original: - [ ] #task Mark this task complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:14.499][debug][tasks.Task] toggle() ==> 1   : - [x] #task Mark this task complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:15.678][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:15.678][debug][tasks.Task] toggle() original: - [ ] #task **check**: Checked all above methods for **completing tasks** - and they worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:15.678][debug][tasks.Task] toggle() ==> 1   : - [x] #task **check**: Checked all above methods for **completing tasks** - and they worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:16.510][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:16.511][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:16.511][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:16.511][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:21.403][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:21.403][debug][tasks.Task] toggle() original: * [x] #task Mark this task not complete in **Source view** using **Tasks: Toggle task done** command ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:21.404][debug][tasks.Task] toggle() ==> 1   : * [ ] #task Mark this task not complete in **Source view** using **Tasks: Toggle task done** command 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:23.424][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:23.426][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:23.426][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:23.426][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:26.118][debug][tasks.Task] toggle(): task line number: 74. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:26.118][debug][tasks.Task] toggle() original: * [x] #task Mark this task not complete by clicking on it in **Reading view** ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:26.119][debug][tasks.Task] toggle() ==> 1   : * [ ] #task Mark this task not complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:26.119][debug][tasks.File] replaceTaskWithTasks(): task line number: 74. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:26.119][debug][tasks.File] replaceTaskWithTasks() original: * [x] #task Mark this task not complete by clicking on it in **Reading view** ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:26.119][debug][tasks.File] replaceTaskWithTasks() ==> 1   : * [ ] #task Mark this task not complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:26.119][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:26.124][debug][tasks.File] Found original markdown at original line number 74 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:26.174][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:26.174][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:26.175][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:26.175][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:28.258][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:28.259][debug][tasks.Task] toggle() original: * [x] #task Mark this task not complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:28.259][debug][tasks.Task] toggle() ==> 1   : * [ ] #task Mark this task not complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:29.518][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:29.519][debug][tasks.Task] toggle() original: * [ ] #task **check**: Checked all above methods for **un-completing tasks** - and they worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:29.519][debug][tasks.Task] toggle() ==> 1   : * [x] #task **check**: Checked all above methods for **un-completing tasks** - and they worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:30.278][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:30.280][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:30.281][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:30.281][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:38.224][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:38.224][debug][tasks.Task] toggle() original: > - [ ] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:38.228][debug][tasks.Task] toggle() ==> 1   : > - [ ] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:38.228][debug][tasks.Task] toggle() ==> 2   : > - [x] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:40.268][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:40.270][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 38 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:40.270][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:40.270][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:42.939][debug][tasks.Task] toggle(): task line number: 89. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:42.939][debug][tasks.Task] toggle() original: > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:42.941][debug][tasks.Task] toggle() ==> 1   : > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:42.941][debug][tasks.Task] toggle() ==> 2   : > > - [x] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:42.941][debug][tasks.File] replaceTaskWithTasks(): task line number: 89. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:42.941][debug][tasks.File] replaceTaskWithTasks() original: > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:42.942][debug][tasks.File] replaceTaskWithTasks() ==> 1   : > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:42.942][debug][tasks.File] replaceTaskWithTasks() ==> 2   : > > - [x] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:42.942][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:42.945][debug][tasks.File] Found original markdown at original line number 89 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:43.018][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:43.019][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 39 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:43.019][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:43.019][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:45.898][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:45.898][debug][tasks.Task] toggle() original: - [ ] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:45.900][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:45.901][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:47.929][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:47.930][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 40 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:47.930][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:47.930][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:49.497][debug][tasks.Task] toggle(): task line number: 92. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:49.497][debug][tasks.Task] toggle() original: > - [ ] #task **check**: Checked all above steps for **recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:49.497][debug][tasks.Task] toggle() ==> 1   : > - [x] #task **check**: Checked all above steps for **recurring tasks** worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:49.498][debug][tasks.File] replaceTaskWithTasks(): task line number: 92. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:49.498][debug][tasks.File] replaceTaskWithTasks() original: > - [ ] #task **check**: Checked all above steps for **recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:49.498][debug][tasks.File] replaceTaskWithTasks() ==> 1   : > - [x] #task **check**: Checked all above steps for **recurring tasks** worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:49.498][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:49.527][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:49.527][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 40 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:49.527][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:49.528][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:50.712][debug][tasks.Events] TasksEvents.triggerRequestCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:50.712][debug][tasks.Events] TasksEvents.onCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:59.122][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:59.123][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting non-recurring task in **Source view** using **Tasks: Toggle task done** command 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:45:59.123][debug][tasks.Task] toggle() ==> 1   : - [x] #task Complete this auto-deleting non-recurring task in **Source view** using **Tasks: Toggle task done** command 🏁 delete 📅 2024-10-27 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:01.153][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:01.155][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 39 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:01.155][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:01.155][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:06.179][debug][tasks.Task] toggle(): task line number: 104. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:06.179][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:06.179][debug][tasks.Task] toggle() ==> 1   : - [x] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:06.179][debug][tasks.File] replaceTaskWithTasks(): task line number: 104. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:06.180][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:06.180][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:06.183][debug][tasks.File] Found original markdown at original line number 104 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:06.240][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:06.241][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 38 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:06.241][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:06.241][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:15.858][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:15.858][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting non-recurring task in **Live Preview** 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:15.859][debug][tasks.Task] toggle() ==> 1   : - [x] #task Complete this auto-deleting non-recurring task in **Live Preview** 🏁 delete 📅 2024-10-27 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:17.888][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:17.889][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:17.889][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:17.890][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:21.238][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:21.238][debug][tasks.Task] toggle() original: - [ ] #task **check**: Checked all above steps for **auto-deleting non-recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:21.238][debug][tasks.Task] toggle() ==> 1   : - [x] #task **check**: Checked all above steps for **auto-deleting non-recurring tasks** worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:23.273][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:23.275][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:23.275][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:23.275][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:34.004][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:34.005][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:34.008][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:34.008][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-27 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:36.036][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:36.038][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:36.038][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:36.038][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.599][debug][tasks.Task] toggle(): task line number: 112. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.599][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.601][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.601][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.601][debug][tasks.File] replaceTaskWithTasks(): task line number: 112. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.601][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.601][debug][tasks.File] replaceTaskWithTasks() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.602][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.605][debug][tasks.File] Found original markdown at original line number 112 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.651][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.652][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.652][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:42.652][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:48.258][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:48.259][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:48.260][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:48.260][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-27 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:50.289][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:50.291][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:50.291][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:50.291][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:54.319][debug][tasks.Task] toggle(): task line number: 114. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:54.319][debug][tasks.Task] toggle() original: - [ ] #task **check**: Checked all above steps for **auto-deleting recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:54.320][debug][tasks.Task] toggle() ==> 1   : - [x] #task **check**: Checked all above steps for **auto-deleting recurring tasks** worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:54.320][debug][tasks.File] replaceTaskWithTasks(): task line number: 114. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:54.320][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task **check**: Checked all above steps for **auto-deleting recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:54.320][debug][tasks.File] replaceTaskWithTasks() ==> 1   : - [x] #task **check**: Checked all above steps for **auto-deleting recurring tasks** worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:54.321][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:54.325][debug][tasks.File] Found original markdown at original line number 114 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:54.373][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:54.374][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:54.374][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:46:54.374][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:07.297][debug][tasks.Task] toggle(): task line number: 122. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:07.297][debug][tasks.Task] toggle() original: + [ ] #task View this file in **Reading view** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:07.297][debug][tasks.Task] toggle() ==> 1   : + [x] #task View this file in **Reading view** and confirm that the tasks in this section are listed ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:07.297][debug][tasks.File] replaceTaskWithTasks(): task line number: 122. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:07.297][debug][tasks.File] replaceTaskWithTasks() original: + [ ] #task View this file in **Reading view** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:07.297][debug][tasks.File] replaceTaskWithTasks() ==> 1   : + [x] #task View this file in **Reading view** and confirm that the tasks in this section are listed ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:07.297][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:07.307][debug][tasks.File] Found original markdown at original line number 122 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:07.363][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:07.363][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:07.364][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:07.364][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:10.078][debug][tasks.Task] toggle(): task line number: 123. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:10.079][debug][tasks.Task] toggle() original: + [ ] #task View this file in **Live Preview** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:10.079][debug][tasks.Task] toggle() ==> 1   : + [x] #task View this file in **Live Preview** and confirm that the tasks in this section are listed ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:10.080][debug][tasks.File] replaceTaskWithTasks(): task line number: 123. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:10.080][debug][tasks.File] replaceTaskWithTasks() original: + [ ] #task View this file in **Live Preview** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:10.080][debug][tasks.File] replaceTaskWithTasks() ==> 1   : + [x] #task View this file in **Live Preview** and confirm that the tasks in this section are listed ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:10.080][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:10.085][debug][tasks.File] Found original markdown at original line number 123 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:10.145][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:10.146][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:10.146][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:10.146][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:12.863][debug][tasks.Task] toggle(): task line number: 124. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:12.864][debug][tasks.Task] toggle() original: + [ ] #task **check**: Checked all above steps for **viewing task blocks** worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:12.864][debug][tasks.Task] toggle() ==> 1   : + [x] #task **check**: Checked all above steps for **viewing task blocks** worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:12.864][debug][tasks.File] replaceTaskWithTasks(): task line number: 124. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:12.864][debug][tasks.File] replaceTaskWithTasks() original: + [ ] #task **check**: Checked all above steps for **viewing task blocks** worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:12.864][debug][tasks.File] replaceTaskWithTasks() ==> 1   : + [x] #task **check**: Checked all above steps for **viewing task blocks** worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:12.864][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:12.868][debug][tasks.File] Found original markdown at original line number 124 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:12.921][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:12.922][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:12.922][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:12.922][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:14.308][debug][tasks.Events] TasksEvents.triggerRequestCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:14.309][debug][tasks.Events] TasksEvents.onCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:25.520][debug][tasks.File] replaceTaskWithTasks(): task line number: 147. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:25.520][debug][tasks.File] replaceTaskWithTasks() original: > - [ ] #task Sample task: I have all the supported date types ➕ 2024-09-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:25.520][debug][tasks.File] replaceTaskWithTasks() ==> 1   : > - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:25.520][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:25.569][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:25.570][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:25.570][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:25.570][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.379][debug][tasks.Task] toggle(): task line number: 151. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.379][debug][tasks.Task] toggle() original:   - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.380][debug][tasks.Task] toggle() ==> 1   :   - [x] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.380][debug][tasks.File] replaceTaskWithTasks(): task line number: 151. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.380][debug][tasks.File] replaceTaskWithTasks() original:   - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.380][debug][tasks.File] replaceTaskWithTasks() ==> 1   :   - [x] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.381][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.394][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.394][debug][tasks.File] timeout = 1 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.395][debug][tasks.File] tryRepetitive after 1 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.396][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.396][debug][tasks.File] timeout = 10 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.407][debug][tasks.File] tryRepetitive after 2 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.408][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.408][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.509][debug][tasks.File] tryRepetitive after 3 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.510][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.510][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.612][debug][tasks.File] tryRepetitive after 4 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.612][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.612][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.714][debug][tasks.File] tryRepetitive after 5 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.715][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.715][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.816][debug][tasks.File] tryRepetitive after 6 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.817][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.818][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.919][debug][tasks.File] tryRepetitive after 7 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.920][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:32.920][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:33.023][debug][tasks.File] tryRepetitive after 8 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:33.024][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:33.024][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:33.126][debug][tasks.File] tryRepetitive after 9 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:33.129][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:33.129][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:33.231][debug][tasks.File] tryRepetitive after 10 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:33.232][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:33.232][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:33.333][debug][tasks.File] tryRepetitive after 11 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-22:47:33.334][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:20924 Tasks: Could not find the correct task line to update.
+
+The task line not updated is:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+
+In this markdown file:
+"Manual Testing/Smoke Testing the Tasks Plugin.md"
+
+Note: further clicks on this checkbox will usually now be ignored until the file is opened (or certain, specific edits are made - it's complicated).
+
+Recommendations:
+
+1. Close all panes that have the above file open, and then re-open the file.
+
+2. Check for exactly identical copies of the task line, in this file, and see if you can make them different.
+
+errorAndNotice @ plugin:obsidian-tasks-plugin:20924
+eval @ plugin:obsidian-tasks-plugin:20967
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20914
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+replaceTaskWithTasks @ plugin:obsidian-tasks-plugin:20899
+eval @ plugin:obsidian-tasks-plugin:29691

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Console Logs/obsidian.md-1735686885469 - Tasks using Obsidian 1.1.1 - Cannot find task to edit after date picker.log
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Console Logs/obsidian.md-1735686885469 - Tasks using Obsidian 1.1.1 - Cannot find task to edit after date picker.log
@@ -1,0 +1,489 @@
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:39.127][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:39.128][debug][tasks.Task] toggle() original: - [ ] #task Mark this task complete in **Source view** using **Tasks: Toggle task done** command 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:39.128][debug][tasks.Task] toggle() ==> 1   : - [x] #task Mark this task complete in **Source view** using **Tasks: Toggle task done** command ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:41.147][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:41.149][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:41.149][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:41.150][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:42.203][debug][tasks.Task] toggle(): task line number: 65. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:42.203][debug][tasks.Task] toggle() original: - [ ] #task Mark this task complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:42.204][debug][tasks.Task] toggle() ==> 1   : - [x] #task Mark this task complete by clicking on it in **Reading view** ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:42.204][debug][tasks.File] replaceTaskWithTasks(): task line number: 65. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:42.204][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Mark this task complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:42.204][debug][tasks.File] replaceTaskWithTasks() ==> 1   : - [x] #task Mark this task complete by clicking on it in **Reading view** ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:42.205][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:42.209][debug][tasks.File] Found original markdown at original line number 65 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:42.255][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:42.256][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:42.256][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:42.256][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:47.903][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:47.903][debug][tasks.Task] toggle() original: - [ ] #task Mark this task complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:47.903][debug][tasks.Task] toggle() ==> 1   : - [x] #task Mark this task complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:48.843][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:48.843][debug][tasks.Task] toggle() original: - [ ] #task **check**: Checked all above methods for **completing tasks** - and they worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:48.844][debug][tasks.Task] toggle() ==> 1   : - [x] #task **check**: Checked all above methods for **completing tasks** - and they worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:49.920][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:49.923][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:49.923][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:49.923][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:53.002][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:53.003][debug][tasks.Task] toggle() original: * [x] #task Mark this task not complete in **Source view** using **Tasks: Toggle task done** command ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:53.003][debug][tasks.Task] toggle() ==> 1   : * [ ] #task Mark this task not complete in **Source view** using **Tasks: Toggle task done** command 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.026][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.029][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.029][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.029][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.243][debug][tasks.Task] toggle(): task line number: 74. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.243][debug][tasks.Task] toggle() original: * [x] #task Mark this task not complete by clicking on it in **Reading view** ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.243][debug][tasks.Task] toggle() ==> 1   : * [ ] #task Mark this task not complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.244][debug][tasks.File] replaceTaskWithTasks(): task line number: 74. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.244][debug][tasks.File] replaceTaskWithTasks() original: * [x] #task Mark this task not complete by clicking on it in **Reading view** ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.244][debug][tasks.File] replaceTaskWithTasks() ==> 1   : * [ ] #task Mark this task not complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.244][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.247][debug][tasks.File] Found original markdown at original line number 74 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.294][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.295][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.295][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:55.295][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:56.942][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:56.942][debug][tasks.Task] toggle() original: * [x] #task Mark this task not complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:56.943][debug][tasks.Task] toggle() ==> 1   : * [ ] #task Mark this task not complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:58.041][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:58.041][debug][tasks.Task] toggle() original: * [ ] #task **check**: Checked all above methods for **un-completing tasks** - and they worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:58.042][debug][tasks.Task] toggle() ==> 1   : * [x] #task **check**: Checked all above methods for **un-completing tasks** - and they worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:58.960][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:58.963][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:58.963][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:12:58.963][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:09.203][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:09.204][debug][tasks.Task] toggle() original: > - [ ] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:09.207][debug][tasks.Task] toggle() ==> 1   : > - [ ] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:09.207][debug][tasks.Task] toggle() ==> 2   : > - [x] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:11.230][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:11.232][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 38 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:11.232][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:11.232][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.303][debug][tasks.Task] toggle(): task line number: 89. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.304][debug][tasks.Task] toggle() original: > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.305][debug][tasks.Task] toggle() ==> 1   : > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.306][debug][tasks.Task] toggle() ==> 2   : > > - [x] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.306][debug][tasks.File] replaceTaskWithTasks(): task line number: 89. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.306][debug][tasks.File] replaceTaskWithTasks() original: > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.306][debug][tasks.File] replaceTaskWithTasks() ==> 1   : > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.306][debug][tasks.File] replaceTaskWithTasks() ==> 2   : > > - [x] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.306][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.309][debug][tasks.File] Found original markdown at original line number 89 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.374][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.375][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 39 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.376][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:14.376][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:16.463][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:16.464][debug][tasks.Task] toggle() original: - [ ] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:16.465][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:16.465][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.241][debug][tasks.Task] toggle(): task line number: 92. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.241][debug][tasks.Task] toggle() original: > - [ ] #task **check**: Checked all above steps for **recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.242][debug][tasks.Task] toggle() ==> 1   : > - [x] #task **check**: Checked all above steps for **recurring tasks** worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.242][debug][tasks.File] replaceTaskWithTasks(): task line number: 92. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.242][debug][tasks.File] replaceTaskWithTasks() original: > - [ ] #task **check**: Checked all above steps for **recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.242][debug][tasks.File] replaceTaskWithTasks() ==> 1   : > - [x] #task **check**: Checked all above steps for **recurring tasks** worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.242][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.301][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.302][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 39 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.302][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.302][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.505][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.506][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 40 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.506][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:18.506][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:19.376][debug][tasks.Events] TasksEvents.triggerRequestCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:19.378][debug][tasks.Events] TasksEvents.onCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:22.526][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:22.526][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting non-recurring task in **Source view** using **Tasks: Toggle task done** command 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:22.527][debug][tasks.Task] toggle() ==> 1   : - [x] #task Complete this auto-deleting non-recurring task in **Source view** using **Tasks: Toggle task done** command 🏁 delete 📅 2024-10-27 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.560][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.561][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 39 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.562][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.562][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.883][debug][tasks.Task] toggle(): task line number: 104. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.884][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.884][debug][tasks.Task] toggle() ==> 1   : - [x] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.884][debug][tasks.File] replaceTaskWithTasks(): task line number: 104. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.884][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.885][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.889][debug][tasks.File] Found original markdown at original line number 104 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.945][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.946][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 38 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.946][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:24.946][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:28.843][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:28.843][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting non-recurring task in **Live Preview** 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:28.844][debug][tasks.Task] toggle() ==> 1   : - [x] #task Complete this auto-deleting non-recurring task in **Live Preview** 🏁 delete 📅 2024-10-27 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:30.683][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:30.684][debug][tasks.Task] toggle() original: - [ ] #task **check**: Checked all above steps for **auto-deleting non-recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:30.684][debug][tasks.Task] toggle() ==> 1   : - [x] #task **check**: Checked all above steps for **auto-deleting non-recurring tasks** worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:30.868][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:30.870][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:30.870][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:30.870][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:40.545][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:40.546][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:40.549][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:40.550][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-27 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:42.577][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:42.578][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:42.578][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:42.579][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.423][debug][tasks.Task] toggle(): task line number: 112. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.424][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.425][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.425][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.426][debug][tasks.File] replaceTaskWithTasks(): task line number: 112. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.426][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.426][debug][tasks.File] replaceTaskWithTasks() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.426][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.431][debug][tasks.File] Found original markdown at original line number 112 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.477][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.478][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.478][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:45.478][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:49.123][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:49.123][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:49.124][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:49.125][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-27 ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:50.463][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:50.464][debug][tasks.Task] toggle() original: - [ ] #task **check**: Checked all above steps for **auto-deleting recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:50.464][debug][tasks.Task] toggle() ==> 1   : - [x] #task **check**: Checked all above steps for **auto-deleting recurring tasks** worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:51.149][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:51.150][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:51.150][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:51.150][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:53.323][debug][tasks.Task] toggle(): task line number: 122. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:53.323][debug][tasks.Task] toggle() original: + [ ] #task View this file in **Reading view** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:53.323][debug][tasks.Task] toggle() ==> 1   : + [x] #task View this file in **Reading view** and confirm that the tasks in this section are listed ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:53.323][debug][tasks.File] replaceTaskWithTasks(): task line number: 122. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:53.323][debug][tasks.File] replaceTaskWithTasks() original: + [ ] #task View this file in **Reading view** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:53.323][debug][tasks.File] replaceTaskWithTasks() ==> 1   : + [x] #task View this file in **Reading view** and confirm that the tasks in this section are listed ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:53.323][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:53.328][debug][tasks.File] Found original markdown at original line number 122 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:53.382][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:53.383][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:53.383][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:53.383][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:56.683][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:56.683][debug][tasks.Task] toggle() original: + [ ] #task View this file in **Live Preview** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:56.684][debug][tasks.Task] toggle() ==> 1   : + [x] #task View this file in **Live Preview** and confirm that the tasks in this section are listed ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:57.743][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:57.744][debug][tasks.Task] toggle() original: + [ ] #task **check**: Checked all above steps for **viewing task blocks** worked 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:57.744][debug][tasks.Task] toggle() ==> 1   : + [x] #task **check**: Checked all above steps for **viewing task blocks** worked ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:58.709][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:58.710][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:58.711][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:13:58.711][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:04.184][debug][tasks.File] replaceTaskWithTasks(): task line number: 147. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:04.185][debug][tasks.File] replaceTaskWithTasks() original: > - [ ] #task Sample task: I have all the supported date types ➕ 2024-09-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:04.185][debug][tasks.File] replaceTaskWithTasks() ==> 1   : > - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:04.185][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:04.240][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:04.241][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:04.241][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:04.241][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.603][debug][tasks.Task] toggle(): task line number: 151. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.604][debug][tasks.Task] toggle() original:   - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.604][debug][tasks.Task] toggle() ==> 1   :   - [x] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.605][debug][tasks.File] replaceTaskWithTasks(): task line number: 151. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.605][debug][tasks.File] replaceTaskWithTasks() original:   - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.605][debug][tasks.File] replaceTaskWithTasks() ==> 1   :   - [x] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. ✅ 2024-12-31 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.606][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.613][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.613][debug][tasks.File] timeout = 1 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.615][debug][tasks.File] tryRepetitive after 1 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.615][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.616][debug][tasks.File] timeout = 10 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.626][debug][tasks.File] tryRepetitive after 2 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.627][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.627][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.728][debug][tasks.File] tryRepetitive after 3 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.729][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.729][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.831][debug][tasks.File] tryRepetitive after 4 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.832][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.832][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.933][debug][tasks.File] tryRepetitive after 5 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.934][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:06.934][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.036][debug][tasks.File] tryRepetitive after 6 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.038][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.038][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.140][debug][tasks.File] tryRepetitive after 7 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.142][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.142][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.244][debug][tasks.File] tryRepetitive after 8 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.246][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.246][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.348][debug][tasks.File] tryRepetitive after 9 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.350][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.350][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.451][debug][tasks.File] tryRepetitive after 10 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.455][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.455][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.557][debug][tasks.File] tryRepetitive after 11 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2024-12-31-23:14:07.558][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2024-12-31 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:20924 Tasks: Could not find the correct task line to update.
+
+The task line not updated is:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+
+In this markdown file:
+"Manual Testing/Smoke Testing the Tasks Plugin.md"
+
+Note: further clicks on this checkbox will usually now be ignored until the file is opened (or certain, specific edits are made - it's complicated).
+
+Recommendations:
+
+1. Close all panes that have the above file open, and then re-open the file.
+
+2. Check for exactly identical copies of the task line, in this file, and see if you can make them different.
+
+errorAndNotice @ plugin:obsidian-tasks-plugin:20924
+eval @ plugin:obsidian-tasks-plugin:20967
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20914
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+replaceTaskWithTasks @ plugin:obsidian-tasks-plugin:20899
+eval @ plugin:obsidian-tasks-plugin:29691

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Console Logs/obsidian.md-1735721982045 - Tasks using Obsidian 1.4.0 - Found task to edit after date picker when callout removed.log
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Console Logs/obsidian.md-1735721982045 - Tasks using Obsidian 1.4.0 - Found task to edit after date picker when callout removed.log
@@ -1,0 +1,206 @@
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:20.994][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:20.995][debug][tasks.Task] toggle() original: - [ ] #task Mark this task complete in **Source view** using **Tasks: Toggle task done** command 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:20.995][debug][tasks.Task] toggle() ==> 1   : - [x] #task Mark this task complete in **Source view** using **Tasks: Toggle task done** command ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:22.465][debug][tasks.Events] TasksEvents.off() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:22.465][debug][tasks.Events] TasksEvents.off() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:23.021][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:23.023][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:23.023][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:23.023][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:25.723][debug][tasks.Task] toggle(): task line number: 65. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:25.723][debug][tasks.Task] toggle() original: - [ ] #task Mark this task complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:25.723][debug][tasks.Task] toggle() ==> 1   : - [x] #task Mark this task complete by clicking on it in **Reading view** ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:25.724][debug][tasks.File] replaceTaskWithTasks(): task line number: 65. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:25.724][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Mark this task complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:25.724][debug][tasks.File] replaceTaskWithTasks() ==> 1   : - [x] #task Mark this task complete by clicking on it in **Reading view** ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:25.724][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:25.727][debug][tasks.File] Found original markdown at original line number 65 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:25.778][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:25.779][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:25.779][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:25.779][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:27.501][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:27.501][debug][tasks.Task] toggle() original: - [ ] #task Mark this task complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:27.502][debug][tasks.Task] toggle() ==> 1   : - [x] #task Mark this task complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:28.480][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:28.481][debug][tasks.Task] toggle() original: - [ ] #task **check**: Checked all above methods for **completing tasks** - and they worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:28.481][debug][tasks.Task] toggle() ==> 1   : - [x] #task **check**: Checked all above methods for **completing tasks** - and they worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:29.531][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:29.532][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:29.532][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:29.532][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:32.386][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:32.387][debug][tasks.Task] toggle() original: * [x] #task Mark this task not complete in **Source view** using **Tasks: Toggle task done** command ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:32.387][debug][tasks.Task] toggle() ==> 1   : * [ ] #task Mark this task not complete in **Source view** using **Tasks: Toggle task done** command 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.022][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.023][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.024][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.024][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.139][debug][tasks.Task] toggle(): task line number: 74. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.139][debug][tasks.Task] toggle() original: * [x] #task Mark this task not complete by clicking on it in **Reading view** ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.139][debug][tasks.Task] toggle() ==> 1   : * [ ] #task Mark this task not complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.139][debug][tasks.File] replaceTaskWithTasks(): task line number: 74. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.140][debug][tasks.File] replaceTaskWithTasks() original: * [x] #task Mark this task not complete by clicking on it in **Reading view** ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.140][debug][tasks.File] replaceTaskWithTasks() ==> 1   : * [ ] #task Mark this task not complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.140][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.141][debug][tasks.File] Found original markdown at original line number 74 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.178][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.179][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.179][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:34.179][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:36.181][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:36.181][debug][tasks.Task] toggle() original: * [x] #task Mark this task not complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:36.181][debug][tasks.Task] toggle() ==> 1   : * [ ] #task Mark this task not complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:37.300][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:37.301][debug][tasks.Task] toggle() original: * [ ] #task **check**: Checked all above methods for **un-completing tasks** - and they worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:37.301][debug][tasks.Task] toggle() ==> 1   : * [x] #task **check**: Checked all above methods for **un-completing tasks** - and they worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:38.201][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:38.202][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:38.202][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:38.202][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:41.756][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:41.757][debug][tasks.Task] toggle() original: > - [ ] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:41.761][debug][tasks.Task] toggle() ==> 1   : > - [ ] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:41.761][debug][tasks.Task] toggle() ==> 2   : > - [x] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:43.796][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:43.798][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 38 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:43.798][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:43.798][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.182][debug][tasks.Task] toggle(): task line number: 89. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.183][debug][tasks.Task] toggle() original: > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.184][debug][tasks.Task] toggle() ==> 1   : > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.184][debug][tasks.Task] toggle() ==> 2   : > > - [x] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.184][debug][tasks.File] replaceTaskWithTasks(): task line number: 89. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.185][debug][tasks.File] replaceTaskWithTasks() original: > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.185][debug][tasks.File] replaceTaskWithTasks() ==> 1   : > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.185][debug][tasks.File] replaceTaskWithTasks() ==> 2   : > > - [x] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.185][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.188][debug][tasks.File] Found original markdown at original line number 89 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.263][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.264][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 39 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.264][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:50.264][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:53.600][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:53.601][debug][tasks.Task] toggle() original: - [ ] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:53.602][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:53.602][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.638][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.640][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 40 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.640][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.640][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.779][debug][tasks.Task] toggle(): task line number: 92. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.779][debug][tasks.Task] toggle() original: > - [ ] #task **check**: Checked all above steps for **recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.779][debug][tasks.Task] toggle() ==> 1   : > - [x] #task **check**: Checked all above steps for **recurring tasks** worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.779][debug][tasks.File] replaceTaskWithTasks(): task line number: 92. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.780][debug][tasks.File] replaceTaskWithTasks() original: > - [ ] #task **check**: Checked all above steps for **recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.780][debug][tasks.File] replaceTaskWithTasks() ==> 1   : > - [x] #task **check**: Checked all above steps for **recurring tasks** worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.780][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.812][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.813][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 40 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.813][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:55.813][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:58.592][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:58.592][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting non-recurring task in **Source view** using **Tasks: Toggle task done** command 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:58:58.593][debug][tasks.Task] toggle() ==> 1   : - [x] #task Complete this auto-deleting non-recurring task in **Source view** using **Tasks: Toggle task done** command 🏁 delete 📅 2024-10-27 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:00.621][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:00.623][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 39 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:00.623][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:00.623][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:04.341][debug][tasks.Task] toggle(): task line number: 104. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:04.341][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:04.341][debug][tasks.Task] toggle() ==> 1   : - [x] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:04.342][debug][tasks.File] replaceTaskWithTasks(): task line number: 104. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:04.342][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:04.342][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:04.347][debug][tasks.File] Found original markdown at original line number 104 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:04.399][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:04.400][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 38 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:04.400][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:04.400][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:06.041][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:06.041][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting non-recurring task in **Live Preview** 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:06.042][debug][tasks.Task] toggle() ==> 1   : - [x] #task Complete this auto-deleting non-recurring task in **Live Preview** 🏁 delete 📅 2024-10-27 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:06.960][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:06.960][debug][tasks.Task] toggle() original: - [ ] #task **check**: Checked all above steps for **auto-deleting non-recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:06.960][debug][tasks.Task] toggle() ==> 1   : - [x] #task **check**: Checked all above steps for **auto-deleting non-recurring tasks** worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:07.768][debug][tasks.Events] TasksEvents.triggerRequestCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:07.769][debug][tasks.Events] TasksEvents.onCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:08.068][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:08.070][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:08.070][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:08.070][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:11.530][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:11.531][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:11.532][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:11.533][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-27 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:13.564][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:13.565][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:13.566][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:13.566][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.381][debug][tasks.Task] toggle(): task line number: 112. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.381][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.382][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.383][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.383][debug][tasks.File] replaceTaskWithTasks(): task line number: 112. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.383][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.383][debug][tasks.File] replaceTaskWithTasks() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.383][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.386][debug][tasks.File] Found original markdown at original line number 112 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.423][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.424][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.424][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:15.424][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:17.081][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:17.081][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:17.083][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:17.083][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-27 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:18.080][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:18.080][debug][tasks.Task] toggle() original: - [ ] #task **check**: Checked all above steps for **auto-deleting recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:18.080][debug][tasks.Task] toggle() ==> 1   : - [x] #task **check**: Checked all above steps for **auto-deleting recurring tasks** worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:19.105][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:19.106][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:19.106][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:19.106][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:22.681][debug][tasks.Task] toggle(): task line number: 120. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:22.681][debug][tasks.Task] toggle() original: + [ ] #task View this file in **Reading view** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:22.682][debug][tasks.Task] toggle() ==> 1   : + [x] #task View this file in **Reading view** and confirm that the tasks in this section are listed ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:22.682][debug][tasks.File] replaceTaskWithTasks(): task line number: 120. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:22.682][debug][tasks.File] replaceTaskWithTasks() original: + [ ] #task View this file in **Reading view** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:22.682][debug][tasks.File] replaceTaskWithTasks() ==> 1   : + [x] #task View this file in **Reading view** and confirm that the tasks in this section are listed ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:22.683][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:22.735][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:22.736][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:22.736][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:22.736][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:24.319][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:24.320][debug][tasks.Task] toggle() original: + [ ] #task View this file in **Live Preview** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:24.320][debug][tasks.Task] toggle() ==> 1   : + [x] #task View this file in **Live Preview** and confirm that the tasks in this section are listed ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:25.519][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:25.520][debug][tasks.Task] toggle() original: + [ ] #task **check**: Checked all above steps for **viewing task blocks** worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:25.520][debug][tasks.Task] toggle() ==> 1   : + [x] #task **check**: Checked all above steps for **viewing task blocks** worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:26.350][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:26.351][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:26.351][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:26.351][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:28.870][debug][tasks.Events] TasksEvents.triggerRequestCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:28.871][debug][tasks.Events] TasksEvents.onCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:31.400][debug][tasks.File] replaceTaskWithTasks(): task line number: 147. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:31.401][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Sample task: I have all the supported date types ➕ 2024-09-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:31.401][debug][tasks.File] replaceTaskWithTasks() ==> 1   : - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:31.401][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:31.456][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:31.457][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:31.457][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:31.457][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:35.421][debug][tasks.Task] toggle(): task line number: 153. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:35.422][debug][tasks.Task] toggle() original:   - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:35.422][debug][tasks.Task] toggle() ==> 1   :   - [x] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:35.422][debug][tasks.File] replaceTaskWithTasks(): task line number: 153. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:35.423][debug][tasks.File] replaceTaskWithTasks() original:   - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:35.423][debug][tasks.File] replaceTaskWithTasks() ==> 1   :   - [x] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:35.423][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:35.426][debug][tasks.File] Found original markdown at original line number 153 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:35.463][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:35.464][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:35.464][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-08:59:35.464][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Console Logs/obsidian.md-1735727690528 - Tasks using Obsidian 1.4.0 - Cannot find task to edit after date picker - single pane.log
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Console Logs/obsidian.md-1735727690528 - Tasks using Obsidian 1.4.0 - Cannot find task to edit after date picker - single pane.log
@@ -1,0 +1,507 @@
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:46.645][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:46.645][debug][tasks.Task] toggle() original: - [ ] #task Mark this task complete in **Source view** using **Tasks: Toggle task done** command 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:46.646][debug][tasks.Task] toggle() ==> 1   : - [x] #task Mark this task complete in **Source view** using **Tasks: Toggle task done** command ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:47.950][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:47.951][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:47.951][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:47.951][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:50.301][debug][tasks.Task] toggle(): task line number: 65. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:50.301][debug][tasks.Task] toggle() original: - [ ] #task Mark this task complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:50.302][debug][tasks.Task] toggle() ==> 1   : - [x] #task Mark this task complete by clicking on it in **Reading view** ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:50.302][debug][tasks.File] replaceTaskWithTasks(): task line number: 65. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:50.302][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Mark this task complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:50.303][debug][tasks.File] replaceTaskWithTasks() ==> 1   : - [x] #task Mark this task complete by clicking on it in **Reading view** ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:50.303][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:50.307][debug][tasks.File] Found original markdown at original line number 65 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:50.321][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:50.322][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:50.322][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:50.322][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:53.562][debug][tasks.Events] TasksEvents.triggerRequestCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:53.563][debug][tasks.Events] TasksEvents.onCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:56.741][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:56.742][debug][tasks.Task] toggle() original: - [ ] #task Mark this task complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:56.742][debug][tasks.Task] toggle() ==> 1   : - [x] #task Mark this task complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:57.920][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:57.920][debug][tasks.Task] toggle() original: - [ ] #task **check**: Checked all above methods for **completing tasks** - and they worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:57.920][debug][tasks.Task] toggle() ==> 1   : - [x] #task **check**: Checked all above methods for **completing tasks** - and they worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:58.776][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:58.778][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:58.778][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:31:58.778][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:09.687][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:09.687][debug][tasks.Task] toggle() original: * [x] #task Mark this task not complete in **Source view** using **Tasks: Toggle task done** command ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:09.688][debug][tasks.Task] toggle() ==> 1   : * [ ] #task Mark this task not complete in **Source view** using **Tasks: Toggle task done** command 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:11.113][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:11.114][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:11.114][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:11.114][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:13.281][debug][tasks.Task] toggle(): task line number: 74. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:13.282][debug][tasks.Task] toggle() original: * [x] #task Mark this task not complete by clicking on it in **Reading view** ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:13.282][debug][tasks.Task] toggle() ==> 1   : * [ ] #task Mark this task not complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:13.283][debug][tasks.File] replaceTaskWithTasks(): task line number: 74. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:13.283][debug][tasks.File] replaceTaskWithTasks() original: * [x] #task Mark this task not complete by clicking on it in **Reading view** ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:13.283][debug][tasks.File] replaceTaskWithTasks() ==> 1   : * [ ] #task Mark this task not complete by clicking on it in **Reading view** 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:13.283][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:13.288][debug][tasks.File] Found original markdown at original line number 74 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:13.298][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:13.299][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:13.299][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:13.299][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:22.442][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:22.443][debug][tasks.Task] toggle() original: * [x] #task Mark this task not complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== ✅ 2022-07-05 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:22.443][debug][tasks.Task] toggle() ==> 1   : * [ ] #task Mark this task not complete by clicking on it in **Live Preview** - ==ensure the checkbox is redrawn correctly== 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:24.477][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:24.478][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:24.478][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:24.478][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:24.521][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:24.521][debug][tasks.Task] toggle() original: * [ ] #task **check**: Checked all above methods for **un-completing tasks** - and they worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:24.521][debug][tasks.Task] toggle() ==> 1   : * [x] #task **check**: Checked all above methods for **un-completing tasks** - and they worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:26.344][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:26.345][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:26.345][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:26.345][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:37.618][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:37.618][debug][tasks.Task] toggle() original: > - [ ] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:37.622][debug][tasks.Task] toggle() ==> 1   : > - [ ] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:37.623][debug][tasks.Task] toggle() ==> 2   : > - [x] #task Complete this recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:39.169][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:39.170][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 38 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:39.170][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:39.170][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.222][debug][tasks.Task] toggle(): task line number: 89. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.222][debug][tasks.Task] toggle() original: > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.224][debug][tasks.Task] toggle() ==> 1   : > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.224][debug][tasks.Task] toggle() ==> 2   : > > - [x] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.225][debug][tasks.File] replaceTaskWithTasks(): task line number: 89. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.225][debug][tasks.File] replaceTaskWithTasks() original: > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.225][debug][tasks.File] replaceTaskWithTasks() ==> 1   : > > - [ ] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.225][debug][tasks.File] replaceTaskWithTasks() ==> 2   : > > - [x] #task Complete this recurring task in **Reading view** 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.225][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.229][debug][tasks.File] Found original markdown at original line number 89 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.242][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.243][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 39 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.243][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:42.243][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:48.442][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:48.442][debug][tasks.Task] toggle() original: - [ ] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:48.444][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-18 ⏳ 2022-02-19 📅 2022-02-20 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:48.444][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🛫 2022-02-17 ⏳ 2022-02-18 📅 2022-02-19 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:50.476][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:50.478][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 40 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:50.478][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:50.478][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:54.841][debug][tasks.Task] toggle(): task line number: 92. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:54.841][debug][tasks.Task] toggle() original: > - [ ] #task **check**: Checked all above steps for **recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:54.842][debug][tasks.Task] toggle() ==> 1   : > - [x] #task **check**: Checked all above steps for **recurring tasks** worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:54.842][debug][tasks.File] replaceTaskWithTasks(): task line number: 92. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:54.843][debug][tasks.File] replaceTaskWithTasks() original: > - [ ] #task **check**: Checked all above steps for **recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:54.843][debug][tasks.File] replaceTaskWithTasks() ==> 1   : > - [x] #task **check**: Checked all above steps for **recurring tasks** worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:54.843][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:54.873][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:54.875][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 40 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:54.875][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:32:54.875][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:06.856][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:06.856][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting non-recurring task in **Source view** using **Tasks: Toggle task done** command 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:06.857][debug][tasks.Task] toggle() ==> 1   : - [x] #task Complete this auto-deleting non-recurring task in **Source view** using **Tasks: Toggle task done** command 🏁 delete 📅 2024-10-27 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:08.886][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:08.888][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 39 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:08.888][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:08.888][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:11.482][debug][tasks.Task] toggle(): task line number: 104. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:11.482][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:11.483][debug][tasks.Task] toggle() ==> 1   : - [x] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:11.483][debug][tasks.File] replaceTaskWithTasks(): task line number: 104. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:11.483][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Complete this auto-deleting non-recurring task in **Reading view** 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:11.483][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:11.488][debug][tasks.File] Found original markdown at original line number 104 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:11.501][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:11.503][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 38 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:11.503][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:11.503][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:22.823][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:22.823][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting non-recurring task in **Live Preview** 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:22.823][debug][tasks.Task] toggle() ==> 1   : - [x] #task Complete this auto-deleting non-recurring task in **Live Preview** 🏁 delete 📅 2024-10-27 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:23.801][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:23.802][debug][tasks.Task] toggle() original: - [ ] #task **check**: Checked all above steps for **auto-deleting non-recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:23.802][debug][tasks.Task] toggle() ==> 1   : - [x] #task **check**: Checked all above steps for **auto-deleting non-recurring tasks** worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:24.857][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:24.858][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:24.858][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:24.858][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:31.698][debug][tasks.Task] toggle(): task line number: 0. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:31.698][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:31.700][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:31.700][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this auto-deleting recurring task in **Source view** using **Tasks: Toggle task done** command 🔁 every day 🏁 delete 📅 2024-10-27 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:33.735][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:33.737][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:33.737][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:33:33.737][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.682][debug][tasks.Task] toggle(): task line number: 112. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.682][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.684][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.684][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.684][debug][tasks.File] replaceTaskWithTasks(): task line number: 112. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.684][debug][tasks.File] replaceTaskWithTasks() original: - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.685][debug][tasks.File] replaceTaskWithTasks() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Reading view** 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.685][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.699][debug][tasks.File] Found original markdown at original line number 112 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.729][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.730][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.730][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:12.730][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:22.883][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:22.883][debug][tasks.Task] toggle() original: - [ ] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-27 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:22.884][debug][tasks.Task] toggle() ==> 1   : - [ ] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-28 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:22.884][debug][tasks.Task] toggle() ==> 2   : - [x] #task Complete this auto-deleting recurring task in **Live Preview** - ==ensure the checkbox is redrawn correctly== 🔁 every day 🏁 delete 📅 2024-10-27 ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:23.862][debug][tasks.Task] toggle(): task line number: 0. file path: "" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:23.863][debug][tasks.Task] toggle() original: - [ ] #task **check**: Checked all above steps for **auto-deleting recurring tasks** worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:23.863][debug][tasks.Task] toggle() ==> 1   : - [x] #task **check**: Checked all above steps for **auto-deleting recurring tasks** worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:24.910][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:24.912][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:24.912][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:24.912][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:31.102][debug][tasks.Task] toggle(): task line number: 122. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:31.102][debug][tasks.Task] toggle() original: + [ ] #task View this file in **Reading view** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:31.103][debug][tasks.Task] toggle() ==> 1   : + [x] #task View this file in **Reading view** and confirm that the tasks in this section are listed ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:31.103][debug][tasks.File] replaceTaskWithTasks(): task line number: 122. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:31.103][debug][tasks.File] replaceTaskWithTasks() original: + [ ] #task View this file in **Reading view** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:31.104][debug][tasks.File] replaceTaskWithTasks() ==> 1   : + [x] #task View this file in **Reading view** and confirm that the tasks in this section are listed ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:31.104][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:31.109][debug][tasks.File] Found original markdown at original line number 122 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:31.122][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:31.124][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:31.124][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:31.124][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:34.442][debug][tasks.Task] toggle(): task line number: 123. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:34.442][debug][tasks.Task] toggle() original: + [ ] #task View this file in **Live Preview** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:34.442][debug][tasks.Task] toggle() ==> 1   : + [x] #task View this file in **Live Preview** and confirm that the tasks in this section are listed ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:34.442][debug][tasks.File] replaceTaskWithTasks(): task line number: 123. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:34.442][debug][tasks.File] replaceTaskWithTasks() original: + [ ] #task View this file in **Live Preview** and confirm that the tasks in this section are listed 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:34.442][debug][tasks.File] replaceTaskWithTasks() ==> 1   : + [x] #task View this file in **Live Preview** and confirm that the tasks in this section are listed ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:34.443][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:34.445][debug][tasks.File] Found original markdown at original line number 123 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:34.470][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:34.471][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:34.471][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:34.471][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:36.083][debug][tasks.Task] toggle(): task line number: 124. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:36.083][debug][tasks.Task] toggle() original: + [ ] #task **check**: Checked all above steps for **viewing task blocks** worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:36.083][debug][tasks.Task] toggle() ==> 1   : + [x] #task **check**: Checked all above steps for **viewing task blocks** worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:36.084][debug][tasks.File] replaceTaskWithTasks(): task line number: 124. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:36.084][debug][tasks.File] replaceTaskWithTasks() original: + [ ] #task **check**: Checked all above steps for **viewing task blocks** worked 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:36.084][debug][tasks.File] replaceTaskWithTasks() ==> 1   : + [x] #task **check**: Checked all above steps for **viewing task blocks** worked ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:36.084][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:36.089][debug][tasks.File] Found original markdown at original line number 124 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:36.113][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:36.114][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:36.114][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:36.114][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:43.663][debug][tasks.File] replaceTaskWithTasks(): task line number: 147. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:43.663][debug][tasks.File] replaceTaskWithTasks() original: > - [ ] #task Sample task: I have all the supported date types ➕ 2024-09-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:43.664][debug][tasks.File] replaceTaskWithTasks() ==> 1   : > - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:43.664][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:43.703][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:43.704][debug][tasks.Cache] Cache.indexFile: Manual Testing/Smoke Testing the Tasks Plugin.md: read 37 task(s) 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:43.704][debug][tasks.Cache] Cache.notifySubscribers() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:43.704][debug][tasks.Events] TasksEvents.triggerCacheUpdate() 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.642][debug][tasks.Task] toggle(): task line number: 151. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.642][debug][tasks.Task] toggle() original:   - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.643][debug][tasks.Task] toggle() ==> 1   :   - [x] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.643][debug][tasks.File] replaceTaskWithTasks(): task line number: 151. file path: "Manual Testing/Smoke Testing the Tasks Plugin.md" 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.643][debug][tasks.File] replaceTaskWithTasks() original:   - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.643][debug][tasks.File] replaceTaskWithTasks() ==> 1   :   - [x] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated. ✅ 2025-01-01 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.643][debug][tasks.File] tryRepetitive after 0 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.648][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.649][debug][tasks.File] timeout = 1 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.650][debug][tasks.File] tryRepetitive after 1 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.651][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.651][debug][tasks.File] timeout = 10 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.662][debug][tasks.File] tryRepetitive after 2 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.663][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.663][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.764][debug][tasks.File] tryRepetitive after 3 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.765][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.765][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.866][debug][tasks.File] tryRepetitive after 4 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.866][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.867][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.968][debug][tasks.File] tryRepetitive after 5 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.970][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:45.970][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.072][debug][tasks.File] tryRepetitive after 6 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.074][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.074][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.175][debug][tasks.File] tryRepetitive after 7 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.177][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.178][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.279][debug][tasks.File] tryRepetitive after 8 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.280][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.280][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.382][debug][tasks.File] tryRepetitive after 9 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.385][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.385][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.486][debug][tasks.File] tryRepetitive after 10 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.487][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.487][debug][tasks.File] timeout = 100 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.589][debug][tasks.File] tryRepetitive after 11 previous tries 
+plugin:obsidian-tasks-plugin:15966 [2025-01-01-10:34:46.591][debug][tasks.File] Tasks: Unable to find task in file Manual Testing/Smoke Testing the Tasks Plugin.md.
+Expected task:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+Found task:
+> - [ ] #task Sample task: I have all the supported date types ➕ 2025-01-01 🛫 2024-09-02 ⏳ 2024-09-03 📅 2024-09-04 ❌ 2024-09-05 ✅ 2024-09-06 
+plugin:obsidian-tasks-plugin:20924 Tasks: Could not find the correct task line to update.
+
+The task line not updated is:
+  - [ ] #task **left**-click on a date value, and use the date picker to select and save a different date. Check that the date is updated.
+
+In this markdown file:
+"Manual Testing/Smoke Testing the Tasks Plugin.md"
+
+Note: further clicks on this checkbox will usually now be ignored until the file is opened (or certain, specific edits are made - it's complicated).
+
+Recommendations:
+
+1. Close all panes that have the above file open, and then re-open the file.
+
+2. Check for exactly identical copies of the task line, in this file, and see if you can make them different.
+
+errorAndNotice @ plugin:obsidian-tasks-plugin:20924
+eval @ plugin:obsidian-tasks-plugin:20967
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20973
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+eval @ plugin:obsidian-tasks-plugin:20972
+setTimeout (async)
+eval @ plugin:obsidian-tasks-plugin:20972
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+retry @ plugin:obsidian-tasks-plugin:20949
+eval @ plugin:obsidian-tasks-plugin:20998
+rejected @ plugin:obsidian-tasks-plugin:220
+Promise.then (async)
+step @ plugin:obsidian-tasks-plugin:225
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+tryRepetitive @ plugin:obsidian-tasks-plugin:20939
+eval @ plugin:obsidian-tasks-plugin:20914
+eval @ plugin:obsidian-tasks-plugin:226
+__async @ plugin:obsidian-tasks-plugin:210
+replaceTaskWithTasks @ plugin:obsidian-tasks-plugin:20899
+eval @ plugin:obsidian-tasks-plugin:29691

--- a/src/Obsidian/TasksEvents.ts
+++ b/src/Obsidian/TasksEvents.ts
@@ -24,6 +24,8 @@ export class TasksEvents {
 
     public onCacheUpdate(handler: (cacheData: CacheUpdateData) => void): EventRef {
         this.logger.debug('TasksEvents.onCacheUpdate()');
+        // @ts-expect-error: error TS2345: Argument of type '(cacheData: CacheUpdateData) => void'
+        // is not assignable to parameter of type '(...data: unknown[]) => unknown'.
         return this.obsidianEvents.on(Event.CacheUpdate, handler);
     }
 
@@ -34,6 +36,8 @@ export class TasksEvents {
 
     public onRequestCacheUpdate(handler: (fn: (cacheData: CacheUpdateData) => void) => void): EventRef {
         this.logger.debug('TasksEvents.onRequestCacheUpdate()');
+        // @ts-expect-error: error TS2345: Argument of type '(cacheData: CacheUpdateData) => void'
+        // is not assignable to parameter of type '(...data: unknown[]) => unknown'.
         return this.obsidianEvents.on(Event.RequestCacheUpdate, handler);
     }
 

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -156,7 +156,7 @@ class QueryRenderChild extends MarkdownRenderChild {
             allTasks: this.plugin.getTasks(),
             allMarkdownFiles: this.app.vault.getMarkdownFiles(),
             backlinksClickHandler: createBacklinksClickHandler(this.app),
-            backlinksMousedownHandler,
+            backlinksMousedownHandler: createBacklinksMousedownHandler(this.app),
             editTaskPencilClickHandler,
         });
 
@@ -200,19 +200,21 @@ function createBacklinksClickHandler(app: App): BacklinksEventHandler {
     };
 }
 
-async function backlinksMousedownHandler(ev: MouseEvent, task: Task) {
-    // Open in a new tab on middle-click.
-    // This distinction is not available in the 'click' event, so we handle the 'mousedown' event
-    // solely for this.
-    // (for regular left-click we prefer the 'click' event, and not to just do everything here, because
-    // the 'click' event is more generic for touch devices etc.)
-    if (ev.button === 1) {
-        const result = await getTaskLineAndFile(task, app.vault);
-        if (result) {
-            const [line, file] = result;
-            const leaf = app.workspace.getLeaf('tab');
-            ev.preventDefault();
-            await leaf.openFile(file, { eState: { line: line } });
+function createBacklinksMousedownHandler(app: App): BacklinksEventHandler {
+    return async function backlinksMousedownHandler(ev: MouseEvent, task: Task) {
+        // Open in a new tab on middle-click.
+        // This distinction is not available in the 'click' event, so we handle the 'mousedown' event
+        // solely for this.
+        // (for regular left-click we prefer the 'click' event, and not to just do everything here, because
+        // the 'click' event is more generic for touch devices etc.)
+        if (ev.button === 1) {
+            const result = await getTaskLineAndFile(task, app.vault);
+            if (result) {
+                const [line, file] = result;
+                const leaf = app.workspace.getLeaf('tab');
+                ev.preventDefault();
+                await leaf.openFile(file, { eState: { line: line } });
+            }
         }
-    }
+    };
 }

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -18,7 +18,7 @@ import { PostponeMenu } from '../ui/Menus/PostponeMenu';
 import { TaskLineRenderer, type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
 
 export type BacklinksEventHandler = (ev: MouseEvent, task: Task) => Promise<void>;
-type EditButtonClickHandler = (event: MouseEvent, task: Task, allTasks: Task[]) => void;
+export type EditButtonClickHandler = (event: MouseEvent, task: Task, allTasks: Task[]) => void;
 
 export interface QueryRendererParameters {
     allTasks: Task[];

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -17,7 +17,7 @@ import { Task } from '../Task/Task';
 import { PostponeMenu } from '../ui/Menus/PostponeMenu';
 import { TaskLineRenderer, type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
 
-type BacklinksEventHandler = (ev: MouseEvent, task: Task) => Promise<void>;
+export type BacklinksEventHandler = (ev: MouseEvent, task: Task) => Promise<void>;
 type EditButtonClickHandler = (event: MouseEvent, task: Task, allTasks: Task[]) => void;
 
 export interface QueryRendererParameters {

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -649,8 +649,6 @@ describe('accessing links in file', function () {
         });
 
         it('should access links in frontmatter', () => {
-            // Update to Obsidian API 1.4.0 to access cachedMetadata.frontmatterLinks
-            // @ts-expect-error TS2551: Property frontmatterLinks does not exist on type CachedMetadata
             const frontMatterLinks = cachedMetadata['frontmatterLinks'];
             expect(frontMatterLinks).toBeDefined();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,10 +1112,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/codemirror@0.0.108":
-  version "0.0.108"
-  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.108.tgz#e640422b666bf49251b384c390cdeb2362585bde"
-  integrity sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==
+"@types/codemirror@5.60.8":
+  version "5.60.8"
+  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-5.60.8.tgz#b647d04b470e8e1836dd84b2879988fc55c9de68"
+  integrity sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==
   dependencies:
     "@types/tern" "*"
 
@@ -4573,12 +4573,12 @@ object.values@^1.1.7:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
 
-obsidian@^1.1.1:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/obsidian/-/obsidian-1.2.5.tgz#86a075de3894303b90450fb98af1293918d13bc3"
-  integrity sha512-RKN4W3PaHsoWwlNRg1SV+iJssQ5vnQYzsCSfmFAUHvA8Q8nzk4pW3HGWXSvor3ZM532KECljG86lEx02OvBwpA==
+obsidian@^1.4.0:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/obsidian/-/obsidian-1.7.2.tgz#2d989288742ae7a65760fd87a953d1ff2a402808"
+  integrity sha512-k9hN9brdknJC+afKr5FQzDRuEFGDKbDjfCazJwpgibwCAoZNYHYV8p/s3mM8I6AsnKrPKNXf8xGuMZ4enWelZQ==
   dependencies:
-    "@types/codemirror" "0.0.108"
+    "@types/codemirror" "5.60.8"
     moment "2.29.4"
 
 once@^1.3.0:


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

Update the Obsidian API version to 1.4.0, released July 26, 2023.

## Motivation and Context

This is in preparation for adopting ["obsidian-typings"](https://github.com/Fevol/obsidian-typings) in a later step, to improve the developer experience.

## How has this been tested?

- Automated tests
- Smoke tests

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
