### PR TITLE
feat: Task Line Modal with given description

### DIFF
--- a/src/Api/TasksApiV1.ts
+++ b/src/Api/TasksApiV1.ts
@@ -9,6 +9,7 @@ export interface TasksApiV1 {
      * an empty string, if data entry was cancelled.
      */
     createTaskLineModal(): Promise<string>;
+    createTaskLineModalFromString(description: string): Promise<string>;
 
     /**
      * Executes the 'Tasks: Toggle task done' command on the supplied line string

--- a/src/Api/createTaskLineModal.ts
+++ b/src/Api/createTaskLineModal.ts
@@ -19,6 +19,10 @@ export type taskModalFactory = {
     (app: App, onSubmit: (updatedTasks: Task[]) => void): ITaskModal;
 };
 
+export type taskModalFactoryFromString = {
+    (app: App, onSubmit: (updatedTasks: Task[]) => void, description: string): ITaskModal;
+};
+
 /**
  * Opens the Tasks UI and returns the Markdown string for the task entered.
  *
@@ -41,6 +45,26 @@ export const createTaskLineModal = (app: App, taskModalFactory: taskModalFactory
     };
 
     const taskModal = taskModalFactory(app, onSubmit);
+    taskModal.open();
+    return waitForClose;
+};
+
+export const createTaskLineModalFromString = (
+    app: App,
+    taskModalFactoryFromString: taskModalFactoryFromString,
+    description: string,
+): Promise<string> => {
+    let resolvePromise: (input: string) => void;
+    const waitForClose = new Promise<string>((resolve, _) => {
+        resolvePromise = resolve;
+    });
+
+    const onSubmit = (updatedTasks: Task[]): void => {
+        const line = updatedTasks.map((task: Task) => task.toFileLineString()).join('\n');
+        resolvePromise(line);
+    };
+
+    const taskModal = taskModalFactoryFromString(app, onSubmit, description);
     taskModal.open();
     return waitForClose;
 };

--- a/src/Api/createTaskLineModalHelper.ts
+++ b/src/Api/createTaskLineModalHelper.ts
@@ -1,8 +1,8 @@
 import type { App } from 'obsidian';
 import type { Task } from '../Task/Task';
-import { taskFromLine } from '../Commands/CreateOrEditTaskParser';
+import { taskFromLine, taskFromString } from '../Commands/CreateOrEditTaskParser';
 import { TaskModal } from '../Obsidian/TaskModal';
-import type { ITaskModal, taskModalFactory } from './createTaskLineModal';
+import type { ITaskModal, taskModalFactory, taskModalFactoryFromString } from './createTaskLineModal';
 
 /**
  * Factory method to create a new {@link TaskModal}.
@@ -26,5 +26,14 @@ export const defaultTaskModalFactory: taskModalFactory = (
     //      One option is to make the allTasks parameter to the Edit task modal be optional,
     //      and if it's not provided, then hide the dependency fields in the modal.
     //      For now, we pass in an empty list of tasks.
+    return new TaskModal({ app, task, onSubmit, allTasks: [] }) as ITaskModal;
+};
+
+export const defaultTaskModalFactoryfromString: taskModalFactoryFromString = (
+    app: App,
+    onSubmit: (updatedTasks: Task[]) => void,
+    description: string,
+): ITaskModal => {
+    const task = taskFromString({ description });
     return new TaskModal({ app, task, onSubmit, allTasks: [] }) as ITaskModal;
 };

--- a/src/Api/index.ts
+++ b/src/Api/index.ts
@@ -1,8 +1,8 @@
 import type { App } from 'obsidian';
 import { toggleLine } from '../Commands/ToggleDone';
-import { createTaskLineModal } from './createTaskLineModal';
+import { createTaskLineModal, createTaskLineModalFromString } from './createTaskLineModal';
 import type { TasksApiV1 } from './TasksApiV1';
-import { defaultTaskModalFactory } from './createTaskLineModalHelper';
+import { defaultTaskModalFactory, defaultTaskModalFactoryfromString } from './createTaskLineModalHelper';
 
 /**
  * Factory method for API v1
@@ -13,6 +13,9 @@ export const tasksApiV1 = (app: App): TasksApiV1 => {
     return {
         createTaskLineModal: (): Promise<string> => {
             return createTaskLineModal(app, defaultTaskModalFactory);
+        },
+        createTaskLineModalFromString: (description: string): Promise<string> => {
+            return createTaskLineModalFromString(app, defaultTaskModalFactoryfromString, description);
         },
         executeToggleTaskDoneCommand: (line: string, path: string) => toggleLine(line, path).text,
     };

--- a/src/Commands/CreateOrEditTaskParser.ts
+++ b/src/Commands/CreateOrEditTaskParser.ts
@@ -143,3 +143,29 @@ export const taskFromLine = ({ line, path }: { line: string; path: string }): Ta
         dependsOn: [],
     });
 };
+
+export const taskFromString = ({ description }: { description: string }): Task => {
+    const createdDate = getDefaultCreatedDate();
+    return new Task({
+        status: Status.TODO,
+        description: description,
+        taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('')),
+        indentation: '',
+        listMarker: '-',
+        priority: Priority.None,
+        createdDate,
+        startDate: null,
+        scheduledDate: null,
+        dueDate: null,
+        doneDate: null,
+        cancelledDate: null,
+        recurrence: null,
+        onCompletion: OnCompletion.Ignore,
+        dependsOn: [],
+        id: '',
+        blockLink: '',
+        tags: [],
+        originalMarkdown: '',
+        scheduledDateIsInferred: false,
+    });
+};


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
  - **WARNING: If the link is absent, the PR may be closed without review**, due to the workload that such reviews usually require.
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

I'm not very familiar with JavaScript and GitHub, so I would appreciate any corrections and advice to ensure my pull request is acceptable. Thank you!

Writing task descriptions repeatedly can be exhausting. To simplify this process, I've added a new function, createTaskLineModalFromString, to the API. This function is similar to createTaskLineModal but allows the description to be passed as an argument. When called, it opens the same modal window but with the description field already filled in.

Please review my changes and provide any feedback or suggestions for improvement.

## Motivation and Context

## How has this been tested?

I have tested this new function using QuickAdd Capture with the following format:

```js quickadd
const editor = this.app.workspace.activeEditor.editor;
const cursor = editor.getCursor().line;
const matches = editor.getLine(cursor).match(/[А-Яа-яA-Za-z0-9]+.*$/);
var description = "";
if (matches.length != 0) {
    description = matches[0].trim();
}

return await this.app.plugins.plugins['obsidian-tasks-plugin'].apiV1.createTaskLineModalFromString(description) + "\n";
```

## Screenshots (if appropriate)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
