### PR TITLE
feat: Simplify 'explain' text

### DIFF
--- a/docs/Queries/Explaining Queries.md
+++ b/docs/Queries/Explaining Queries.md
@@ -52,10 +52,6 @@ Explanation of this Tasks code block query:
 
   due before tomorrow =>
     due date is before 2022-10-22 (Saturday 22nd October 2022)
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.
 ```
 <!-- endSnippet -->
 
@@ -85,10 +81,6 @@ Explanation of this Tasks code block query:
 
   path regex matches /^Root/Sub-Folder/Sample File\.md/i =>
     using regex:     '^Root\/Sub-Folder\/Sample File\.md' with flag 'i'
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.
 ```
 <!-- endSnippet -->
 
@@ -117,10 +109,6 @@ Explanation of this Tasks code block query:
       due before tomorrow =>
         due date is before 2022-10-22 (Saturday 22nd October 2022)
       is recurring
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.
 ```
 <!-- endSnippet -->
 
@@ -170,10 +158,6 @@ Explanation of this Tasks code block query:
           description includes 7
         NOT:
           description includes 7
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.
 ```
 <!-- endSnippet -->
 
@@ -209,10 +193,6 @@ Explanation of the global query:
 
   heading includes tasks
 
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.
-
   At most 50 tasks.
 
 Explanation of this Tasks code block query:
@@ -223,10 +203,6 @@ Explanation of this Tasks code block query:
     due date is between:
       2022-10-24 (Monday 24th October 2022) and
       2022-10-30 (Sunday 30th October 2022) inclusive
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.
 ```
 <!-- endSnippet -->
 
@@ -277,10 +253,6 @@ Explanation of this Tasks code block query:
 
   description includes Some Cryptic String {{! Inline comments are removed before search }} =>
   description includes Some Cryptic String
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.
 ```
 <!-- endSnippet -->
 

--- a/docs/Queries/Line Continuations.md
+++ b/docs/Queries/Line Continuations.md
@@ -38,10 +38,6 @@ Explanation of this Tasks code block query:
     OR (At least one of):
       priority is highest
       priority is lowest
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.
 ```
 <!-- endSnippet -->
 
@@ -81,10 +77,6 @@ Explanation of this Tasks code block query:
 
   description includes \\ =>
   description includes \
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.
 ```
 <!-- endSnippet -->
 

--- a/docs/Queries/Regular Expressions.md
+++ b/docs/Queries/Regular Expressions.md
@@ -97,10 +97,6 @@ Explanation of this Tasks code block query:
 
   path regex matches /^Root/Sub-Folder/Sample File\.md/i =>
     using regex:     '^Root\/Sub-Folder\/Sample File\.md' with flag 'i'
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.
 ```
 <!-- endSnippet -->
 

--- a/docs/Scripting/Placeholders.md
+++ b/docs/Scripting/Placeholders.md
@@ -65,10 +65,6 @@ Explanation of this Tasks code block query:
 
   description includes Some Cryptic String {{! Inline comments are removed before search }} =>
   description includes Some Cryptic String
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.
 ```
 <!-- endSnippet -->
 

--- a/src/Query/Explain/Explainer.ts
+++ b/src/Query/Explain/Explainer.ts
@@ -58,7 +58,7 @@ export class Explainer {
 
     public explainGroups(query: Query) {
         if (query.grouping.length === 0) {
-            return this.indent('No grouping instructions supplied.\n');
+            return '';
         }
 
         return query.grouping.map((group) => group.statement.explainStatement(this.indentation)).join('\n\n') + '\n';
@@ -66,7 +66,7 @@ export class Explainer {
 
     public explainSorters(query: Query) {
         if (query.sorting.length === 0) {
-            return this.indent('No sorting instructions supplied.\n');
+            return '';
         }
 
         return query.sorting.map((sort) => sort.statement.explainStatement(this.indentation)).join('\n\n') + '\n';

--- a/tests/Config/DebugSettings.test.ts
+++ b/tests/Config/DebugSettings.test.ts
@@ -37,8 +37,6 @@ describe('DebugSettings', () => {
         expect(query.explainQuery()).toMatchInlineSnapshot(`
             "No filters supplied. All tasks will match the query.
 
-            No grouping instructions supplied.
-
             sort by status
 
             NOTE: All sort instructions, including default sort order, are disabled, due to 'ignoreSortInstructions' setting.

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_boolean_combinations.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_boolean_combinations.approved.explanation.text
@@ -7,7 +7,3 @@ Explanation of this Tasks code block query:
       due before tomorrow =>
         due date is before 2022-10-22 (Saturday 22nd October 2022)
       is recurring
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_expands_dates.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_expands_dates.approved.explanation.text
@@ -8,7 +8,3 @@ Explanation of this Tasks code block query:
 
   due before tomorrow =>
     due date is before 2022-10-22 (Saturday 22nd October 2022)
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_explains_task_block_with_global_query_active.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_explains_task_block_with_global_query_active.approved.explanation.text
@@ -2,10 +2,6 @@ Explanation of the global query:
 
   heading includes tasks
 
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.
-
   At most 50 tasks.
 
 Explanation of this Tasks code block query:
@@ -16,7 +12,3 @@ Explanation of this Tasks code block query:
     due date is between:
       2022-10-24 (Monday 24th October 2022) and
       2022-10-30 (Sunday 30th October 2022) inclusive
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_line_continuation_-_double_slash.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_line_continuation_-_double_slash.approved.explanation.text
@@ -2,7 +2,3 @@ Explanation of this Tasks code block query:
 
   description includes \\ =>
   description includes \
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_line_continuation_-_single_slash.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_line_continuation_-_single_slash.approved.explanation.text
@@ -7,7 +7,3 @@ Explanation of this Tasks code block query:
     OR (At least one of):
       priority is highest
       priority is lowest
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_nested_boolean_combinations.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_nested_boolean_combinations.approved.explanation.text
@@ -20,7 +20,3 @@ Explanation of this Tasks code block query:
           description includes 7
         NOT:
           description includes 7
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_placeholders.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_placeholders.approved.explanation.text
@@ -20,7 +20,3 @@ Explanation of this Tasks code block query:
 
   description includes Some Cryptic String {{! Inline comments are removed before search }} =>
   description includes Some Cryptic String
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_regular_expression.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_regular_expression.approved.explanation.text
@@ -2,7 +2,3 @@ Explanation of this Tasks code block query:
 
   path regex matches /^Root/Sub-Folder/Sample File\.md/i =>
     using regex:     '^Root\/Sub-Folder\/Sample File\.md' with flag 'i'
-
-  No grouping instructions supplied.
-
-  No sorting instructions supplied.

--- a/tests/Query/Filter/ReferenceDocs/FilterReference/DateFieldReference.test.explain_date_reference_filters-date-examples.approved.explanation.text
+++ b/tests/Query/Filter/ReferenceDocs/FilterReference/DateFieldReference.test.explain_date_reference_filters-date-examples.approved.explanation.text
@@ -31,7 +31,3 @@ due 14 October =>
 
 due May =>
   due date is on 2023-05-01 (Monday 1st May 2023)
-
-No grouping instructions supplied.
-
-No sorting instructions supplied.

--- a/tests/Query/Filter/ReferenceDocs/FilterReference/DateFieldReference.test.explain_date_reference_last-this-next-week-month-quarter-year.approved.explanation.text
+++ b/tests/Query/Filter/ReferenceDocs/FilterReference/DateFieldReference.test.explain_date_reference_last-this-next-week-month-quarter-year.approved.explanation.text
@@ -72,7 +72,3 @@ due next year =>
     2024-12-31 (Tuesday 31st December 2024) inclusive
 
 description includes ------------------------------
-
-No grouping instructions supplied.
-
-No sorting instructions supplied.

--- a/tests/Query/Filter/ReferenceDocs/FilterReference/DateFieldReference.test.explain_date_reference_last-this-next-weekday.approved.explanation.text
+++ b/tests/Query/Filter/ReferenceDocs/FilterReference/DateFieldReference.test.explain_date_reference_last-this-next-weekday.approved.explanation.text
@@ -102,7 +102,3 @@ due next sunday =>
   due date is on 2023-04-23 (Sunday 23rd April 2023)
 
 description includes ------------------------------
-
-No grouping instructions supplied.
-
-No sorting instructions supplied.

--- a/tests/Query/Filter/TextField.test.explains_regular_expression_searches_bulk_test.approved.txt
+++ b/tests/Query/Filter/TextField.test.explains_regular_expression_searches_bulk_test.approved.txt
@@ -106,8 +106,4 @@ tags regex does not match /(home|town)/ =>
 tags regex matches /(home|pc_mac|town)/ =>
   using regex:     '(home|pc_mac|town)' with no flags
 
-No grouping instructions supplied.
-
-No sorting instructions supplied.
-
 Error: None

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -817,8 +817,6 @@ Problem statement:
 
                     {{query.file.property('task_instruction')}} =>
                     group by filename
-
-                    No sorting instructions supplied.
                     "
                 `);
             });
@@ -831,10 +829,6 @@ Problem statement:
                 expect(query.explainQuery()).toMatchInlineSnapshot(`
                     "{{query.file.property('task_instruction_with_spaces')}} =>
                     path includes query_using_properties
-
-                    No grouping instructions supplied.
-
-                    No sorting instructions supplied.
                     "
                 `);
             });
@@ -860,8 +854,6 @@ group by folder
 
                     {{query.file.property('task_instructions')}}: statement 3 after expansion of placeholder =>
                     group by filename
-
-                    No sorting instructions supplied.
                     "
                 `);
             });
@@ -911,10 +903,6 @@ filter by function \\
                         return roots.includes(task.file.root);
                      =>
                     filter by function if (!query.file.hasProperty('root_dirs_to_search')) { throw Error('Please set the "root_dirs_to_search" list property, with each value ending in a backslash...'); } const roots = query.file.property('root_dirs_to_search'); return roots.includes(task.file.root);
-
-                    No grouping instructions supplied.
-
-                    No sorting instructions supplied.
                     "
                 `);
 
@@ -1541,10 +1529,6 @@ describe('Query', () => {
             const query = new Query(source);
             expect(query.explainQuery()).toMatchInlineSnapshot(`
                 "description includes hello
-
-                No grouping instructions supplied.
-
-                No sorting instructions supplied.
                 "
             `);
         });
@@ -1824,10 +1808,6 @@ with \ backslash)`;
                   OR (At least one of):
                     description includes line 1
                     description includes line 1 continued with \\ backslash
-
-                No grouping instructions supplied.
-
-                No sorting instructions supplied.
                 "
             `);
             expect(queryUpperCase.explainQuery()).toMatchInlineSnapshot(`
@@ -1839,10 +1819,6 @@ with \ backslash)`;
                   OR (At least one of):
                     description includes line 1
                     description includes line 1 continued with \\ backslash
-
-                No grouping instructions supplied.
-
-                No sorting instructions supplied.
                 "
             `);
         });

--- a/tests/Query/QueryRendererHelper.test.ts
+++ b/tests/Query/QueryRendererHelper.test.ts
@@ -22,10 +22,6 @@ describe('explain', () => {
             "Explanation of this Tasks code block query:
 
               No filters supplied. All tasks will match the query.
-
-              No grouping instructions supplied.
-
-              No sorting instructions supplied.
             "
         `);
     });
@@ -42,10 +38,6 @@ describe('explain', () => {
             Explanation of this Tasks code block query:
 
               No filters supplied. All tasks will match the query.
-
-              No grouping instructions supplied.
-
-              No sorting instructions supplied.
             "
         `);
     });
@@ -60,17 +52,9 @@ describe('explain', () => {
 
               description includes hello
 
-              No grouping instructions supplied.
-
-              No sorting instructions supplied.
-
             Explanation of this Tasks code block query:
 
               No filters supplied. All tasks will match the query.
-
-              No grouping instructions supplied.
-
-              No sorting instructions supplied.
             "
         `);
     });
@@ -86,25 +70,13 @@ describe('explain', () => {
 
               description includes hello
 
-              No grouping instructions supplied.
-
-              No sorting instructions supplied.
-
             Explanation of the query file defaults (from properties/frontmatter in the query's file):
 
               not done
 
-              No grouping instructions supplied.
-
-              No sorting instructions supplied.
-
             Explanation of this Tasks code block query:
 
               No filters supplied. All tasks will match the query.
-
-              No grouping instructions supplied.
-
-              No sorting instructions supplied.
             "
         `);
     });
@@ -123,17 +95,9 @@ describe('explain', () => {
 
               description includes hello
 
-              No grouping instructions supplied.
-
-              No sorting instructions supplied.
-
             Explanation of this Tasks code block query:
 
               No filters supplied. All tasks will match the query.
-
-              No grouping instructions supplied.
-
-              No sorting instructions supplied.
             "
         `);
     });
@@ -147,10 +111,6 @@ describe('explain', () => {
             "Explanation of this Tasks code block query:
 
               No filters supplied. All tasks will match the query.
-
-              No grouping instructions supplied.
-
-              No sorting instructions supplied.
             "
         `);
     });
@@ -167,17 +127,9 @@ describe('explain', () => {
 
               description includes I came from the tasks_query_extra_instructions property
 
-              No grouping instructions supplied.
-
-              No sorting instructions supplied.
-
             Explanation of this Tasks code block query:
 
               description includes I came from the code block
-
-              No grouping instructions supplied.
-
-              No sorting instructions supplied.
             "
         `);
     });


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: _no direct request - but I have noticed since the addition of "Query File Defaults" that `explain` output is becoming very cluttered_
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

Remove this output from `explain` output:

```
  No grouping instructions supplied.
```

And this:

```
  No sorting instructions supplied.
```



## Motivation and Context

Where there is both a "Global Query" and "Query File Defaults", that text could appear 3 times in `explain` output, making it just very cluttered, I found.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Exploratory testing
- Updating existing automated tests

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
