### PR TITLE
docs: Fix "Unsupported markdown: list" mermaid diagram errors

### DIFF
--- a/docs/Getting Started/Task Dependencies.md
+++ b/docs/Getting Started/Task Dependencies.md
@@ -35,8 +35,8 @@ flowchart BT
 
 classDef TASK        stroke-width:3px,font-family:monospace;
 
-2["- [ ] do this first 🆔 abcdef"]:::TASK
-1["- [ ] do this after first ⛔ abcdef"]:::TASK
+2["\- [ ] do this first 🆔 abcdef"]:::TASK
+1["\- [ ] do this after first ⛔ abcdef"]:::TASK
 1-- depends on --> 2
 
 linkStyle default stroke:gray
@@ -51,8 +51,8 @@ flowchart BT
 
 classDef TASK        stroke-width:3px,font-family:monospace;
 
-2["- [ ] do this first&nbsp;&nbsp;[id:: abcdef]"]:::TASK
-1["- [ ] do this after first&nbsp;&nbsp;[dependsOn:: abcdef]"]:::TASK
+2["\- [ ] do this first&nbsp;&nbsp;[id:: abcdef]"]:::TASK
+1["\- [ ] do this after first&nbsp;&nbsp;[dependsOn:: abcdef]"]:::TASK
 1-- depends on --> 2
 
 linkStyle default stroke:gray
@@ -274,8 +274,8 @@ is not blocked
 >
 > classDef TASK        stroke-width:3px,font-family:monospace;
 >
-> 2["- [ ] this is blocking  🆔 abcdef"]:::TASK
-> 1["- [ ] this is blocked&nbsp ⛔ abcdef"]:::TASK
+> 2["\- [ ] this is blocking  🆔 abcdef"]:::TASK
+> 1["\- [ ] this is blocked&nbsp ⛔ abcdef"]:::TASK
 > 1-- depends on --> 2
 >
 > linkStyle default stroke:gray
@@ -289,8 +289,8 @@ is not blocked
 >
 > classDef TASK        stroke-width:3px,font-family:monospace;
 >
-> 4["- [ ] not blocking  🆔 abcdef"]:::TASK
-> 3["- [x] not blocked&nbsp ⛔ abcdef"]:::TASK
+> 4["\- [ ] not blocking  🆔 abcdef"]:::TASK
+> 3["\- [x] not blocked&nbsp ⛔ abcdef"]:::TASK
 > 3-- depends on --> 4
 >
 > linkStyle default stroke:gray
@@ -304,9 +304,9 @@ is not blocked
 >
 > classDef TASK        stroke-width:3px,font-family:monospace;
 >
-> 5["- [x] not blocking  🆔 abcdef"]:::TASK
-> 4["- [ ] blocking 🆔 ghijkl"]:::TASK
-> 3["- [ ] blocked ⛔ abcdef,ghijkl"]:::TASK
+> 5["\- [x] not blocking  🆔 abcdef"]:::TASK
+> 4["\- [ ] blocking 🆔 ghijkl"]:::TASK
+> 3["\- [ ] blocked ⛔ abcdef,ghijkl"]:::TASK
 > 3-- depends on --> 5
 > 3-- depends on --> 4
 >


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
    - Fixes #3360

## Description

Fix "Unsupported markdown: list" errors on mermaid diagrams in the "Tasks Dependencies" page.

Diagrams on the 'Task Dependencies' page were broken by Obsidian's update to Mermaid 11.

Fixes #3360

## Motivation and Context

Fix #3360 by escaping the markdown list character in Mermaid diagrams.

This works around the following Mermaid issue:

- <https://github.com/mermaid-js/mermaid/issues/6099>

## How has this been tested?

- Viewing the edited docs in Obsidian 1.8.9.

## Screenshots (if appropriate)

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/3ae7339b-94de-4cb4-817b-e576b6b795c3) | ![image](https://github.com/user-attachments/assets/e6dc6eba-c214-40f6-9a32-67157147d5fd) | 


## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
