### PR TITLE
Fix OS Dependant Test

### DIFF
--- a/tests/Integration/ESBuildConfig.test.ts
+++ b/tests/Integration/ESBuildConfig.test.ts
@@ -39,7 +39,7 @@ function getTasksPluginCopyrightBanner(): string {
 describe('Check esbuild.config.mjs', () => {
     const bannerContent = getTasksPluginCopyrightBanner();
     it('check licensing', () => {
-        expect(bannerContent).toContain('License obsidian-tasks:\nMIT License');
+        expect(bannerContent).toMatch(/License obsidian-tasks:(\r\n|\r|\n)MIT License/);
         expect(bannerContent).toContain('Clare Macrae, Ilyas Landikov and Martin Schenck');
     });
 


### PR DESCRIPTION
This test checks that a file in the repo itself has specific contents.

On windows git maps all line endings to CLRF by default. Which causes this test to fail unless that "feature" is disabled.

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
  - **WARNING: If the link is absent, the PR may be closed without review**, due to the workload that such reviews usually require.
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

This test checks to see if a file in the repo contains a substring. It assumes that file is using simple newlines. On windows git will (by default) convert all line endings to CLRF. Which makes the test fail.

This updates the test to be newline agnostic.

## Motivation and Context

Checking out the repo and running the tests on windows with default git settings causes this test to fail.

## How has this been tested?

The test no longer fails on my windows machine.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
