### PR TITLE
fix: Reinstate date picker on iPhone - week starts on Monday

### DIFF
--- a/docs/Editing/Editing Dates.md
+++ b/docs/Editing/Editing Dates.md
@@ -35,6 +35,8 @@ There is a [[#Date-picker on task dates]] and a [[#Context menu on task dates]],
 | In Tasks query search results | Live Preview | ✅     |
 | In Tasks query search results | Reading mode | ✅     |
 
+On iPhone, and probably iPad too, this date-picker hard-codes the start of the week to Monday, instead of respecting the user's settings. We are tracking this in [issue #3239](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3239).
+
 ## Context menu on task dates
 
 > [!released]

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -28,7 +28,7 @@ export function promptForDate(
         locale: {
             // Try to determine the first day of the week based on the locale, or use Monday
             // if unavailable
-            firstDayOfWeek: (new Intl.Locale(navigator.language) as any).weekInfo.firstDay ?? 1,
+            firstDayOfWeek: (new Intl.Locale(navigator.language) as any).weekInfo?.firstDay ?? 1,
         },
         onClose: async (selectedDates, _dateStr, instance) => {
             if (selectedDates.length > 0) {

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -20,16 +20,15 @@ export function promptForDate(
     const currentValue = task[dateFieldToEdit];
     // TODO figure out how Today's date is determined: if Obsidian is left
     //      running overnight, the flatpickr modal shows the previous day as Today.
-    // Try to determine the first day of the week based on the locale, or use Monday
-    // if unavailable
-    const firstDayOfWeek = (new Intl.Locale(navigator.language) as any).weekInfo.firstDay ?? 1;
     const fp = flatpickr(parentElement, {
         defaultDate: currentValue ? currentValue.format('YYYY-MM-DD') : new Date(),
         disableMobile: true,
         enableTime: false, // Optional: Enable time picker
         dateFormat: 'Y-m-d', // Adjust the date and time format as needed
         locale: {
-            firstDayOfWeek: firstDayOfWeek,
+            // Try to determine the first day of the week based on the locale, or use Monday
+            // if unavailable
+            firstDayOfWeek: (new Intl.Locale(navigator.language) as any).weekInfo.firstDay ?? 1,
         },
         onClose: async (selectedDates, _dateStr, instance) => {
             if (selectedDates.length > 0) {

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -22,8 +22,7 @@ export function promptForDate(
     //      running overnight, the flatpickr modal shows the previous day as Today.
     // Try to determine the first day of the week based on the locale, or use Monday
     // if unavailable
-    const firstDayOfWeekFromLocale = (new Intl.Locale(navigator.language) as any).weekInfo.firstDay;
-    const firstDayOfWeek = firstDayOfWeekFromLocale ?? 1;
+    const firstDayOfWeek = (new Intl.Locale(navigator.language) as any).weekInfo.firstDay ?? 1;
     const fp = flatpickr(parentElement, {
         defaultDate: currentValue ? currentValue.format('YYYY-MM-DD') : new Date(),
         disableMobile: true,

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -23,14 +23,8 @@ export function promptForDate(
     // Try to determine the first day of the week based on the locale, or use Monday
     // if unavailable
     const weekInfo = (new Intl.Locale(navigator.language) as any).weekInfo;
-    console.log(`promptForDate(): weekInfo: ${JSON.stringify(weekInfo, null, 4)}`);
-
     const firstDayOfWeekFromLocale = weekInfo.firstDay;
-    console.log(`promptForDate(): firstDayOfWeekFromLocale: ${firstDayOfWeekFromLocale}`);
-
     const firstDayOfWeek = firstDayOfWeekFromLocale ?? 1;
-    console.log(`promptForDate(): firstDayOfWeek: ${firstDayOfWeek}`);
-
     const fp = flatpickr(parentElement, {
         defaultDate: currentValue ? currentValue.format('YYYY-MM-DD') : new Date(),
         disableMobile: true,

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -22,8 +22,7 @@ export function promptForDate(
     //      running overnight, the flatpickr modal shows the previous day as Today.
     // Try to determine the first day of the week based on the locale, or use Monday
     // if unavailable
-    const weekInfo = (new Intl.Locale(navigator.language) as any).weekInfo;
-    const firstDayOfWeekFromLocale = weekInfo.firstDay;
+    const firstDayOfWeekFromLocale = (new Intl.Locale(navigator.language) as any).weekInfo.firstDay;
     const firstDayOfWeek = firstDayOfWeekFromLocale ?? 1;
     const fp = flatpickr(parentElement, {
         defaultDate: currentValue ? currentValue.format('YYYY-MM-DD') : new Date(),


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:
- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: 
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)


## Description

- Revert some debug logging I added on `main`
- Reinstate date picker on iPhone - week starts on Monday.
- Document that the Reading Mode/Results date-picker remains hard-coded to start on Mondays, on iPhone and probably iPad too.

Note that the date picker in Reading Mode and Tasks query Results remains hard-coded to start on Monday, because it turned out that the code added in #3259 to address #3239 works well on Android, but gave an error on iPhone (and probably iPad too).

Thanks to @esm7 for suggesting the fix.

## Motivation and Context

This fixes #3341.

## How has this been tested?

On my iPhone 13 Pro Max - with iOS 17.1.1.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
