### PR TITLE
feat: Explain 'ignore global filter'

### DIFF
--- a/docs/Queries/Global Query.md
+++ b/docs/Queries/Global Query.md
@@ -35,7 +35,7 @@ You can set a global query in the settings that Tasks will add to the start of a
 
 If you need to ignore the Global Query in a given Tasks block you may add `ignore global query` instruction to any place of the block.
 
-For example, this allows you to have your task seaches ignore certain folders by default. And then in few searches, you can enable searching for tasks in those folders.
+For example, this allows you to have your task searches ignore certain folders by default. And then in a few searches, you can enable searching for tasks in those folders.
 
 > [!example]
 >
@@ -43,6 +43,9 @@ For example, this allows you to have your task seaches ignore certain folders by
 > tags include work
 > ignore global query
 > ```
+
+> [!note]
+> Any use of `ignore global query` inside the Global Query itself is harmless, but ignored.
 
 > [!released]
 The `ignore global query` instruction was added in Tasks 4.6.0.

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -49,7 +49,9 @@ export class GlobalQuery {
      * @param tasksFile
      */
     public query(tasksFile: OptionalTasksFile = undefined): Query {
-        return new Query(this._source, tasksFile);
+        const query = new Query(this._source, tasksFile);
+        query.removeIllegalGlobalQueryInstructions();
+        return query;
     }
 
     /**

--- a/src/Query/Explain/Explainer.ts
+++ b/src/Query/Explain/Explainer.ts
@@ -33,6 +33,7 @@ export class Explainer {
          *     - end with a single newline.
          */
         const results: string[] = [];
+        results.push(this.explainIgnoreGlobalQuery(query));
         results.push(this.explainFilters(query));
         results.push(this.explainGroups(query));
         results.push(this.explainSorters(query));
@@ -48,6 +49,13 @@ export class Explainer {
         result += 'Query has an error:\n';
         result += query.error + '\n';
         return result;
+    }
+
+    private explainIgnoreGlobalQuery(query: Query) {
+        if (!query.ignoreGlobalQuery) {
+            return '';
+        }
+        return this.indent('ignore global query\n');
     }
 
     public explainFilters(query: Query) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -117,6 +117,7 @@ export class Query implements IQuery {
                 break;
             case this.explainQueryRegexp.test(line):
                 this._queryLayoutOptions.explainQuery = true;
+                // We intentionally do not explain the 'explain' statement, as it clutters up documentation.
                 break;
             case this.ignoreGlobalQueryRegexp.test(line):
                 this._ignoreGlobalQuery = true;

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -96,6 +96,16 @@ export class Query implements IQuery {
         }
     }
 
+    /**
+     * Remove any instructions that are not valid for Global Queries:
+     */
+    public removeIllegalGlobalQueryInstructions() {
+        // It does not make sense to use 'ignore global query'
+        // in global queries: the value is ignored, and it would be confusing
+        // for 'explain' output to report that it had been supplied:
+        this._ignoreGlobalQuery = false;
+    }
+
     public get filePath(): string | undefined {
         return this.tasksFile?.path ?? undefined;
     }

--- a/src/Query/QueryRendererHelper.ts
+++ b/src/Query/QueryRendererHelper.ts
@@ -40,8 +40,8 @@ export function explainResults(
     }
 
     const explainer = new Explainer('  ');
-    function explainQuery(label: string, globalQueryQuery: Query) {
-        return `${label}:\n\n${explainer.explainQuery(globalQueryQuery)}`;
+    function explainQuery(label: string, query: Query) {
+        return `${label}:\n\n${explainer.explainQuery(query)}`;
     }
 
     const tasksBlockQuery = new Query(source, tasksFile);

--- a/tests/Config/GlobalQuery.test.ts
+++ b/tests/Config/GlobalQuery.test.ts
@@ -32,7 +32,7 @@ describe('GlobalQuery tests', () => {
         expect(globalQuery.query().source).toEqual('# this should be the new global query');
     });
 
-    it.failing('should ignore any "ignore global query" instruction', () => {
+    it('should ignore any "ignore global query" instruction', () => {
         const globalQuery = new GlobalQuery('ignore global query');
 
         expect(globalQuery.query().ignoreGlobalQuery).toEqual(false);

--- a/tests/Config/GlobalQuery.test.ts
+++ b/tests/Config/GlobalQuery.test.ts
@@ -32,6 +32,12 @@ describe('GlobalQuery tests', () => {
         expect(globalQuery.query().source).toEqual('# this should be the new global query');
     });
 
+    it.failing('should ignore any "ignore global query" instruction', () => {
+        const globalQuery = new GlobalQuery('ignore global query');
+
+        expect(globalQuery.query().ignoreGlobalQuery).toEqual(false);
+    });
+
     it.each(['', ' ', '\n', '\n     \n    ', '  \n    \n'])(
         'should have no instructions if only line breaks and spaces were set in the query',
         (globalQuerySource) => {

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -343,6 +343,11 @@ describe('explain layout instructions', () => {
         expect(explainLayout('full')).toEqual('full\n');
         expect(explainLayout('full mode')).toEqual('full mode\n');
     });
+
+    it('should NOT explain explain', () => {
+        // Intentionally do not explain the 'explain' instruction, as it just clutters up the documentation.
+        expect(explainLayout('explain')).toEqual('');
+    });
 });
 
 describe('explain limits', () => {

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -65,6 +65,8 @@ show urgency
 short mode
 limit 50
 limit groups 3
+
+ignore global query
 `;
 
     it('all types of instruction - not indented', () => {

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -75,7 +75,9 @@ ignore global query
 
         const query = new Query(sampleOfAllInstructionTypes, new TasksFile('sample.md'));
         expect(explainer.explainQuery(query)).toMatchInlineSnapshot(`
-            "filter by function \\
+            "ignore global query
+
+            filter by function \\
                  task.path === '{{query.file.path}}'
              =>
             filter by function task.path === '{{query.file.path}}' =>
@@ -128,7 +130,9 @@ ignore global query
         const query = new Query(sampleOfAllInstructionTypes, new TasksFile('sample.md'));
         const indentedExplainer = new Explainer('  ');
         expect(indentedExplainer.explainQuery(query)).toMatchInlineSnapshot(`
-            "  filter by function \\
+            "  ignore global query
+
+              filter by function \\
                    task.path === '{{query.file.path}}'
                =>
               filter by function task.path === '{{query.file.path}}' =>

--- a/tests/Query/QueryRendererHelper.test.ts
+++ b/tests/Query/QueryRendererHelper.test.ts
@@ -148,6 +148,8 @@ describe('explain', () => {
         expect(explainResults(query.source, new GlobalFilter(), globalQuery)).toMatchInlineSnapshot(`
             "Explanation of this Tasks code block query:
 
+              ignore global query
+
               No filters supplied. All tasks will match the query.
             "
         `);
@@ -162,6 +164,8 @@ describe('explain', () => {
         const query = new Query(source, queryFile);
         expect(explainResults(query.source, new GlobalFilter(), globalQuery, queryFile)).toMatchInlineSnapshot(`
             "Explanation of the Query File Defaults (from properties/frontmatter in the query's file):
+
+              ignore global query
 
               description includes I came from the TQ_extra_instructions property
 

--- a/tests/Query/QueryRendererHelper.test.ts
+++ b/tests/Query/QueryRendererHelper.test.ts
@@ -175,6 +175,27 @@ describe('explain', () => {
             "
         `);
     });
+
+    it.failing('should discard "ignore global query" from explanation if present in the global query itself', () => {
+        const globalQuery = new GlobalQuery('ignore global query');
+        const querySource = 'description includes from query';
+
+        const explanation = explainResults(querySource, new GlobalFilter(), globalQuery);
+
+        // It does not make sense to put 'ignore global query' in the global query.
+        // If the user did so, we should ignore it in any explanations.
+        expect(explanation).not.toContain('ignore global query');
+        expect(explanation).toMatchInlineSnapshot(`
+            "Explanation of the global query:
+
+              No filters supplied. All tasks will match the query.
+
+            Explanation of this Tasks code block query:
+
+              description includes from query
+            "
+        `);
+    });
 });
 
 /**

--- a/tests/Query/QueryRendererHelper.test.ts
+++ b/tests/Query/QueryRendererHelper.test.ts
@@ -176,7 +176,7 @@ describe('explain', () => {
         `);
     });
 
-    it.failing('should discard "ignore global query" from explanation if present in the global query itself', () => {
+    it('should discard "ignore global query" from explanation if present in the global query itself', () => {
         const globalQuery = new GlobalQuery('ignore global query');
         const querySource = 'description includes from query';
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
  - **WARNING: If the link is absent, the PR may be closed without review**, due to the workload that such reviews usually require.
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Make 'ignore global query' visible in `explain` output when it used outside of the Global Query.

Also explicitly confirm that the `explain` instruction is not explained, as it clutters up the docs and would not add any extra useful information.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Make the `explain` output cover all instructions.

## How has this been tested?

- New tests
- Exploratory testing

## Screenshots (if appropriate)

Sample note:

~~~
---
TQ_extra_instructions: |-
  ignore global query
  happens before today
---

# Explain Filters

## Show ignore global query

```tasks
explain
ignore global query
limit 1
```
~~~

Gives this:

![image](https://github.com/user-attachments/assets/77d4ec11-3afc-474b-9509-5a00f4d81920)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
