### PR TITLE
Fix detect query property edits

### DIFF
--- a/docs/Getting Started/Obsidian Properties.md
+++ b/docs/Getting Started/Obsidian Properties.md
@@ -183,6 +183,57 @@ group by function \
     return value ? window.moment(value).format('YYYY MMMM') : 'no date'
 ```
 
+## Using Query Properties in Placeholders
+
+> [!released]
+> Use of Obsidian properties in placeholders was introduced in Tasks X.Y.Z.
+
+- It is now possible to use properties in the query file:
+  - `query.file.hasProperty()` works.
+  - `query.file.property()` works.
+
+Imagine this text at the top of the note containing the query:
+
+```yaml
+---
+search-text: exercise
+---
+```
+
+It can be used in your query in two ways:
+
+1. A search term from front-matter embedded via placeholder:
+
+    ```javascript
+    description includes {{query.file.property('search-text')}}
+    ```
+
+1. Scripting, which allows creation of a custom filter, which works when the search term is empty
+
+    ```javascript
+    filter by function \
+        if (!query.file.hasProperty('search-text')) return true; \
+        const propertyLower = query.file.property('search-text').toLowerCase(); \
+        if (propertyLower === '') return true; \
+        return task.description.toLowerCase().includes(propertyLower);
+    ```
+
+> [!warning] Using properties with no value
+> Currently when a property in a placeholder is not set:
+>
+> - in text instructions, the string used is currently `null`, which is not likely to be the intent
+> - in numeric instructions, the value used is `null` which gives an error
+
+> [!Info]
+> In a future release, we will likely allow Tasks to silently ignore built filters created from properties that have no value.
+
+> [!Info]
+> In a future release, we will likely introduce standard property names for instructions that will automatically be included inside Tasks queries.
+> Perhaps:
+>
+> - tasks-search-explain: true/false
+> - tasks-search-limit: number
+
 ## How does Tasks interpret Obsidian Properties?
 
 Consider a file with the following example properties (or "Frontmatter"):
@@ -237,11 +288,3 @@ The following table shows how most of those properties are interpreted in Tasks 
 | `task.file.property('tags')` | `string[]` | `['#tag-from-file-properties']` |
 
 <!-- placeholder to force blank line after included text --><!-- endInclude -->
-
-## Limitations
-
-- It is not yet possible to use properties in the query file:
-  - `query.file.hasProperty()` does not yet work.
-  - `query.file.property()` does not yet work.
-
-We are tracking this in [issue #3083](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3083).

--- a/docs/Scripting/Query Properties.md
+++ b/docs/Scripting/Query Properties.md
@@ -34,6 +34,10 @@ This page documents all the available pieces of information in Queries that you 
 | `query.file.folder` | `string` | `'root/sub-folder/'` |
 | `query.file.filename` | `string` | `'file containing query.md'` |
 | `query.file.filenameWithoutExtension` | `string` | `'file containing query'` |
+| `query.file.hasProperty('task_instruction')` | `boolean` | `true` |
+| `query.file.hasProperty('non_existent_property')` | `boolean` | `false` |
+| `query.file.property('task_instruction')` | `string` | `'group by filename'` |
+| `query.file.property('non_existent_property')` | `null` | `null` |
 
 <!-- placeholder to force blank line after included text --><!-- endInclude -->
 
@@ -42,6 +46,8 @@ This page documents all the available pieces of information in Queries that you 
 1. The presence of `.md` filename extensions is chosen to match the existing conventions in the Tasks filter instructions [[Filters#File Path|path]] and [[Filters#File Name|filename]].
 1. `query.file.pathWithoutExtension` was added in Tasks 4.8.0.
 1. `query.file.filenameWithoutExtension` was added in Tasks 4.8.0.
+1. `query.file.hasProperty()` was added in Tasks X.Y.Z.
+1. `query.file.property()` was added in Tasks X.Y.Z.
 
 ## Values for Query Search Properties
 

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -42,8 +42,6 @@ export class QueryRenderer {
         //    not yet available, so empty.
         //  - Multi-line properties are supported, but they cannot contain
         //    continuation lines.
-        // TODO Some of this the following code will need to be repeated in metadataCache.on('changed')
-        //      so need to separate out the logic somehow.
         const app = this.app;
         const filePath = context.sourcePath;
         const tFile = app.vault.getAbstractFileByPath(filePath);
@@ -127,7 +125,6 @@ class QueryRenderChild extends MarkdownRenderChild {
                     return;
                 }
 
-                // TODO We need to debounce this.
                 this.handleMetadataOrFilePathChange(filePath, fileCache);
             }),
         );

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -119,14 +119,14 @@ class QueryRenderChild extends MarkdownRenderChild {
         this.reloadQueryAtMidnight();
 
         this.registerEvent(
-            this.app.metadataCache.on('changed', (sourceFile, data, fileCache) => {
+            this.app.metadataCache.on('changed', (sourceFile, _data, fileCache) => {
                 const filePath = sourceFile.path;
                 if (filePath !== this.queryResultsRenderer.filePath) {
-                    console.log(`Different file - ignore the edit: '${filePath}'; ${data}'`);
+                    // We get notified of edits to all files, and are only interested in the
+                    // file where our query is.
                     return;
                 }
 
-                console.log(`Metadata changed - regenerating all queries in: '${filePath}'; ${data}'`);
                 // TODO We need to debounce this.
                 // TODO This very primitive first version redraws all queries for *every* edit to the file containing
                 //      this query, regardless of whether the frontmatter has changed or not.

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -132,9 +132,7 @@ class QueryRenderChild extends MarkdownRenderChild {
                 //      this query, regardless of whether the frontmatter has changed or not.
                 // TODO It may even create duplicate refreshes when the query itself is edited
                 // TODO Only do this if the metadata has changed - as this also gets called when the note body is changed.
-                const newTasksFile = new TasksFile(filePath, fileCache ?? {});
-                this.queryResultsRenderer.setTasksFile(newTasksFile);
-                this.events.triggerRequestCacheUpdate(this.render.bind(this));
+                this.handleMetadataOrFilePathChange(filePath, fileCache);
             }),
         );
 

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -141,11 +141,6 @@ class QueryRenderChild extends MarkdownRenderChild {
         this.registerEvent(
             this.app.vault.on('rename', (tFile: TAbstractFile, _oldPath: string) => {
                 const filePath = tFile.path;
-                if (filePath === this.queryResultsRenderer.filePath) {
-                    // The path actually hadn't changed
-                    return;
-                }
-
                 const app = this.app;
                 let fileCache: CachedMetadata | null = null;
                 if (tFile && tFile instanceof TFile) {

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -146,11 +146,15 @@ class QueryRenderChild extends MarkdownRenderChild {
                 if (tFile && tFile instanceof TFile) {
                     fileCache = app.metadataCache.getFileCache(tFile);
                 }
-                const newTasksFile = new TasksFile(filePath, fileCache ?? {});
-                this.queryResultsRenderer.setTasksFile(newTasksFile);
-                this.events.triggerRequestCacheUpdate(this.render.bind(this));
+                this.handleMetadataOrFilePathChange(filePath, fileCache);
             }),
         );
+    }
+
+    private handleMetadataOrFilePathChange(filePath: string, fileCache: CachedMetadata | null) {
+        const newTasksFile = new TasksFile(filePath, fileCache ?? {});
+        this.queryResultsRenderer.setTasksFile(newTasksFile);
+        this.events.triggerRequestCacheUpdate(this.render.bind(this));
     }
 
     onunload() {

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -138,13 +138,11 @@ class QueryRenderChild extends MarkdownRenderChild {
 
         this.registerEvent(
             this.app.vault.on('rename', (tFile: TAbstractFile, _oldPath: string) => {
-                const filePath = tFile.path;
-                const app = this.app;
                 let fileCache: CachedMetadata | null = null;
                 if (tFile && tFile instanceof TFile) {
-                    fileCache = app.metadataCache.getFileCache(tFile);
+                    fileCache = this.app.metadataCache.getFileCache(tFile);
                 }
-                this.handleMetadataOrFilePathChange(filePath, fileCache);
+                this.handleMetadataOrFilePathChange(tFile.path, fileCache);
             }),
         );
     }

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -131,13 +131,8 @@ class QueryRenderChild extends MarkdownRenderChild {
                 // TODO This very primitive first version redraws all queries for *every* edit to the file containing
                 //      this query, regardless of whether the frontmatter has changed or not.
                 // TODO It may even create duplicate refreshes when the query itself is edited
-                const oldTasksFile = this.queryResultsRenderer.tasksFile;
+                // TODO Only do this if the metadata has changed - as this also gets called when the note body is changed.
                 const newTasksFile = new TasksFile(filePath, fileCache ?? {});
-                console.log(`TasksFile Old: ${oldTasksFile}`);
-                console.log(`TasksFile New: ${newTasksFile}`);
-                console.log('Done...');
-
-                // TODO Only do this if the metadata has changed.
                 this.queryResultsRenderer.setTasksFile(newTasksFile);
                 this.events.triggerRequestCacheUpdate(this.render.bind(this));
             }),
@@ -150,7 +145,6 @@ class QueryRenderChild extends MarkdownRenderChild {
                     // The path actually hadn't changed
                     return;
                 }
-                console.log(`File renamed - regenerating all queries in: '${filePath}'`);
 
                 const app = this.app;
                 let fileCache: CachedMetadata | null = null;

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -42,7 +42,7 @@ export class QueryResultsRenderer {
     public readonly source: string;
 
     // The path of the file that contains the instruction block, and cached data from that file.
-    public tasksFile: TasksFile;
+    private _tasksFile: TasksFile;
 
     public query: IQuery;
     protected queryType: string; // whilst there is only one query type, there is no point logging this value
@@ -62,7 +62,7 @@ export class QueryResultsRenderer {
         textRenderer: TextRenderer = TaskLineRenderer.obsidianMarkdownRenderer,
     ) {
         this.source = source;
-        this.tasksFile = tasksFile;
+        this._tasksFile = tasksFile;
         this.renderMarkdown = renderMarkdown;
         this.obsidianComponent = obsidianComponent;
         this.textRenderer = textRenderer;
@@ -85,6 +85,14 @@ export class QueryResultsRenderer {
 
     private makeQueryFromSourceAndTasksFile() {
         return getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
+    }
+
+    public get tasksFile(): TasksFile {
+        return this._tasksFile;
+    }
+
+    public set tasksFile(value: TasksFile) {
+        this._tasksFile = value;
     }
 
     public get filePath(): string | undefined {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -42,7 +42,8 @@ export class QueryResultsRenderer {
     public readonly source: string;
 
     // The path of the file that contains the instruction block, and cached data from that file.
-    // This is updated when the query file's frontmatter is modified.
+    // This can be updated when the query file's frontmatter is modified.
+    // It is up to the caller to determine when to do this though.
     private _tasksFile: TasksFile;
 
     public query: IQuery;
@@ -92,16 +93,13 @@ export class QueryResultsRenderer {
         return this._tasksFile;
     }
 
+    /**
+     * Reload the query with new file information, such as to update query placeholders.
+     * @param newFile
+     */
     public setTasksFile(newFile: TasksFile) {
-        // For now, this always updates the query when the TasksFile changes.
-        // TODO For efficiency, only update if either the path or raw frontmatter has been changed.
-
         this._tasksFile = newFile;
-        // Recreate the query, as placeholders and file properties may have changed.
         this.query = this.makeQueryFromSourceAndTasksFile();
-
-        // It is up to the caller to ensure that any search results are re-rendered.
-        // TODO Somehow provide information back to the caller to say whether query has been changed.
     }
 
     public get filePath(): string | undefined {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -42,7 +42,7 @@ export class QueryResultsRenderer {
     public readonly source: string;
 
     // The path of the file that contains the instruction block, and cached data from that file.
-    public readonly tasksFile: TasksFile;
+    public tasksFile: TasksFile;
 
     public query: IQuery;
     protected queryType: string; // whilst there is only one query type, there is no point logging this value

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -72,15 +72,19 @@ export class QueryResultsRenderer {
         // added later.
         switch (className) {
             case 'block-language-tasks':
-                this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
+                this.query = this.makeQueryFromSourceAndTasksFile();
                 this.queryType = 'tasks';
                 break;
 
             default:
-                this.query = getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
+                this.query = this.makeQueryFromSourceAndTasksFile();
                 this.queryType = 'tasks';
                 break;
         }
+    }
+
+    private makeQueryFromSourceAndTasksFile() {
+        return getQueryForQueryRenderer(this.source, GlobalQuery.getInstance(), this.tasksFile);
     }
 
     public get filePath(): string | undefined {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -42,6 +42,7 @@ export class QueryResultsRenderer {
     public readonly source: string;
 
     // The path of the file that contains the instruction block, and cached data from that file.
+    // This is updated when the query file's frontmatter is modified.
     private _tasksFile: TasksFile;
 
     public query: IQuery;
@@ -91,8 +92,16 @@ export class QueryResultsRenderer {
         return this._tasksFile;
     }
 
-    public set tasksFile(value: TasksFile) {
-        this._tasksFile = value;
+    public setTasksFile(newFile: TasksFile) {
+        // For now, this always updates the query when the TasksFile changes.
+        // TODO For efficiency, only update if either the path or raw frontmatter has been changed.
+
+        this._tasksFile = newFile;
+        // Recreate the query, as placeholders and file properties may have changed.
+        this.query = this.makeQueryFromSourceAndTasksFile();
+
+        // It is up to the caller to ensure that any search results are re-rendered.
+        // TODO Somehow provide information back to the caller to say whether query has been changed.
     }
 
     public get filePath(): string | undefined {

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -93,3 +93,18 @@ ${toMarkdown(allTasks)}
         await verifyRenderedTasksHTML(allTasks, showTree + 'description includes grandchild');
     });
 });
+
+describe('QueryResultsRenderer - responding to file edits', () => {
+    it.failing('should update the query its file path is changed', () => {
+        // Arrange
+        const source = 'path includes {{query.file.path}}';
+        const renderer = makeQueryResultsRenderer(source, new TasksFile('oldPath.md'));
+        expect(renderer.query.explainQuery()).toContain('path includes oldPath.md');
+
+        // Act
+        renderer.tasksFile = new TasksFile('newPath.md');
+
+        // Assert
+        expect(renderer.query.explainQuery()).toContain('path includes newPath.md');
+    });
+});

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -95,14 +95,14 @@ ${toMarkdown(allTasks)}
 });
 
 describe('QueryResultsRenderer - responding to file edits', () => {
-    it.failing('should update the query its file path is changed', () => {
+    it('should update the query its file path is changed', () => {
         // Arrange
         const source = 'path includes {{query.file.path}}';
         const renderer = makeQueryResultsRenderer(source, new TasksFile('oldPath.md'));
         expect(renderer.query.explainQuery()).toContain('path includes oldPath.md');
 
         // Act
-        renderer.tasksFile = new TasksFile('newPath.md');
+        renderer.setTasksFile(new TasksFile('newPath.md'));
 
         // Assert
         expect(renderer.query.explainQuery()).toContain('path includes newPath.md');

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -26,16 +26,20 @@ afterEach(() => {
     jest.useRealTimers();
 });
 
+function makeQueryResultsRenderer(source: string, tasksFile: TasksFile) {
+    return new QueryResultsRenderer(
+        'block-language-tasks',
+        source,
+        tasksFile,
+        () => Promise.resolve(),
+        null,
+        mockHTMLRenderer,
+    );
+}
+
 describe('QueryResultsRenderer tests', () => {
     async function verifyRenderedTasksHTML(allTasks: Task[], source: string = '') {
-        const renderer = new QueryResultsRenderer(
-            'block-language-tasks',
-            source,
-            new TasksFile('query.md'),
-            () => Promise.resolve(),
-            null,
-            mockHTMLRenderer,
-        );
+        const renderer = makeQueryResultsRenderer(source, new TasksFile('query.md'));
         const queryRendererParameters = {
             allTasks,
             allMarkdownFiles: [],

--- a/tests/Scripting/QueryProperties.test.query_file_properties.approved.md
+++ b/tests/Scripting/QueryProperties.test.query_file_properties.approved.md
@@ -8,6 +8,10 @@
 | `query.file.folder` | `string` | `'root/sub-folder/'` |
 | `query.file.filename` | `string` | `'file containing query.md'` |
 | `query.file.filenameWithoutExtension` | `string` | `'file containing query'` |
+| `query.file.hasProperty('task_instruction')` | `boolean` | `true` |
+| `query.file.hasProperty('non_existent_property')` | `boolean` | `false` |
+| `query.file.property('task_instruction')` | `string` | `'group by filename'` |
+| `query.file.property('non_existent_property')` | `null` | `null` |
 
 
 <!-- placeholder to force blank line after included text -->

--- a/tests/Scripting/QueryProperties.test.ts
+++ b/tests/Scripting/QueryProperties.test.ts
@@ -5,12 +5,15 @@ import { MarkdownTable } from '../../src/lib/MarkdownTable';
 import { parseAndEvaluateExpression } from '../../src/Scripting/TaskExpression';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { TasksFile } from '../../src/Scripting/TasksFile';
+import { getTasksFileFromMockData } from '../TestingTools/MockDataHelpers';
+import query_using_properties from '../Obsidian/__test_data__/query_using_properties.json';
 import { addBackticks, determineExpressionType, formatToRepresentType } from './ScriptingTestHelpers';
 
 describe('query', () => {
     function verifyFieldDataForReferenceDocs(fields: string[]) {
         const markdownTable = new MarkdownTable(['Field', 'Type', 'Example']);
-        const tasksFile = new TasksFile('root/sub-folder/file containing query.md');
+        const cachedMetadata = getTasksFileFromMockData(query_using_properties).cachedMetadata;
+        const tasksFile = new TasksFile('root/sub-folder/file containing query.md', cachedMetadata);
         const task = new TaskBuilder()
             .description('... an array with all the Tasks-tracked tasks in the vault ...')
             .build();
@@ -35,6 +38,10 @@ describe('query', () => {
             'query.file.folder',
             'query.file.filename',
             'query.file.filenameWithoutExtension',
+            "query.file.hasProperty('task_instruction')",
+            "query.file.hasProperty('non_existent_property')",
+            "query.file.property('task_instruction')",
+            "query.file.property('non_existent_property')",
         ]);
     });
 


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
    - https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3154
    - https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3083
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

**Summary**: This is all about making the following features releasable, by fixing bugs in the initial implementation and adding documentation:

- https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3154
- https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3083

**Detail**:

1. When the user **edits any Obsidian properties in the query file**, refresh the query, in case any frontmatter properties were used in the query
2. When the user **moves or renames the file containing the query**, refresh the query, in case the query's path used in the query, such as via placeholders
3. Add some **initial documentation** for `query.file.hasProperty()` and `query.file.property()`

## Motivation and Context

This builds on the following PRs:

- https://github.com/obsidian-tasks-group/obsidian-tasks/pull/3242
- https://github.com/obsidian-tasks-group/obsidian-tasks/pull/3245

They enabled queries to access `query.file.hasProperty()` and `query.file.property()`, but with the major limitation that the query file had to be re-opened for the changes to take effect.

## How has this been tested?

- Automated tests, where possible.
- Lots of exploratory testing

## Screenshots (if appropriate)

*Video coming soon*

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
