### PR TITLE
chore: Run pre-commit checks on .svelte and json test data files

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,6 +16,9 @@ pre-commit:
     lint:
       glob: '*.ts'
       run: yarn lint "{staged_files}" && git add "{staged_files}"
+    lint-svelte:
+      glob: '*.svelte'
+      run: yarn lint && git add "{staged_files}"
     lint-markdown:
       glob: '*.md'
       run: yarn lint:markdown && git add "{staged_files}"
@@ -24,4 +27,7 @@ pre-commit:
       run: yarn test "{staged_files}" --findRelatedTests --passWithNoTests
     test-json:
       glob: 'tests/Obsidian/__test_data__/*.json'
+      run: yarn test
+    test-svelte:
+      glob: '*.svelte'
       run: yarn test

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,3 +22,6 @@ pre-commit:
     test:
       glob: '*.ts'
       run: yarn test "{staged_files}" --findRelatedTests --passWithNoTests
+    test-json:
+      glob: 'tests/Obsidian/__test_data__/*.json'
+      run: yarn test


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

Make the `lefthook` checks run all tests and lint all files, as appropriate, when `*.svelte` and `tests/Obsidian/__test_data__/*.json` are committed.

I have been unable to find a way to run the tests selectively, so have opted for just running all tests when those files are edited.

I wrote the technique up here:

- [Jest's --findRelatedTests doesn't notice JSON files](https://stackoverflow.com/a/79437866/104370)

## Motivation and Context

@ilandikov and I have both been tripped up by the pre-commit checks:

- not finding errors in .svelte files
- not running tests if .svelte or test data .json files are edited


## How has this been tested?

By trying to commit broken files, and confirming that the commit failed.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
