### PR TITLE
fix: Handle Enter key event for IME inputs

### DIFF
--- a/src/ui/Dependency.svelte
+++ b/src/ui/Dependency.svelte
@@ -55,6 +55,8 @@
                 }
                 break;
             case 'Enter':
+                if (e.isComposing) return;
+
                 if (searchIndex !== null) {
                     e.preventDefault();
                     addTask(searchResults[searchIndex]);

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -127,7 +127,7 @@
     };
 
     const _onDescriptionKeyDown = (e: KeyboardEvent) => {
-        if (e.key === 'Enter') {
+        if (e.key === 'Enter' && !e.isComposing) {
             e.preventDefault();
             if (formIsValid) _onSubmit();
         }


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2214

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

“Create or edit Task" Modal input, there was a conflict between the Enter key event used to confirm IME conversions and the Enter key event used to create tasks, causing unintended behavior.

This has been corrected so that the Enter key is not used to create a task when the IME conversion is confirmed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Manually tested the following

- When using IME, the task is not created when the conversion is confirmed with the Enter key. When the Enter key is pressed again, the task is created.
- When IME is not used, the task is created when the Enter key is pressed.

## Screenshots (if appropriate)

**before fix**


https://github.com/user-attachments/assets/b7b2b078-cf09-4048-a69e-11e2dc169e7b



**after fix**

https://github.com/user-attachments/assets/3b02cec2-ef10-438b-8bbc-0edc05f25d46




## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [-] My change requires a change to the documentation.
- [-] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - I was not sure if testing was needed for this change, so please let me know if it is needed.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
