### PR TITLE
refactor: make ListItem class more similar to Task

### DIFF
--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -101,6 +101,22 @@ export class ListItem {
 
         // Not testing status character as it is implied from the original markdown
 
+        // Note: sectionStart changes every time a line is added or deleted before
+        //       any of the tasks in a file. This does mean that redrawing of tasks blocks
+        //       happens more often than is ideal.
+        const args: Array<keyof ListItem> = [
+            'description',
+            'path',
+            'lineNumber',
+            'sectionStart',
+            'sectionIndex',
+            'precedingHeader',
+        ];
+
+        for (const el of args) {
+            if (this[el]?.toString() !== other[el]?.toString()) return false;
+        }
+
         return ListItem.listsAreIdentical(this.children, other.children);
     }
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -145,15 +145,15 @@ export class ListItem {
         }
     }
 
-    get lineNumber(): number {
+    public get lineNumber(): number {
         return this.taskLocation.lineNumber;
     }
 
-    get sectionStart(): number {
+    public get sectionStart(): number {
         return this.taskLocation.sectionStart;
     }
 
-    get sectionIndex(): number {
+    public get sectionIndex(): number {
         return this.taskLocation.sectionIndex;
     }
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -95,17 +95,13 @@ export class ListItem {
             return false;
         }
 
-        if (this.originalMarkdown !== other.originalMarkdown) {
-            return false;
-        }
-
-        // Not testing status character as it is implied from the original markdown
-
         // Note: sectionStart changes every time a line is added or deleted before
         //       any of the tasks in a file. This does mean that redrawing of tasks blocks
         //       happens more often than is ideal.
         const args: Array<keyof ListItem> = [
+            'originalMarkdown',
             'description',
+            'statusCharacter',
             'path',
             'lineNumber',
             'sectionStart',

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -134,7 +134,7 @@ export class ListItem {
     }
 
     /**
-     * Return the name of the file containing the task, with the .md extension removed.
+     * Return the name of the file containing this object, with the .md extension removed.
      */
     public get filename(): string | null {
         const fileNameMatch = this.path.match(/([^/]+)\.md$/);

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -1,6 +1,7 @@
+import type { TasksFile } from '../Scripting/TasksFile';
+import type { Task } from './Task';
 import type { TaskLocation } from './TaskLocation';
 import { TaskRegularExpressions } from './TaskRegularExpressions';
-import type { Task } from './Task';
 
 export class ListItem {
     // The original line read from file.
@@ -122,5 +123,41 @@ export class ListItem {
         }
 
         return list1.every((item, index) => item.identicalTo(list2[index]));
+    }
+
+    public get path(): string {
+        return this.taskLocation.path;
+    }
+
+    public get file(): TasksFile {
+        return this.taskLocation.tasksFile;
+    }
+
+    /**
+     * Return the name of the file containing the task, with the .md extension removed.
+     */
+    public get filename(): string | null {
+        const fileNameMatch = this.path.match(/([^/]+)\.md$/);
+        if (fileNameMatch !== null) {
+            return fileNameMatch[1];
+        } else {
+            return null;
+        }
+    }
+
+    get lineNumber(): number {
+        return this.taskLocation.lineNumber;
+    }
+
+    get sectionStart(): number {
+        return this.taskLocation.sectionStart;
+    }
+
+    get sectionIndex(): number {
+        return this.taskLocation.sectionIndex;
+    }
+
+    public get precedingHeader(): string | null {
+        return this.taskLocation.precedingHeader;
     }
 }

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -1,24 +1,23 @@
 import type { Moment } from 'moment';
-import { getSettings, getUserSelectedTaskFormat } from '../Config/Settings';
 import { GlobalFilter } from '../Config/GlobalFilter';
-import { StatusRegistry } from '../Statuses/StatusRegistry';
-import type { Status } from '../Statuses/Status';
+import { getSettings, getUserSelectedTaskFormat } from '../Config/Settings';
+import { DateFallback } from '../DateTime/DateFallback';
 import { compareByDate } from '../DateTime/DateTools';
 import { TasksDate } from '../DateTime/TasksDate';
-import { StatusType } from '../Statuses/StatusConfiguration';
-import type { TasksFile } from '../Scripting/TasksFile';
-import { PriorityTools } from '../lib/PriorityTools';
 import { logging } from '../lib/logging';
 import { logEndOfTaskEdit, logStartOfTaskEdit } from '../lib/LogTasksHelper';
-import { DateFallback } from '../DateTime/DateFallback';
+import { PriorityTools } from '../lib/PriorityTools';
+import type { Status } from '../Statuses/Status';
+import { StatusType } from '../Statuses/StatusConfiguration';
+import { StatusRegistry } from '../Statuses/StatusRegistry';
 import { ListItem } from './ListItem';
 import type { Occurrence } from './Occurrence';
-import { Urgency } from './Urgency';
+import { OnCompletion, handleOnCompletion } from './OnCompletion';
+import type { Priority } from './Priority';
 import type { Recurrence } from './Recurrence';
 import type { TaskLocation } from './TaskLocation';
-import type { Priority } from './Priority';
 import { TaskRegularExpressions } from './TaskRegularExpressions';
-import { OnCompletion, handleOnCompletion } from './OnCompletion';
+import { Urgency } from './Urgency';
 
 /**
  * Storage for the task line, broken down in to sections.
@@ -616,10 +615,6 @@ export class Task extends ListItem {
         return this._urgency;
     }
 
-    public get path(): string {
-        return this.taskLocation.path;
-    }
-
     /**
      * Return {@link cancelledDate} as a {@link TasksDate}, so the field names in scripting docs are consistent with the existing search instruction names, and null values are easy to deal with.
      */
@@ -724,38 +719,6 @@ export class Task extends ListItem {
 
     public get hasHeading(): boolean {
         return this.precedingHeader !== null;
-    }
-
-    public get file(): TasksFile {
-        return this.taskLocation.tasksFile;
-    }
-
-    /**
-     * Return the name of the file containing the task, with the .md extension removed.
-     */
-    public get filename(): string | null {
-        const fileNameMatch = this.path.match(/([^/]+)\.md$/);
-        if (fileNameMatch !== null) {
-            return fileNameMatch[1];
-        } else {
-            return null;
-        }
-    }
-
-    get lineNumber(): number {
-        return this.taskLocation.lineNumber;
-    }
-
-    get sectionStart(): number {
-        return this.taskLocation.sectionStart;
-    }
-
-    get sectionIndex(): number {
-        return this.taskLocation.sectionIndex;
-    }
-
-    public get precedingHeader(): string | null {
-        return this.taskLocation.precedingHeader;
     }
 
     /**

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -1,23 +1,23 @@
 import type { Moment } from 'moment';
-import { GlobalFilter } from '../Config/GlobalFilter';
 import { getSettings, getUserSelectedTaskFormat } from '../Config/Settings';
-import { DateFallback } from '../DateTime/DateFallback';
+import { GlobalFilter } from '../Config/GlobalFilter';
+import { StatusRegistry } from '../Statuses/StatusRegistry';
+import type { Status } from '../Statuses/Status';
 import { compareByDate } from '../DateTime/DateTools';
 import { TasksDate } from '../DateTime/TasksDate';
+import { StatusType } from '../Statuses/StatusConfiguration';
+import { PriorityTools } from '../lib/PriorityTools';
 import { logging } from '../lib/logging';
 import { logEndOfTaskEdit, logStartOfTaskEdit } from '../lib/LogTasksHelper';
-import { PriorityTools } from '../lib/PriorityTools';
-import type { Status } from '../Statuses/Status';
-import { StatusType } from '../Statuses/StatusConfiguration';
-import { StatusRegistry } from '../Statuses/StatusRegistry';
+import { DateFallback } from '../DateTime/DateFallback';
 import { ListItem } from './ListItem';
 import type { Occurrence } from './Occurrence';
-import { OnCompletion, handleOnCompletion } from './OnCompletion';
-import type { Priority } from './Priority';
+import { Urgency } from './Urgency';
 import type { Recurrence } from './Recurrence';
 import type { TaskLocation } from './TaskLocation';
+import type { Priority } from './Priority';
 import { TaskRegularExpressions } from './TaskRegularExpressions';
-import { Urgency } from './Urgency';
+import { OnCompletion, handleOnCompletion } from './OnCompletion';
 
 /**
  * Storage for the task line, broken down in to sections.

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -777,13 +777,8 @@ export class Task extends ListItem {
         //       happens more often than is ideal.
         let args: Array<keyof Task> = [
             'description',
-            'path',
             'indentation',
             'listMarker',
-            'lineNumber',
-            'sectionStart',
-            'sectionIndex',
-            'precedingHeader',
             'priority',
             'blockLink',
             'scheduledDateIsInferred',

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -46,8 +46,6 @@ export class Task extends ListItem {
     public readonly indentation: string;
     public readonly listMarker: string;
 
-    public readonly taskLocation: TaskLocation;
-
     public readonly tags: string[];
 
     public readonly priority: Priority;
@@ -126,7 +124,6 @@ export class Task extends ListItem {
         this.description = description;
         this.indentation = indentation;
         this.listMarker = listMarker;
-        this.taskLocation = taskLocation;
 
         this.tags = tags;
 

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -211,6 +211,13 @@ describe('identicalTo', () => {
 
         expect(listItem.identicalTo(task)).toEqual(false);
     });
+
+    it('should recognise different path', () => {
+        const item1 = new ListItem('- same', null, TaskLocation.fromUnknownPosition(new TasksFile('anything.md')));
+        const item2 = new ListItem('- same', null, TaskLocation.fromUnknownPosition(new TasksFile('something.md')));
+
+        expect(item2.identicalTo(item1)).toEqual(false);
+    });
 });
 
 describe('checking if list item lists are identical', () => {

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -173,7 +173,7 @@ describe('identicalTo', () => {
         expect(listItem1.identicalTo(listItem2)).toEqual(true);
     });
 
-    it('should test different markdown', () => {
+    it('should test different descriptions', () => {
         const listItem1 = new ListItem('- description', null, taskLocation);
         const listItem2 = new ListItem('- description two', null, taskLocation);
         expect(listItem1.identicalTo(listItem2)).toEqual(false);

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -173,7 +173,7 @@ describe('identicalTo', () => {
         expect(listItem1.identicalTo(listItem2)).toEqual(true);
     });
 
-    it('should test different descriptions', () => {
+    it('should recognise different descriptions', () => {
         const listItem1 = new ListItem('- description', null, taskLocation);
         const listItem2 = new ListItem('- description two', null, taskLocation);
         expect(listItem1.identicalTo(listItem2)).toEqual(false);


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- move `TaskLocation`-related getters from `Task` to `LIstItem`
- make `ListItem.identicalTo()` test `taskLocation` property

## Motivation and Context

- #3170 

## How has this been tested?

- new & existing unit test

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
