### PR TITLE
fix: Prevent Auto-Suggest for 'NON_TASK' statuses

### DIFF
--- a/docs/Editing/Auto-Suggest.md
+++ b/docs/Editing/Auto-Suggest.md
@@ -39,11 +39,12 @@ Here is a more detailed walk through of the creation of a new task, which can be
 
     **Note**: the auto-suggest menu pops up only if the cursor is in a line that is recognized as a task, that is, the line contains:
 
-     - a bullet with a checkbox, that is, one of:
+     - a bullet with a checkbox, that is, starting with one of these three characters:
          - `- [ ]`
          - `* [ ]`
          - `+ [ ]`
-     - and the global filter (if any)
+     - and the global filter (if any),
+     - and the status character (between `[` and `]`) does not have [[Status Types|status type]] `NON_TASK`.
 
      Tasks also tries to display the auto-suggest menu based on context. For example, suggestions will only appear
       within square brackets `[]` or parentheses `()` when using the [[Dataview Format#Bracketed inline fields|Dataview Task Format]].
@@ -135,8 +136,6 @@ There are some Auto-Suggest behaviours that might be improved in future releases
     - This phrase still needs to be typed manually.
     - We are tracking this in [issue #2066](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2066).
 - It currently pops up when editing completed tasks. This may be changed in future.
-- It currently pops up when editing NON_TASK tasks. This may be changed in future.
-  - We are tracking this in [issue #1509](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/1509).
 - The [[Create or edit Task#Date abbreviations|date abbreviations offered by "Create or edit task"]] only work after a space is typed.
 - When Auto-Suggest is used in [[Kanban plugin]] cards (or any other plugins that use the [[Tasks Api#Auto-Suggest Integration|auto-suggest integration]]), the [[Task Dependencies|dependencies]] suggestions are not available, because there is not yet a mechanism for plugins to access all the tasks in the vault.
   - We are tracking this in [issue #3274](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3274).

--- a/docs/Editing/Auto-Suggest.md
+++ b/docs/Editing/Auto-Suggest.md
@@ -44,7 +44,7 @@ Here is a more detailed walk through of the creation of a new task, which can be
          - `* [ ]`
          - `+ [ ]`
      - and the global filter (if any),
-     - and the status character (between `[` and `]`) does not have [[Status Types|status type]] `NON_TASK`.
+     - and the status symbol (the character between `[` and `]`) does not have [[Status Types|status type]] `NON_TASK`.
 
      Tasks also tries to display the auto-suggest menu based on context. For example, suggestions will only appear
       within square brackets `[]` or parentheses `()` when using the [[Dataview Format#Bracketed inline fields|Dataview Task Format]].

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -16,6 +16,7 @@ import { GlobalFilter } from '../Config/GlobalFilter';
 import { TaskRegularExpressions } from '../Task/TaskRegularExpressions';
 import { searchForCandidateTasksForDependency } from '../ui/DependencyHelpers';
 import { escapeRegExp } from '../lib/RegExpTools';
+import { StatusType } from '../Statuses/StatusConfiguration';
 import type { SuggestInfo, SuggestionBuilder } from '.';
 
 /**
@@ -771,6 +772,7 @@ function editorIsRequestingSuggest(
 /**
  * Return true if:
  * - line is a task line, that is, it is a list item with a checkbox.
+ * - the checkbox status character is not a NON_TASK type.
  * - the cursor is in a task line's description.
  *
  * Here, description includes any task signifiers, as well as the vanilla description.
@@ -785,6 +787,11 @@ function cursorIsInTaskLineDescription(line: string, cursorPosition: number) {
     const components = Task.extractTaskComponents(line);
     if (!components) {
         // It is not a task line, that is, it is not a list item with a checkbox:
+        return false;
+    }
+
+    if (components.status.type === StatusType.NON_TASK) {
+        // The user's settings say this status is not a task:
         return false;
     }
 

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -20,6 +20,8 @@ import { verifyMarkdown } from '../TestingTools/VerifyMarkdown';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { MarkdownTable } from '../../src/lib/MarkdownTable';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { StatusRegistry } from '../../src/Statuses/StatusRegistry';
+import { StatusConfiguration, StatusType } from '../../src/Statuses/StatusConfiguration';
 
 window.moment = moment;
 
@@ -574,6 +576,7 @@ describe('onlySuggestIfBracketOpen', () => {
 describe('canSuggestForLine', () => {
     afterEach(() => {
         GlobalFilter.getInstance().reset();
+        resetSettings();
     });
 
     function canSuggestForLineWithCursor(line: string, editor: any = {}) {
@@ -608,6 +611,15 @@ describe('canSuggestForLine', () => {
     it('should not suggest when cursor is in the checkbox', () => {
         expect(canSuggestForLineWithCursor('- [ |] ')).toEqual(false);
         expect(canSuggestForLineWithCursor('- [ ]| ')).toEqual(false);
+    });
+
+    it.failing('should not suggest if cursor is on a task with NON_TASK status', () => {
+        // With the default statuses, ? is TODO, so we should suggest:
+        expect(canSuggestForLineWithCursor('- [?] question|')).toEqual(true);
+
+        StatusRegistry.getInstance().add(new StatusConfiguration('?', 'Question', '_', true, StatusType.NON_TASK));
+        // Now ? is NON_TASK, so we should NOT suggest (issue #1509):
+        expect(canSuggestForLineWithCursor('- [?] question|')).toEqual(false);
     });
 
     it('should suggest when the cursor is at least one character past the checkbox', () => {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -613,7 +613,7 @@ describe('canSuggestForLine', () => {
         expect(canSuggestForLineWithCursor('- [ ]| ')).toEqual(false);
     });
 
-    it.failing('should not suggest if cursor is on a task with NON_TASK status', () => {
+    it('should not suggest if cursor is on a task with NON_TASK status', () => {
         // With the default statuses, ? is TODO, so we should suggest:
         expect(canSuggestForLineWithCursor('- [?] question|')).toEqual(true);
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #1509
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

If the user has defined the status symbol as `NON_TASK` the line should be ignored by the Tasks auto-suggest feature.

## Motivation and Context

Fix #1509.

## How has this been tested?

- New unit test (and confirmed that this failed before the fix)
- Exploratory testing

## Screenshots (if appropriate)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
