### PR TITLE
refactor: add `TaskLocation` to `ListItem`

### DIFF
--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -159,6 +159,6 @@ export class FileParser {
 
     private createListItem(listItem: ListItemCache, line: string, lineNumber: number) {
         const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
-        this.line2ListItem.set(lineNumber, new ListItem(line, parentListItem));
+        this.line2ListItem.set(lineNumber, new ListItem(line, parentListItem, null));
     }
 }

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -157,12 +157,7 @@ export class FileParser {
         return sectionIndex;
     }
 
-    private createListItem(
-        listItem: ListItemCache,
-        line: string,
-        lineNumber: number,
-        taskLocation: TaskLocation | null,
-    ) {
+    private createListItem(listItem: ListItemCache, line: string, lineNumber: number, taskLocation: TaskLocation) {
         const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
         this.line2ListItem.set(lineNumber, new ListItem(line, parentListItem, taskLocation));
     }

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -119,7 +119,7 @@ export class FileParser {
         sectionIndex: number,
     ) {
         if (listItem.task === undefined) {
-            this.createListItem(listItem, line, lineNumber);
+            this.createListItem(listItem, line, lineNumber, taskLocation);
             return sectionIndex;
         }
         let task;
@@ -149,7 +149,7 @@ export class FileParser {
                 }
             } else {
                 // Treat tasks without the global filter as list items
-                this.createListItem(listItem, line, lineNumber);
+                this.createListItem(listItem, line, lineNumber, taskLocation);
             }
         } catch (e) {
             this.errorReporter(e, this.filePath, listItem, line);
@@ -157,8 +157,13 @@ export class FileParser {
         return sectionIndex;
     }
 
-    private createListItem(listItem: ListItemCache, line: string, lineNumber: number) {
+    private createListItem(
+        listItem: ListItemCache,
+        line: string,
+        lineNumber: number,
+        taskLocation: TaskLocation | null,
+    ) {
         const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
-        this.line2ListItem.set(lineNumber, new ListItem(line, parentListItem, null));
+        this.line2ListItem.set(lineNumber, new ListItem(line, parentListItem, taskLocation));
     }
 }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -11,9 +11,9 @@ export class ListItem {
     public readonly description: string;
     public readonly statusCharacter: string | null = null;
 
-    public readonly taskLocation: TaskLocation | null;
+    public readonly taskLocation: TaskLocation;
 
-    constructor(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation | null) {
+    constructor(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         if (nonTaskMatch) {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -1,3 +1,4 @@
+import type { TaskLocation } from './TaskLocation';
 import { TaskRegularExpressions } from './TaskRegularExpressions';
 import type { Task } from './Task';
 
@@ -10,7 +11,9 @@ export class ListItem {
     public readonly description: string;
     public readonly statusCharacter: string | null = null;
 
-    constructor(originalMarkdown: string, parent: ListItem | null) {
+    public readonly taskLocation: TaskLocation | null;
+
+    constructor(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation | null) {
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         if (nonTaskMatch) {
@@ -23,6 +26,8 @@ export class ListItem {
         if (parent !== null) {
             parent.children.push(this);
         }
+
+        this.taskLocation = taskLocation;
     }
 
     /**

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -120,7 +120,7 @@ export class Task extends ListItem {
         scheduledDateIsInferred: boolean;
         parent?: ListItem | null;
     }) {
-        super(originalMarkdown, parent, null);
+        super(originalMarkdown, parent, taskLocation);
         // NEW_TASK_FIELD_EDIT_REQUIRED
         this.status = status;
         this.description = description;

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -120,7 +120,7 @@ export class Task extends ListItem {
         scheduledDateIsInferred: boolean;
         parent?: ListItem | null;
     }) {
-        super(originalMarkdown, parent);
+        super(originalMarkdown, parent, null);
         // NEW_TASK_FIELD_EDIT_REQUIRED
         this.status = status;
         this.description = description;

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -396,10 +396,6 @@ describe('cache', () => {
                 - child list item : ListItem
             "
         `);
-
-        const task = tasks[0];
-        expect(task.taskLocation.lineNumber).toEqual(0);
-        expect(task.children[0].taskLocation).toEqual(null);
     });
 
     it('should read parent task, child listItem and grandchild task', () => {
@@ -517,6 +513,12 @@ describe('cache', () => {
                 - list item child : ListItem
             "
         `);
+
+        const task = tasks[0];
+        expect(task.taskLocation.lineNumber).toEqual(0);
+        expect(task.children[0].taskLocation?.lineNumber).toEqual(1);
+        expect(task.children[1].taskLocation).toEqual(null);
+        expect(task.children[2].taskLocation).toEqual(null);
     });
 
     it('callout', () => {

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -516,9 +516,10 @@ describe('cache', () => {
 
         const task = tasks[0];
         expect(task.taskLocation.lineNumber).toEqual(0);
+        // TODO remove ? and ! after taskLocation cannot be null
         expect(task.children[0].taskLocation?.lineNumber).toEqual(1);
-        expect(task.children[1].taskLocation).toEqual(null);
-        expect(task.children[2].taskLocation).toEqual(null);
+        expect(task.children[1].taskLocation?.lineNumber).toEqual(2);
+        expect(task.children[2].taskLocation?.lineNumber).toEqual(3);
     });
 
     it('callout', () => {

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -516,10 +516,9 @@ describe('cache', () => {
 
         const task = tasks[0];
         expect(task.taskLocation.lineNumber).toEqual(0);
-        // TODO remove ? and ! after taskLocation cannot be null
-        expect(task.children[0].taskLocation?.lineNumber).toEqual(1);
-        expect(task.children[1].taskLocation?.lineNumber).toEqual(2);
-        expect(task.children[2].taskLocation?.lineNumber).toEqual(3);
+        expect(task.children[0].taskLocation.lineNumber).toEqual(1);
+        expect(task.children[1].taskLocation.lineNumber).toEqual(2);
+        expect(task.children[2].taskLocation.lineNumber).toEqual(3);
     });
 
     it('callout', () => {

--- a/tests/Obsidian/Cache.test.ts
+++ b/tests/Obsidian/Cache.test.ts
@@ -396,6 +396,10 @@ describe('cache', () => {
                 - child list item : ListItem
             "
         `);
+
+        const task = tasks[0];
+        expect(task.taskLocation.lineNumber).toEqual(0);
+        expect(task.children[0].taskLocation).toEqual(null);
     });
 
     it('should read parent task, child listItem and grandchild task', () => {

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -12,9 +12,9 @@ import { createChildListItem } from './ListItemHelpers';
 
 window.moment = moment;
 
-describe('list item tests', () => {
-    const taskLocation = TaskLocation.fromUnknownPosition(new TasksFile('anything.md'));
+const taskLocation = TaskLocation.fromUnknownPosition(new TasksFile('anything.md'));
 
+describe('list item tests', () => {
     it('should create list item with empty children and absent parent', () => {
         const listItem = new ListItem('', null, taskLocation);
         expect(listItem).toBeDefined();
@@ -24,9 +24,9 @@ describe('list item tests', () => {
     });
 
     it('should create a list item with 2 children', () => {
-        const listItem = new ListItem('', null, null);
-        const childItem1 = new ListItem('', listItem, null);
-        const childItem2 = new ListItem('', listItem, null);
+        const listItem = new ListItem('', null, taskLocation);
+        const childItem1 = new ListItem('', listItem, taskLocation);
+        const childItem2 = new ListItem('', listItem, taskLocation);
         expect(listItem).toBeDefined();
         expect(childItem1.parent).toEqual(listItem);
         expect(childItem2.parent).toEqual(listItem);
@@ -34,15 +34,15 @@ describe('list item tests', () => {
     });
 
     it('should create a list item with a parent', () => {
-        const parentItem = new ListItem('', null, null);
-        const listItem = new ListItem('', parentItem, null);
+        const parentItem = new ListItem('', null, taskLocation);
+        const listItem = new ListItem('', parentItem, taskLocation);
         expect(listItem).toBeDefined();
         expect(listItem.parent).toEqual(parentItem);
         expect(parentItem.children).toEqual([listItem]);
     });
 
     it('should create a task child for a list item parent', () => {
-        const parentListItem = new ListItem('- parent item', null, null);
+        const parentListItem = new ListItem('- parent item', null, taskLocation);
         const firstReadTask = Task.fromLine({
             line: '    - [ ] child task',
             taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
@@ -62,16 +62,16 @@ describe('list item tests', () => {
             taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
             fallbackDate: null,
         });
-        const childListItem = new ListItem('    - child item', parentTask, null);
+        const childListItem = new ListItem('    - child item', parentTask, taskLocation);
 
         expect(parentTask!.children).toEqual([childListItem]);
         expect(childListItem.parent).toBe(parentTask);
     });
 
     it('should identify root of the hierarchy', () => {
-        const grandParent = new ListItem('- grand parent', null, null);
-        const parent = new ListItem('- parent', grandParent, null);
-        const child = new ListItem('- child', parent, null);
+        const grandParent = new ListItem('- grand parent', null, taskLocation);
+        const parent = new ListItem('- parent', grandParent, taskLocation);
+        const child = new ListItem('- child', parent, taskLocation);
 
         expect(grandParent.root.originalMarkdown).toEqual('- grand parent');
         expect(parent.root.originalMarkdown).toEqual('- grand parent');
@@ -83,7 +83,7 @@ describe('list item tests', () => {
     });
 
     it('should not be a task', () => {
-        const listItem = new ListItem('- list item', null, null);
+        const listItem = new ListItem('- list item', null, taskLocation);
         expect(listItem.isTask).toBe(false);
     });
 
@@ -98,7 +98,7 @@ describe('list item tests', () => {
     ])('should parse description with list item prefix: "%s"', (prefix: string, shouldPass) => {
         const description = 'stuff';
         const line = prefix + description;
-        const listItem = new ListItem(line, null, null);
+        const listItem = new ListItem(line, null, taskLocation);
         expect(listItem.originalMarkdown).toEqual(line);
         if (shouldPass) {
             expect(listItem.description).toEqual(description);
@@ -110,7 +110,7 @@ describe('list item tests', () => {
 
 describe('list item parsing', () => {
     it('should read a list item without checkbox', () => {
-        const item = new ListItem('- without checkbox', null, null);
+        const item = new ListItem('- without checkbox', null, taskLocation);
 
         expect(item.description).toEqual('without checkbox');
         expect(item.originalMarkdown).toEqual('- without checkbox');
@@ -118,7 +118,7 @@ describe('list item parsing', () => {
     });
 
     it('should read a list item with checkbox', () => {
-        const item = new ListItem('- [ ] with checkbox', null, null);
+        const item = new ListItem('- [ ] with checkbox', null, taskLocation);
 
         expect(item.description).toEqual('with checkbox');
         expect(item.originalMarkdown).toEqual('- [ ] with checkbox');
@@ -126,7 +126,7 @@ describe('list item parsing', () => {
     });
 
     it('should read a list item with checkbox', () => {
-        const item = new ListItem('- [x] with checked checkbox', null, null);
+        const item = new ListItem('- [x] with checked checkbox', null, taskLocation);
 
         expect(item.description).toEqual('with checked checkbox');
         expect(item.originalMarkdown).toEqual('- [x] with checked checkbox');
@@ -136,7 +136,7 @@ describe('list item parsing', () => {
     it('should accept a non list item', () => {
         // we tried making the constructor throw if given a non list item
         // but it broke lots of normal Task uses in the tests (TaskBuilder)
-        const item = new ListItem('# Heading', null, null);
+        const item = new ListItem('# Heading', null, taskLocation);
 
         expect(item.description).toEqual('# Heading');
         expect(item.originalMarkdown).toEqual('# Heading');
@@ -147,8 +147,8 @@ describe('list item parsing', () => {
 describe('related items', () => {
     it('should detect if no closest parent task', () => {
         const task = fromLine({ line: '- [ ] task' });
-        const item = new ListItem('- item', null, null);
-        const childOfItem = new ListItem('- child of item', item, null);
+        const item = new ListItem('- item', null, taskLocation);
+        const childOfItem = new ListItem('- child of item', item, taskLocation);
 
         expect(task.findClosestParentTask()).toEqual(null);
         expect(item.findClosestParentTask()).toEqual(null);
@@ -157,8 +157,8 @@ describe('related items', () => {
 
     it('should find the closest parent task', () => {
         const parentTask = fromLine({ line: '- [ ] task' });
-        const child = new ListItem('- item', parentTask, null);
-        const grandChild = new ListItem('- item', child, null);
+        const child = new ListItem('- item', parentTask, taskLocation);
+        const grandChild = new ListItem('- item', child, taskLocation);
 
         expect(parentTask.findClosestParentTask()).toEqual(null);
         expect(child.findClosestParentTask()).toEqual(parentTask);
@@ -168,45 +168,45 @@ describe('related items', () => {
 
 describe('identicalTo', () => {
     it('should test same markdown', () => {
-        const listItem1 = new ListItem('- same description', null, null);
-        const listItem2 = new ListItem('- same description', null, null);
+        const listItem1 = new ListItem('- same description', null, taskLocation);
+        const listItem2 = new ListItem('- same description', null, taskLocation);
         expect(listItem1.identicalTo(listItem2)).toEqual(true);
     });
 
     it('should test different markdown', () => {
-        const listItem1 = new ListItem('- description', null, null);
-        const listItem2 = new ListItem('- description two', null, null);
+        const listItem1 = new ListItem('- description', null, taskLocation);
+        const listItem2 = new ListItem('- description two', null, taskLocation);
         expect(listItem1.identicalTo(listItem2)).toEqual(false);
     });
 
     it('should recognise list items with different number of children', () => {
-        const item1 = new ListItem('- item', null, null);
+        const item1 = new ListItem('- item', null, taskLocation);
         createChildListItem('- child of item1', item1);
 
-        const item2 = new ListItem('- item', null, null);
+        const item2 = new ListItem('- item', null, taskLocation);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise list items with different children', () => {
-        const item1 = new ListItem('- item', null, null);
+        const item1 = new ListItem('- item', null, taskLocation);
         createChildListItem('- child of item1', item1);
 
-        const item2 = new ListItem('- item', null, null);
+        const item2 = new ListItem('- item', null, taskLocation);
         createChildListItem('- child of item2', item2);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise different status characters', () => {
-        const item1 = new ListItem('- [1] item', null, null);
-        const item2 = new ListItem('- [2] item', null, null);
+        const item1 = new ListItem('- [1] item', null, taskLocation);
+        const item2 = new ListItem('- [2] item', null, taskLocation);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise ListItem and Task as different', () => {
-        const listItem = new ListItem('- [ ] description', null, null);
+        const listItem = new ListItem('- [ ] description', null, taskLocation);
         const task = fromLine({ line: '- [ ] description' });
 
         expect(listItem.identicalTo(task)).toEqual(false);
@@ -222,19 +222,19 @@ describe('checking if list item lists are identical', () => {
 
     it('should treat different sized lists as different', () => {
         const list1: ListItem[] = [];
-        const list2: ListItem[] = [new ListItem('- x', null, null)];
+        const list2: ListItem[] = [new ListItem('- x', null, taskLocation)];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 
     it('should detect matching list items as same', () => {
-        const list1: ListItem[] = [new ListItem('- 1', null, null)];
-        const list2: ListItem[] = [new ListItem('- 1', null, null)];
+        const list1: ListItem[] = [new ListItem('- 1', null, taskLocation)];
+        const list2: ListItem[] = [new ListItem('- 1', null, taskLocation)];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(true);
     });
 
     it('- should detect non-matching list items as different', () => {
-        const list1: ListItem[] = [new ListItem('- 1', null, null)];
-        const list2: ListItem[] = [new ListItem('- 2', null, null)];
+        const list1: ListItem[] = [new ListItem('- 1', null, taskLocation)];
+        const list2: ListItem[] = [new ListItem('- 2', null, taskLocation)];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 });
@@ -267,7 +267,7 @@ describe('checking if task lists are identical', () => {
 
 describe('checking if mixed lists are identical', () => {
     it('should recognise mixed lists as unequal', () => {
-        const list1 = [new ListItem('- [ ] description', null, null)];
+        const list1 = [new ListItem('- [ ] description', null, taskLocation)];
         const list2 = [fromLine({ line: '- [ ] description' })];
 
         expect(ListItem.listsAreIdentical(list1, list1)).toEqual(true);

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -181,7 +181,7 @@ describe('identicalTo', () => {
 
     it('should recognise list items with different number of children', () => {
         const item1 = new ListItem('- item', null, taskLocation);
-        createChildListItem('- child of item1', item1, null);
+        createChildListItem('- child of item1', item1);
 
         const item2 = new ListItem('- item', null, taskLocation);
 
@@ -190,10 +190,10 @@ describe('identicalTo', () => {
 
     it('should recognise list items with different children', () => {
         const item1 = new ListItem('- item', null, taskLocation);
-        createChildListItem('- child of item1', item1, null);
+        createChildListItem('- child of item1', item1);
 
         const item2 = new ListItem('- item', null, taskLocation);
-        createChildListItem('- child of item2', item2, null);
+        createChildListItem('- child of item2', item2);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -13,8 +13,9 @@ import { createChildListItem } from './ListItemHelpers';
 window.moment = moment;
 
 describe('list item tests', () => {
+    const taskLocation = TaskLocation.fromUnknownPosition(new TasksFile('anything.md'));
+
     it('should create list item with empty children and absent parent', () => {
-        const taskLocation = TaskLocation.fromUnknownPosition(new TasksFile('anything.md'));
         const listItem = new ListItem('', null, taskLocation);
         expect(listItem).toBeDefined();
         expect(listItem.children).toEqual([]);

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -14,16 +14,16 @@ window.moment = moment;
 
 describe('list item tests', () => {
     it('should create list item with empty children and absent parent', () => {
-        const listItem = new ListItem('', null);
+        const listItem = new ListItem('', null, null);
         expect(listItem).toBeDefined();
         expect(listItem.children).toEqual([]);
         expect(listItem.parent).toEqual(null);
     });
 
     it('should create a list item with 2 children', () => {
-        const listItem = new ListItem('', null);
-        const childItem1 = new ListItem('', listItem);
-        const childItem2 = new ListItem('', listItem);
+        const listItem = new ListItem('', null, null);
+        const childItem1 = new ListItem('', listItem, null);
+        const childItem2 = new ListItem('', listItem, null);
         expect(listItem).toBeDefined();
         expect(childItem1.parent).toEqual(listItem);
         expect(childItem2.parent).toEqual(listItem);
@@ -31,15 +31,15 @@ describe('list item tests', () => {
     });
 
     it('should create a list item with a parent', () => {
-        const parentItem = new ListItem('', null);
-        const listItem = new ListItem('', parentItem);
+        const parentItem = new ListItem('', null, null);
+        const listItem = new ListItem('', parentItem, null);
         expect(listItem).toBeDefined();
         expect(listItem.parent).toEqual(parentItem);
         expect(parentItem.children).toEqual([listItem]);
     });
 
     it('should create a task child for a list item parent', () => {
-        const parentListItem = new ListItem('- parent item', null);
+        const parentListItem = new ListItem('- parent item', null, null);
         const firstReadTask = Task.fromLine({
             line: '    - [ ] child task',
             taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
@@ -59,16 +59,16 @@ describe('list item tests', () => {
             taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
             fallbackDate: null,
         });
-        const childListItem = new ListItem('    - child item', parentTask);
+        const childListItem = new ListItem('    - child item', parentTask, null);
 
         expect(parentTask!.children).toEqual([childListItem]);
         expect(childListItem.parent).toBe(parentTask);
     });
 
     it('should identify root of the hierarchy', () => {
-        const grandParent = new ListItem('- grand parent', null);
-        const parent = new ListItem('- parent', grandParent);
-        const child = new ListItem('- child', parent);
+        const grandParent = new ListItem('- grand parent', null, null);
+        const parent = new ListItem('- parent', grandParent, null);
+        const child = new ListItem('- child', parent, null);
 
         expect(grandParent.root.originalMarkdown).toEqual('- grand parent');
         expect(parent.root.originalMarkdown).toEqual('- grand parent');
@@ -80,7 +80,7 @@ describe('list item tests', () => {
     });
 
     it('should not be a task', () => {
-        const listItem = new ListItem('- list item', null);
+        const listItem = new ListItem('- list item', null, null);
         expect(listItem.isTask).toBe(false);
     });
 
@@ -95,7 +95,7 @@ describe('list item tests', () => {
     ])('should parse description with list item prefix: "%s"', (prefix: string, shouldPass) => {
         const description = 'stuff';
         const line = prefix + description;
-        const listItem = new ListItem(line, null);
+        const listItem = new ListItem(line, null, null);
         expect(listItem.originalMarkdown).toEqual(line);
         if (shouldPass) {
             expect(listItem.description).toEqual(description);
@@ -107,7 +107,7 @@ describe('list item tests', () => {
 
 describe('list item parsing', () => {
     it('should read a list item without checkbox', () => {
-        const item = new ListItem('- without checkbox', null);
+        const item = new ListItem('- without checkbox', null, null);
 
         expect(item.description).toEqual('without checkbox');
         expect(item.originalMarkdown).toEqual('- without checkbox');
@@ -115,7 +115,7 @@ describe('list item parsing', () => {
     });
 
     it('should read a list item with checkbox', () => {
-        const item = new ListItem('- [ ] with checkbox', null);
+        const item = new ListItem('- [ ] with checkbox', null, null);
 
         expect(item.description).toEqual('with checkbox');
         expect(item.originalMarkdown).toEqual('- [ ] with checkbox');
@@ -123,7 +123,7 @@ describe('list item parsing', () => {
     });
 
     it('should read a list item with checkbox', () => {
-        const item = new ListItem('- [x] with checked checkbox', null);
+        const item = new ListItem('- [x] with checked checkbox', null, null);
 
         expect(item.description).toEqual('with checked checkbox');
         expect(item.originalMarkdown).toEqual('- [x] with checked checkbox');
@@ -133,7 +133,7 @@ describe('list item parsing', () => {
     it('should accept a non list item', () => {
         // we tried making the constructor throw if given a non list item
         // but it broke lots of normal Task uses in the tests (TaskBuilder)
-        const item = new ListItem('# Heading', null);
+        const item = new ListItem('# Heading', null, null);
 
         expect(item.description).toEqual('# Heading');
         expect(item.originalMarkdown).toEqual('# Heading');
@@ -144,8 +144,8 @@ describe('list item parsing', () => {
 describe('related items', () => {
     it('should detect if no closest parent task', () => {
         const task = fromLine({ line: '- [ ] task' });
-        const item = new ListItem('- item', null);
-        const childOfItem = new ListItem('- child of item', item);
+        const item = new ListItem('- item', null, null);
+        const childOfItem = new ListItem('- child of item', item, null);
 
         expect(task.findClosestParentTask()).toEqual(null);
         expect(item.findClosestParentTask()).toEqual(null);
@@ -154,8 +154,8 @@ describe('related items', () => {
 
     it('should find the closest parent task', () => {
         const parentTask = fromLine({ line: '- [ ] task' });
-        const child = new ListItem('- item', parentTask);
-        const grandChild = new ListItem('- item', child);
+        const child = new ListItem('- item', parentTask, null);
+        const grandChild = new ListItem('- item', child, null);
 
         expect(parentTask.findClosestParentTask()).toEqual(null);
         expect(child.findClosestParentTask()).toEqual(parentTask);
@@ -165,45 +165,45 @@ describe('related items', () => {
 
 describe('identicalTo', () => {
     it('should test same markdown', () => {
-        const listItem1 = new ListItem('- same description', null);
-        const listItem2 = new ListItem('- same description', null);
+        const listItem1 = new ListItem('- same description', null, null);
+        const listItem2 = new ListItem('- same description', null, null);
         expect(listItem1.identicalTo(listItem2)).toEqual(true);
     });
 
     it('should test different markdown', () => {
-        const listItem1 = new ListItem('- description', null);
-        const listItem2 = new ListItem('- description two', null);
+        const listItem1 = new ListItem('- description', null, null);
+        const listItem2 = new ListItem('- description two', null, null);
         expect(listItem1.identicalTo(listItem2)).toEqual(false);
     });
 
     it('should recognise list items with different number of children', () => {
-        const item1 = new ListItem('- item', null);
+        const item1 = new ListItem('- item', null, null);
         createChildListItem('- child of item1', item1);
 
-        const item2 = new ListItem('- item', null);
+        const item2 = new ListItem('- item', null, null);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise list items with different children', () => {
-        const item1 = new ListItem('- item', null);
+        const item1 = new ListItem('- item', null, null);
         createChildListItem('- child of item1', item1);
 
-        const item2 = new ListItem('- item', null);
+        const item2 = new ListItem('- item', null, null);
         createChildListItem('- child of item2', item2);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise different status characters', () => {
-        const item1 = new ListItem('- [1] item', null);
-        const item2 = new ListItem('- [2] item', null);
+        const item1 = new ListItem('- [1] item', null, null);
+        const item2 = new ListItem('- [2] item', null, null);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise ListItem and Task as different', () => {
-        const listItem = new ListItem('- [ ] description', null);
+        const listItem = new ListItem('- [ ] description', null, null);
         const task = fromLine({ line: '- [ ] description' });
 
         expect(listItem.identicalTo(task)).toEqual(false);
@@ -219,19 +219,19 @@ describe('checking if list item lists are identical', () => {
 
     it('should treat different sized lists as different', () => {
         const list1: ListItem[] = [];
-        const list2: ListItem[] = [new ListItem('- x', null)];
+        const list2: ListItem[] = [new ListItem('- x', null, null)];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 
     it('should detect matching list items as same', () => {
-        const list1: ListItem[] = [new ListItem('- 1', null)];
-        const list2: ListItem[] = [new ListItem('- 1', null)];
+        const list1: ListItem[] = [new ListItem('- 1', null, null)];
+        const list2: ListItem[] = [new ListItem('- 1', null, null)];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(true);
     });
 
     it('- should detect non-matching list items as different', () => {
-        const list1: ListItem[] = [new ListItem('- 1', null)];
-        const list2: ListItem[] = [new ListItem('- 2', null)];
+        const list1: ListItem[] = [new ListItem('- 1', null, null)];
+        const list2: ListItem[] = [new ListItem('- 2', null, null)];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 });
@@ -264,7 +264,7 @@ describe('checking if task lists are identical', () => {
 
 describe('checking if mixed lists are identical', () => {
     it('should recognise mixed lists as unequal', () => {
-        const list1 = [new ListItem('- [ ] description', null)];
+        const list1 = [new ListItem('- [ ] description', null, null)];
         const list2 = [fromLine({ line: '- [ ] description' })];
 
         expect(ListItem.listsAreIdentical(list1, list1)).toEqual(true);

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -181,7 +181,7 @@ describe('identicalTo', () => {
 
     it('should recognise list items with different number of children', () => {
         const item1 = new ListItem('- item', null, taskLocation);
-        createChildListItem('- child of item1', item1);
+        createChildListItem('- child of item1', item1, null);
 
         const item2 = new ListItem('- item', null, taskLocation);
 
@@ -190,10 +190,10 @@ describe('identicalTo', () => {
 
     it('should recognise list items with different children', () => {
         const item1 = new ListItem('- item', null, taskLocation);
-        createChildListItem('- child of item1', item1);
+        createChildListItem('- child of item1', item1, null);
 
         const item2 = new ListItem('- item', null, taskLocation);
-        createChildListItem('- child of item2', item2);
+        createChildListItem('- child of item2', item2, null);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -14,10 +14,12 @@ window.moment = moment;
 
 describe('list item tests', () => {
     it('should create list item with empty children and absent parent', () => {
-        const listItem = new ListItem('', null, null);
+        const taskLocation = TaskLocation.fromUnknownPosition(new TasksFile('anything.md'));
+        const listItem = new ListItem('', null, taskLocation);
         expect(listItem).toBeDefined();
         expect(listItem.children).toEqual([]);
         expect(listItem.parent).toEqual(null);
+        expect(listItem.taskLocation).toBe(taskLocation);
     });
 
     it('should create a list item with 2 children', () => {

--- a/tests/Task/ListItemHelpers.ts
+++ b/tests/Task/ListItemHelpers.ts
@@ -1,7 +1,6 @@
 import { ListItem } from '../../src/Task/ListItem';
-import type { TaskLocation } from '../../src/Task/TaskLocation';
 
-export function createChildListItem(originalMarkdown: string, parent: ListItem, _taskLocation: TaskLocation | null) {
+export function createChildListItem(originalMarkdown: string, parent: ListItem) {
     // This exists purely to silence WebStorm about typescript:S1848
     // See https://sonarcloud.io/organizations/obsidian-tasks-group/rules?open=typescript%3AS1848&rule_key=typescript%3AS1848
     // ListItem will incorrectly have line number from its parent

--- a/tests/Task/ListItemHelpers.ts
+++ b/tests/Task/ListItemHelpers.ts
@@ -4,7 +4,6 @@ import { TaskLocation } from '../../src/Task/TaskLocation';
 export function createChildListItem(originalMarkdown: string, parent: ListItem) {
     // This exists purely to silence WebStorm about typescript:S1848
     // See https://sonarcloud.io/organizations/obsidian-tasks-group/rules?open=typescript%3AS1848&rule_key=typescript%3AS1848
-    // TODO remove the ! after taskLocation cannot be null
-    const taskLocation = TaskLocation.fromUnknownPosition(parent.taskLocation!.tasksFile);
+    const taskLocation = TaskLocation.fromUnknownPosition(parent.taskLocation.tasksFile);
     new ListItem(originalMarkdown, parent, taskLocation);
 }

--- a/tests/Task/ListItemHelpers.ts
+++ b/tests/Task/ListItemHelpers.ts
@@ -1,7 +1,8 @@
 import { ListItem } from '../../src/Task/ListItem';
+import type { TaskLocation } from '../../src/Task/TaskLocation';
 
-export function createChildListItem(originalMarkdown: string, parent: ListItem) {
+export function createChildListItem(originalMarkdown: string, parent: ListItem, taskLocation: TaskLocation | null) {
     // This exists purely to silence WebStorm about typescript:S1848
     // See https://sonarcloud.io/organizations/obsidian-tasks-group/rules?open=typescript%3AS1848&rule_key=typescript%3AS1848
-    new ListItem(originalMarkdown, parent, null);
+    new ListItem(originalMarkdown, parent, taskLocation);
 }

--- a/tests/Task/ListItemHelpers.ts
+++ b/tests/Task/ListItemHelpers.ts
@@ -3,5 +3,5 @@ import { ListItem } from '../../src/Task/ListItem';
 export function createChildListItem(originalMarkdown: string, parent: ListItem) {
     // This exists purely to silence WebStorm about typescript:S1848
     // See https://sonarcloud.io/organizations/obsidian-tasks-group/rules?open=typescript%3AS1848&rule_key=typescript%3AS1848
-    new ListItem(originalMarkdown, parent);
+    new ListItem(originalMarkdown, parent, null);
 }

--- a/tests/Task/ListItemHelpers.ts
+++ b/tests/Task/ListItemHelpers.ts
@@ -1,8 +1,10 @@
 import { ListItem } from '../../src/Task/ListItem';
+import { TaskLocation } from '../../src/Task/TaskLocation';
 
 export function createChildListItem(originalMarkdown: string, parent: ListItem) {
     // This exists purely to silence WebStorm about typescript:S1848
     // See https://sonarcloud.io/organizations/obsidian-tasks-group/rules?open=typescript%3AS1848&rule_key=typescript%3AS1848
-    // ListItem will incorrectly have line number from its parent
-    new ListItem(originalMarkdown, parent, parent.taskLocation);
+    // TODO remove the ! after taskLocation cannot be null
+    const taskLocation = TaskLocation.fromUnknownPosition(parent.taskLocation!.tasksFile);
+    new ListItem(originalMarkdown, parent, taskLocation);
 }

--- a/tests/Task/ListItemHelpers.ts
+++ b/tests/Task/ListItemHelpers.ts
@@ -1,8 +1,9 @@
 import { ListItem } from '../../src/Task/ListItem';
 import type { TaskLocation } from '../../src/Task/TaskLocation';
 
-export function createChildListItem(originalMarkdown: string, parent: ListItem, taskLocation: TaskLocation | null) {
+export function createChildListItem(originalMarkdown: string, parent: ListItem, _taskLocation: TaskLocation | null) {
     // This exists purely to silence WebStorm about typescript:S1848
     // See https://sonarcloud.io/organizations/obsidian-tasks-group/rules?open=typescript%3AS1848&rule_key=typescript%3AS1848
-    new ListItem(originalMarkdown, parent, taskLocation);
+    // ListItem will incorrectly have line number from its parent
+    new ListItem(originalMarkdown, parent, parent.taskLocation);
 }

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -1742,7 +1742,7 @@ describe('identicalTo', () => {
     it('should recognise different numbers of child items', () => {
         const task1 = new TaskBuilder().build();
         const task2 = new TaskBuilder().build();
-        createChildListItem('- child of task2', task2);
+        createChildListItem('- child of task2', task2, null);
 
         expect(task2.identicalTo(task1)).toEqual(false);
     });
@@ -1750,8 +1750,8 @@ describe('identicalTo', () => {
     it('should recognise different description in child list items', () => {
         const task1 = new TaskBuilder().build();
         const task2 = new TaskBuilder().build();
-        createChildListItem('- child of task1', task1);
-        createChildListItem('- child of task2', task2);
+        createChildListItem('- child of task1', task1, null);
+        createChildListItem('- child of task2', task2, null);
 
         expect(task2.identicalTo(task1)).toEqual(false);
     });

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -1742,7 +1742,7 @@ describe('identicalTo', () => {
     it('should recognise different numbers of child items', () => {
         const task1 = new TaskBuilder().build();
         const task2 = new TaskBuilder().build();
-        createChildListItem('- child of task2', task2, null);
+        createChildListItem('- child of task2', task2);
 
         expect(task2.identicalTo(task1)).toEqual(false);
     });
@@ -1750,8 +1750,8 @@ describe('identicalTo', () => {
     it('should recognise different description in child list items', () => {
         const task1 = new TaskBuilder().build();
         const task2 = new TaskBuilder().build();
-        createChildListItem('- child of task1', task1, null);
-        createChildListItem('- child of task2', task2, null);
+        createChildListItem('- child of task1', task1);
+        createChildListItem('- child of task2', task2);
 
         expect(task2.identicalTo(task1)).toEqual(false);
     });


### PR DESCRIPTION
Done by pairing with @claremacrae 

# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- add `TaskLocation` to `ListItem` (`TaskLocation` not removed from `Task`)

<!--- Describe your changes in detail -->

## Motivation and Context

- prepare to add event listener to non-task list items with checkbox that would check/uncheck them

## How has this been tested?

- unit tests

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
