### PR TITLE
refactor: Finish implementing ListItem.fromListItemLine()

### DIFF
--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -159,6 +159,7 @@ export class FileParser {
 
     private createListItem(listItem: ListItemCache, line: string, lineNumber: number, taskLocation: TaskLocation) {
         const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
-        this.line2ListItem.set(lineNumber, ListItem.fromListItemLine(line, parentListItem, taskLocation)!);
+        const newListItem = ListItem.fromListItemLine(line, parentListItem, taskLocation);
+        this.line2ListItem.set(lineNumber, newListItem!);
     }
 }

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -159,6 +159,6 @@ export class FileParser {
 
     private createListItem(listItem: ListItemCache, line: string, lineNumber: number, taskLocation: TaskLocation) {
         const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
-        this.line2ListItem.set(lineNumber, ListItem.fromListItemLine(line, parentListItem, taskLocation));
+        this.line2ListItem.set(lineNumber, ListItem.fromListItemLine(line, parentListItem, taskLocation)!);
     }
 }

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -158,7 +158,7 @@ export class FileParser {
     }
 
     private createListItem(listItem: ListItemCache, line: string, lineNumber: number, taskLocation: TaskLocation) {
-        const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
+        const parentListItem = this.line2ListItem.get(listItem.parent) ?? null;
         const newListItem = ListItem.fromListItemLine(line, parentListItem, taskLocation);
         if (newListItem === null) {
             // This should be unreachable.

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -160,6 +160,13 @@ export class FileParser {
     private createListItem(listItem: ListItemCache, line: string, lineNumber: number, taskLocation: TaskLocation) {
         const parentListItem: ListItem | null = this.line2ListItem.get(listItem.parent) ?? null;
         const newListItem = ListItem.fromListItemLine(line, parentListItem, taskLocation);
-        this.line2ListItem.set(lineNumber, newListItem!);
+        if (newListItem === null) {
+            // This should be unreachable.
+            this.logger.warn(
+                'Unexpected failure to create a list item from line: ' + line + ' in file: ' + this.filePath,
+            );
+            return;
+        }
+        this.line2ListItem.set(lineNumber, newListItem);
     }
 }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -211,6 +211,10 @@ export class ListItem {
     }
 
     public checkOrUncheck(): ListItem {
+        if (this.statusCharacter === null) {
+            return this;
+        }
+
         const newStatusCharacter = this.statusCharacter === ' ' ? 'x' : ' ';
         const newMarkdown = this.originalMarkdown.replace(
             RegExp(TaskRegularExpressions.checkboxRegex),

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -47,7 +47,11 @@ export class ListItem {
         this.taskLocation = taskLocation;
     }
 
-    public static fromListItemLine(originalMarkdown: string, parent: ListItem | null, taskLocation: TaskLocation) {
+    public static fromListItemLine(
+        originalMarkdown: string,
+        parent: ListItem | null,
+        taskLocation: TaskLocation,
+    ): ListItem | null {
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
         let indentation = '';
         let listMarker = '';
@@ -213,7 +217,7 @@ export class ListItem {
             `[${newStatusCharacter}]`,
         );
 
-        return ListItem.fromListItemLine(newMarkdown, null, this.taskLocation);
+        return ListItem.fromListItemLine(newMarkdown, null, this.taskLocation)!;
     }
 
     public toFileLineString(): string {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -47,6 +47,16 @@ export class ListItem {
         this.taskLocation = taskLocation;
     }
 
+    /**
+     * Takes the given line from an Obsidian note and returns a ListItem object.
+     *
+     * @static
+     * @param {string} originalMarkdown - The full line in the note to parse.
+     * @param {ListItem | null} parent - The optional parent Task or ListItem of the new instance.
+     * @param {TaskLocation} taskLocation - The location of the ListItem.
+     * @return {ListItem | null}
+     * @see Task.fromLine
+     */
     public static fromListItemLine(
         originalMarkdown: string,
         parent: ListItem | null,

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -221,7 +221,15 @@ export class ListItem {
             `[${newStatusCharacter}]`,
         );
 
-        return ListItem.fromListItemLine(newMarkdown, null, this.taskLocation)!;
+        return new ListItem({
+            ...this,
+            originalMarkdown: newMarkdown,
+            statusCharacter: newStatusCharacter,
+            // The purpose of this method is just to update the status character on one single line in the file.
+            // This will trigger an update, making Cache re-read the whole file,
+            // which will then identify and re-create any parent-child relationships.
+            parent: null,
+        });
     }
 
     public toFileLineString(): string {

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -163,6 +163,7 @@ export class Task extends ListItem {
      * @param {(Moment | null)} fallbackDate - The date to use as the scheduled date if no other date is set
      * @return {*}  {(Task | null)}
      * @see parseTaskSignifiers
+     * @see ListItem.fromListItemLine
      */
     public static fromLine({
         line,

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -387,8 +387,7 @@ describe('list item checking and unchecking', () => {
 
         const newListItem = listItem.checkOrUncheck();
 
-        expect(newListItem.statusCharacter).toEqual(null);
-        expect(newListItem.originalMarkdown).toEqual('- no checkbox');
+        expect(newListItem).toBe(listItem);
     });
 
     it('should preserve a non-checklist item with checkbox-like string in description', () => {
@@ -396,7 +395,6 @@ describe('list item checking and unchecking', () => {
 
         const newListItem = listItem.checkOrUncheck();
 
-        expect(newListItem.statusCharacter).toEqual(null);
-        expect(newListItem.originalMarkdown).toEqual('- this looks like a checkbox [f]');
+        expect(newListItem).toBe(listItem);
     });
 });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -391,7 +391,7 @@ describe('list item checking and unchecking', () => {
         expect(newListItem.originalMarkdown).toEqual('- no checkbox');
     });
 
-    it.failing('should preserve a non-checklist item with checkbox-like string in description', () => {
+    it('should preserve a non-checklist item with checkbox-like string in description', () => {
         const listItem = ListItem.fromListItemLine('- this looks like a checkbox [f]', null, taskLocation)!;
 
         const newListItem = listItem.checkOrUncheck();

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -352,7 +352,7 @@ describe('list item checking and unchecking', () => {
     it('should create a checked list item', () => {
         const listItem = ListItem.fromListItemLine(
             '- [ ] description',
-            ListItem.fromListItemLine('- [ ] parent', null, taskLocation)!,
+            ListItem.fromListItemLine('- [ ] parent', null, taskLocation),
             taskLocation,
         )!;
 

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -16,7 +16,7 @@ const taskLocation = TaskLocation.fromUnknownPosition(new TasksFile('anything.md
 
 describe('list item tests', () => {
     it('should create list item with empty children and absent parent', () => {
-        const listItem = ListItem.fromListItemLine('', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('', null, taskLocation)!;
         expect(listItem).toBeDefined();
         expect(listItem.children).toEqual([]);
         expect(listItem.parent).toEqual(null);
@@ -24,9 +24,9 @@ describe('list item tests', () => {
     });
 
     it('should create a list item with 2 children', () => {
-        const listItem = ListItem.fromListItemLine('', null, taskLocation);
-        const childItem1 = ListItem.fromListItemLine('', listItem, taskLocation);
-        const childItem2 = ListItem.fromListItemLine('', listItem, taskLocation);
+        const listItem = ListItem.fromListItemLine('', null, taskLocation)!;
+        const childItem1 = ListItem.fromListItemLine('', listItem, taskLocation)!;
+        const childItem2 = ListItem.fromListItemLine('', listItem, taskLocation)!;
         expect(listItem).toBeDefined();
         expect(childItem1.parent).toEqual(listItem);
         expect(childItem2.parent).toEqual(listItem);
@@ -34,15 +34,15 @@ describe('list item tests', () => {
     });
 
     it('should create a list item with a parent', () => {
-        const parentItem = ListItem.fromListItemLine('', null, taskLocation);
-        const listItem = ListItem.fromListItemLine('', parentItem, taskLocation);
+        const parentItem = ListItem.fromListItemLine('', null, taskLocation)!;
+        const listItem = ListItem.fromListItemLine('', parentItem, taskLocation)!;
         expect(listItem).toBeDefined();
         expect(listItem.parent).toEqual(parentItem);
         expect(parentItem.children).toEqual([listItem]);
     });
 
     it('should create a task child for a list item parent', () => {
-        const parentListItem = ListItem.fromListItemLine('- parent item', null, taskLocation);
+        const parentListItem = ListItem.fromListItemLine('- parent item', null, taskLocation)!;
         const firstReadTask = Task.fromLine({
             line: '    - [ ] child task',
             taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
@@ -62,16 +62,16 @@ describe('list item tests', () => {
             taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
             fallbackDate: null,
         });
-        const childListItem = ListItem.fromListItemLine('    - child item', parentTask, taskLocation);
+        const childListItem = ListItem.fromListItemLine('    - child item', parentTask, taskLocation)!;
 
         expect(parentTask!.children).toEqual([childListItem]);
         expect(childListItem.parent).toBe(parentTask);
     });
 
     it('should identify root of the hierarchy', () => {
-        const grandParent = ListItem.fromListItemLine('- grand parent', null, taskLocation);
-        const parent = ListItem.fromListItemLine('- parent', grandParent, taskLocation);
-        const child = ListItem.fromListItemLine('- child', parent, taskLocation);
+        const grandParent = ListItem.fromListItemLine('- grand parent', null, taskLocation)!;
+        const parent = ListItem.fromListItemLine('- parent', grandParent, taskLocation)!;
+        const child = ListItem.fromListItemLine('- child', parent, taskLocation)!;
 
         expect(grandParent.root.originalMarkdown).toEqual('- grand parent');
         expect(parent.root.originalMarkdown).toEqual('- grand parent');
@@ -83,7 +83,7 @@ describe('list item tests', () => {
     });
 
     it('should not be a task', () => {
-        const listItem = ListItem.fromListItemLine('- list item', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('- list item', null, taskLocation)!;
         expect(listItem.isTask).toBe(false);
     });
 
@@ -98,7 +98,7 @@ describe('list item tests', () => {
     ])('should parse description with list item prefix: "%s"', (prefix: string, shouldPass) => {
         const description = 'stuff';
         const line = prefix + description;
-        const listItem = ListItem.fromListItemLine(line, null, taskLocation);
+        const listItem = ListItem.fromListItemLine(line, null, taskLocation)!;
         expect(listItem.originalMarkdown).toEqual(line);
         if (shouldPass) {
             expect(listItem.description).toEqual(description);
@@ -110,7 +110,7 @@ describe('list item tests', () => {
 
 describe('list item parsing', () => {
     it('should read a list item without checkbox', () => {
-        const item = ListItem.fromListItemLine('- without checkbox', null, taskLocation);
+        const item = ListItem.fromListItemLine('- without checkbox', null, taskLocation)!;
 
         expect(item.description).toEqual('without checkbox');
         expect(item.originalMarkdown).toEqual('- without checkbox');
@@ -120,7 +120,7 @@ describe('list item parsing', () => {
     });
 
     it('should read a list item with checkbox', () => {
-        const item = ListItem.fromListItemLine('- [ ] with checkbox', null, taskLocation);
+        const item = ListItem.fromListItemLine('- [ ] with checkbox', null, taskLocation)!;
 
         expect(item.description).toEqual('with checkbox');
         expect(item.originalMarkdown).toEqual('- [ ] with checkbox');
@@ -128,7 +128,7 @@ describe('list item parsing', () => {
     });
 
     it('should read a list item with checkbox', () => {
-        const item = ListItem.fromListItemLine('- [x] with checked checkbox', null, taskLocation);
+        const item = ListItem.fromListItemLine('- [x] with checked checkbox', null, taskLocation)!;
 
         expect(item.description).toEqual('with checked checkbox');
         expect(item.originalMarkdown).toEqual('- [x] with checked checkbox');
@@ -136,23 +136,23 @@ describe('list item parsing', () => {
     });
 
     it('should read a list item with indentation', () => {
-        const item = ListItem.fromListItemLine('  - indented', null, taskLocation);
+        const item = ListItem.fromListItemLine('  - indented', null, taskLocation)!;
 
         expect(item.description).toEqual('indented');
         expect(item.indentation).toEqual('  ');
     });
 
     it('should read a list marker', () => {
-        expect(ListItem.fromListItemLine('* xxx', null, taskLocation).listMarker).toEqual('*');
-        expect(ListItem.fromListItemLine('- xxx', null, taskLocation).listMarker).toEqual('-');
-        expect(ListItem.fromListItemLine('+ xxx', null, taskLocation).listMarker).toEqual('+');
-        expect(ListItem.fromListItemLine('2. xxx', null, taskLocation).listMarker).toEqual('2.');
+        expect(ListItem.fromListItemLine('* xxx', null, taskLocation)!.listMarker).toEqual('*');
+        expect(ListItem.fromListItemLine('- xxx', null, taskLocation)!.listMarker).toEqual('-');
+        expect(ListItem.fromListItemLine('+ xxx', null, taskLocation)!.listMarker).toEqual('+');
+        expect(ListItem.fromListItemLine('2. xxx', null, taskLocation)!.listMarker).toEqual('2.');
     });
 
     it('should accept a non list item', () => {
         // we tried making the constructor throw if given a non list item
         // but it broke lots of normal Task uses in the tests (TaskBuilder)
-        const item = ListItem.fromListItemLine('# Heading', null, taskLocation);
+        const item = ListItem.fromListItemLine('# Heading', null, taskLocation)!;
 
         expect(item.description).toEqual('# Heading');
         expect(item.originalMarkdown).toEqual('# Heading');
@@ -162,25 +162,25 @@ describe('list item parsing', () => {
 
 describe('list item writing', () => {
     it('should write a simple list item', () => {
-        const item = ListItem.fromListItemLine('- simple', null, taskLocation);
+        const item = ListItem.fromListItemLine('- simple', null, taskLocation)!;
 
         expect(item.toFileLineString()).toEqual('- simple');
     });
 
     it('should write a simple check list item', () => {
-        const item = ListItem.fromListItemLine('- [ ] simple checklist', null, taskLocation);
+        const item = ListItem.fromListItemLine('- [ ] simple checklist', null, taskLocation)!;
 
         expect(item.toFileLineString()).toEqual('- [ ] simple checklist');
     });
 
     it('should write an indented list item', () => {
-        const item = ListItem.fromListItemLine('    - indented', null, taskLocation);
+        const item = ListItem.fromListItemLine('    - indented', null, taskLocation)!;
 
         expect(item.toFileLineString()).toEqual('    - indented');
     });
 
     it('should write a list item with a different list marker', () => {
-        const item = ListItem.fromListItemLine('* star', null, taskLocation);
+        const item = ListItem.fromListItemLine('* star', null, taskLocation)!;
 
         expect(item.toFileLineString()).toEqual('* star');
     });
@@ -189,8 +189,8 @@ describe('list item writing', () => {
 describe('related items', () => {
     it('should detect if no closest parent task', () => {
         const task = fromLine({ line: '- [ ] task' });
-        const item = ListItem.fromListItemLine('- item', null, taskLocation);
-        const childOfItem = ListItem.fromListItemLine('- child of item', item, taskLocation);
+        const item = ListItem.fromListItemLine('- item', null, taskLocation)!;
+        const childOfItem = ListItem.fromListItemLine('- child of item', item, taskLocation)!;
 
         expect(task.findClosestParentTask()).toEqual(null);
         expect(item.findClosestParentTask()).toEqual(null);
@@ -199,8 +199,8 @@ describe('related items', () => {
 
     it('should find the closest parent task', () => {
         const parentTask = fromLine({ line: '- [ ] task' });
-        const child = ListItem.fromListItemLine('- item', parentTask, taskLocation);
-        const grandChild = ListItem.fromListItemLine('- item', child, taskLocation);
+        const child = ListItem.fromListItemLine('- item', parentTask, taskLocation)!;
+        const grandChild = ListItem.fromListItemLine('- item', child, taskLocation)!;
 
         expect(parentTask.findClosestParentTask()).toEqual(null);
         expect(child.findClosestParentTask()).toEqual(parentTask);
@@ -210,59 +210,59 @@ describe('related items', () => {
 
 describe('identicalTo', () => {
     it('should test same markdown', () => {
-        const listItem1 = ListItem.fromListItemLine('- same description', null, taskLocation);
-        const listItem2 = ListItem.fromListItemLine('- same description', null, taskLocation);
+        const listItem1 = ListItem.fromListItemLine('- same description', null, taskLocation)!;
+        const listItem2 = ListItem.fromListItemLine('- same description', null, taskLocation)!;
         expect(listItem1.identicalTo(listItem2)).toEqual(true);
     });
 
     it('should recognise different descriptions', () => {
-        const listItem1 = ListItem.fromListItemLine('- description', null, taskLocation);
-        const listItem2 = ListItem.fromListItemLine('- description two', null, taskLocation);
+        const listItem1 = ListItem.fromListItemLine('- description', null, taskLocation)!;
+        const listItem2 = ListItem.fromListItemLine('- description two', null, taskLocation)!;
         expect(listItem1.identicalTo(listItem2)).toEqual(false);
     });
 
     it('should recognise list items with different number of children', () => {
-        const item1 = ListItem.fromListItemLine('- item', null, taskLocation);
+        const item1 = ListItem.fromListItemLine('- item', null, taskLocation)!;
         createChildListItem('- child of item1', item1);
 
-        const item2 = ListItem.fromListItemLine('- item', null, taskLocation);
+        const item2 = ListItem.fromListItemLine('- item', null, taskLocation)!;
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise list items with different children', () => {
-        const item1 = ListItem.fromListItemLine('- item', null, taskLocation);
+        const item1 = ListItem.fromListItemLine('- item', null, taskLocation)!;
         createChildListItem('- child of item1', item1);
 
-        const item2 = ListItem.fromListItemLine('- item', null, taskLocation);
+        const item2 = ListItem.fromListItemLine('- item', null, taskLocation)!;
         createChildListItem('- child of item2', item2);
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise different status characters', () => {
-        const item1 = ListItem.fromListItemLine('- [1] item', null, taskLocation);
-        const item2 = ListItem.fromListItemLine('- [2] item', null, taskLocation);
+        const item1 = ListItem.fromListItemLine('- [1] item', null, taskLocation)!;
+        const item2 = ListItem.fromListItemLine('- [2] item', null, taskLocation)!;
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise different indentation', () => {
-        const item1 = ListItem.fromListItemLine('- item', null, taskLocation);
-        const item2 = ListItem.fromListItemLine('    - item', null, taskLocation);
+        const item1 = ListItem.fromListItemLine('- item', null, taskLocation)!;
+        const item2 = ListItem.fromListItemLine('    - item', null, taskLocation)!;
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise different listMarker', () => {
-        const item1 = ListItem.fromListItemLine('- item', null, taskLocation);
-        const item2 = ListItem.fromListItemLine('* item', null, taskLocation);
+        const item1 = ListItem.fromListItemLine('- item', null, taskLocation)!;
+        const item2 = ListItem.fromListItemLine('* item', null, taskLocation)!;
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
 
     it('should recognise ListItem and Task as different', () => {
-        const listItem = ListItem.fromListItemLine('- [ ] description', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('- [ ] description', null, taskLocation)!;
         const task = fromLine({ line: '- [ ] description' });
 
         expect(listItem.identicalTo(task)).toEqual(false);
@@ -273,12 +273,12 @@ describe('identicalTo', () => {
             '- same',
             null,
             TaskLocation.fromUnknownPosition(new TasksFile('anything.md')),
-        );
+        )!;
         const item2 = ListItem.fromListItemLine(
             '- same',
             null,
             TaskLocation.fromUnknownPosition(new TasksFile('something.md')),
-        );
+        )!;
 
         expect(item2.identicalTo(item1)).toEqual(false);
     });
@@ -293,19 +293,19 @@ describe('checking if list item lists are identical', () => {
 
     it('should treat different sized lists as different', () => {
         const list1: ListItem[] = [];
-        const list2: ListItem[] = [ListItem.fromListItemLine('- x', null, taskLocation)];
+        const list2: ListItem[] = [ListItem.fromListItemLine('- x', null, taskLocation)!];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 
     it('should detect matching list items as same', () => {
-        const list1: ListItem[] = [ListItem.fromListItemLine('- 1', null, taskLocation)];
-        const list2: ListItem[] = [ListItem.fromListItemLine('- 1', null, taskLocation)];
+        const list1: ListItem[] = [ListItem.fromListItemLine('- 1', null, taskLocation)!];
+        const list2: ListItem[] = [ListItem.fromListItemLine('- 1', null, taskLocation)!];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(true);
     });
 
     it('- should detect non-matching list items as different', () => {
-        const list1: ListItem[] = [ListItem.fromListItemLine('- 1', null, taskLocation)];
-        const list2: ListItem[] = [ListItem.fromListItemLine('- 2', null, taskLocation)];
+        const list1: ListItem[] = [ListItem.fromListItemLine('- 1', null, taskLocation)!];
+        const list2: ListItem[] = [ListItem.fromListItemLine('- 2', null, taskLocation)!];
         expect(ListItem.listsAreIdentical(list1, list2)).toBe(false);
     });
 });
@@ -338,7 +338,7 @@ describe('checking if task lists are identical', () => {
 
 describe('checking if mixed lists are identical', () => {
     it('should recognise mixed lists as unequal', () => {
-        const list1 = [ListItem.fromListItemLine('- [ ] description', null, taskLocation)];
+        const list1 = [ListItem.fromListItemLine('- [ ] description', null, taskLocation)!];
         const list2 = [fromLine({ line: '- [ ] description' })];
 
         expect(ListItem.listsAreIdentical(list1, list1)).toEqual(true);
@@ -352,9 +352,9 @@ describe('list item checking and unchecking', () => {
     it('should create a checked list item', () => {
         const listItem = ListItem.fromListItemLine(
             '- [ ] description',
-            ListItem.fromListItemLine('- [ ] parent', null, taskLocation),
+            ListItem.fromListItemLine('- [ ] parent', null, taskLocation)!,
             taskLocation,
-        );
+        )!;
 
         const checkedListItem = listItem.checkOrUncheck();
 
@@ -365,7 +365,7 @@ describe('list item checking and unchecking', () => {
     });
 
     it('should create a checked list item and preserve the list marker', () => {
-        const listItem = ListItem.fromListItemLine('* [ ] check me', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('* [ ] check me', null, taskLocation)!;
 
         const checkedListItem = listItem.checkOrUncheck();
 
@@ -374,7 +374,7 @@ describe('list item checking and unchecking', () => {
     });
 
     it('should create an unchecked list item', () => {
-        const listItem = ListItem.fromListItemLine('4. [#] uncheck me', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('4. [#] uncheck me', null, taskLocation)!;
 
         const checkedListItem = listItem.checkOrUncheck();
 
@@ -383,7 +383,7 @@ describe('list item checking and unchecking', () => {
     });
 
     it('should preserve a non-checklist item', () => {
-        const listItem = ListItem.fromListItemLine('- no checkbox', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('- no checkbox', null, taskLocation)!;
 
         const newListItem = listItem.checkOrUncheck();
 
@@ -392,7 +392,7 @@ describe('list item checking and unchecking', () => {
     });
 
     it.failing('should preserve a non-checklist item with checkbox-like string in description', () => {
-        const listItem = ListItem.fromListItemLine('- this looks like a checkbox [f]', null, taskLocation);
+        const listItem = ListItem.fromListItemLine('- this looks like a checkbox [f]', null, taskLocation)!;
 
         const newListItem = listItem.checkOrUncheck();
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Done by pairing with @ilandikov.

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

`ListItem.fromListItemLine()` now returns `null` if the given line is not a list item.

This makes it consistent with the corresponding method on `Task` and fixes a failing test.

## Motivation and Context

- Part of a series of clean-up steps after the initial fixing of #3170.

## How has this been tested?

Unit tests.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
