### PR TITLE
refactor: Move code for rendering ListItems to TaskLineRenderer

### DIFF
--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -6,7 +6,6 @@ import type { IQuery } from '../IQuery';
 import { QueryLayout } from '../Layout/QueryLayout';
 import { TaskLayout } from '../Layout/TaskLayout';
 import { PerformanceTracker } from '../lib/PerformanceTracker';
-import { replaceTaskWithTasks } from '../Obsidian/File';
 import { explainResults, getQueryForQueryRenderer } from '../Query/QueryRendererHelper';
 import { State } from '../Obsidian/Cache';
 import type { GroupDisplayHeading } from '../Query/Group/GroupDisplayHeading';
@@ -16,7 +15,7 @@ import type { TasksFile } from '../Scripting/TasksFile';
 import type { ListItem } from '../Task/ListItem';
 import { Task } from '../Task/Task';
 import { PostponeMenu } from '../ui/Menus/PostponeMenu';
-import { TaskLineRenderer, type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
+import { TaskLineRenderer, type TextRenderer, createAndAppendElement, renderListItem } from './TaskLineRenderer';
 
 export type BacklinksEventHandler = (ev: MouseEvent, task: Task) => Promise<void>;
 export type EditButtonClickHandler = (event: MouseEvent, task: Task, allTasks: Task[]) => void;
@@ -34,61 +33,6 @@ export interface QueryRendererParameters {
     backlinksClickHandler: BacklinksEventHandler;
     backlinksMousedownHandler: BacklinksEventHandler;
     editTaskPencilClickHandler: EditButtonClickHandler;
-}
-
-async function renderListItem(
-    taskList: HTMLUListElement,
-    listItem: ListItem,
-    listItemIndex: number,
-    textRenderer: any,
-    obsidianComponent: Component | null,
-) {
-    const li = createAndAppendElement('li', taskList);
-
-    if (listItem.statusCharacter) {
-        const checkbox = createAndAppendElement('input', li);
-        checkbox.classList.add('task-list-item-checkbox');
-        checkbox.type = 'checkbox';
-
-        checkbox.addEventListener('click', (event: MouseEvent) => {
-            event.preventDefault();
-            // It is required to stop propagation so that obsidian won't write the file with the
-            // checkbox (un)checked. Obsidian would write after us and overwrite our change.
-            event.stopPropagation();
-
-            // Should be re-rendered as enabled after update in file.
-            checkbox.disabled = true;
-
-            const checkedOrUncheckedListItem = listItem.checkOrUncheck();
-            replaceTaskWithTasks({ originalTask: listItem, newTasks: checkedOrUncheckedListItem });
-        });
-
-        if (listItem.statusCharacter !== ' ') {
-            checkbox.checked = true;
-            li.classList.add('is-checked');
-        }
-
-        li.classList.add('task-list-item');
-
-        // Set these to be compatible with stock obsidian lists:
-        li.setAttribute('data-task', listItem.statusCharacter.trim());
-        // Trim to ensure empty attribute for space. Same way as obsidian.
-        li.setAttribute('data-line', listItemIndex.toString());
-    }
-
-    const span = createAndAppendElement('span', li);
-    await textRenderer(listItem.description, span, listItem.findClosestParentTask()?.path ?? '', obsidianComponent);
-
-    // Unwrap the p-tag that was created by the MarkdownRenderer:
-    const pElement = span.querySelector('p');
-    if (pElement !== null) {
-        while (pElement.firstChild) {
-            span.insertBefore(pElement.firstChild, pElement);
-        }
-        pElement.remove();
-    }
-
-    return li;
 }
 
 /**

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -361,15 +361,7 @@ export class QueryResultsRenderer {
         listItem: ListItem,
         listItemIndex: number,
     ) {
-        const textRenderer = this.textRenderer;
-        const obsidianComponent = this.obsidianComponent;
-        return await _taskLineRenderer.renderListItem(
-            taskList,
-            listItem,
-            listItemIndex,
-            textRenderer,
-            obsidianComponent,
-        );
+        return await _taskLineRenderer.renderListItem(taskList, listItem, listItemIndex);
     }
 
     private async addTask(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -357,11 +357,11 @@ export class QueryResultsRenderer {
 
     private async addListItem(
         taskList: HTMLUListElement,
-        _taskLineRenderer: TaskLineRenderer,
+        taskLineRenderer: TaskLineRenderer,
         listItem: ListItem,
         listItemIndex: number,
     ) {
-        return await _taskLineRenderer.renderListItem(taskList, listItem, listItemIndex);
+        return await taskLineRenderer.renderListItem(taskList, listItem, listItemIndex);
     }
 
     private async addTask(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -15,7 +15,7 @@ import type { TasksFile } from '../Scripting/TasksFile';
 import type { ListItem } from '../Task/ListItem';
 import { Task } from '../Task/Task';
 import { PostponeMenu } from '../ui/Menus/PostponeMenu';
-import { TaskLineRenderer, type TextRenderer, createAndAppendElement, renderListItem } from './TaskLineRenderer';
+import { TaskLineRenderer, type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
 
 export type BacklinksEventHandler = (ev: MouseEvent, task: Task) => Promise<void>;
 export type EditButtonClickHandler = (event: MouseEvent, task: Task, allTasks: Task[]) => void;
@@ -363,7 +363,13 @@ export class QueryResultsRenderer {
     ) {
         const textRenderer = this.textRenderer;
         const obsidianComponent = this.obsidianComponent;
-        return await renderListItem(taskList, listItem, listItemIndex, textRenderer, obsidianComponent);
+        return await _taskLineRenderer.renderListItem(
+            taskList,
+            listItem,
+            listItemIndex,
+            textRenderer,
+            obsidianComponent,
+        );
     }
 
     private async addTask(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -353,14 +353,14 @@ export class QueryResultsRenderer {
             return await this.addTask(taskList, taskLineRenderer, listItem, taskIndex, queryRendererParameters);
         }
 
-        return await this.addListItem(taskList, listItem, taskIndex, taskLineRenderer);
+        return await this.addListItem(taskList, taskLineRenderer, listItem, taskIndex);
     }
 
     private async addListItem(
         taskList: HTMLUListElement,
+        _taskLineRenderer: TaskLineRenderer,
         listItem: ListItem,
         listItemIndex: number,
-        _taskLineRenderer: TaskLineRenderer,
     ) {
         const li = createAndAppendElement('li', taskList);
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -362,6 +362,9 @@ export class QueryResultsRenderer {
         listItem: ListItem,
         listItemIndex: number,
     ) {
+        const textRenderer = this.textRenderer;
+        const obsidianComponent = this.obsidianComponent;
+
         const li = createAndAppendElement('li', taskList);
 
         if (listItem.statusCharacter) {
@@ -396,12 +399,7 @@ export class QueryResultsRenderer {
         }
 
         const span = createAndAppendElement('span', li);
-        await this.textRenderer(
-            listItem.description,
-            span,
-            listItem.findClosestParentTask()?.path ?? '',
-            this.obsidianComponent,
-        );
+        await textRenderer(listItem.description, span, listItem.findClosestParentTask()?.path ?? '', obsidianComponent);
 
         // Unwrap the p-tag that was created by the MarkdownRenderer:
         const pElement = span.querySelector('p');

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -36,6 +36,61 @@ export interface QueryRendererParameters {
     editTaskPencilClickHandler: EditButtonClickHandler;
 }
 
+async function renderListItem(
+    taskList: HTMLUListElement,
+    listItem: ListItem,
+    listItemIndex: number,
+    textRenderer: any,
+    obsidianComponent: Component | null,
+) {
+    const li = createAndAppendElement('li', taskList);
+
+    if (listItem.statusCharacter) {
+        const checkbox = createAndAppendElement('input', li);
+        checkbox.classList.add('task-list-item-checkbox');
+        checkbox.type = 'checkbox';
+
+        checkbox.addEventListener('click', (event: MouseEvent) => {
+            event.preventDefault();
+            // It is required to stop propagation so that obsidian won't write the file with the
+            // checkbox (un)checked. Obsidian would write after us and overwrite our change.
+            event.stopPropagation();
+
+            // Should be re-rendered as enabled after update in file.
+            checkbox.disabled = true;
+
+            const checkedOrUncheckedListItem = listItem.checkOrUncheck();
+            replaceTaskWithTasks({ originalTask: listItem, newTasks: checkedOrUncheckedListItem });
+        });
+
+        if (listItem.statusCharacter !== ' ') {
+            checkbox.checked = true;
+            li.classList.add('is-checked');
+        }
+
+        li.classList.add('task-list-item');
+
+        // Set these to be compatible with stock obsidian lists:
+        li.setAttribute('data-task', listItem.statusCharacter.trim());
+        // Trim to ensure empty attribute for space. Same way as obsidian.
+        li.setAttribute('data-line', listItemIndex.toString());
+    }
+
+    const span = createAndAppendElement('span', li);
+    await textRenderer(listItem.description, span, listItem.findClosestParentTask()?.path ?? '', obsidianComponent);
+
+    // Unwrap the p-tag that was created by the MarkdownRenderer:
+    const pElement = span.querySelector('p');
+    if (pElement !== null) {
+        while (pElement.firstChild) {
+            span.insertBefore(pElement.firstChild, pElement);
+        }
+        pElement.remove();
+    }
+
+    return li;
+}
+
 /**
  * The `QueryResultsRenderer` class is responsible for rendering the results
  * of a query applied to a set of tasks.
@@ -364,53 +419,7 @@ export class QueryResultsRenderer {
     ) {
         const textRenderer = this.textRenderer;
         const obsidianComponent = this.obsidianComponent;
-
-        const li = createAndAppendElement('li', taskList);
-
-        if (listItem.statusCharacter) {
-            const checkbox = createAndAppendElement('input', li);
-            checkbox.classList.add('task-list-item-checkbox');
-            checkbox.type = 'checkbox';
-
-            checkbox.addEventListener('click', (event: MouseEvent) => {
-                event.preventDefault();
-                // It is required to stop propagation so that obsidian won't write the file with the
-                // checkbox (un)checked. Obsidian would write after us and overwrite our change.
-                event.stopPropagation();
-
-                // Should be re-rendered as enabled after update in file.
-                checkbox.disabled = true;
-
-                const checkedOrUncheckedListItem = listItem.checkOrUncheck();
-                replaceTaskWithTasks({ originalTask: listItem, newTasks: checkedOrUncheckedListItem });
-            });
-
-            if (listItem.statusCharacter !== ' ') {
-                checkbox.checked = true;
-                li.classList.add('is-checked');
-            }
-
-            li.classList.add('task-list-item');
-
-            // Set these to be compatible with stock obsidian lists:
-            li.setAttribute('data-task', listItem.statusCharacter.trim());
-            // Trim to ensure empty attribute for space. Same way as obsidian.
-            li.setAttribute('data-line', listItemIndex.toString());
-        }
-
-        const span = createAndAppendElement('span', li);
-        await textRenderer(listItem.description, span, listItem.findClosestParentTask()?.path ?? '', obsidianComponent);
-
-        // Unwrap the p-tag that was created by the MarkdownRenderer:
-        const pElement = span.querySelector('p');
-        if (pElement !== null) {
-            while (pElement.firstChild) {
-                span.insertBefore(pElement.firstChild, pElement);
-            }
-            pElement.remove();
-        }
-
-        return li;
+        return await renderListItem(taskList, listItem, listItemIndex, textRenderer, obsidianComponent);
     }
 
     private async addTask(

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -353,10 +353,15 @@ export class QueryResultsRenderer {
             return await this.addTask(taskList, taskLineRenderer, listItem, taskIndex, queryRendererParameters);
         }
 
-        return await this.addListItem(taskList, listItem, taskIndex);
+        return await this.addListItem(taskList, listItem, taskIndex, taskLineRenderer);
     }
 
-    private async addListItem(taskList: HTMLUListElement, listItem: ListItem, listItemIndex: number) {
+    private async addListItem(
+        taskList: HTMLUListElement,
+        listItem: ListItem,
+        listItemIndex: number,
+        _taskLineRenderer: TaskLineRenderer,
+    ) {
         const li = createAndAppendElement('li', taskList);
 
         if (listItem.statusCharacter) {

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -405,8 +405,6 @@ export class TaskLineRenderer {
     }
 
     public async renderListItem(taskList: HTMLUListElement, listItem: ListItem, listItemIndex: number) {
-        const textRenderer = this.textRenderer;
-        const obsidianComponent = this.obsidianComponent;
         const li = createAndAppendElement('li', taskList);
 
         if (listItem.statusCharacter) {
@@ -441,7 +439,12 @@ export class TaskLineRenderer {
         }
 
         const span = createAndAppendElement('span', li);
-        await textRenderer(listItem.description, span, listItem.findClosestParentTask()?.path ?? '', obsidianComponent);
+        await this.textRenderer(
+            listItem.description,
+            span,
+            listItem.findClosestParentTask()?.path ?? '',
+            this.obsidianComponent,
+        );
 
         // Unwrap the p-tag that was created by the MarkdownRenderer:
         const pElement = span.querySelector('p');

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -14,6 +14,7 @@ import { defaultTaskSaver } from '../ui/Menus/TaskEditingMenu';
 import { promptForDate } from '../ui/Menus/DatePicker';
 import { splitDateText } from '../DateTime/Postponer';
 import { DateMenu } from '../ui/Menus/DateMenu';
+import type { ListItem } from '../Task/ListItem';
 import { TaskFieldRenderer } from './TaskFieldRenderer';
 
 /**
@@ -402,4 +403,59 @@ export class TaskLineRenderer {
             });
         });
     }
+}
+
+export async function renderListItem(
+    taskList: HTMLUListElement,
+    listItem: ListItem,
+    listItemIndex: number,
+    textRenderer: any,
+    obsidianComponent: Component | null,
+) {
+    const li = createAndAppendElement('li', taskList);
+
+    if (listItem.statusCharacter) {
+        const checkbox = createAndAppendElement('input', li);
+        checkbox.classList.add('task-list-item-checkbox');
+        checkbox.type = 'checkbox';
+
+        checkbox.addEventListener('click', (event: MouseEvent) => {
+            event.preventDefault();
+            // It is required to stop propagation so that obsidian won't write the file with the
+            // checkbox (un)checked. Obsidian would write after us and overwrite our change.
+            event.stopPropagation();
+
+            // Should be re-rendered as enabled after update in file.
+            checkbox.disabled = true;
+
+            const checkedOrUncheckedListItem = listItem.checkOrUncheck();
+            replaceTaskWithTasks({ originalTask: listItem, newTasks: checkedOrUncheckedListItem });
+        });
+
+        if (listItem.statusCharacter !== ' ') {
+            checkbox.checked = true;
+            li.classList.add('is-checked');
+        }
+
+        li.classList.add('task-list-item');
+
+        // Set these to be compatible with stock obsidian lists:
+        li.setAttribute('data-task', listItem.statusCharacter.trim());
+        // Trim to ensure empty attribute for space. Same way as obsidian.
+        li.setAttribute('data-line', listItemIndex.toString());
+    }
+
+    const span = createAndAppendElement('span', li);
+    await textRenderer(listItem.description, span, listItem.findClosestParentTask()?.path ?? '', obsidianComponent);
+
+    // Unwrap the p-tag that was created by the MarkdownRenderer:
+    const pElement = span.querySelector('p');
+    if (pElement !== null) {
+        while (pElement.firstChild) {
+            span.insertBefore(pElement.firstChild, pElement);
+        }
+        pElement.remove();
+    }
+
+    return li;
 }

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -409,9 +409,9 @@ export class TaskLineRenderer {
         listItem: ListItem,
         listItemIndex: number,
         textRenderer: any,
-        obsidianComponent: Component | null,
+        _obsidianComponent: Component | null,
     ) {
-        return await renderListItem(taskList, listItem, listItemIndex, textRenderer, obsidianComponent);
+        return await renderListItem(taskList, listItem, listItemIndex, textRenderer, this.obsidianComponent);
     }
 }
 

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -403,6 +403,16 @@ export class TaskLineRenderer {
             });
         });
     }
+
+    public async renderListItem(
+        taskList: HTMLUListElement,
+        listItem: ListItem,
+        listItemIndex: number,
+        textRenderer: any,
+        obsidianComponent: Component | null,
+    ) {
+        return await renderListItem(taskList, listItem, listItemIndex, textRenderer, obsidianComponent);
+    }
 }
 
 export async function renderListItem(

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -404,13 +404,7 @@ export class TaskLineRenderer {
         });
     }
 
-    public async renderListItem(
-        taskList: HTMLUListElement,
-        listItem: ListItem,
-        listItemIndex: number,
-        _textRenderer: any,
-        _obsidianComponent: Component | null,
-    ) {
+    public async renderListItem(taskList: HTMLUListElement, listItem: ListItem, listItemIndex: number) {
         return await renderListItem(taskList, listItem, listItemIndex, this.textRenderer, this.obsidianComponent);
     }
 }

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -405,7 +405,9 @@ export class TaskLineRenderer {
     }
 
     public async renderListItem(taskList: HTMLUListElement, listItem: ListItem, listItemIndex: number) {
-        return await renderListItem(taskList, listItem, listItemIndex, this.textRenderer, this.obsidianComponent);
+        const textRenderer = this.textRenderer;
+        const obsidianComponent = this.obsidianComponent;
+        return await renderListItem(taskList, listItem, listItemIndex, textRenderer, obsidianComponent);
     }
 }
 

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -408,10 +408,10 @@ export class TaskLineRenderer {
         taskList: HTMLUListElement,
         listItem: ListItem,
         listItemIndex: number,
-        textRenderer: any,
+        _textRenderer: any,
         _obsidianComponent: Component | null,
     ) {
-        return await renderListItem(taskList, listItem, listItemIndex, textRenderer, this.obsidianComponent);
+        return await renderListItem(taskList, listItem, listItemIndex, this.textRenderer, this.obsidianComponent);
     }
 }
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Done by pairing with @ilandikov.

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)


## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

## Motivation and Context

Move some code that in #3338 was copied from `TaskLineRenderer` back to that file.

There is still code duplication, but at least it is all in one file now.

## How has this been tested?

With unit tests.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
