### PR TITLE
fix: register handlers before the layout is ready

### DIFF
--- a/src/Obsidian/InlineRenderer.ts
+++ b/src/Obsidian/InlineRenderer.ts
@@ -24,7 +24,11 @@ import { TaskLocation } from '../Task/TaskLocation';
  */
 export class InlineRenderer {
     constructor({ plugin }: { plugin: Plugin }) {
-        plugin.registerMarkdownPostProcessor(this._markdownPostProcessor.bind(this));
+        plugin.registerMarkdownPostProcessor((el, ctx) => {
+            plugin.app.workspace.onLayoutReady(() => {
+                this.markdownPostProcessor(el, ctx);
+            });
+        });
     }
 
     public markdownPostProcessor = this._markdownPostProcessor.bind(this);

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -38,7 +38,11 @@ export class QueryRenderer {
         this.plugin = plugin;
         this.events = events;
 
-        plugin.registerMarkdownCodeBlockProcessor('tasks', this._addQueryRenderChild.bind(this));
+        plugin.registerMarkdownCodeBlockProcessor('tasks', (source, el, ctx) => {
+            plugin.app.workspace.onLayoutReady(() => {
+                this.addQueryRenderChild(source, el, ctx);
+            });
+        });
     }
 
     public addQueryRenderChild = this._addQueryRenderChild.bind(this);

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,11 +60,8 @@ export default class TasksPlugin extends Plugin {
             events,
         });
 
-        this.app.workspace.onLayoutReady(() => {
-            // Only execute searches after Obsidian finishes loading.
-            this.inlineRenderer = new InlineRenderer({ plugin: this });
-            this.queryRenderer = new QueryRenderer({ plugin: this, events });
-        });
+        this.inlineRenderer = new InlineRenderer({ plugin: this });
+        this.queryRenderer = new QueryRenderer({ plugin: this, events });
 
         // Update types.json.
         this.setObsidianPropertiesTypes();


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [X] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

Tasks code block has to be executed AFTER the layout is ready but the handler might need to be registered BEFORE that.

This enables Tasks to show results forany Queries in Callouts in Live Preview, when already opened at start-up.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Fixed #3366

<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Manual testing locally

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [X] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [X] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
