### PR TITLE
fix: render non-task list items in tree

### DIFF
--- a/docs/Queries/Layout.md
+++ b/docs/Queries/Layout.md
@@ -136,6 +136,7 @@ The `show tree` instruction enables us to see the parent/child relationships in 
 
 - For now, **all child tasks and list items are displayed**, regardless of whether they match the query.
   - In the screenshot above, `Decide who to invite` did not match the `not done` query, but it is still shown.
+  - If you are using the Global Filter, any child tasks without the Global Filter are rendered without their checkbox. We are tracking this in [issue #3170](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3170).
 - Any **sorting instructions only affect the sorting of the left-most tasks** in the results list.
   - Child tasks and list items are displayed in the order that they appear in the file. They are not affected by any `sort by` instructions.
 - For now, the **tree layout is turned off by default**, whilst we explore how it should interact with the filtering instructions.

--- a/resources/sample_vaults/Tasks-Demo/Test Data/inheritance_non_task_child.md
+++ b/resources/sample_vaults/Tasks-Demo/Test Data/inheritance_non_task_child.md
@@ -1,3 +1,9 @@
 -  [ ] #task task parent
     - [ ] #task task child
     - [ ] non-task child
+    - list item child
+
+```tasks
+filename includes {{query.file.filename}}
+show tree
+```

--- a/resources/sample_vaults/Tasks-Demo/Test Data/inheritance_non_task_child.md
+++ b/resources/sample_vaults/Tasks-Demo/Test Data/inheritance_non_task_child.md
@@ -1,0 +1,3 @@
+-  [ ] #task task parent
+    - [ ] #task task child
+    - [ ] non-task child

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -119,8 +119,7 @@ export class FileParser {
         sectionIndex: number,
     ) {
         if (listItem.task === undefined) {
-            const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
-            this.line2ListItem.set(lineNumber, new ListItem(line, parentListItem));
+            this.createListItem(listItem, line, lineNumber);
             return sectionIndex;
         }
         let task;
@@ -157,5 +156,10 @@ export class FileParser {
             this.errorReporter(e, this.filePath, listItem, line);
         }
         return sectionIndex;
+    }
+
+    private createListItem(listItem: ListItemCache, line: string, lineNumber: number) {
+        const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
+        this.line2ListItem.set(lineNumber, new ListItem(line, parentListItem));
     }
 }

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -148,6 +148,10 @@ export class FileParser {
                     sectionIndex++;
                     this.tasks.push(task);
                 }
+            } else {
+                // Treat tasks without the global filter as list items
+                const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
+                this.line2ListItem.set(lineNumber, new ListItem(line, parentListItem));
             }
         } catch (e) {
             this.errorReporter(e, this.filePath, listItem, line);

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -149,8 +149,7 @@ export class FileParser {
                 }
             } else {
                 // Treat tasks without the global filter as list items
-                const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
-                this.line2ListItem.set(lineNumber, new ListItem(line, parentListItem));
+                this.createListItem(listItem, line, lineNumber);
             }
         } catch (e) {
             this.errorReporter(e, this.filePath, listItem, line);

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -12,7 +12,7 @@ export class ListItem {
 
     constructor(originalMarkdown: string, parent: ListItem | null) {
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
-        const nonTaskMatch = originalMarkdown.match(TaskRegularExpressions.nonTaskRegex);
+        const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         if (nonTaskMatch) {
             this.description = nonTaskMatch[5].trim();
             this.statusCharacter = nonTaskMatch[4] ?? null;

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -8,12 +8,14 @@ export class ListItem {
     public readonly parent: ListItem | null = null;
     public readonly children: ListItem[] = [];
     public readonly description: string;
+    public readonly statusCharacter: string | null = null;
 
     constructor(originalMarkdown: string, parent: ListItem | null) {
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         const nonTaskMatch = originalMarkdown.match(TaskRegularExpressions.nonTaskRegex);
         if (nonTaskMatch) {
             this.description = nonTaskMatch[5].trim();
+            this.statusCharacter = nonTaskMatch[4] ?? null;
         }
         this.originalMarkdown = originalMarkdown;
         this.parent = parent;

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -11,6 +11,10 @@ export class ListItem {
 
     constructor(originalMarkdown: string, parent: ListItem | null) {
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
+        const nonTaskMatch = originalMarkdown.match(TaskRegularExpressions.nonTaskRegex);
+        if (nonTaskMatch) {
+            this.description = nonTaskMatch[5].trim();
+        }
         this.originalMarkdown = originalMarkdown;
         this.parent = parent;
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -93,6 +93,8 @@ export class ListItem {
             return false;
         }
 
+        // Not testing status character as it is implied from the original markdown
+
         return ListItem.listsAreIdentical(this.children, other.children);
     }
 

--- a/src/Task/TaskRegularExpressions.ts
+++ b/src/Task/TaskRegularExpressions.ts
@@ -31,6 +31,12 @@ export class TaskRegularExpressions {
     );
 
     // Used with the "Create or Edit Task" command to parse indentation and status if present
+    // It matches the following:
+    // - Indentation
+    // - List marker
+    // - Checkbox with status character
+    // - Status character
+    // - Rest of task after checkbox markdown
     public static readonly nonTaskRegex = new RegExp(
         TaskRegularExpressions.indentationRegex.source +
             TaskRegularExpressions.listMarkerRegex.source +

--- a/tests/Obsidian/AllCacheSampleData.ts
+++ b/tests/Obsidian/AllCacheSampleData.ts
@@ -26,6 +26,7 @@ import inheritance_2siblings from './__test_data__/inheritance_2siblings.json';
 import inheritance_listitem_listitem_task from './__test_data__/inheritance_listitem_listitem_task.json';
 import inheritance_listitem_task from './__test_data__/inheritance_listitem_task.json';
 import inheritance_listitem_task_siblings from './__test_data__/inheritance_listitem_task_siblings.json';
+import inheritance_non_task_child from './__test_data__/inheritance_non_task_child.json';
 import inheritance_rendering_sample from './__test_data__/inheritance_rendering_sample.json';
 import inheritance_task_2listitem_3task from './__test_data__/inheritance_task_2listitem_3task.json';
 import inheritance_task_listitem from './__test_data__/inheritance_task_listitem.json';
@@ -96,6 +97,7 @@ export function allCacheSampleData() {
         inheritance_listitem_listitem_task,
         inheritance_listitem_task,
         inheritance_listitem_task_siblings,
+        inheritance_non_task_child,
         inheritance_rendering_sample,
         inheritance_task_2listitem_3task,
         inheritance_task_listitem,

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -503,6 +503,7 @@ describe('cache', () => {
         expect(printRoots(tasks)).toMatchInlineSnapshot(`
             "-  [ ] #task task parent : Task
                 - [ ] #task task child : Task
+                - [ ] non-task child : ListItem
             "
         `);
     });

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -495,6 +495,12 @@ describe('cache', () => {
             "-  [ ] #task task parent
                 - [ ] #task task child
                 - [ ] non-task child
+                - list item child
+
+            \`\`\`tasks
+            filename includes {{query.file.filename}}
+            show tree
+            \`\`\`
             "
         `);
 
@@ -504,6 +510,7 @@ describe('cache', () => {
             "-  [ ] #task task parent : Task
                 - [ ] #task task child : Task
                 - [ ] non-task child : ListItem
+                - list item child : ListItem
             "
         `);
     });

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -3,6 +3,7 @@
  */
 import moment from 'moment/moment';
 import type { CachedMetadata } from 'obsidian';
+import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import type { ListItem } from '../../src/Task/ListItem';
 import { getTasksFileFromMockData, listPathAndData } from '../TestingTools/MockDataHelpers';
 import inheritance_1parent1child from './__test_data__/inheritance_1parent1child.json';
@@ -19,6 +20,7 @@ import inheritance_2siblings from './__test_data__/inheritance_2siblings.json';
 import inheritance_listitem_listitem_task from './__test_data__/inheritance_listitem_listitem_task.json';
 import inheritance_listitem_task from './__test_data__/inheritance_listitem_task.json';
 import inheritance_listitem_task_siblings from './__test_data__/inheritance_listitem_task_siblings.json';
+import inheritance_non_task_child from './__test_data__/inheritance_non_task_child.json';
 import inheritance_task_2listitem_3task from './__test_data__/inheritance_task_2listitem_3task.json';
 import inheritance_task_listitem from './__test_data__/inheritance_task_listitem.json';
 import inheritance_task_listitem_mixed_grandchildren from './__test_data__/inheritance_task_listitem_mixed_grandchildren.json';
@@ -94,6 +96,10 @@ function printRoots(listItems: ListItem[]) {
     });
     return rootHierarchies;
 }
+
+afterEach(() => {
+    GlobalFilter.getInstance().reset();
+});
 
 describe('cache', () => {
     it('should read one task', () => {
@@ -476,6 +482,27 @@ describe('cache', () => {
                     - grandchild list item 1 : ListItem
                     - [ ] grandchild task : Task
                     - grandchild list item 2 : ListItem
+            "
+        `);
+    });
+
+    it('should read non task check box when global filter is enabled', () => {
+        GlobalFilter.getInstance().set('#task');
+
+        const data = inheritance_non_task_child;
+        const tasks = readTasksFromSimulatedFile(data);
+        expect(data.fileContents).toMatchInlineSnapshot(`
+            "-  [ ] #task task parent
+                - [ ] #task task child
+                - [ ] non-task child
+            "
+        `);
+
+        expect(tasks.length).toEqual(2);
+
+        expect(printRoots(tasks)).toMatchInlineSnapshot(`
+            "-  [ ] #task task parent : Task
+                - [ ] #task task child : Task
             "
         `);
     });

--- a/tests/Obsidian/__test_data__/inheritance_non_task_child.json
+++ b/tests/Obsidian/__test_data__/inheritance_non_task_child.json
@@ -1,0 +1,111 @@
+{
+  "cachedMetadata": {
+    "listItems": [
+      {
+        "parent": -1,
+        "position": {
+          "end": {
+            "col": 24,
+            "line": 0,
+            "offset": 24
+          },
+          "start": {
+            "col": 0,
+            "line": 0,
+            "offset": 0
+          }
+        },
+        "task": " "
+      },
+      {
+        "parent": 0,
+        "position": {
+          "end": {
+            "col": 26,
+            "line": 1,
+            "offset": 51
+          },
+          "start": {
+            "col": 3,
+            "line": 1,
+            "offset": 28
+          }
+        },
+        "task": " "
+      },
+      {
+        "parent": 0,
+        "position": {
+          "end": {
+            "col": 24,
+            "line": 2,
+            "offset": 76
+          },
+          "start": {
+            "col": 3,
+            "line": 2,
+            "offset": 55
+          }
+        },
+        "task": " "
+      }
+    ],
+    "sections": [
+      {
+        "position": {
+          "end": {
+            "col": 24,
+            "line": 2,
+            "offset": 76
+          },
+          "start": {
+            "col": 0,
+            "line": 0,
+            "offset": 0
+          }
+        },
+        "type": "list"
+      }
+    ],
+    "tags": [
+      {
+        "position": {
+          "end": {
+            "col": 12,
+            "line": 0,
+            "offset": 12
+          },
+          "start": {
+            "col": 7,
+            "line": 0,
+            "offset": 7
+          }
+        },
+        "tag": "#task"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 15,
+            "line": 1,
+            "offset": 40
+          },
+          "start": {
+            "col": 10,
+            "line": 1,
+            "offset": 35
+          }
+        },
+        "tag": "#task"
+      }
+    ]
+  },
+  "fileContents": "-  [ ] #task task parent\n    - [ ] #task task child\n    - [ ] non-task child\n",
+  "filePath": "Test Data/inheritance_non_task_child.md",
+  "getAllTags": [
+    "#task",
+    "#task"
+  ],
+  "obsidianApiVersion": "1.8.0",
+  "parseFrontMatterTags": null
+}

--- a/tests/Obsidian/__test_data__/inheritance_non_task_child.json
+++ b/tests/Obsidian/__test_data__/inheritance_non_task_child.json
@@ -48,15 +48,30 @@
           }
         },
         "task": " "
+      },
+      {
+        "parent": 0,
+        "position": {
+          "end": {
+            "col": 21,
+            "line": 3,
+            "offset": 98
+          },
+          "start": {
+            "col": 3,
+            "line": 3,
+            "offset": 80
+          }
+        }
       }
     ],
     "sections": [
       {
         "position": {
           "end": {
-            "col": 24,
-            "line": 2,
-            "offset": 76
+            "col": 21,
+            "line": 3,
+            "offset": 98
           },
           "start": {
             "col": 0,
@@ -65,6 +80,21 @@
           }
         },
         "type": "list"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 3,
+            "line": 8,
+            "offset": 164
+          },
+          "start": {
+            "col": 0,
+            "line": 5,
+            "offset": 100
+          }
+        },
+        "type": "code"
       }
     ],
     "tags": [
@@ -100,7 +130,7 @@
       }
     ]
   },
-  "fileContents": "-  [ ] #task task parent\n    - [ ] #task task child\n    - [ ] non-task child\n",
+  "fileContents": "-  [ ] #task task parent\n    - [ ] #task task child\n    - [ ] non-task child\n    - list item child\n\n```tasks\nfilename includes {{query.file.filename}}\nshow tree\n```\n",
   "filePath": "Test Data/inheritance_non_task_child.md",
   "getAllTags": [
     "#task",

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_should_render_non_task_check_box_when_global_filter_is_enabled.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_should_render_non_task_check_box_when_global_filter_is_enabled.approved.html
@@ -1,0 +1,53 @@
+<!--
+- [ ] #task task parent
+    - [ ] #task task child
+-->
+
+<div>
+  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="0"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>#task task parent</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">inheritance_non_task_child</a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="normal"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>#task task child</span></span>
+          </span>
+          <span class="task-extras">
+            <span class="tasks-backlink">
+              (
+              <a rel="noopener" target="_blank" class="internal-link">inheritance_non_task_child</a>
+              )
+            </span>
+            <a class="tasks-edit" title="Edit task" href="#"></a>
+          </span>
+        </li>
+        <li><span>[ ] non-task child</span></li>
+      </ul>
+    </li>
+  </ul>
+  <div class="task-count">2 tasks</div>
+</div>

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_should_render_non_task_check_box_when_global_filter_is_enabled.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_should_render_non_task_check_box_when_global_filter_is_enabled.approved.html
@@ -46,6 +46,7 @@
           </span>
         </li>
         <li><span>[ ] non-task child</span></li>
+        <li><span>list item child</span></li>
       </ul>
     </li>
   </ul>

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_should_render_non_task_check_box_when_global_filter_is_enabled.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_tests_should_render_non_task_check_box_when_global_filter_is_enabled.approved.html
@@ -45,7 +45,7 @@
             <a class="tasks-edit" title="Edit task" href="#"></a>
           </span>
         </li>
-        <li><span>[ ] non-task child</span></li>
+        <li><span>non-task child</span></li>
         <li><span>list item child</span></li>
       </ul>
     </li>

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -3,9 +3,11 @@
  */
 import moment from 'moment';
 import type { Task } from 'Task/Task';
+import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { State } from '../../src/Obsidian/Cache';
 import { QueryResultsRenderer } from '../../src/Renderer/QueryResultsRenderer';
 import { TasksFile } from '../../src/Scripting/TasksFile';
+import inheritance_non_task_child from '../Obsidian/__test_data__/inheritance_non_task_child.json';
 import inheritance_rendering_sample from '../Obsidian/__test_data__/inheritance_rendering_sample.json';
 import inheritance_task_2listitem_3task from '../Obsidian/__test_data__/inheritance_task_2listitem_3task.json';
 import { readTasksFromSimulatedFile } from '../Obsidian/SimulatedFile';
@@ -24,6 +26,7 @@ beforeEach(() => {
 
 afterEach(() => {
     jest.useRealTimers();
+    GlobalFilter.getInstance().reset();
 });
 
 function makeQueryResultsRenderer(source: string, tasksFile: TasksFile) {
@@ -91,6 +94,12 @@ ${toMarkdown(allTasks)}
         // example chosen to match subtasks whose parents do not match the query
         const allTasks = readTasksFromSimulatedFile(inheritance_task_2listitem_3task);
         await verifyRenderedTasksHTML(allTasks, showTree + 'description includes grandchild');
+    });
+
+    it('should render non task check box when global filter is enabled', async () => {
+        GlobalFilter.getInstance().set('#task');
+        const allTasks = readTasksFromSimulatedFile(inheritance_non_task_child);
+        await verifyRenderedTasksHTML(allTasks, showTree);
     });
 });
 

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -129,6 +129,16 @@ describe('list item parsing', () => {
         expect(item.originalMarkdown).toEqual('- [x] with checked checkbox');
         expect(item.statusCharacter).toEqual('x');
     });
+
+    it('should accept a non list item', () => {
+        // we tried making the constructor throw if given a non list item
+        // but it broke lots of normal Task uses in the tests (TaskBuilder)
+        const item = new ListItem('# Heading', null);
+
+        expect(item.description).toEqual('# Heading');
+        expect(item.originalMarkdown).toEqual('# Heading');
+        expect(item.statusCharacter).toEqual(null);
+    });
 });
 
 describe('related items', () => {

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -185,6 +185,13 @@ describe('identicalTo', () => {
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
+    it('should recognise different status characters', () => {
+        const item1 = new ListItem('- [1] item', null);
+        const item2 = new ListItem('- [2] item', null);
+
+        expect(item2.identicalTo(item1)).toEqual(false);
+    });
+
     it('should recognise ListItem and Task as different', () => {
         const listItem = new ListItem('- [ ] description', null);
         const task = fromLine({ line: '- [ ] description' });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -106,11 +106,18 @@ describe('list item tests', () => {
 });
 
 describe('list items with checkbox', () => {
-    it.failing('should read a list item with checkbox', () => {
+    it('should read a list item with checkbox', () => {
         const item = new ListItem('- [ ] with checkbox', null);
 
         expect(item.description).toEqual('with checkbox');
         expect(item.originalMarkdown).toEqual('- [ ] with checkbox');
+    });
+
+    it('should read a list item with checkbox', () => {
+        const item = new ListItem('- [x] with checked checkbox', null);
+
+        expect(item.description).toEqual('with checked checkbox');
+        expect(item.originalMarkdown).toEqual('- [x] with checked checkbox');
     });
 });
 

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -105,6 +105,15 @@ describe('list item tests', () => {
     });
 });
 
+describe('list items with checkbox', () => {
+    it.failing('should read a list item with checkbox', () => {
+        const item = new ListItem('- [ ] with checkbox', null);
+
+        expect(item.description).toEqual('with checkbox');
+        expect(item.originalMarkdown).toEqual('- [ ] with checkbox');
+    });
+});
+
 describe('related items', () => {
     it('should detect if no closest parent task', () => {
         const task = fromLine({ line: '- [ ] task' });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -105,7 +105,7 @@ describe('list item tests', () => {
     });
 });
 
-describe('list items with checkbox', () => {
+describe('list item parsing', () => {
     it('should read a list item without checkbox', () => {
         const item = new ListItem('- without checkbox', null);
 

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -106,11 +106,20 @@ describe('list item tests', () => {
 });
 
 describe('list items with checkbox', () => {
+    it('should read a list item without checkbox', () => {
+        const item = new ListItem('- without checkbox', null);
+
+        expect(item.description).toEqual('without checkbox');
+        expect(item.originalMarkdown).toEqual('- without checkbox');
+        expect(item.statusCharacter).toEqual(null);
+    });
+
     it('should read a list item with checkbox', () => {
         const item = new ListItem('- [ ] with checkbox', null);
 
         expect(item.description).toEqual('with checkbox');
         expect(item.originalMarkdown).toEqual('- [ ] with checkbox');
+        expect(item.statusCharacter).toEqual(' ');
     });
 
     it('should read a list item with checkbox', () => {
@@ -118,6 +127,7 @@ describe('list items with checkbox', () => {
 
         expect(item.description).toEqual('with checked checkbox');
         expect(item.originalMarkdown).toEqual('- [x] with checked checkbox');
+        expect(item.statusCharacter).toEqual('x');
     });
 });
 

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -188,6 +188,7 @@ describe('EditableTask tests', () => {
                   "type": "TODO",
                 },
               },
+              "statusCharacter": " ",
               "tags": [
                 "#todo",
                 "#health",


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- some progress on addressing #3170
- `ListItem` now optionally stores a status character

## Motivation and Context

- see #3170

## How has this been tested?

- unit tests

## Screenshots

With this markdown - and a global filter `#task`:

~~~
-  [ ] #task task parent
    - [ ] #task task child
    - [ ] non-task child
    - list item child

```tasks
filename includes {{query.file.filename}}
show tree
```
~~~

![image](https://github.com/user-attachments/assets/c16ec8e2-2b80-4a6e-b891-52666218154d)


## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
