### PR TITLE
refactor: `ListItem` construction

### DIFF
--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -159,6 +159,6 @@ export class FileParser {
 
     private createListItem(listItem: ListItemCache, line: string, lineNumber: number, taskLocation: TaskLocation) {
         const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
-        this.line2ListItem.set(lineNumber, new ListItem(line, parentListItem, taskLocation));
+        this.line2ListItem.set(lineNumber, ListItem.fromListItemLine(line, parentListItem, taskLocation));
     }
 }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -16,8 +16,15 @@ export class ListItem {
 
     public readonly taskLocation: TaskLocation;
 
-    constructor(_obj: { originalMarkdown: string; parent: ListItem | null; taskLocation: TaskLocation }) {
-        const originalMarkdown = _obj.originalMarkdown;
+    constructor({
+        originalMarkdown,
+        parent,
+        taskLocation,
+    }: {
+        originalMarkdown: string;
+        parent: ListItem | null;
+        taskLocation: TaskLocation;
+    }) {
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         if (nonTaskMatch) {
@@ -27,14 +34,13 @@ export class ListItem {
             this.statusCharacter = nonTaskMatch[4] ?? null;
         }
         this.originalMarkdown = originalMarkdown;
-        const parent = _obj.parent;
-        this.parent = parent;
 
+        this.parent = parent;
         if (parent !== null) {
             parent.children.push(this);
         }
 
-        this.taskLocation = _obj.taskLocation;
+        this.taskLocation = taskLocation;
     }
 
     public static fromListItemLine(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -19,9 +19,10 @@ export class ListItem {
     protected constructor(
         _originalMarkdown: string,
         parent: ListItem | null,
-        taskLocation: TaskLocation,
+        _taskLocation: TaskLocation,
         _obj: {
             originalMarkdown: string;
+            taskLocation: TaskLocation;
         },
     ) {
         const originalMarkdown = _obj.originalMarkdown;
@@ -40,11 +41,11 @@ export class ListItem {
             parent.children.push(this);
         }
 
-        this.taskLocation = taskLocation;
+        this.taskLocation = _obj.taskLocation;
     }
 
     public static fromListItemLine(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {
-        return new ListItem(originalMarkdown, parent, taskLocation, { originalMarkdown });
+        return new ListItem(originalMarkdown, parent, taskLocation, { originalMarkdown, taskLocation });
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -16,7 +16,7 @@ export class ListItem {
 
     public readonly taskLocation: TaskLocation;
 
-    constructor(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {
+    protected constructor(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         if (nonTaskMatch) {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -16,7 +16,14 @@ export class ListItem {
 
     public readonly taskLocation: TaskLocation;
 
-    protected constructor(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {
+    protected constructor(
+        originalMarkdown: string,
+        parent: ListItem | null,
+        taskLocation: TaskLocation,
+        _obj: {
+            originalMarkdown: string;
+        } | null = null,
+    ) {
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         if (nonTaskMatch) {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -17,13 +17,14 @@ export class ListItem {
     public readonly taskLocation: TaskLocation;
 
     protected constructor(
-        originalMarkdown: string,
+        _originalMarkdown: string,
         parent: ListItem | null,
         taskLocation: TaskLocation,
         _obj: {
             originalMarkdown: string;
-        } | null = null,
+        },
     ) {
+        const originalMarkdown = _obj.originalMarkdown;
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         if (nonTaskMatch) {
@@ -43,7 +44,7 @@ export class ListItem {
     }
 
     public static fromListItemLine(line: string, parent: ListItem | null, taskLocation: TaskLocation) {
-        return new ListItem(line, parent, taskLocation);
+        return new ListItem(line, parent, taskLocation, { originalMarkdown: line });
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -43,8 +43,8 @@ export class ListItem {
         this.taskLocation = taskLocation;
     }
 
-    public static fromListItemLine(line: string, parent: ListItem | null, taskLocation: TaskLocation) {
-        return new ListItem(line, parent, taskLocation, { originalMarkdown: line });
+    public static fromListItemLine(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {
+        return new ListItem(originalMarkdown, parent, taskLocation, { originalMarkdown });
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -195,7 +195,7 @@ export class ListItem {
             `[${newStatusCharacter}]`,
         );
 
-        return new ListItem(newMarkdown, null, this.taskLocation);
+        return ListItem.fromListItemLine(newMarkdown, null, this.taskLocation);
     }
 
     public toFileLineString(): string {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -21,6 +21,7 @@ export class ListItem {
         indentation,
         listMarker,
         statusCharacter,
+        description,
         parent,
         taskLocation,
     }: {
@@ -28,17 +29,14 @@ export class ListItem {
         indentation: string;
         listMarker: string;
         statusCharacter: string | null;
+        description: string;
         parent: ListItem | null;
         taskLocation: TaskLocation;
     }) {
-        this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         this.indentation = indentation;
         this.listMarker = listMarker;
         this.statusCharacter = statusCharacter;
-        const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
-        if (nonTaskMatch) {
-            this.description = nonTaskMatch[5].trim();
-        }
+        this.description = description;
         this.originalMarkdown = originalMarkdown;
 
         this.parent = parent;
@@ -54,13 +52,23 @@ export class ListItem {
         let indentation = '';
         let listMarker = '';
         let statusCharacter = null;
+        let description = '';
         if (nonTaskMatch) {
             indentation = nonTaskMatch[1];
             listMarker = nonTaskMatch[2];
             statusCharacter = nonTaskMatch[4] ?? null;
+            description = nonTaskMatch[5].trim();
         }
 
-        return new ListItem({ originalMarkdown, indentation, listMarker, statusCharacter, taskLocation, parent });
+        return new ListItem({
+            originalMarkdown,
+            indentation,
+            listMarker,
+            statusCharacter,
+            description,
+            taskLocation,
+            parent,
+        });
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -16,10 +16,7 @@ export class ListItem {
 
     public readonly taskLocation: TaskLocation;
 
-    constructor(
-        _parent: ListItem | null,
-        _obj: { originalMarkdown: string; parent: ListItem | null; taskLocation: TaskLocation },
-    ) {
+    constructor(_obj: { originalMarkdown: string; parent: ListItem | null; taskLocation: TaskLocation }) {
         const originalMarkdown = _obj.originalMarkdown;
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
@@ -41,7 +38,7 @@ export class ListItem {
     }
 
     public static fromListItemLine(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {
-        return new ListItem(parent, { originalMarkdown, taskLocation, parent });
+        return new ListItem({ originalMarkdown, taskLocation, parent });
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -16,15 +16,7 @@ export class ListItem {
 
     public readonly taskLocation: TaskLocation;
 
-    protected constructor(
-        _originalMarkdown: string,
-        parent: ListItem | null,
-        _taskLocation: TaskLocation,
-        _obj: {
-            originalMarkdown: string;
-            taskLocation: TaskLocation;
-        },
-    ) {
+    constructor(parent: ListItem | null, _obj: { originalMarkdown: string; taskLocation: TaskLocation }) {
         const originalMarkdown = _obj.originalMarkdown;
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
@@ -45,7 +37,7 @@ export class ListItem {
     }
 
     public static fromListItemLine(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {
-        return new ListItem(originalMarkdown, parent, taskLocation, { originalMarkdown, taskLocation });
+        return new ListItem(parent, { originalMarkdown, taskLocation });
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -10,7 +10,7 @@ export class ListItem {
     public readonly parent: ListItem | null = null;
     public readonly children: ListItem[] = [];
     public readonly indentation: string;
-    public readonly listMarker: string = '';
+    public readonly listMarker: string;
     public readonly description: string;
     public readonly statusCharacter: string | null = null;
 
@@ -19,19 +19,21 @@ export class ListItem {
     constructor({
         originalMarkdown,
         indentation,
+        listMarker,
         parent,
         taskLocation,
     }: {
         originalMarkdown: string;
         indentation: string;
+        listMarker: string;
         parent: ListItem | null;
         taskLocation: TaskLocation;
     }) {
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         this.indentation = indentation;
+        this.listMarker = listMarker;
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         if (nonTaskMatch) {
-            this.listMarker = nonTaskMatch[2];
             this.description = nonTaskMatch[5].trim();
             this.statusCharacter = nonTaskMatch[4] ?? null;
         }
@@ -48,11 +50,13 @@ export class ListItem {
     public static fromListItemLine(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         let indentation = '';
+        let listMarker = '';
         if (nonTaskMatch) {
             indentation = nonTaskMatch[1];
+            listMarker = nonTaskMatch[2];
         }
 
-        return new ListItem({ originalMarkdown, indentation, taskLocation, parent });
+        return new ListItem({ originalMarkdown, indentation, listMarker, taskLocation, parent });
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -16,7 +16,10 @@ export class ListItem {
 
     public readonly taskLocation: TaskLocation;
 
-    constructor(parent: ListItem | null, _obj: { originalMarkdown: string; taskLocation: TaskLocation }) {
+    constructor(
+        _parent: ListItem | null,
+        _obj: { originalMarkdown: string; parent: ListItem | null; taskLocation: TaskLocation },
+    ) {
         const originalMarkdown = _obj.originalMarkdown;
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
@@ -27,6 +30,7 @@ export class ListItem {
             this.statusCharacter = nonTaskMatch[4] ?? null;
         }
         this.originalMarkdown = originalMarkdown;
+        const parent = _obj.parent;
         this.parent = parent;
 
         if (parent !== null) {
@@ -37,7 +41,7 @@ export class ListItem {
     }
 
     public static fromListItemLine(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {
-        return new ListItem(parent, { originalMarkdown, taskLocation });
+        return new ListItem(parent, { originalMarkdown, taskLocation, parent });
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -7,7 +7,7 @@ export class ListItem {
     // The original line read from file.
     public readonly originalMarkdown: string;
 
-    public readonly parent: ListItem | null = null;
+    public readonly parent: ListItem | null;
     public readonly children: ListItem[] = [];
     public readonly indentation: string;
     public readonly listMarker: string;

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -18,17 +18,19 @@ export class ListItem {
 
     constructor({
         originalMarkdown,
+        indentation,
         parent,
         taskLocation,
     }: {
         originalMarkdown: string;
+        indentation: string;
         parent: ListItem | null;
         taskLocation: TaskLocation;
     }) {
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         if (nonTaskMatch) {
-            this.indentation = nonTaskMatch[1];
+            this.indentation = indentation;
             this.listMarker = nonTaskMatch[2];
             this.description = nonTaskMatch[5].trim();
             this.statusCharacter = nonTaskMatch[4] ?? null;
@@ -44,7 +46,13 @@ export class ListItem {
     }
 
     public static fromListItemLine(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {
-        return new ListItem({ originalMarkdown, taskLocation, parent });
+        const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
+        let indentation = '';
+        if (nonTaskMatch) {
+            indentation = nonTaskMatch[1];
+        }
+
+        return new ListItem({ originalMarkdown, indentation, taskLocation, parent });
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -12,7 +12,7 @@ export class ListItem {
     public readonly indentation: string;
     public readonly listMarker: string;
     public readonly description: string;
-    public readonly statusCharacter: string | null = null;
+    public readonly statusCharacter: string | null;
 
     public readonly taskLocation: TaskLocation;
 
@@ -20,22 +20,24 @@ export class ListItem {
         originalMarkdown,
         indentation,
         listMarker,
+        statusCharacter,
         parent,
         taskLocation,
     }: {
         originalMarkdown: string;
         indentation: string;
         listMarker: string;
+        statusCharacter: string | null;
         parent: ListItem | null;
         taskLocation: TaskLocation;
     }) {
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
         this.indentation = indentation;
         this.listMarker = listMarker;
+        this.statusCharacter = statusCharacter;
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         if (nonTaskMatch) {
             this.description = nonTaskMatch[5].trim();
-            this.statusCharacter = nonTaskMatch[4] ?? null;
         }
         this.originalMarkdown = originalMarkdown;
 
@@ -51,12 +53,14 @@ export class ListItem {
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         let indentation = '';
         let listMarker = '';
+        let statusCharacter = null;
         if (nonTaskMatch) {
             indentation = nonTaskMatch[1];
             listMarker = nonTaskMatch[2];
+            statusCharacter = nonTaskMatch[4] ?? null;
         }
 
-        return new ListItem({ originalMarkdown, indentation, listMarker, taskLocation, parent });
+        return new ListItem({ originalMarkdown, indentation, listMarker, statusCharacter, taskLocation, parent });
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -35,6 +35,10 @@ export class ListItem {
         this.taskLocation = taskLocation;
     }
 
+    public static fromListItemLine(line: string, parent: ListItem | null, taskLocation: TaskLocation) {
+        return new ListItem(line, parent, taskLocation);
+    }
+
     /**
      * Return the top-level parent of this list item or task,
      * which will not be indented.

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -9,7 +9,7 @@ export class ListItem {
 
     public readonly parent: ListItem | null = null;
     public readonly children: ListItem[] = [];
-    public readonly indentation: string = '';
+    public readonly indentation: string;
     public readonly listMarker: string = '';
     public readonly description: string;
     public readonly statusCharacter: string | null = null;
@@ -28,9 +28,9 @@ export class ListItem {
         taskLocation: TaskLocation;
     }) {
         this.description = originalMarkdown.replace(TaskRegularExpressions.listItemRegex, '').trim();
+        this.indentation = indentation;
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         if (nonTaskMatch) {
-            this.indentation = indentation;
             this.listMarker = nonTaskMatch[2];
             this.description = nonTaskMatch[5].trim();
             this.statusCharacter = nonTaskMatch[4] ?? null;

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -117,7 +117,7 @@ export class Task extends ListItem {
         scheduledDateIsInferred: boolean;
         parent?: ListItem | null;
     }) {
-        super(parent, { originalMarkdown, taskLocation });
+        super(parent, { originalMarkdown, taskLocation, parent });
         // NEW_TASK_FIELD_EDIT_REQUIRED
         this.status = status;
         this.description = description;

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -117,7 +117,7 @@ export class Task extends ListItem {
         scheduledDateIsInferred: boolean;
         parent?: ListItem | null;
     }) {
-        super(originalMarkdown, parent, taskLocation);
+        super(originalMarkdown, parent, taskLocation, { originalMarkdown });
         // NEW_TASK_FIELD_EDIT_REQUIRED
         this.status = status;
         this.description = description;

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -122,6 +122,7 @@ export class Task extends ListItem {
             indentation,
             listMarker,
             statusCharacter: status.symbol,
+            description,
             taskLocation,
             parent,
         });

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -117,7 +117,7 @@ export class Task extends ListItem {
         scheduledDateIsInferred: boolean;
         parent?: ListItem | null;
     }) {
-        super({ originalMarkdown, taskLocation, parent });
+        super({ originalMarkdown, indentation, taskLocation, parent });
         // NEW_TASK_FIELD_EDIT_REQUIRED
         this.status = status;
         this.description = description;

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -117,7 +117,7 @@ export class Task extends ListItem {
         scheduledDateIsInferred: boolean;
         parent?: ListItem | null;
     }) {
-        super(originalMarkdown, parent, taskLocation, { originalMarkdown });
+        super(originalMarkdown, parent, taskLocation, { originalMarkdown, taskLocation });
         // NEW_TASK_FIELD_EDIT_REQUIRED
         this.status = status;
         this.description = description;

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -117,7 +117,14 @@ export class Task extends ListItem {
         scheduledDateIsInferred: boolean;
         parent?: ListItem | null;
     }) {
-        super({ originalMarkdown, indentation, listMarker, taskLocation, parent });
+        super({
+            originalMarkdown,
+            indentation,
+            listMarker,
+            statusCharacter: status.symbol,
+            taskLocation,
+            parent,
+        });
         // NEW_TASK_FIELD_EDIT_REQUIRED
         this.status = status;
         this.description = description;

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -117,7 +117,7 @@ export class Task extends ListItem {
         scheduledDateIsInferred: boolean;
         parent?: ListItem | null;
     }) {
-        super(originalMarkdown, parent, taskLocation, { originalMarkdown, taskLocation });
+        super(parent, { originalMarkdown, taskLocation });
         // NEW_TASK_FIELD_EDIT_REQUIRED
         this.status = status;
         this.description = description;

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -117,7 +117,7 @@ export class Task extends ListItem {
         scheduledDateIsInferred: boolean;
         parent?: ListItem | null;
     }) {
-        super({ originalMarkdown, indentation, taskLocation, parent });
+        super({ originalMarkdown, indentation, listMarker, taskLocation, parent });
         // NEW_TASK_FIELD_EDIT_REQUIRED
         this.status = status;
         this.description = description;

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -117,7 +117,7 @@ export class Task extends ListItem {
         scheduledDateIsInferred: boolean;
         parent?: ListItem | null;
     }) {
-        super(parent, { originalMarkdown, taskLocation, parent });
+        super({ originalMarkdown, taskLocation, parent });
         // NEW_TASK_FIELD_EDIT_REQUIRED
         this.status = status;
         this.description = description;

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -120,7 +120,7 @@ describe('list item parsing', () => {
     });
 
     it('should read a list item with checkbox', () => {
-        const item = new ListItem('- [ ] with checkbox', null, taskLocation);
+        const item = ListItem.fromListItemLine('- [ ] with checkbox', null, taskLocation);
 
         expect(item.description).toEqual('with checkbox');
         expect(item.originalMarkdown).toEqual('- [ ] with checkbox');
@@ -128,7 +128,7 @@ describe('list item parsing', () => {
     });
 
     it('should read a list item with checkbox', () => {
-        const item = new ListItem('- [x] with checked checkbox', null, taskLocation);
+        const item = ListItem.fromListItemLine('- [x] with checked checkbox', null, taskLocation);
 
         expect(item.description).toEqual('with checked checkbox');
         expect(item.originalMarkdown).toEqual('- [x] with checked checkbox');
@@ -136,17 +136,17 @@ describe('list item parsing', () => {
     });
 
     it('should read a list item with indentation', () => {
-        const item = new ListItem('  - indented', null, taskLocation);
+        const item = ListItem.fromListItemLine('  - indented', null, taskLocation);
 
         expect(item.description).toEqual('indented');
         expect(item.indentation).toEqual('  ');
     });
 
     it('should read a list marker', () => {
-        expect(new ListItem('* xxx', null, taskLocation).listMarker).toEqual('*');
-        expect(new ListItem('- xxx', null, taskLocation).listMarker).toEqual('-');
-        expect(new ListItem('+ xxx', null, taskLocation).listMarker).toEqual('+');
-        expect(new ListItem('2. xxx', null, taskLocation).listMarker).toEqual('2.');
+        expect(ListItem.fromListItemLine('* xxx', null, taskLocation).listMarker).toEqual('*');
+        expect(ListItem.fromListItemLine('- xxx', null, taskLocation).listMarker).toEqual('-');
+        expect(ListItem.fromListItemLine('+ xxx', null, taskLocation).listMarker).toEqual('+');
+        expect(ListItem.fromListItemLine('2. xxx', null, taskLocation).listMarker).toEqual('2.');
     });
 
     it('should accept a non list item', () => {

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -110,7 +110,7 @@ describe('list item tests', () => {
 
 describe('list item parsing', () => {
     it('should read a list item without checkbox', () => {
-        const item = new ListItem('- without checkbox', null, taskLocation);
+        const item = ListItem.fromListItemLine('- without checkbox', null, taskLocation);
 
         expect(item.description).toEqual('without checkbox');
         expect(item.originalMarkdown).toEqual('- without checkbox');

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -16,7 +16,7 @@ const taskLocation = TaskLocation.fromUnknownPosition(new TasksFile('anything.md
 
 describe('list item tests', () => {
     it('should create list item with empty children and absent parent', () => {
-        const listItem = new ListItem('', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('', null, taskLocation);
         expect(listItem).toBeDefined();
         expect(listItem.children).toEqual([]);
         expect(listItem.parent).toEqual(null);
@@ -24,9 +24,9 @@ describe('list item tests', () => {
     });
 
     it('should create a list item with 2 children', () => {
-        const listItem = new ListItem('', null, taskLocation);
-        const childItem1 = new ListItem('', listItem, taskLocation);
-        const childItem2 = new ListItem('', listItem, taskLocation);
+        const listItem = ListItem.fromListItemLine('', null, taskLocation);
+        const childItem1 = ListItem.fromListItemLine('', listItem, taskLocation);
+        const childItem2 = ListItem.fromListItemLine('', listItem, taskLocation);
         expect(listItem).toBeDefined();
         expect(childItem1.parent).toEqual(listItem);
         expect(childItem2.parent).toEqual(listItem);
@@ -34,15 +34,15 @@ describe('list item tests', () => {
     });
 
     it('should create a list item with a parent', () => {
-        const parentItem = new ListItem('', null, taskLocation);
-        const listItem = new ListItem('', parentItem, taskLocation);
+        const parentItem = ListItem.fromListItemLine('', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('', parentItem, taskLocation);
         expect(listItem).toBeDefined();
         expect(listItem.parent).toEqual(parentItem);
         expect(parentItem.children).toEqual([listItem]);
     });
 
     it('should create a task child for a list item parent', () => {
-        const parentListItem = new ListItem('- parent item', null, taskLocation);
+        const parentListItem = ListItem.fromListItemLine('- parent item', null, taskLocation);
         const firstReadTask = Task.fromLine({
             line: '    - [ ] child task',
             taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
@@ -62,16 +62,16 @@ describe('list item tests', () => {
             taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
             fallbackDate: null,
         });
-        const childListItem = new ListItem('    - child item', parentTask, taskLocation);
+        const childListItem = ListItem.fromListItemLine('    - child item', parentTask, taskLocation);
 
         expect(parentTask!.children).toEqual([childListItem]);
         expect(childListItem.parent).toBe(parentTask);
     });
 
     it('should identify root of the hierarchy', () => {
-        const grandParent = new ListItem('- grand parent', null, taskLocation);
-        const parent = new ListItem('- parent', grandParent, taskLocation);
-        const child = new ListItem('- child', parent, taskLocation);
+        const grandParent = ListItem.fromListItemLine('- grand parent', null, taskLocation);
+        const parent = ListItem.fromListItemLine('- parent', grandParent, taskLocation);
+        const child = ListItem.fromListItemLine('- child', parent, taskLocation);
 
         expect(grandParent.root.originalMarkdown).toEqual('- grand parent');
         expect(parent.root.originalMarkdown).toEqual('- grand parent');
@@ -83,7 +83,7 @@ describe('list item tests', () => {
     });
 
     it('should not be a task', () => {
-        const listItem = new ListItem('- list item', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('- list item', null, taskLocation);
         expect(listItem.isTask).toBe(false);
     });
 
@@ -98,7 +98,7 @@ describe('list item tests', () => {
     ])('should parse description with list item prefix: "%s"', (prefix: string, shouldPass) => {
         const description = 'stuff';
         const line = prefix + description;
-        const listItem = new ListItem(line, null, taskLocation);
+        const listItem = ListItem.fromListItemLine(line, null, taskLocation);
         expect(listItem.originalMarkdown).toEqual(line);
         if (shouldPass) {
             expect(listItem.description).toEqual(description);
@@ -152,7 +152,7 @@ describe('list item parsing', () => {
     it('should accept a non list item', () => {
         // we tried making the constructor throw if given a non list item
         // but it broke lots of normal Task uses in the tests (TaskBuilder)
-        const item = new ListItem('# Heading', null, taskLocation);
+        const item = ListItem.fromListItemLine('# Heading', null, taskLocation);
 
         expect(item.description).toEqual('# Heading');
         expect(item.originalMarkdown).toEqual('# Heading');
@@ -162,25 +162,25 @@ describe('list item parsing', () => {
 
 describe('list item writing', () => {
     it('should write a simple list item', () => {
-        const item = new ListItem('- simple', null, taskLocation);
+        const item = ListItem.fromListItemLine('- simple', null, taskLocation);
 
         expect(item.toFileLineString()).toEqual('- simple');
     });
 
     it('should write a simple check list item', () => {
-        const item = new ListItem('- [ ] simple checklist', null, taskLocation);
+        const item = ListItem.fromListItemLine('- [ ] simple checklist', null, taskLocation);
 
         expect(item.toFileLineString()).toEqual('- [ ] simple checklist');
     });
 
     it('should write an indented list item', () => {
-        const item = new ListItem('    - indented', null, taskLocation);
+        const item = ListItem.fromListItemLine('    - indented', null, taskLocation);
 
         expect(item.toFileLineString()).toEqual('    - indented');
     });
 
     it('should write a list item with a different list marker', () => {
-        const item = new ListItem('* star', null, taskLocation);
+        const item = ListItem.fromListItemLine('* star', null, taskLocation);
 
         expect(item.toFileLineString()).toEqual('* star');
     });
@@ -189,8 +189,8 @@ describe('list item writing', () => {
 describe('related items', () => {
     it('should detect if no closest parent task', () => {
         const task = fromLine({ line: '- [ ] task' });
-        const item = new ListItem('- item', null, taskLocation);
-        const childOfItem = new ListItem('- child of item', item, taskLocation);
+        const item = ListItem.fromListItemLine('- item', null, taskLocation);
+        const childOfItem = ListItem.fromListItemLine('- child of item', item, taskLocation);
 
         expect(task.findClosestParentTask()).toEqual(null);
         expect(item.findClosestParentTask()).toEqual(null);
@@ -199,8 +199,8 @@ describe('related items', () => {
 
     it('should find the closest parent task', () => {
         const parentTask = fromLine({ line: '- [ ] task' });
-        const child = new ListItem('- item', parentTask, taskLocation);
-        const grandChild = new ListItem('- item', child, taskLocation);
+        const child = ListItem.fromListItemLine('- item', parentTask, taskLocation);
+        const grandChild = ListItem.fromListItemLine('- item', child, taskLocation);
 
         expect(parentTask.findClosestParentTask()).toEqual(null);
         expect(child.findClosestParentTask()).toEqual(parentTask);
@@ -210,53 +210,61 @@ describe('related items', () => {
 
 describe('identicalTo', () => {
     it('should test same markdown', () => {
-        const listItem1 = new ListItem('- same description', null, taskLocation);
-        const listItem2 = new ListItem('- same description', null, taskLocation);
+        const listItem1 = ListItem.fromListItemLine('- same description', null, taskLocation);
+        const listItem2 = ListItem.fromListItemLine('- same description', null, taskLocation);
         expect(listItem1.identicalTo(listItem2)).toEqual(true);
     });
 
     it('should recognise different descriptions', () => {
-        const listItem1 = new ListItem('- description', null, taskLocation);
-        const listItem2 = new ListItem('- description two', null, taskLocation);
+        const listItem1 = ListItem.fromListItemLine('- description', null, taskLocation);
+        const listItem2 = ListItem.fromListItemLine('- description two', null, taskLocation);
         expect(listItem1.identicalTo(listItem2)).toEqual(false);
     });
 
     it('should recognise list items with different number of children', () => {
-        const item1 = new ListItem('- item', null, taskLocation);
+        const item1 = ListItem.fromListItemLine('- item', null, taskLocation);
         createChildListItem('- child of item1', item1);
 
-        const item2 = new ListItem('- item', null, taskLocation);
+        const item2 = ListItem.fromListItemLine('- item', null, taskLocation);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise list items with different children', () => {
-        const item1 = new ListItem('- item', null, taskLocation);
+        const item1 = ListItem.fromListItemLine('- item', null, taskLocation);
         createChildListItem('- child of item1', item1);
 
-        const item2 = new ListItem('- item', null, taskLocation);
+        const item2 = ListItem.fromListItemLine('- item', null, taskLocation);
         createChildListItem('- child of item2', item2);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise different status characters', () => {
-        const item1 = new ListItem('- [1] item', null, taskLocation);
-        const item2 = new ListItem('- [2] item', null, taskLocation);
+        const item1 = ListItem.fromListItemLine('- [1] item', null, taskLocation);
+        const item2 = ListItem.fromListItemLine('- [2] item', null, taskLocation);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise ListItem and Task as different', () => {
-        const listItem = new ListItem('- [ ] description', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('- [ ] description', null, taskLocation);
         const task = fromLine({ line: '- [ ] description' });
 
         expect(listItem.identicalTo(task)).toEqual(false);
     });
 
     it('should recognise different path', () => {
-        const item1 = new ListItem('- same', null, TaskLocation.fromUnknownPosition(new TasksFile('anything.md')));
-        const item2 = new ListItem('- same', null, TaskLocation.fromUnknownPosition(new TasksFile('something.md')));
+        const item1 = ListItem.fromListItemLine(
+            '- same',
+            null,
+            TaskLocation.fromUnknownPosition(new TasksFile('anything.md')),
+        );
+        const item2 = ListItem.fromListItemLine(
+            '- same',
+            null,
+            TaskLocation.fromUnknownPosition(new TasksFile('something.md')),
+        );
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
@@ -271,19 +279,19 @@ describe('checking if list item lists are identical', () => {
 
     it('should treat different sized lists as different', () => {
         const list1: ListItem[] = [];
-        const list2: ListItem[] = [new ListItem('- x', null, taskLocation)];
+        const list2: ListItem[] = [ListItem.fromListItemLine('- x', null, taskLocation)];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 
     it('should detect matching list items as same', () => {
-        const list1: ListItem[] = [new ListItem('- 1', null, taskLocation)];
-        const list2: ListItem[] = [new ListItem('- 1', null, taskLocation)];
+        const list1: ListItem[] = [ListItem.fromListItemLine('- 1', null, taskLocation)];
+        const list2: ListItem[] = [ListItem.fromListItemLine('- 1', null, taskLocation)];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(true);
     });
 
     it('- should detect non-matching list items as different', () => {
-        const list1: ListItem[] = [new ListItem('- 1', null, taskLocation)];
-        const list2: ListItem[] = [new ListItem('- 2', null, taskLocation)];
+        const list1: ListItem[] = [ListItem.fromListItemLine('- 1', null, taskLocation)];
+        const list2: ListItem[] = [ListItem.fromListItemLine('- 2', null, taskLocation)];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 });
@@ -316,7 +324,7 @@ describe('checking if task lists are identical', () => {
 
 describe('checking if mixed lists are identical', () => {
     it('should recognise mixed lists as unequal', () => {
-        const list1 = [new ListItem('- [ ] description', null, taskLocation)];
+        const list1 = [ListItem.fromListItemLine('- [ ] description', null, taskLocation)];
         const list2 = [fromLine({ line: '- [ ] description' })];
 
         expect(ListItem.listsAreIdentical(list1, list1)).toEqual(true);
@@ -328,9 +336,9 @@ describe('checking if mixed lists are identical', () => {
 
 describe('list item checking and unchecking', () => {
     it('should create a checked list item', () => {
-        const listItem = new ListItem(
+        const listItem = ListItem.fromListItemLine(
             '- [ ] description',
-            new ListItem('- [ ] parent', null, taskLocation),
+            ListItem.fromListItemLine('- [ ] parent', null, taskLocation),
             taskLocation,
         );
 
@@ -343,7 +351,7 @@ describe('list item checking and unchecking', () => {
     });
 
     it('should create a checked list item and preserve the list marker', () => {
-        const listItem = new ListItem('* [ ] check me', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('* [ ] check me', null, taskLocation);
 
         const checkedListItem = listItem.checkOrUncheck();
 
@@ -352,7 +360,7 @@ describe('list item checking and unchecking', () => {
     });
 
     it('should create an unchecked list item', () => {
-        const listItem = new ListItem('4. [#] uncheck me', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('4. [#] uncheck me', null, taskLocation);
 
         const checkedListItem = listItem.checkOrUncheck();
 
@@ -361,7 +369,7 @@ describe('list item checking and unchecking', () => {
     });
 
     it('should preserve a non-checklist item', () => {
-        const listItem = new ListItem('- no checkbox', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('- no checkbox', null, taskLocation);
 
         const newListItem = listItem.checkOrUncheck();
 
@@ -370,7 +378,7 @@ describe('list item checking and unchecking', () => {
     });
 
     it.failing('should preserve a non-checklist item with checkbox-like string in description', () => {
-        const listItem = new ListItem('- this looks like a checkbox [f]', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('- this looks like a checkbox [f]', null, taskLocation);
 
         const newListItem = listItem.checkOrUncheck();
 

--- a/tests/Task/ListItemHelpers.ts
+++ b/tests/Task/ListItemHelpers.ts
@@ -5,5 +5,5 @@ export function createChildListItem(originalMarkdown: string, parent: ListItem) 
     // This exists purely to silence WebStorm about typescript:S1848
     // See https://sonarcloud.io/organizations/obsidian-tasks-group/rules?open=typescript%3AS1848&rule_key=typescript%3AS1848
     const taskLocation = TaskLocation.fromUnknownPosition(parent.taskLocation.tasksFile);
-    new ListItem(originalMarkdown, parent, taskLocation);
+    ListItem.fromListItemLine(originalMarkdown, parent, taskLocation);
 }

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -65,13 +65,13 @@ describe('TaskBuilder', () => {
                 nullOrUnsetFields.push(key);
             }
         }
-        return nullOrUnsetFields;
+        return nullOrUnsetFields.sort();
     }
 
     it('createFullyPopulatedTask() should populate every field', () => {
         const task: Task = TaskBuilder.createFullyPopulatedTask();
 
-        expect(getNullOrUnsetFields(task)).toEqual(['parent', 'children']);
+        expect(getNullOrUnsetFields(task)).toEqual(['children', 'parent']);
         expect(getNullOrUnsetFields(task.taskLocation)).toEqual([]);
 
         expect(task.originalMarkdown).toEqual(

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -65,7 +65,7 @@ describe('TaskBuilder', () => {
                 nullOrUnsetFields.push(key);
             }
         }
-        return nullOrUnsetFields.sort();
+        return nullOrUnsetFields.sort((a, b) => a.localeCompare(b));
     }
 
     it('createFullyPopulatedTask() should populate every field', () => {


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- Add `ListItem.fromListItemLine()` method, similar to `Task.fromLine()`
- Use `ListItem.fromListItemLine()` instead of the constructor
- Use destructured parameter in `ListItem` constructor similar to `Task`

## Motivation and Context

- Make `ListItem` shape and patters similar to `Task`

This is in preparation for allowing `ListItem.fromListItemLine()` to return `null` if given a non-list-item line.

## How has this been tested?

- Unit tests

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
