### PR TITLE
docs: Improve the API and QuickAdd pages

### DIFF
--- a/docs/Advanced/Tasks Api.md
+++ b/docs/Advanced/Tasks Api.md
@@ -69,6 +69,13 @@ console.log(taskLine);
 > [!warning]
 > This function returns a `Promise` - always `await` the result!
 
+> [!Tip]- Find plugins that use the Tasks API to create tasks
+> [Search GitHub for plugins which may use this function](https://github.com/search?q=createTaskLineModal+NOT+is%3Afork+NOT+repo%3Aobsidian-tasks-group%2Fobsidian-tasks+NOT+path%3A*.md&type=code), and by using `createTaskLineModal()`, will fully respect your Tasks settings.
+> > [!warning]
+> >
+> > - You will need to be logged in to GitHub for this search to work.
+> > - Not all of these plugins have been reviewed by the Obsidian team: you should search for them in `Settings` > `Community plugins` - or review in [Plugins - Obsidian](https://obsidian.md/plugins) - for safety.
+
 ### Usage with QuickAdd
 One of the most common usage scenarios is probably in combination with the [QuickAdd](https://github.com/chhoumann/quickadd) plugin
 to automatically add tasks to a specific file.

--- a/docs/Advanced/Tasks Api.md
+++ b/docs/Advanced/Tasks Api.md
@@ -67,7 +67,7 @@ console.log(taskLine);
 ```
 
 > [!warning]
-> This function is returns a `Promise` - always `await` the result!
+> This function returns a `Promise` - always `await` the result!
 
 ### Usage with QuickAdd
 One of the most common usage scenarios is probably in combination with the [QuickAdd](https://github.com/chhoumann/quickadd) plugin

--- a/docs/Advanced/Tasks Api.md
+++ b/docs/Advanced/Tasks Api.md
@@ -75,23 +75,19 @@ to automatically add tasks to a specific file.
 
 For this you need to enter the following code as the Capture format:
 
-<!-- markdownlint-disable code-fence-style -->
-~~~markdown
+````markdown
 ```js quickadd
 return await this.app.plugins.plugins['obsidian-tasks-plugin'].apiV1.createTaskLineModal();
 ```
-~~~
-<!-- markdownlint-enable code-fence-style -->
+````
 
 Or if you would like a newline character to be added after your new task line, use this as the Capture format instead:
 
-<!-- markdownlint-disable code-fence-style -->
-~~~markdown
+````markdown
 ```js quickadd
 return await this.app.plugins.plugins['obsidian-tasks-plugin'].apiV1.createTaskLineModal() + '\n';
 ```
-~~~
-<!-- markdownlint-enable code-fence-style -->
+````
 
 For details refer to [QuickAdd - Inline scripts](https://quickadd.obsidian.guide/docs/InlineScripts).
 

--- a/docs/Advanced/Tasks Api.md
+++ b/docs/Advanced/Tasks Api.md
@@ -73,44 +73,7 @@ console.log(taskLine);
 One of the most common usage scenarios is probably in combination with the [QuickAdd](https://github.com/chhoumann/quickadd) plugin
 to automatically add tasks to a specific file.
 
-For this you need to enter the following code as the Capture format:
-
-````markdown
-```js quickadd
-return await this.app.plugins.plugins['obsidian-tasks-plugin'].apiV1.createTaskLineModal();
-```
-````
-
-Or if you would like a newline character to be added after your new task line, use this as the Capture format instead:
-
-````markdown
-```js quickadd
-return await this.app.plugins.plugins['obsidian-tasks-plugin'].apiV1.createTaskLineModal() + '\n';
-```
-````
-
-For details refer to [QuickAdd - Inline scripts](https://quickadd.obsidian.guide/docs/InlineScripts).
-
-#### Create the QuickAdd Capture
-
-Use these steps to make the following options appear (tested in QuickAdd 0.12.0):
-
-![Screenshot - Create the QuickAdd Capture](../../images/quickadd-settings-create-capture.png)
-
-1. Open the QuickAdd options.
-2. Type the name `Add task` in the `Name` box.
-3. Click on the `Template` button and select `Capture`.
-4. Click `Add Choice`.
-
-#### Configure the QuickAdd Capture
-
-![Screenshot - Open the QuickAdd Capture Configuration](../../images/quickadd-settings-configure-capture.png)
-
-1. In the new row that was added, click on the cog (⚙) icon.
-2. Now fill in the values below. (See above for the code to enter in to the `Capture format` box.)
-
-Screenshot of QuickAdd capture settings (example)
-![Screenshot - Edit the QuickAdd Capture Configuration](../../images/api-create-taskline-modal-quickadd-capture-example.png)
+See [[QuickAdd#Launching the Edit task modal via QuickAdd|Launching the Edit task modal via QuickAdd]] for full details of how to do this.
 
 ## `executeToggleTaskDoneCommand: (line: string, path: string) => string;`
 

--- a/docs/Advanced/Tasks Api.md
+++ b/docs/Advanced/Tasks Api.md
@@ -138,6 +138,13 @@ This can be used, for example, to display the Auto-Suggest on non-task lines. [S
 > If the `Editor` is not a `MarkdownView`, the functionality is slightly limited.
 > It won't be possible to create [[Task Dependencies]] fields `id` and `dependsOn`.
 
+> [!Tip]- Find plugins that use the Tasks API to suggest task properties
+> [Search GitHub for plugins which may use this function](https://github.com/search?q=showTasksPluginAutoSuggest+NOT+is%3Afork+NOT+repo%3Aobsidian-tasks-group%2Fobsidian-tasks+NOT+path%3A*.md&type=code), and by using `showTasksPluginAutoSuggest()`, will fully respect your Tasks settings.
+> > [!warning]
+> >
+> > - You will need to be logged in to GitHub for this search to work.
+> > - Not all of these plugins have been reviewed by the Obsidian team: you should search for them in `Settings` > `Community plugins` - or review in [Plugins - Obsidian](https://obsidian.md/plugins) - for safety.
+
 ## Limitations of the Tasks API
 
 - Editing tasks:

--- a/docs/Advanced/Tasks Api.md
+++ b/docs/Advanced/Tasks Api.md
@@ -92,6 +92,13 @@ const result = tasksApi.executeToggleTaskDoneCommand(taskLine, sourceFile.path);
 console.log(result); // "- [x] This is a task 📅 2024-04-24 ✅ 2024-04-23"
 ```
 
+> [!Tip]- Find plugins that use the Tasks API to toggle tasks
+> [Search GitHub for plugins which may use this function](https://github.com/search?q=executeToggleTaskDoneCommand+NOT+is%3Afork+NOT+repo%3Aobsidian-tasks-group%2Fobsidian-tasks+NOT+path%3A*.md&type=code), and by using `executeToggleTaskDoneCommand()`, will fully respect your Tasks settings.
+> > [!warning]
+> >
+> > - You will need to be logged in to GitHub for this search to work.
+> > - Not all of these plugins have been reviewed by the Obsidian team: you should search for them in `Settings` > `Community plugins` - or review in [Plugins - Obsidian](https://obsidian.md/plugins) - for safety.
+
 ## Auto-Suggest Integration
 
 > [!released]

--- a/docs/Advanced/Tasks Api.md
+++ b/docs/Advanced/Tasks Api.md
@@ -96,6 +96,8 @@ const taskLine = '- [ ] This is a task 📅 2024-04-24';
 
 const result = tasksApi.executeToggleTaskDoneCommand(taskLine, sourceFile.path);
 
+// Do whatever you want with the returned value.
+// It's just a string containing the Markdown for the toggled task.
 console.log(result); // "- [x] This is a task 📅 2024-04-24 ✅ 2024-04-23"
 ```
 

--- a/docs/Other Plugins/QuickAdd.md
+++ b/docs/Other Plugins/QuickAdd.md
@@ -10,7 +10,46 @@ aliases:
 
 ## Launching the Edit task modal via QuickAdd
 
-See [[Tasks Api#Usage with QuickAdd]] for how to use the [[Create or edit Task]] modal to add a task.
+This section shows how to use QuickAdd with the [[Create or edit Task]] modal to automatically add tasks to a specific file.
+
+For this you need to enter the following code as the Capture format:
+
+````markdown
+```js quickadd
+return await this.app.plugins.plugins['obsidian-tasks-plugin'].apiV1.createTaskLineModal();
+```
+````
+
+Or if you would like a newline character to be added after your new task line, use this as the Capture format instead:
+
+````markdown
+```js quickadd
+return await this.app.plugins.plugins['obsidian-tasks-plugin'].apiV1.createTaskLineModal() + '\n';
+```
+````
+
+For details refer to [QuickAdd - Inline scripts](https://quickadd.obsidian.guide/docs/InlineScripts).
+
+### Create the QuickAdd Capture
+
+Use these steps to make the following options appear (tested in QuickAdd 0.12.0):
+
+![Screenshot - Create the QuickAdd Capture](../../images/quickadd-settings-create-capture.png)
+
+1. Open the QuickAdd options.
+2. Type the name `Add task` in the `Name` box.
+3. Click on the `Template` button and select `Capture`.
+4. Click `Add Choice`.
+
+### Configure the QuickAdd Capture
+
+![Screenshot - Open the QuickAdd Capture Configuration](../../images/quickadd-settings-configure-capture.png)
+
+1. In the new row that was added, click on the cog (⚙) icon.
+2. Now fill in the values below. (See above for the code to enter in to the `Capture format` box.)
+
+Screenshot of QuickAdd capture settings (example)
+![Screenshot - Edit the QuickAdd Capture Configuration](../../images/api-create-taskline-modal-quickadd-capture-example.png)
 
 ## Creating your own shortcut to build a task
 


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

## Description

Some small improvements to the Tasks API docs

- Move the QuickAdd work-through from the API page to the QuickAdd page
- Add links showing how to find plugins which use each of the API functions
- Make it clearer that the caller needs to save the result of `executeToggleTaskDoneCommand()` - this fixes #3287

## Motivation and Context

- Improve the structure of the API page
- Make it easy to find plugins that use the API
- Fix #3287

## How has this been tested?

- Reviewing the edited docs in Obsidian

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
