### PR TITLE
refactor: Remove need to construct temporary Task objects

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/Test Data/internal_heading_links.md
+++ b/resources/sample_vaults/Tasks-Demo/Test Data/internal_heading_links.md
@@ -41,3 +41,13 @@ This file contains test cases for internal heading links in tasks.
 ## Escaped Links
 
 - [ ] #task Task with \[\[#Escaped Links\]\] escaped link
+
+## Search
+
+Hover over each heading in these tasks, and to make the Page Preview plugin show that the links exist.
+
+```tasks
+path includes {{query.file.path}}
+group by heading
+hide backlinks
+```

--- a/src/Obsidian/InlineRenderer.ts
+++ b/src/Obsidian/InlineRenderer.ts
@@ -133,7 +133,7 @@ export class InlineRenderer {
             }
             const dataLine: string = renderedElement.getAttr('data-line') ?? '0';
             const taskIndex: number = Number.parseInt(dataLine, 10);
-            const taskElement = await taskLineRenderer.renderTaskLine(task, taskIndex);
+            const taskElement = await taskLineRenderer.renderTaskLine({ task: task, taskIndex: taskIndex });
 
             // If the rendered element contains a sub-list or sub-div (e.g. the
             // folding arrow), we need to keep it.

--- a/src/Obsidian/InlineRenderer.ts
+++ b/src/Obsidian/InlineRenderer.ts
@@ -133,7 +133,11 @@ export class InlineRenderer {
             }
             const dataLine: string = renderedElement.getAttr('data-line') ?? '0';
             const taskIndex: number = Number.parseInt(dataLine, 10);
-            const taskElement = await taskLineRenderer.renderTaskLine({ task: task, taskIndex: taskIndex });
+            const taskElement = await taskLineRenderer.renderTaskLine({
+                task: task,
+                taskIndex: taskIndex,
+                isTaskInQueryFile: true,
+            });
 
             // If the rendered element contains a sub-list or sub-div (e.g. the
             // folding arrow), we need to keep it.

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -529,8 +529,6 @@ export class QueryResultsRenderer {
                         // Replace the first instance of this link:
                         description = description.replace(link.original, fullLink);
                     }
-                } else {
-                    return task;
                 }
             }
         }

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -375,8 +375,8 @@ export class QueryResultsRenderer {
         const listItem = await taskLineRenderer.renderTaskLine({
             task: task,
             taskIndex: taskIndex,
-            isFilenameUnique: isFilenameUnique,
             isTaskInQueryFile: this.filePath === task.path,
+            isFilenameUnique: isFilenameUnique,
         });
 
         // Remove all footnotes. They don't re-appear in another document.

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -512,27 +512,27 @@ export class QueryResultsRenderer {
         // Skip if task is from the same file as the query
         if (this.taskIsInQueryFile(task)) {
             return task;
-        }
+        } else {
+            const linkCache = task.file.cachedMetadata.links;
+            if (!linkCache) return task;
 
-        const linkCache = task.file.cachedMetadata.links;
-        if (!linkCache) return task;
+            // Find links in the task description
+            const taskLinks = linkCache.filter((link) => {
+                return (
+                    link.position.start.line === task.taskLocation.lineNumber &&
+                    task.description.includes(link.original) &&
+                    link.link.startsWith('#')
+                );
+            });
+            if (taskLinks.length === 0) return task;
 
-        // Find links in the task description
-        const taskLinks = linkCache.filter((link) => {
-            return (
-                link.position.start.line === task.taskLocation.lineNumber &&
-                task.description.includes(link.original) &&
-                link.link.startsWith('#')
-            );
-        });
-        if (taskLinks.length === 0) return task;
-
-        // a task can only be from one file, so we can replace all the internal links
-        //in the description with the new file path
-        for (const link of taskLinks) {
-            const fullLink = `[[${task.path}${link.link}|${link.displayText}]]`;
-            // Replace the first instance of this link:
-            description = description.replace(link.original, fullLink);
+            // a task can only be from one file, so we can replace all the internal links
+            //in the description with the new file path
+            for (const link of taskLinks) {
+                const fullLink = `[[${task.path}${link.link}|${link.displayText}]]`;
+                // Replace the first instance of this link:
+                description = description.replace(link.original, fullLink);
+            }
         }
 
         if (description === task.description) {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -507,7 +507,7 @@ export class QueryResultsRenderer {
 
     private processTaskLinks(task: Task): Task {
         // Skip if task is from the same file as the query
-        if (this.filePath === task.path) {
+        if (this.taskIsInQueryFile(task)) {
             return task;
         }
 
@@ -541,6 +541,10 @@ export class QueryResultsRenderer {
             // Preserve the original task's location information
             taskLocation: task.taskLocation,
         });
+    }
+
+    private taskIsInQueryFile(task: Task) {
+        return this.filePath === task.path;
     }
 
     private addPostponeButton(listItem: HTMLElement, task: Task, shortMode: boolean) {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -521,9 +521,7 @@ export class QueryResultsRenderer {
                         link.link.startsWith('#')
                     );
                 });
-                if (taskLinks.length === 0) {
-                    return task;
-                } else {
+                if (taskLinks.length !== 0) {
                     // a task can only be from one file, so we can replace all the internal links
                     //in the description with the new file path
                     for (const link of taskLinks) {
@@ -531,6 +529,8 @@ export class QueryResultsRenderer {
                         // Replace the first instance of this link:
                         description = description.replace(link.original, fullLink);
                     }
+                } else {
+                    return task;
                 }
             }
         }

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -525,14 +525,16 @@ export class QueryResultsRenderer {
                         link.link.startsWith('#')
                     );
                 });
-                if (taskLinks.length === 0) return task;
-
-                // a task can only be from one file, so we can replace all the internal links
-                //in the description with the new file path
-                for (const link of taskLinks) {
-                    const fullLink = `[[${task.path}${link.link}|${link.displayText}]]`;
-                    // Replace the first instance of this link:
-                    description = description.replace(link.original, fullLink);
+                if (taskLinks.length === 0) {
+                    return task;
+                } else {
+                    // a task can only be from one file, so we can replace all the internal links
+                    //in the description with the new file path
+                    for (const link of taskLinks) {
+                        const fullLink = `[[${task.path}${link.link}|${link.displayText}]]`;
+                        // Replace the first instance of this link:
+                        description = description.replace(link.original, fullLink);
+                    }
                 }
             }
         }

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -378,6 +378,7 @@ export class QueryResultsRenderer {
             task: processedTask,
             taskIndex: taskIndex,
             isFilenameUnique: isFilenameUnique,
+            appleSauce: this.taskIsInQueryFile(task),
         });
 
         // Remove all footnotes. They don't re-appear in another document.

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -383,7 +383,7 @@ export class QueryResultsRenderer {
             task: processedTask,
             taskIndex: taskIndex,
             isFilenameUnique: isFilenameUnique,
-            appleSauce: this.taskIsInQueryFile(task),
+            isTaskInQueryFile: this.taskIsInQueryFile(task),
         });
 
         // Remove all footnotes. They don't re-appear in another document.

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -532,8 +532,6 @@ export class QueryResultsRenderer {
                         description = description.replace(link.original, fullLink);
                     }
                 }
-            } else {
-                return task;
             }
         }
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -507,10 +507,12 @@ export class QueryResultsRenderer {
     }
 
     private processTaskLinks(task: Task): Task {
+        const taskIsInQueryFile = this.taskIsInQueryFile(task);
+
         let description = task.description;
 
         // Skip if task is from the same file as the query
-        if (!this.taskIsInQueryFile(task)) {
+        if (!taskIsInQueryFile) {
             const linkCache = task.file.cachedMetadata.links;
             if (linkCache) {
                 // Find links in the task description

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -535,6 +535,10 @@ export class QueryResultsRenderer {
             description = description.replace(link.original, fullLink);
         }
 
+        if (description === task.description) {
+            return task;
+        }
+
         // Return a new Task with the updated description
         return new Task({
             ...task,

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -374,7 +374,11 @@ export class QueryResultsRenderer {
         const isFilenameUnique = this.isFilenameUnique({ task }, queryRendererParameters.allMarkdownFiles);
         const processedTask = this.processTaskLinks(task);
 
-        const listItem = await taskLineRenderer.renderTaskLine(processedTask, taskIndex, isFilenameUnique);
+        const listItem = await taskLineRenderer.renderTaskLine({
+            task: processedTask,
+            taskIndex: taskIndex,
+            isFilenameUnique: isFilenameUnique,
+        });
 
         // Remove all footnotes. They don't re-appear in another document.
         const footnotes = listItem.querySelectorAll('[data-footnote-id]');

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -507,6 +507,8 @@ export class QueryResultsRenderer {
     }
 
     private processTaskLinks(task: Task): Task {
+        let description = task.description;
+
         // Skip if task is from the same file as the query
         if (this.taskIsInQueryFile(task)) {
             return task;
@@ -524,8 +526,6 @@ export class QueryResultsRenderer {
             );
         });
         if (taskLinks.length === 0) return task;
-
-        let description = task.description;
 
         // a task can only be from one file, so we can replace all the internal links
         //in the description with the new file path

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -15,7 +15,12 @@ import type { TasksFile } from '../Scripting/TasksFile';
 import type { ListItem } from '../Task/ListItem';
 import { Task } from '../Task/Task';
 import { PostponeMenu } from '../ui/Menus/PostponeMenu';
-import { TaskLineRenderer, type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
+import {
+    TaskLineRenderer,
+    type TextRenderer,
+    adjustRelativeLinksInDescription,
+    createAndAppendElement,
+} from './TaskLineRenderer';
 
 export type BacklinksEventHandler = (ev: MouseEvent, task: Task) => Promise<void>;
 export type EditButtonClickHandler = (event: MouseEvent, task: Task, allTasks: Task[]) => void;
@@ -33,35 +38,6 @@ export interface QueryRendererParameters {
     backlinksClickHandler: BacklinksEventHandler;
     backlinksMousedownHandler: BacklinksEventHandler;
     editTaskPencilClickHandler: EditButtonClickHandler;
-}
-
-function adjustRelativeLinksInDescription(task: Task, taskIsInQueryFile: boolean) {
-    let description = task.description;
-
-    // Skip if task is from the same file as the query
-    if (!taskIsInQueryFile) {
-        const linkCache = task.file.cachedMetadata.links;
-        if (linkCache) {
-            // Find links in the task description
-            const taskLinks = linkCache.filter((link) => {
-                return (
-                    link.position.start.line === task.taskLocation.lineNumber &&
-                    task.description.includes(link.original) &&
-                    link.link.startsWith('#')
-                );
-            });
-            if (taskLinks.length !== 0) {
-                // a task can only be from one file, so we can replace all the internal links
-                //in the description with the new file path
-                for (const link of taskLinks) {
-                    const fullLink = `[[${task.path}${link.link}|${link.displayText}]]`;
-                    // Replace the first instance of this link:
-                    description = description.replace(link.original, fullLink);
-                }
-            }
-        }
-    }
-    return description;
 }
 
 /**

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -514,24 +514,26 @@ export class QueryResultsRenderer {
             return task;
         } else {
             const linkCache = task.file.cachedMetadata.links;
-            if (!linkCache) return task;
+            if (!linkCache) {
+                return task;
+            } else {
+                // Find links in the task description
+                const taskLinks = linkCache.filter((link) => {
+                    return (
+                        link.position.start.line === task.taskLocation.lineNumber &&
+                        task.description.includes(link.original) &&
+                        link.link.startsWith('#')
+                    );
+                });
+                if (taskLinks.length === 0) return task;
 
-            // Find links in the task description
-            const taskLinks = linkCache.filter((link) => {
-                return (
-                    link.position.start.line === task.taskLocation.lineNumber &&
-                    task.description.includes(link.original) &&
-                    link.link.startsWith('#')
-                );
-            });
-            if (taskLinks.length === 0) return task;
-
-            // a task can only be from one file, so we can replace all the internal links
-            //in the description with the new file path
-            for (const link of taskLinks) {
-                const fullLink = `[[${task.path}${link.link}|${link.displayText}]]`;
-                // Replace the first instance of this link:
-                description = description.replace(link.original, fullLink);
+                // a task can only be from one file, so we can replace all the internal links
+                //in the description with the new file path
+                for (const link of taskLinks) {
+                    const fullLink = `[[${task.path}${link.link}|${link.displayText}]]`;
+                    // Replace the first instance of this link:
+                    description = description.replace(link.original, fullLink);
+                }
             }
         }
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -376,7 +376,7 @@ export class QueryResultsRenderer {
             task: task,
             taskIndex: taskIndex,
             isFilenameUnique: isFilenameUnique,
-            isTaskInQueryFile: this.taskIsInQueryFile(task),
+            isTaskInQueryFile: this.isTaskInQueryFile(task),
         });
 
         // Remove all footnotes. They don't re-appear in another document.
@@ -504,7 +504,7 @@ export class QueryResultsRenderer {
         }
     }
 
-    private taskIsInQueryFile(task: Task) {
+    private isTaskInQueryFile(task: Task): boolean {
         return this.filePath === task.path;
     }
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -512,9 +512,7 @@ export class QueryResultsRenderer {
         // Skip if task is from the same file as the query
         if (!this.taskIsInQueryFile(task)) {
             const linkCache = task.file.cachedMetadata.links;
-            if (!linkCache) {
-                return task;
-            } else {
+            if (linkCache) {
                 // Find links in the task description
                 const taskLinks = linkCache.filter((link) => {
                     return (
@@ -534,6 +532,8 @@ export class QueryResultsRenderer {
                         description = description.replace(link.original, fullLink);
                     }
                 }
+            } else {
+                return task;
             }
         }
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -376,7 +376,7 @@ export class QueryResultsRenderer {
             task: task,
             taskIndex: taskIndex,
             isFilenameUnique: isFilenameUnique,
-            isTaskInQueryFile: this.isTaskInQueryFile(task),
+            isTaskInQueryFile: this.filePath === task.path,
         });
 
         // Remove all footnotes. They don't re-appear in another document.
@@ -503,11 +503,6 @@ export class QueryResultsRenderer {
             backLink.append(')');
         }
     }
-
-    private isTaskInQueryFile(task: Task): boolean {
-        return this.filePath === task.path;
-    }
-
     private addPostponeButton(listItem: HTMLElement, task: Task, shortMode: boolean) {
         const amount = 1;
         const timeUnit = 'day';

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -510,9 +510,7 @@ export class QueryResultsRenderer {
         let description = task.description;
 
         // Skip if task is from the same file as the query
-        if (this.taskIsInQueryFile(task)) {
-            return task;
-        } else {
+        if (!this.taskIsInQueryFile(task)) {
             const linkCache = task.file.cachedMetadata.links;
             if (!linkCache) {
                 return task;
@@ -537,6 +535,8 @@ export class QueryResultsRenderer {
                     }
                 }
             }
+        } else {
+            return task;
         }
 
         if (description === task.description) {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -372,10 +372,8 @@ export class QueryResultsRenderer {
         queryRendererParameters: QueryRendererParameters,
     ) {
         const isFilenameUnique = this.isFilenameUnique({ task }, queryRendererParameters.allMarkdownFiles);
-        const processedTask = this.processTaskLinks(task);
-
         const listItem = await taskLineRenderer.renderTaskLine({
-            task: processedTask,
+            task: task,
             taskIndex: taskIndex,
             isFilenameUnique: isFilenameUnique,
             isTaskInQueryFile: this.taskIsInQueryFile(task),
@@ -504,22 +502,6 @@ export class QueryResultsRenderer {
         if (!shortMode) {
             backLink.append(')');
         }
-    }
-
-    private processTaskLinks(task: Task): Task {
-        const description = task.description;
-
-        if (description === task.description) {
-            return task;
-        }
-
-        // Return a new Task with the updated description
-        return new Task({
-            ...task,
-            description,
-            // Preserve the original task's location information
-            taskLocation: task.taskLocation,
-        });
     }
 
     private taskIsInQueryFile(task: Task) {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -15,12 +15,7 @@ import type { TasksFile } from '../Scripting/TasksFile';
 import type { ListItem } from '../Task/ListItem';
 import { Task } from '../Task/Task';
 import { PostponeMenu } from '../ui/Menus/PostponeMenu';
-import {
-    TaskLineRenderer,
-    type TextRenderer,
-    adjustRelativeLinksInDescription,
-    createAndAppendElement,
-} from './TaskLineRenderer';
+import { TaskLineRenderer, type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
 
 export type BacklinksEventHandler = (ev: MouseEvent, task: Task) => Promise<void>;
 export type EditButtonClickHandler = (event: MouseEvent, task: Task, allTasks: Task[]) => void;
@@ -512,8 +507,7 @@ export class QueryResultsRenderer {
     }
 
     private processTaskLinks(task: Task): Task {
-        const taskIsInQueryFile = this.taskIsInQueryFile(task);
-        const description = adjustRelativeLinksInDescription(task, taskIsInQueryFile);
+        const description = task.description;
 
         if (description === task.description) {
             return task;

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -535,8 +535,6 @@ export class QueryResultsRenderer {
                     }
                 }
             }
-        } else {
-            return task;
         }
 
         if (description === task.description) {

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -293,11 +293,9 @@ export class TaskLineRenderer {
     }
 
     private async renderDescription(task: Task, span: HTMLSpanElement, isTaskInQueryFile: boolean) {
-        if (isTaskInQueryFile) {
-            console.log('Remove me!');
-        }
-
-        let description = GlobalFilter.getInstance().removeAsWordFromDependingOnSettings(task.description);
+        let description = GlobalFilter.getInstance().removeAsWordFromDependingOnSettings(
+            adjustRelativeLinksInDescription(task, isTaskInQueryFile),
+        );
 
         const { debugSettings } = getSettings();
         if (debugSettings.showTaskHiddenData) {

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -130,17 +130,23 @@ export class TaskLineRenderer {
      * @param isFilenameUnique Whether the name of the file that contains the task is unique in the vault.
      *                         If it is undefined, the outcome will be the same as with a unique file name:
      *                         the file name only. If set to `true`, the full path will be returned.
+     * @param appleSauce
      */
     public async renderTaskLine({
         task,
         taskIndex,
         isFilenameUnique,
+        appleSauce,
     }: {
         task: Task;
         taskIndex: number;
         isFilenameUnique?: boolean;
+        appleSauce?: boolean;
     }): Promise<HTMLLIElement> {
         const li = createAndAppendElement('li', this.parentUlElement);
+        if (appleSauce) {
+            return li;
+        }
 
         li.classList.add('task-list-item', 'plugin-tasks-list-item');
 

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -336,7 +336,9 @@ export class TaskLineRenderer {
         let description = task.description;
 
         // Skip if task is from the same file as the query
-        if (!isTaskInQueryFile) {
+        if (isTaskInQueryFile) {
+            return task.description;
+        } else {
             const linkCache = task.file.cachedMetadata.links;
             if (linkCache) {
                 // Find links in the task description

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -343,23 +343,23 @@ export class TaskLineRenderer {
         const linkCache = task.file.cachedMetadata.links;
         if (!linkCache) {
             return task.description;
-        } else {
-            // Find links in the task description
-            const taskLinks = linkCache.filter((link) => {
-                return (
-                    link.position.start.line === task.taskLocation.lineNumber &&
-                    task.description.includes(link.original) &&
-                    link.link.startsWith('#')
-                );
-            });
-            if (taskLinks.length !== 0) {
-                // a task can only be from one file, so we can replace all the internal links
-                //in the description with the new file path
-                for (const link of taskLinks) {
-                    const fullLink = `[[${task.path}${link.link}|${link.displayText}]]`;
-                    // Replace the first instance of this link:
-                    description = description.replace(link.original, fullLink);
-                }
+        }
+
+        // Find links in the task description
+        const taskLinks = linkCache.filter((link) => {
+            return (
+                link.position.start.line === task.taskLocation.lineNumber &&
+                task.description.includes(link.original) &&
+                link.link.startsWith('#')
+            );
+        });
+        if (taskLinks.length !== 0) {
+            // a task can only be from one file, so we can replace all the internal links
+            //in the description with the new file path
+            for (const link of taskLinks) {
+                const fullLink = `[[${task.path}${link.link}|${link.displayText}]]`;
+                // Replace the first instance of this link:
+                description = description.replace(link.original, fullLink);
             }
         }
         return description;

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -145,7 +145,7 @@ export class TaskLineRenderer {
     }): Promise<HTMLLIElement> {
         const li = createAndAppendElement('li', this.parentUlElement);
         if (appleSauce) {
-            return li;
+            console.log('Remove me!');
         }
 
         li.classList.add('task-list-item', 'plugin-tasks-list-item');

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -293,8 +293,8 @@ export class TaskLineRenderer {
     }
 
     private async renderDescription(task: Task, span: HTMLSpanElement, isTaskInQueryFile: boolean) {
-        const descriptionWithLinksFixed = this.adjustRelativeLinksInDescription(task, isTaskInQueryFile);
-        let description = GlobalFilter.getInstance().removeAsWordFromDependingOnSettings(descriptionWithLinksFixed);
+        let description = this.adjustRelativeLinksInDescription(task, isTaskInQueryFile);
+        description = GlobalFilter.getInstance().removeAsWordFromDependingOnSettings(description);
 
         const { debugSettings } = getSettings();
         if (debugSettings.showTaskHiddenData) {

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -131,7 +131,15 @@ export class TaskLineRenderer {
      *                         If it is undefined, the outcome will be the same as with a unique file name:
      *                         the file name only. If set to `true`, the full path will be returned.
      */
-    public async renderTaskLine(task: Task, taskIndex: number, isFilenameUnique?: boolean): Promise<HTMLLIElement> {
+    public async renderTaskLine({
+        task,
+        taskIndex,
+        isFilenameUnique,
+    }: {
+        task: Task;
+        taskIndex: number;
+        isFilenameUnique?: boolean;
+    }): Promise<HTMLLIElement> {
         const li = createAndAppendElement('li', this.parentUlElement);
 
         li.classList.add('task-list-item', 'plugin-tasks-list-item');

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -333,8 +333,6 @@ export class TaskLineRenderer {
     }
 
     private adjustRelativeLinksInDescription(task: Task, isTaskInQueryFile: boolean) {
-        let description = task.description;
-
         // Skip if task is from the same file as the query
         if (isTaskInQueryFile) {
             return task.description;
@@ -353,6 +351,8 @@ export class TaskLineRenderer {
                 link.link.startsWith('#')
             );
         });
+
+        let description = task.description;
         if (taskLinks.length !== 0) {
             // a task can only be from one file, so we can replace all the internal links
             //in the description with the new file path

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -476,3 +476,32 @@ export class TaskLineRenderer {
         return li;
     }
 }
+
+export function adjustRelativeLinksInDescription(task: Task, taskIsInQueryFile: boolean) {
+    let description = task.description;
+
+    // Skip if task is from the same file as the query
+    if (!taskIsInQueryFile) {
+        const linkCache = task.file.cachedMetadata.links;
+        if (linkCache) {
+            // Find links in the task description
+            const taskLinks = linkCache.filter((link) => {
+                return (
+                    link.position.start.line === task.taskLocation.lineNumber &&
+                    task.description.includes(link.original) &&
+                    link.link.startsWith('#')
+                );
+            });
+            if (taskLinks.length !== 0) {
+                // a task can only be from one file, so we can replace all the internal links
+                //in the description with the new file path
+                for (const link of taskLinks) {
+                    const fullLink = `[[${task.path}${link.link}|${link.displayText}]]`;
+                    // Replace the first instance of this link:
+                    description = description.replace(link.original, fullLink);
+                }
+            }
+        }
+    }
+    return description;
+}

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -338,25 +338,25 @@ export class TaskLineRenderer {
         // Skip if task is from the same file as the query
         if (isTaskInQueryFile) {
             return task.description;
-        } else {
-            const linkCache = task.file.cachedMetadata.links;
-            if (linkCache) {
-                // Find links in the task description
-                const taskLinks = linkCache.filter((link) => {
-                    return (
-                        link.position.start.line === task.taskLocation.lineNumber &&
-                        task.description.includes(link.original) &&
-                        link.link.startsWith('#')
-                    );
-                });
-                if (taskLinks.length !== 0) {
-                    // a task can only be from one file, so we can replace all the internal links
-                    //in the description with the new file path
-                    for (const link of taskLinks) {
-                        const fullLink = `[[${task.path}${link.link}|${link.displayText}]]`;
-                        // Replace the first instance of this link:
-                        description = description.replace(link.original, fullLink);
-                    }
+        }
+
+        const linkCache = task.file.cachedMetadata.links;
+        if (linkCache) {
+            // Find links in the task description
+            const taskLinks = linkCache.filter((link) => {
+                return (
+                    link.position.start.line === task.taskLocation.lineNumber &&
+                    task.description.includes(link.original) &&
+                    link.link.startsWith('#')
+                );
+            });
+            if (taskLinks.length !== 0) {
+                // a task can only be from one file, so we can replace all the internal links
+                //in the description with the new file path
+                for (const link of taskLinks) {
+                    const fullLink = `[[${task.path}${link.link}|${link.displayText}]]`;
+                    // Replace the first instance of this link:
+                    description = description.replace(link.original, fullLink);
                 }
             }
         }

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -294,7 +294,7 @@ export class TaskLineRenderer {
 
     private async renderDescription(task: Task, span: HTMLSpanElement, isTaskInQueryFile: boolean) {
         let description = GlobalFilter.getInstance().removeAsWordFromDependingOnSettings(
-            adjustRelativeLinksInDescription(task, isTaskInQueryFile),
+            this.adjustRelativeLinksInDescription(task, isTaskInQueryFile),
         );
 
         const { debugSettings } = getSettings();
@@ -330,6 +330,10 @@ export class TaskLineRenderer {
         span.querySelectorAll('.footnotes').forEach((footnoteElement) => {
             footnoteElement.remove();
         });
+    }
+
+    private adjustRelativeLinksInDescription(task: Task, isTaskInQueryFile: boolean) {
+        return adjustRelativeLinksInDescription(task, isTaskInQueryFile);
     }
 
     /*

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -293,9 +293,8 @@ export class TaskLineRenderer {
     }
 
     private async renderDescription(task: Task, span: HTMLSpanElement, isTaskInQueryFile: boolean) {
-        let description = GlobalFilter.getInstance().removeAsWordFromDependingOnSettings(
-            this.adjustRelativeLinksInDescription(task, isTaskInQueryFile),
-        );
+        const descriptionWithLinksFixed = this.adjustRelativeLinksInDescription(task, isTaskInQueryFile);
+        let description = GlobalFilter.getInstance().removeAsWordFromDependingOnSettings(descriptionWithLinksFixed);
 
         const { debugSettings } = getSettings();
         if (debugSettings.showTaskHiddenData) {

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -286,17 +286,17 @@ export class TaskLineRenderer {
         task: Task,
         isTaskInQueryFile: boolean,
     ) {
-        if (isTaskInQueryFile) {
-            console.log('Remove me!');
-        }
-
         if (component === TaskLayoutComponent.Description) {
-            return await this.renderDescription(task, span);
+            return await this.renderDescription(task, span, isTaskInQueryFile);
         }
         span.innerHTML = componentString;
     }
 
-    private async renderDescription(task: Task, span: HTMLSpanElement) {
+    private async renderDescription(task: Task, span: HTMLSpanElement, isTaskInQueryFile: boolean) {
+        if (isTaskInQueryFile) {
+            console.log('Remove me!');
+        }
+
         let description = GlobalFilter.getInstance().removeAsWordFromDependingOnSettings(task.description);
 
         const { debugSettings } = getSettings();

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -341,7 +341,9 @@ export class TaskLineRenderer {
         }
 
         const linkCache = task.file.cachedMetadata.links;
-        if (linkCache) {
+        if (!linkCache) {
+            return task.description;
+        } else {
             // Find links in the task description
             const taskLinks = linkCache.filter((link) => {
                 return (

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -144,15 +144,11 @@ export class TaskLineRenderer {
         isTaskInQueryFile: boolean;
     }): Promise<HTMLLIElement> {
         const li = createAndAppendElement('li', this.parentUlElement);
-        if (isTaskInQueryFile) {
-            console.log('Remove me!');
-        }
-
         li.classList.add('task-list-item', 'plugin-tasks-list-item');
 
         const textSpan = createAndAppendElement('span', li);
         textSpan.classList.add('tasks-list-text');
-        await this.taskToHtml(task, textSpan, li);
+        await this.taskToHtml(task, textSpan, li, isTaskInQueryFile);
 
         // NOTE: this area is mentioned in `CONTRIBUTING.md` under "How does Tasks handle status changes". When
         // moving the code, remember to update that reference too.
@@ -207,7 +203,12 @@ export class TaskLineRenderer {
         return li;
     }
 
-    private async taskToHtml(task: Task, parentElement: HTMLElement, li: HTMLLIElement): Promise<void> {
+    private async taskToHtml(
+        task: Task,
+        parentElement: HTMLElement,
+        li: HTMLLIElement,
+        isTaskInQueryFile: boolean,
+    ): Promise<void> {
         const fieldRenderer = new TaskFieldRenderer();
         const emojiSerializer = TASK_FORMATS.tasksPluginEmoji.taskSerializer;
         // Render and build classes for all the task's visible components
@@ -226,7 +227,7 @@ export class TaskLineRenderer {
                 // to differentiate between the container of the text and the text itself, so it will be possible
                 // to do things like surrounding only the text (rather than its whole placeholder) with a highlight
                 const internalSpan = createAndAppendElement('span', span);
-                await this.renderComponentText(internalSpan, componentString, component, task);
+                await this.renderComponentText(internalSpan, componentString, component, task, isTaskInQueryFile);
                 this.addInternalClasses(component, internalSpan);
 
                 // Add the component's CSS class describing what this component is (priority, due date etc.)
@@ -283,7 +284,12 @@ export class TaskLineRenderer {
         componentString: string,
         component: TaskLayoutComponent,
         task: Task,
+        isTaskInQueryFile: boolean,
     ) {
+        if (isTaskInQueryFile) {
+            console.log('Remove me!');
+        }
+
         if (component === TaskLayoutComponent.Description) {
             return await this.renderDescription(task, span);
         }

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -130,21 +130,21 @@ export class TaskLineRenderer {
      * @param isFilenameUnique Whether the name of the file that contains the task is unique in the vault.
      *                         If it is undefined, the outcome will be the same as with a unique file name:
      *                         the file name only. If set to `true`, the full path will be returned.
-     * @param appleSauce
+     * @param isTaskInQueryFile
      */
     public async renderTaskLine({
         task,
         taskIndex,
         isFilenameUnique,
-        appleSauce,
+        isTaskInQueryFile,
     }: {
         task: Task;
         taskIndex: number;
         isFilenameUnique?: boolean;
-        appleSauce?: boolean;
+        isTaskInQueryFile?: boolean;
     }): Promise<HTMLLIElement> {
         const li = createAndAppendElement('li', this.parentUlElement);
-        if (appleSauce) {
+        if (isTaskInQueryFile) {
             console.log('Remove me!');
         }
 

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -141,7 +141,7 @@ export class TaskLineRenderer {
         task: Task;
         taskIndex: number;
         isFilenameUnique?: boolean;
-        isTaskInQueryFile?: boolean;
+        isTaskInQueryFile: boolean;
     }): Promise<HTMLLIElement> {
         const li = createAndAppendElement('li', this.parentUlElement);
         if (isTaskInQueryFile) {

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -337,7 +337,7 @@ export class TaskLineRenderer {
             return task.description;
         }
 
-        // Skip if the task is in a file with no lines
+        // Skip if the task is in a file with no links
         const linkCache = task.file.cachedMetadata.links;
         if (!linkCache) {
             return task.description;

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -338,6 +338,7 @@ export class TaskLineRenderer {
             return task.description;
         }
 
+        // Skip if the task is in a file with no lines
         const linkCache = task.file.cachedMetadata.links;
         if (!linkCache) {
             return task.description;

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -127,21 +127,21 @@ export class TaskLineRenderer {
      * @note Output is based on the {@link DefaultTaskSerializer}'s format, with default (emoji) symbols
      * @param task The task to be rendered.
      * @param taskIndex Task's index in the list. This affects `data-line` data attributes of the list item.
+     * @param isTaskInQueryFile
      * @param isFilenameUnique Whether the name of the file that contains the task is unique in the vault.
      *                         If it is undefined, the outcome will be the same as with a unique file name:
      *                         the file name only. If set to `true`, the full path will be returned.
-     * @param isTaskInQueryFile
      */
     public async renderTaskLine({
         task,
         taskIndex,
-        isFilenameUnique,
         isTaskInQueryFile,
+        isFilenameUnique,
     }: {
         task: Task;
         taskIndex: number;
-        isFilenameUnique?: boolean;
         isTaskInQueryFile: boolean;
+        isFilenameUnique?: boolean;
     }): Promise<HTMLLIElement> {
         const li = createAndAppendElement('li', this.parentUlElement);
         li.classList.add('task-list-item', 'plugin-tasks-list-item');

--- a/tests/Obsidian/__test_data__/internal_heading_links.json
+++ b/tests/Obsidian/__test_data__/internal_heading_links.json
@@ -192,6 +192,22 @@
             "offset": 902
           }
         }
+      },
+      {
+        "heading": "Search",
+        "level": 2,
+        "position": {
+          "end": {
+            "col": 9,
+            "line": 44,
+            "offset": 988
+          },
+          "start": {
+            "col": 0,
+            "line": 44,
+            "offset": 979
+          }
+        }
       }
     ],
     "links": [
@@ -859,6 +875,51 @@
           }
         },
         "type": "list"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 9,
+            "line": 44,
+            "offset": 988
+          },
+          "start": {
+            "col": 0,
+            "line": 44,
+            "offset": 979
+          }
+        },
+        "type": "heading"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 102,
+            "line": 46,
+            "offset": 1092
+          },
+          "start": {
+            "col": 0,
+            "line": 46,
+            "offset": 990
+          }
+        },
+        "type": "paragraph"
+      },
+      {
+        "position": {
+          "end": {
+            "col": 3,
+            "line": 52,
+            "offset": 1172
+          },
+          "start": {
+            "col": 0,
+            "line": 48,
+            "offset": 1094
+          }
+        },
+        "type": "code"
       }
     ],
     "tags": [
@@ -1014,7 +1075,7 @@
       }
     ]
   },
-  "fileContents": "# Internal Heading Links Test\n\nThis file contains test cases for internal heading links in tasks.\n\n## Simple Headers\n\n## Another Header\n\n## Basic Internal Links\n\n- [ ] #task Task with<br>[[#Basic Internal Links]]\n\n## Multiple Links In One Task\n\n- [ ] #task Task with<br>[[#Multiple Links In One Task]] and<br>[[#Simple Headers]]\n\n## External File Links\n\n- [ ] #task Task with<br>[[Other File]]\n\n## Mixed Link Types\n\n- [ ] #task Task with<br>[[Other File]] and<br>[[#Mixed Link Types]]\n\n## Header Links With File Reference\n\n- [ ] #task<br>[[#Header Links With File Reference]] then<br>[[Other File#Some Header]] and<br>[[#Another Header]]\n\n## Headers-With_Special Characters\n\n- [ ] #task Task with<br>[[#Headers-With_Special Characters]]\n\n## Aliased Links\n\n- [ ] #task Task with<br>[[#Aliased Links|I am an alias]]\n\n## Links In Code Blocks\n\n- [ ] #task Task with `[[#Links In Code Blocks]]` code block\n\n## Escaped Links\n\n- [ ] #task Task with \\[\\[#Escaped Links\\]\\] escaped link\n",
+  "fileContents": "# Internal Heading Links Test\n\nThis file contains test cases for internal heading links in tasks.\n\n## Simple Headers\n\n## Another Header\n\n## Basic Internal Links\n\n- [ ] #task Task with<br>[[#Basic Internal Links]]\n\n## Multiple Links In One Task\n\n- [ ] #task Task with<br>[[#Multiple Links In One Task]] and<br>[[#Simple Headers]]\n\n## External File Links\n\n- [ ] #task Task with<br>[[Other File]]\n\n## Mixed Link Types\n\n- [ ] #task Task with<br>[[Other File]] and<br>[[#Mixed Link Types]]\n\n## Header Links With File Reference\n\n- [ ] #task<br>[[#Header Links With File Reference]] then<br>[[Other File#Some Header]] and<br>[[#Another Header]]\n\n## Headers-With_Special Characters\n\n- [ ] #task Task with<br>[[#Headers-With_Special Characters]]\n\n## Aliased Links\n\n- [ ] #task Task with<br>[[#Aliased Links|I am an alias]]\n\n## Links In Code Blocks\n\n- [ ] #task Task with `[[#Links In Code Blocks]]` code block\n\n## Escaped Links\n\n- [ ] #task Task with \\[\\[#Escaped Links\\]\\] escaped link\n\n## Search\n\nHover over each heading in these tasks, and to make the Page Preview plugin show that the links exist.\n\n```tasks\npath includes {{query.file.path}}\ngroup by heading\nhide backlinks\n```\n",
   "filePath": "Test Data/internal_heading_links.md",
   "getAllTags": [
     "#task",

--- a/tests/Renderer/TaskLineRenderer.test.ts
+++ b/tests/Renderer/TaskLineRenderer.test.ts
@@ -46,7 +46,7 @@ async function renderListItem(
         taskLayoutOptions: taskLayoutOptions ?? new TaskLayoutOptions(),
         queryLayoutOptions: queryLayoutOptions ?? new QueryLayoutOptions(),
     });
-    return await taskLineRenderer.renderTaskLine(task, 0);
+    return await taskLineRenderer.renderTaskLine({ task: task, taskIndex: 0 });
 }
 
 function getTextSpan(listItem: HTMLElement) {
@@ -89,7 +89,7 @@ describe('task line rendering - HTML', () => {
             taskLayoutOptions: new TaskLayoutOptions(),
             queryLayoutOptions: new QueryLayoutOptions(),
         });
-        const listItem = await taskLineRenderer.renderTaskLine(new TaskBuilder().build(), 0);
+        const listItem = await taskLineRenderer.renderTaskLine({ task: new TaskBuilder().build(), taskIndex: 0 });
 
         // Just one element
         expect(ulElement.children.length).toEqual(1);

--- a/tests/Renderer/TaskLineRenderer.test.ts
+++ b/tests/Renderer/TaskLineRenderer.test.ts
@@ -46,7 +46,7 @@ async function renderListItem(
         taskLayoutOptions: taskLayoutOptions ?? new TaskLayoutOptions(),
         queryLayoutOptions: queryLayoutOptions ?? new QueryLayoutOptions(),
     });
-    return await taskLineRenderer.renderTaskLine({ task: task, taskIndex: 0 });
+    return await taskLineRenderer.renderTaskLine({ task: task, taskIndex: 0, isTaskInQueryFile: true });
 }
 
 function getTextSpan(listItem: HTMLElement) {
@@ -89,7 +89,11 @@ describe('task line rendering - HTML', () => {
             taskLayoutOptions: new TaskLayoutOptions(),
             queryLayoutOptions: new QueryLayoutOptions(),
         });
-        const listItem = await taskLineRenderer.renderTaskLine({ task: new TaskBuilder().build(), taskIndex: 0 });
+        const listItem = await taskLineRenderer.renderTaskLine({
+            task: new TaskBuilder().build(),
+            taskIndex: 0,
+            isTaskInQueryFile: true,
+        });
 
         // Just one element
         expect(ulElement.children.length).toEqual(1);


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Done by pairing with @ilandikov.

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

This refactors the fix for https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3297

## Motivation and Context

The goal was to remove the need to create new `Task` objects during rendering.

## How has this been tested?

- Automated tests
- Manual exploratory testing, by adding a Tasks search to:
    - `resources/sample_vaults/Tasks-Demo/Test Data/internal_heading_links.md`

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
