### PR TITLE
feat: Include layout instructions in 'explain' output

### DIFF
--- a/docs/Queries/Explaining Queries.md
+++ b/docs/Queries/Explaining Queries.md
@@ -21,7 +21,6 @@ This has a number of benefits:
   - This often explains why tasks are missing from results.
 - If there is a [[Global Query|global query]] enabled, it too is included in the explanation.
 - Any [[query file defaults]]-generated instructions are listed (since Tasks 7.15.0).
-  - Note that `show/hide` [[layout]] are not yet shown in `explain` output, however. We are tracking this in [issue #2093](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2093).
 - Any [[Grouping|'group by']] instructions are listed (since Tasks 5.4.0).
 - Any [[Sorting|'sort by']] instructions are listed (since Tasks 5.4.0).
 
@@ -255,21 +254,15 @@ Explanation of the Query File Defaults (from properties/frontmatter in the query
 
   not done
 
+  short mode
+
+  show tree
+
 Explanation of this Tasks code block query:
 
   No filters supplied. All tasks will match the query.
 ```
 <!-- endSnippet -->
-
-> [!info]- Why are the generated layout instructions not visible?
-> The Query File Defaults will have generated these instructions:
->
-> ```text
-> short mode
-> show tree
-> ```
->
-> Currently, the `explain` output does not display [[layout]] instructions.  We are tracking this in [issue #2093](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2093).
 
 ### Placeholder values are expanded
 

--- a/src/Query/Explain/Explainer.ts
+++ b/src/Query/Explain/Explainer.ts
@@ -58,8 +58,7 @@ export class Explainer {
     }
 
     public explainGroups(query: Query) {
-        const statements = query.grouping.map((group) => group.statement);
-        return this.explainStatements(statements);
+        return this.explainStatements(query.grouping.map((group) => group.statement));
     }
 
     public explainSorters(query: Query) {

--- a/src/Query/Explain/Explainer.ts
+++ b/src/Query/Explain/Explainer.ts
@@ -62,11 +62,7 @@ export class Explainer {
     }
 
     public explainSorters(query: Query) {
-        if (query.sorting.length === 0) {
-            return '';
-        }
-
-        return query.sorting.map((sort) => sort.statement.explainStatement(this.indentation)).join('\n\n') + '\n';
+        return this.explainStatements(query.sorting.map((group) => group.statement));
     }
 
     public explainQueryLimits(query: Query) {

--- a/src/Query/Explain/Explainer.ts
+++ b/src/Query/Explain/Explainer.ts
@@ -1,5 +1,6 @@
 import { getSettings } from '../../Config/Settings';
 import type { Query } from '../Query';
+import type { Statement } from '../Statement';
 
 export class Explainer {
     private readonly indentation: string;
@@ -58,11 +59,7 @@ export class Explainer {
 
     public explainGroups(query: Query) {
         const statements = query.grouping.map((group) => group.statement);
-        if (statements.length === 0) {
-            return '';
-        }
-
-        return statements.map((statement) => statement.explainStatement(this.indentation)).join('\n\n') + '\n';
+        return this.explainStatements(statements);
     }
 
     public explainSorters(query: Query) {
@@ -106,6 +103,14 @@ export class Explainer {
             );
         }
         return result;
+    }
+
+    private explainStatements(statements: Statement[]) {
+        if (statements.length === 0) {
+            return '';
+        }
+
+        return statements.map((statement) => statement.explainStatement(this.indentation)).join('\n\n') + '\n';
     }
 
     private indent(description: string) {

--- a/src/Query/Explain/Explainer.ts
+++ b/src/Query/Explain/Explainer.ts
@@ -36,6 +36,7 @@ export class Explainer {
         results.push(this.explainFilters(query));
         results.push(this.explainGroups(query));
         results.push(this.explainSorters(query));
+        results.push(this.explainLayout(query));
         results.push(this.explainQueryLimits(query));
         results.push(this.explainDebugSettings());
 
@@ -63,6 +64,10 @@ export class Explainer {
 
     public explainSorters(query: Query) {
         return this.explainStatements(query.sorting.map((group) => group.statement));
+    }
+
+    public explainLayout(query: Query) {
+        return this.explainStatements(query.layoutStatements);
     }
 
     public explainQueryLimits(query: Query) {

--- a/src/Query/Explain/Explainer.ts
+++ b/src/Query/Explain/Explainer.ts
@@ -57,11 +57,12 @@ export class Explainer {
     }
 
     public explainGroups(query: Query) {
-        if (query.grouping.length === 0) {
+        const statements = query.grouping.map((group) => group.statement);
+        if (statements.length === 0) {
             return '';
         }
 
-        return query.grouping.map((group) => group.statement.explainStatement(this.indentation)).join('\n\n') + '\n';
+        return statements.map((statement) => statement.explainStatement(this.indentation)).join('\n\n') + '\n';
     }
 
     public explainSorters(query: Query) {

--- a/src/Query/Explain/Explainer.ts
+++ b/src/Query/Explain/Explainer.ts
@@ -63,7 +63,7 @@ export class Explainer {
     }
 
     public explainSorters(query: Query) {
-        return this.explainStatements(query.sorting.map((group) => group.statement));
+        return this.explainStatements(query.sorting.map((sort) => sort.statement));
     }
 
     public explainLayout(query: Query) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -124,7 +124,7 @@ export class Query implements IQuery {
             case this.parseGroupBy(line, statement):
                 break;
             case this.hideOptionsRegexp.test(line):
-                this.parseHideOptions(line, statement);
+                this.parseHideOptions(statement);
                 break;
             case this.commentRegexp.test(line):
                 // Comment lines are ignored
@@ -341,7 +341,7 @@ ${statement.explainStatement('    ')}
         }
     }
 
-    private parseHideOptions(_line: string, statement: Statement): void {
+    private parseHideOptions(statement: Statement): void {
         const line = statement.anyPlaceholdersExpanded;
         const hideOptionsMatch = line.match(this.hideOptionsRegexp);
         if (hideOptionsMatch === null) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -113,6 +113,7 @@ export class Query implements IQuery {
                 break;
             case this.fullModeRegexp.test(line):
                 this._queryLayoutOptions.shortMode = false;
+                this.saveLayoutStatement(statement);
                 break;
             case this.explainQueryRegexp.test(line):
                 this._queryLayoutOptions.explainQuery = true;

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -124,7 +124,7 @@ export class Query implements IQuery {
             case this.parseGroupBy(line, statement):
                 break;
             case this.hideOptionsRegexp.test(line):
-                this.parseHideOptions(line);
+                this.parseHideOptions(line, statement);
                 break;
             case this.commentRegexp.test(line):
                 // Comment lines are ignored
@@ -341,7 +341,8 @@ ${statement.explainStatement('    ')}
         }
     }
 
-    private parseHideOptions(line: string): void {
+    private parseHideOptions(_line: string, statement: Statement): void {
+        const line = statement.anyPlaceholdersExpanded;
         const hideOptionsMatch = line.match(this.hideOptionsRegexp);
         if (hideOptionsMatch === null) {
             return;

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -354,6 +354,7 @@ ${statement.explainStatement('    ')}
         const option = hideOptionsMatch[2].toLowerCase();
 
         if (parseQueryShowHideOptions(this._queryLayoutOptions, option, hide)) {
+            this.saveLayoutStatement(statement);
             return;
         }
         if (parseTaskShowHideOptions(this._taskLayoutOptions, option, !hide)) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -109,6 +109,7 @@ export class Query implements IQuery {
         switch (true) {
             case this.shortModeRegexp.test(line):
                 this._queryLayoutOptions.shortMode = true;
+                this.saveLayoutStatement(statement);
                 break;
             case this.fullModeRegexp.test(line):
                 this._queryLayoutOptions.shortMode = false;

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -34,8 +34,11 @@ export class Query implements IQuery {
 
     private _limit: number | undefined = undefined;
     private _taskGroupLimit: number | undefined = undefined;
+
     private readonly _taskLayoutOptions: TaskLayoutOptions = new TaskLayoutOptions();
     private readonly _queryLayoutOptions: QueryLayoutOptions = new QueryLayoutOptions();
+    public readonly layoutStatements: Statement[] = [];
+
     private readonly _filters: Filter[] = [];
     private _error: string | undefined = undefined;
     private readonly _sorting: Sorter[] = [];
@@ -354,9 +357,14 @@ ${statement.explainStatement('    ')}
             return;
         }
         if (parseTaskShowHideOptions(this._taskLayoutOptions, option, !hide)) {
+            this.saveLayoutStatement(statement);
             return;
         }
         this.setError('do not understand hide/show option', new Statement(line, line));
+    }
+
+    private saveLayoutStatement(statement: Statement) {
+        this.layoutStatements.push(statement);
     }
 
     private parseFilter(line: string, statement: Statement) {

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_query_file_defaults_explanation.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_query_file_defaults_explanation.approved.explanation.text
@@ -5,6 +5,8 @@ Explanation of the Query File Defaults (from properties/frontmatter in the query
 
   not done
 
+  show tree
+
 Explanation of this Tasks code block query:
 
   No filters supplied. All tasks will match the query.

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_query_file_defaults_explanation.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_query_file_defaults_explanation.approved.explanation.text
@@ -5,6 +5,8 @@ Explanation of the Query File Defaults (from properties/frontmatter in the query
 
   not done
 
+  short mode
+
   show tree
 
 Explanation of this Tasks code block query:

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -316,7 +316,8 @@ describe('explain layout instructions', () => {
     it('should explain hide due date', () => {
         const source = 'hide due date';
         const query = new Query(source);
-        expect(explainer.explainLayout(query)).toMatchInlineSnapshot(`
+        const layoutExplanation = explainer.explainLayout(query);
+        expect(layoutExplanation).toMatchInlineSnapshot(`
             "hide due date
             "
         `);

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -313,10 +313,14 @@ describe('explain sorters', () => {
 });
 
 describe('explain layout instructions', () => {
+    function explainLayout(source: string) {
+        const query = new Query(source);
+        return explainer.explainLayout(query);
+    }
+
     it('should explain hide due date', () => {
         const source = 'hide due date';
-        const query = new Query(source);
-        const layoutExplanation = explainer.explainLayout(query);
+        const layoutExplanation = explainLayout(source);
         expect(layoutExplanation).toMatchInlineSnapshot(`
             "hide due date
             "

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -106,6 +106,8 @@ limit groups 3
 
             sort by path
 
+            show urgency
+
             At most 50 tasks.
 
             At most 3 tasks per group (if any "group by" options are supplied).
@@ -154,6 +156,8 @@ limit groups 3
               sort by description reverse
 
               sort by path
+
+              show urgency
 
               At most 50 tasks.
 
@@ -321,6 +325,13 @@ describe('explain layout instructions', () => {
     it('should explain hide due date', () => {
         expect(explainLayout('hide due date')).toMatchInlineSnapshot(`
             "hide due date
+            "
+        `);
+    });
+
+    it('should explain show tree', () => {
+        expect(explainLayout('show tree')).toMatchInlineSnapshot(`
+            "show tree
             "
         `);
     });

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -346,6 +346,13 @@ describe('explain layout instructions', () => {
             "
         `);
     });
+
+    it('should explain full mode', () => {
+        expect(explainLayout('full mode')).toMatchInlineSnapshot(`
+            "full mode
+            "
+        `);
+    });
 });
 
 describe('explain limits', () => {

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -108,6 +108,8 @@ limit groups 3
 
             show urgency
 
+            short mode
+
             At most 50 tasks.
 
             At most 3 tasks per group (if any "group by" options are supplied).
@@ -158,6 +160,8 @@ limit groups 3
               sort by path
 
               show urgency
+
+              short mode
 
               At most 50 tasks.
 
@@ -332,6 +336,13 @@ describe('explain layout instructions', () => {
     it('should explain show tree', () => {
         expect(explainLayout('show tree')).toMatchInlineSnapshot(`
             "show tree
+            "
+        `);
+    });
+
+    it('should explain short mode', () => {
+        expect(explainLayout('short mode')).toMatchInlineSnapshot(`
+            "short mode
             "
         `);
     });

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -335,10 +335,12 @@ describe('explain layout instructions', () => {
     });
 
     it('should explain short mode', () => {
+        expect(explainLayout('short')).toEqual('short\n');
         expect(explainLayout('short mode')).toEqual('short mode\n');
     });
 
     it('should explain full mode', () => {
+        expect(explainLayout('full')).toEqual('full\n');
         expect(explainLayout('full mode')).toEqual('full mode\n');
     });
 });

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -327,31 +327,19 @@ describe('explain layout instructions', () => {
     }
 
     it('should explain hide due date', () => {
-        expect(explainLayout('hide due date')).toMatchInlineSnapshot(`
-            "hide due date
-            "
-        `);
+        expect(explainLayout('hide due date')).toEqual('hide due date\n');
     });
 
     it('should explain show tree', () => {
-        expect(explainLayout('show tree')).toMatchInlineSnapshot(`
-            "show tree
-            "
-        `);
+        expect(explainLayout('show tree')).toEqual('show tree\n');
     });
 
     it('should explain short mode', () => {
-        expect(explainLayout('short mode')).toMatchInlineSnapshot(`
-            "short mode
-            "
-        `);
+        expect(explainLayout('short mode')).toEqual('short mode\n');
     });
 
     it('should explain full mode', () => {
-        expect(explainLayout('full mode')).toMatchInlineSnapshot(`
-            "full mode
-            "
-        `);
+        expect(explainLayout('full mode')).toEqual('full mode\n');
     });
 });
 

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -320,8 +320,7 @@ describe('explain layout instructions', () => {
 
     it('should explain hide due date', () => {
         const source = 'hide due date';
-        const layoutExplanation = explainLayout(source);
-        expect(layoutExplanation).toMatchInlineSnapshot(`
+        expect(explainLayout(source)).toMatchInlineSnapshot(`
             "hide due date
             "
         `);

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -319,8 +319,7 @@ describe('explain layout instructions', () => {
     }
 
     it('should explain hide due date', () => {
-        const source = 'hide due date';
-        expect(explainLayout(source)).toMatchInlineSnapshot(`
+        expect(explainLayout('hide due date')).toMatchInlineSnapshot(`
             "hide due date
             "
         `);

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -312,6 +312,17 @@ describe('explain sorters', () => {
     });
 });
 
+describe('explain layout instructions', () => {
+    it('should explain hide due date', () => {
+        const source = 'hide due date';
+        const query = new Query(source);
+        expect(explainer.explainLayout(query)).toMatchInlineSnapshot(`
+            "hide due date
+            "
+        `);
+    });
+});
+
 describe('explain limits', () => {
     it('should explain limit 5', () => {
         const source = 'limit 5';

--- a/tests/Query/QueryRendererHelper.test.ts
+++ b/tests/Query/QueryRendererHelper.test.ts
@@ -74,6 +74,30 @@ describe('explain', () => {
 
               not done
 
+              show tags
+
+              show id
+
+              show depends on
+
+              show priority
+
+              show recurrence rule
+
+              show on completion
+
+              show created date
+
+              show start date
+
+              show scheduled date
+
+              show due date
+
+              show cancelled date
+
+              show done date
+
             Explanation of this Tasks code block query:
 
               No filters supplied. All tasks will match the query.

--- a/tests/Query/QueryRendererHelper.test.ts
+++ b/tests/Query/QueryRendererHelper.test.ts
@@ -74,6 +74,8 @@ describe('explain', () => {
 
               not done
 
+              short mode
+
               show tree
 
               show tags

--- a/tests/Query/QueryRendererHelper.test.ts
+++ b/tests/Query/QueryRendererHelper.test.ts
@@ -74,6 +74,8 @@ describe('explain', () => {
 
               not done
 
+              show tree
+
               show tags
 
               show id
@@ -97,6 +99,16 @@ describe('explain', () => {
               show cancelled date
 
               show done date
+
+              show urgency
+
+              show backlink
+
+              show edit button
+
+              show postpone button
+
+              show task count
 
             Explanation of this Tasks code block query:
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: #2093
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Include all the [Layout](https://publish.obsidian.md/tasks/Queries/Layout) instructions in `explain` output.

## Motivation and Context

Fixes #2093.

## How has this been tested?

- Automated tests
- Exploratory testing

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
