### PR TITLE
contrib, chore: Improvements to setting up a build environment, mostly for vscode and windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 *.jsonc text eol=lf
 *.lock text eol=lf
 *.md text eol=lf
+*.mjs text eol=lf
 *.ps1 text eol=lf
 *.py text eol=lf
 *.sh text eol=lf

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,9 @@
 {
     "recommendations": [
-        "DavidAnson.vscode-markdownlint"
+        "DavidAnson.vscode-markdownlint",
+        "gamunu.vscode-yarn",
+        "mrmlnc.vscode-scss",
+        "Orta.vscode-jest",
+        "svelte.svelte-vscode",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "npm.packageManager": "yarn"
+    "npm.packageManager": "yarn",
+    "svelte.enable-ts-plugin" : true,
 }

--- a/contributing/Building/Setting up build environment.md
+++ b/contributing/Building/Setting up build environment.md
@@ -1,7 +1,11 @@
 # Setting up build environment
 
-This project uses Node 16.x, if you also use a different version, look at using `nvm` to manage your Node versions.
-If you are using `nvm`, you can install the 16.x version of Node with `nvm install 16; nvm use <full version number you installed such as 16.10.0>`.
+See [package.json](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/package.json) for which version of Node to use.
+
+Consider using `nvm` which allows you to manage multiple versions of node.
+
+For example, to install node 18.x:\
+ `nvm install 18; nvm use <full version number you installed such as 18.2.0>`.
 
 To setup the local environment after cloning the repository, run the following commands:
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Task management for the Obsidian knowledge base",
   "main": "main.js",
   "engines": {
-    "node": "^16.10.0 || >=18.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "dev": "node esbuild.config.mjs",


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
  - **WARNING: If the link is absent, the PR may be closed without review**, due to the workload that such reviews usually require.
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [x] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

General improvements for contributors using windows and vscode.

- Fixes an issue where a test fails due to line endings being converted to CLRF by default with git on windows.
- Includes more recommended vscode extensions technologies used by this project.
- Updates the minimum node version and documentation, since node 16 no longer works with this project.

## Motivation and Context

[This test](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/0644864a853171e6ba10d02dbeeebd1686bcb42a/tests/Integration/ESBuildConfig.test.ts#L42) is currently broken when the repo is cloned on windows, due to CLRF line conversion.

When setting up my build environment the recommended and configured minimum node version was incompatible with some dependencies. 

These vscode extensions are very useful for this project. All including them does is notify the user when the project is opened for the first time, that these plugins might be useful.

## How has this been tested?

The project builds and tests successfully on my machine now.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
