### PR TITLE
refactor:  `ListItem.fromListItemLine()` now correctly returns `null`

### DIFF
--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -68,21 +68,17 @@ export class ListItem {
             return null;
         }
 
-        const indentation = nonTaskMatch[1];
         const listMarker = nonTaskMatch[2];
-        const statusCharacter = nonTaskMatch[4] ?? null;
-        const description = nonTaskMatch[5].trim();
-
         if (listMarker === undefined) {
             return null;
         }
 
         return new ListItem({
             originalMarkdown,
-            indentation,
+            indentation: nonTaskMatch[1],
             listMarker,
-            statusCharacter,
-            description,
+            statusCharacter: nonTaskMatch[4] ?? null,
+            description: nonTaskMatch[5].trim(),
             taskLocation,
             parent,
         });

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -72,12 +72,10 @@ export class ListItem {
         let listMarker = '';
         let statusCharacter = null;
         let description = '';
-        if (nonTaskMatch) {
-            indentation = nonTaskMatch[1];
-            listMarker = nonTaskMatch[2];
-            statusCharacter = nonTaskMatch[4] ?? null;
-            description = nonTaskMatch[5].trim();
-        }
+        indentation = nonTaskMatch[1];
+        listMarker = nonTaskMatch[2];
+        statusCharacter = nonTaskMatch[4] ?? null;
+        description = nonTaskMatch[5].trim();
 
         if (listMarker === undefined) {
             return null;

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -68,14 +68,10 @@ export class ListItem {
             return null;
         }
 
-        let indentation = '';
-        let listMarker = '';
-        let statusCharacter = null;
-        let description = '';
-        indentation = nonTaskMatch[1];
-        listMarker = nonTaskMatch[2];
-        statusCharacter = nonTaskMatch[4] ?? null;
-        description = nonTaskMatch[5].trim();
+        const indentation = nonTaskMatch[1];
+        const listMarker = nonTaskMatch[2];
+        const statusCharacter = nonTaskMatch[4] ?? null;
+        const description = nonTaskMatch[5].trim();
 
         if (listMarker === undefined) {
             return null;

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -63,6 +63,11 @@ export class ListItem {
         taskLocation: TaskLocation,
     ): ListItem | null {
         const nonTaskMatch = RegExp(TaskRegularExpressions.nonTaskRegex).exec(originalMarkdown);
+        if (!nonTaskMatch) {
+            // In practice we never reach here, because the regexp matches any text even '', but the compiler doesn't know that.
+            return null;
+        }
+
         let indentation = '';
         let listMarker = '';
         let statusCharacter = null;

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -74,6 +74,10 @@ export class ListItem {
             description = nonTaskMatch[5].trim();
         }
 
+        if (listMarker === undefined) {
+            return null;
+        }
+
         return new ListItem({
             originalMarkdown,
             indentation,

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -16,7 +16,7 @@ const taskLocation = TaskLocation.fromUnknownPosition(new TasksFile('anything.md
 
 describe('list item tests', () => {
     it('should create list item with empty children and absent parent', () => {
-        const listItem = ListItem.fromListItemLine('', null, taskLocation)!;
+        const listItem = ListItem.fromListItemLine('- list item', null, taskLocation)!;
         expect(listItem).toBeDefined();
         expect(listItem.children).toEqual([]);
         expect(listItem.parent).toEqual(null);
@@ -24,9 +24,9 @@ describe('list item tests', () => {
     });
 
     it('should create a list item with 2 children', () => {
-        const listItem = ListItem.fromListItemLine('', null, taskLocation)!;
-        const childItem1 = ListItem.fromListItemLine('', listItem, taskLocation)!;
-        const childItem2 = ListItem.fromListItemLine('', listItem, taskLocation)!;
+        const listItem = ListItem.fromListItemLine('- list item', null, taskLocation)!;
+        const childItem1 = ListItem.fromListItemLine('- list item', listItem, taskLocation)!;
+        const childItem2 = ListItem.fromListItemLine('- list item', listItem, taskLocation)!;
         expect(listItem).toBeDefined();
         expect(childItem1.parent).toEqual(listItem);
         expect(childItem2.parent).toEqual(listItem);
@@ -34,8 +34,8 @@ describe('list item tests', () => {
     });
 
     it('should create a list item with a parent', () => {
-        const parentItem = ListItem.fromListItemLine('', null, taskLocation)!;
-        const listItem = ListItem.fromListItemLine('', parentItem, taskLocation)!;
+        const parentItem = ListItem.fromListItemLine('- list item', null, taskLocation)!;
+        const listItem = ListItem.fromListItemLine('- list item', parentItem, taskLocation)!;
         expect(listItem).toBeDefined();
         expect(listItem.parent).toEqual(parentItem);
         expect(parentItem.children).toEqual([listItem]);
@@ -149,14 +149,10 @@ describe('list item parsing', () => {
         expect(ListItem.fromListItemLine('2. xxx', null, taskLocation)!.listMarker).toEqual('2.');
     });
 
-    it('should accept a non list item', () => {
-        // we tried making the constructor throw if given a non list item
-        // but it broke lots of normal Task uses in the tests (TaskBuilder)
+    it('should detect a non-list item', () => {
         const item = ListItem.fromListItemLine('# Heading', null, taskLocation)!;
 
-        expect(item.description).toEqual('# Heading');
-        expect(item.originalMarkdown).toEqual('# Heading');
-        expect(item.statusCharacter).toEqual(null);
+        expect(item).toBeNull();
     });
 });
 


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- `ListItem.fromListItemLine()` now correctly returns `null` for non-list item lines
- This completes work done #3374 

## Motivation and Context

- code improvement

## How has this been tested?

- unit tests

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
