### PR TITLE
refactor: Provide consistent identicalTo() methods

### DIFF
--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -221,4 +221,15 @@ export class TasksFile {
             return lowerCaseSearchKey === lowerCaseKey;
         });
     }
+
+    /**
+     * Compare all the fields in another TasksFile, to detect any differences from this one.
+     *
+     * If any field is different in any way, it will return false.
+     *
+     * @param _other
+     */
+    public identicalTo(_other: TasksFile) {
+        return true;
+    }
 }

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -227,9 +227,12 @@ export class TasksFile {
      *
      * If any field is different in any way, it will return false.
      *
-     * @param _other
+     * @param other
      */
-    public identicalTo(_other: TasksFile) {
+    public identicalTo(other: TasksFile) {
+        if (this.path !== other.path) {
+            return false;
+        }
         return true;
     }
 }

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -233,6 +233,6 @@ export class TasksFile {
         if (this.path !== other.path) {
             return false;
         }
-        return true;
+        return this.rawFrontmatterIdenticalTo(other);
     }
 }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -138,7 +138,7 @@ export class ListItem {
         // Note: taskLocation changes every time a line is added or deleted before
         //       any of the tasks in a file. This does mean that redrawing of tasks blocks
         //       happens more often than is ideal.
-        const args: Array<keyof ListItem> = ['originalMarkdown', 'description', 'statusCharacter'];
+        const args: Array<keyof ListItem> = ['description', 'statusCharacter', 'indentation', 'listMarker'];
 
         for (const el of args) {
             if (this[el]?.toString() !== other[el]?.toString()) return false;

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -135,19 +135,10 @@ export class ListItem {
             return false;
         }
 
-        // Note: sectionStart changes every time a line is added or deleted before
+        // Note: taskLocation changes every time a line is added or deleted before
         //       any of the tasks in a file. This does mean that redrawing of tasks blocks
         //       happens more often than is ideal.
-        const args: Array<keyof ListItem> = [
-            'originalMarkdown',
-            'description',
-            'statusCharacter',
-            'path',
-            'lineNumber',
-            'sectionStart',
-            'sectionIndex',
-            'precedingHeader',
-        ];
+        const args: Array<keyof ListItem> = ['originalMarkdown', 'description', 'statusCharacter'];
 
         for (const el of args) {
             if (this[el]?.toString() !== other[el]?.toString()) return false;

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -153,6 +153,8 @@ export class ListItem {
             if (this[el]?.toString() !== other[el]?.toString()) return false;
         }
 
+        if (!this.taskLocation.identicalTo(other.taskLocation)) return false;
+
         return ListItem.listsAreIdentical(this.children, other.children);
     }
 

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -41,9 +41,6 @@ interface TaskComponents {
 export class Task extends ListItem {
     // NEW_TASK_FIELD_EDIT_REQUIRED
     public readonly status: Status;
-    public readonly description: string;
-    public readonly indentation: string;
-    public readonly listMarker: string;
 
     public readonly tags: string[];
 
@@ -128,9 +125,6 @@ export class Task extends ListItem {
         });
         // NEW_TASK_FIELD_EDIT_REQUIRED
         this.status = status;
-        this.description = description;
-        this.indentation = indentation;
-        this.listMarker = listMarker;
 
         this.tags = tags;
 
@@ -784,9 +778,6 @@ export class Task extends ListItem {
         //       any of the tasks in a file. This does mean that redrawing of tasks blocks
         //       happens more often than is ideal.
         let args: Array<keyof Task> = [
-            'description',
-            'indentation',
-            'listMarker',
             'priority',
             'blockLink',
             'scheduledDateIsInferred',

--- a/src/Task/TaskLocation.ts
+++ b/src/Task/TaskLocation.ts
@@ -99,7 +99,7 @@ export class TaskLocation {
      * @param other
      */
     public identicalTo(other: TaskLocation) {
-        const args: Array<keyof TaskLocation> = ['lineNumber', 'sectionStart', 'sectionIndex'];
+        const args: Array<keyof TaskLocation> = ['lineNumber', 'sectionStart', 'sectionIndex', 'precedingHeader'];
 
         for (const el of args) {
             if (this[el] !== other[el]) return false;

--- a/src/Task/TaskLocation.ts
+++ b/src/Task/TaskLocation.ts
@@ -99,7 +99,7 @@ export class TaskLocation {
      * @param other
      */
     public identicalTo(other: TaskLocation) {
-        const args: Array<keyof TaskLocation> = ['lineNumber'];
+        const args: Array<keyof TaskLocation> = ['lineNumber', 'sectionStart'];
 
         for (const el of args) {
             if (this[el] !== other[el]) return false;

--- a/src/Task/TaskLocation.ts
+++ b/src/Task/TaskLocation.ts
@@ -105,6 +105,6 @@ export class TaskLocation {
             if (this[el] !== other[el]) return false;
         }
 
-        return true;
+        return this._tasksFile.identicalTo(other._tasksFile);
     }
 }

--- a/src/Task/TaskLocation.ts
+++ b/src/Task/TaskLocation.ts
@@ -90,4 +90,15 @@ export class TaskLocation {
         const { _tasksFile, ...rest } = { ...this };
         return rest;
     }
+
+    /**
+     * Compare all the fields in another TaskLocation, to detect any differences from this one.
+     *
+     * If any field is different in any way, it will return false.
+     *
+     * @param _other
+     */
+    public identicalTo(_other: TaskLocation) {
+        return true;
+    }
 }

--- a/src/Task/TaskLocation.ts
+++ b/src/Task/TaskLocation.ts
@@ -96,9 +96,15 @@ export class TaskLocation {
      *
      * If any field is different in any way, it will return false.
      *
-     * @param _other
+     * @param other
      */
-    public identicalTo(_other: TaskLocation) {
+    public identicalTo(other: TaskLocation) {
+        const args: Array<keyof TaskLocation> = ['lineNumber'];
+
+        for (const el of args) {
+            if (this[el] !== other[el]) return false;
+        }
+
         return true;
     }
 }

--- a/src/Task/TaskLocation.ts
+++ b/src/Task/TaskLocation.ts
@@ -105,6 +105,8 @@ export class TaskLocation {
             if (this[el] !== other[el]) return false;
         }
 
+        // We do this at the end because TasksFile objects are more expensive
+        // to compare, due to their storing potentially complext Properties data.
         return this._tasksFile.identicalTo(other._tasksFile);
     }
 }

--- a/src/Task/TaskLocation.ts
+++ b/src/Task/TaskLocation.ts
@@ -99,7 +99,7 @@ export class TaskLocation {
      * @param other
      */
     public identicalTo(other: TaskLocation) {
-        const args: Array<keyof TaskLocation> = ['lineNumber', 'sectionStart'];
+        const args: Array<keyof TaskLocation> = ['lineNumber', 'sectionStart', 'sectionIndex'];
 
         for (const el of args) {
             if (this[el] !== other[el]) return false;

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -333,4 +333,10 @@ describe('TasksFile - properties', () => {
         const rhs = new TasksFile(path, cachedMetadata);
         expect(lhs.identicalTo(rhs)).toEqual(true);
     });
+
+    it('should check path', () => {
+        const lhs = new TasksFile(path, cachedMetadata);
+        const rhs = new TasksFile('somewhere else.md', cachedMetadata);
+        expect(lhs.identicalTo(rhs)).toEqual(false);
+    });
 });

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -339,4 +339,10 @@ describe('TasksFile - properties', () => {
         const rhs = new TasksFile('somewhere else.md', cachedMetadata);
         expect(lhs.identicalTo(rhs)).toEqual(false);
     });
+
+    it('should check cachedMetadata', () => {
+        const lhs = getTasksFileFromMockData(example_kanban);
+        expect(lhs.identicalTo(getTasksFileFromMockData(example_kanban))).toEqual(true);
+        expect(lhs.identicalTo(getTasksFileFromMockData(jason_properties))).toEqual(false);
+    });
 });

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -324,7 +324,7 @@ describe('TasksFile - properties', () => {
     });
 });
 
-describe('TasksFile - properties', () => {
+describe('TasksFile - identicalTo', () => {
     const path = 'a/b/c/d.md';
     const cachedMetadata = {};
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -323,3 +323,14 @@ describe('TasksFile - properties', () => {
         expect(tasksFile.property('capital_property')).toEqual('some value');
     });
 });
+
+describe('TasksFile - properties', () => {
+    const path = 'a/b/c/d.md';
+    const cachedMetadata = {};
+
+    it('should detect identical objects', () => {
+        const lhs = new TasksFile(path, cachedMetadata);
+        const rhs = new TasksFile(path, cachedMetadata);
+        expect(lhs.identicalTo(rhs)).toEqual(true);
+    });
+});

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -247,6 +247,20 @@ describe('identicalTo', () => {
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
+    it('should recognise different indentation', () => {
+        const item1 = ListItem.fromListItemLine('- item', null, taskLocation);
+        const item2 = ListItem.fromListItemLine('    - item', null, taskLocation);
+
+        expect(item2.identicalTo(item1)).toEqual(false);
+    });
+
+    it('should recognise different listMarker', () => {
+        const item1 = ListItem.fromListItemLine('- item', null, taskLocation);
+        const item2 = ListItem.fromListItemLine('* item', null, taskLocation);
+
+        expect(item2.identicalTo(item1)).toEqual(false);
+    });
+
     it('should recognise ListItem and Task as different', () => {
         const listItem = ListItem.fromListItemLine('- [ ] description', null, taskLocation);
         const task = fromLine({ line: '- [ ] description' });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -254,7 +254,7 @@ describe('identicalTo', () => {
         expect(listItem.identicalTo(task)).toEqual(false);
     });
 
-    it('should recognise different path', () => {
+    it('should recognise different taskLocation', () => {
         const item1 = ListItem.fromListItemLine(
             '- same',
             null,

--- a/tests/Task/TaskLocation.test.ts
+++ b/tests/Task/TaskLocation.test.ts
@@ -94,4 +94,9 @@ describe('TaskLocation - identicalTo', function () {
         const rhs = new TaskLocation(tasksFile, 0, sectionStart, sectionIndex, precedingHeader);
         expect(lhs.identicalTo(rhs)).toEqual(false);
     });
+
+    it('should check sectionStart', () => {
+        const rhs = new TaskLocation(tasksFile, lineNumber, 0, sectionIndex, precedingHeader);
+        expect(lhs.identicalTo(rhs)).toEqual(false);
+    });
 });

--- a/tests/Task/TaskLocation.test.ts
+++ b/tests/Task/TaskLocation.test.ts
@@ -90,6 +90,11 @@ describe('TaskLocation - identicalTo', function () {
         expect(lhs.identicalTo(rhs)).toEqual(true);
     });
 
+    it('should check tasksFile', () => {
+        const rhs = new TaskLocation(new TasksFile('y.md'), lineNumber, sectionStart, sectionIndex, precedingHeader);
+        expect(lhs.identicalTo(rhs)).toEqual(false);
+    });
+
     it('should check lineNumber', () => {
         const rhs = new TaskLocation(tasksFile, 0, sectionStart, sectionIndex, precedingHeader);
         expect(lhs.identicalTo(rhs)).toEqual(false);

--- a/tests/Task/TaskLocation.test.ts
+++ b/tests/Task/TaskLocation.test.ts
@@ -88,4 +88,10 @@ describe('TaskLocation - identicalTo', function () {
         const rhs = new TaskLocation(tasksFile, lineNumber, sectionStart, sectionIndex, precedingHeader);
         expect(lhs.identicalTo(rhs)).toEqual(true);
     });
+
+    it('should check lineNumber', () => {
+        const lhs = new TaskLocation(tasksFile, lineNumber, sectionStart, sectionIndex, precedingHeader);
+        const rhs = new TaskLocation(tasksFile, 0, sectionStart, sectionIndex, precedingHeader);
+        expect(lhs.identicalTo(rhs)).toEqual(false);
+    });
 });

--- a/tests/Task/TaskLocation.test.ts
+++ b/tests/Task/TaskLocation.test.ts
@@ -99,4 +99,9 @@ describe('TaskLocation - identicalTo', function () {
         const rhs = new TaskLocation(tasksFile, lineNumber, 0, sectionIndex, precedingHeader);
         expect(lhs.identicalTo(rhs)).toEqual(false);
     });
+
+    it('should check sectionIndex', () => {
+        const rhs = new TaskLocation(tasksFile, lineNumber, sectionStart, 0, precedingHeader);
+        expect(lhs.identicalTo(rhs)).toEqual(false);
+    });
 });

--- a/tests/Task/TaskLocation.test.ts
+++ b/tests/Task/TaskLocation.test.ts
@@ -104,4 +104,18 @@ describe('TaskLocation - identicalTo', function () {
         const rhs = new TaskLocation(tasksFile, lineNumber, sectionStart, 0, precedingHeader);
         expect(lhs.identicalTo(rhs)).toEqual(false);
     });
+
+    it('should check precedingHeader', () => {
+        {
+            const precedingHeader = null;
+            const rhs = new TaskLocation(tasksFile, lineNumber, sectionStart, sectionIndex, precedingHeader);
+            expect(lhs.identicalTo(rhs)).toEqual(false);
+        }
+
+        {
+            const precedingHeader = 'different header';
+            const rhs = new TaskLocation(tasksFile, lineNumber, sectionStart, sectionIndex, precedingHeader);
+            expect(lhs.identicalTo(rhs)).toEqual(false);
+        }
+    });
 });

--- a/tests/Task/TaskLocation.test.ts
+++ b/tests/Task/TaskLocation.test.ts
@@ -83,14 +83,14 @@ describe('TaskLocation - identicalTo', function () {
     const sectionIndex: number = 3;
     const precedingHeader: string | null = 'heading';
 
+    const lhs = new TaskLocation(tasksFile, lineNumber, sectionStart, sectionIndex, precedingHeader);
+
     it('should detect identical objects', () => {
-        const lhs = new TaskLocation(tasksFile, lineNumber, sectionStart, sectionIndex, precedingHeader);
         const rhs = new TaskLocation(tasksFile, lineNumber, sectionStart, sectionIndex, precedingHeader);
         expect(lhs.identicalTo(rhs)).toEqual(true);
     });
 
     it('should check lineNumber', () => {
-        const lhs = new TaskLocation(tasksFile, lineNumber, sectionStart, sectionIndex, precedingHeader);
         const rhs = new TaskLocation(tasksFile, 0, sectionStart, sectionIndex, precedingHeader);
         expect(lhs.identicalTo(rhs)).toEqual(false);
     });

--- a/tests/Task/TaskLocation.test.ts
+++ b/tests/Task/TaskLocation.test.ts
@@ -75,3 +75,17 @@ describe('TaskLocation', () => {
         expect(TaskLocation.fromUnknownPosition(new TasksFile('')).hasKnownPath).toBe(false);
     });
 });
+
+describe('TaskLocation - identicalTo', function () {
+    const tasksFile: TasksFile = new TasksFile('x.md');
+    const lineNumber: number = 40;
+    const sectionStart: number = 30;
+    const sectionIndex: number = 3;
+    const precedingHeader: string | null = 'heading';
+
+    it('should detect identical objects', () => {
+        const lhs = new TaskLocation(tasksFile, lineNumber, sectionStart, sectionIndex, precedingHeader);
+        const rhs = new TaskLocation(tasksFile, lineNumber, sectionStart, sectionIndex, precedingHeader);
+        expect(lhs.identicalTo(rhs)).toEqual(true);
+    });
+});


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Thanks to @ilandikov for pairing on this to help me get it to the finishing line.

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

1. Clearly divide up the responsibilities for checking whether 2 objects have identical content.
2. Remove from `Task` and fields that are now also present in `ListItem`.

## Motivation and Context

With the addition of `ListItem`, we had ended up with some overlap in the responsibilities of:

- `ListItem.identicalTo()`
- `Task.identicalTo()`

This PR adds equivalent methods to `TasksFile` and `TaskLocation`, so that each layer is responsible for checking its own fields.

## How has this been tested?

Automated tests.


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
