### PR TITLE
fix: Stable `group by function task.urgency` order

### DIFF
--- a/docs/Queries/Grouping.md
+++ b/docs/Queries/Grouping.md
@@ -663,6 +663,15 @@ group by function task.urgency.toFixed(3)
 
 - Show the urgency to 3 decimal places, unlike the built-in "group by urgency" which uses 2.
 
+```javascript
+group by function task.urgency
+```
+
+- Show non-integer urgency values to 5 decimal places, and integer ones to 0 decimal places.
+- Sorting of groups by name has been found to be unreliable with varying numbers of decimal places.
+- So to ensure consistent sorting, Tasks will round non-integer numbers to a fixed 5 decimal places, returning the value as a string.
+- This still sorts consistently even when some of the group's values are integers.
+
 <!-- placeholder to force blank line after included text --><!-- endInclude -->
 
 ### Recurrence

--- a/docs/Scripting/Custom Grouping.md
+++ b/docs/Scripting/Custom Grouping.md
@@ -13,6 +13,7 @@ publish: true
 
 - Define your own custom task groups, using JavaScript expressions such as:
   - `group by function task.urgency.toFixed(3)`
+  - See [[#Number property examples]] below for how floating point numbers are treated, if the precision (number of decimal places) is not specified.
 - There are loads of examples in [[Grouping]].
   - Search for `group by function` in that file.
 - Find all the **supported tasks properties** in [[Task Properties]] and [[Quick Reference]].

--- a/docs/Scripting/Custom Grouping.md
+++ b/docs/Scripting/Custom Grouping.md
@@ -193,6 +193,15 @@ group by function task.urgency.toFixed(3)
 
 - Show the urgency to 3 decimal places, unlike the built-in "group by urgency" which uses 2.
 
+```javascript
+group by function task.urgency
+```
+
+- Show non-integer urgency values to 5 decimal places, and integer ones to 0 decimal places.
+- Sorting of groups by name has been found to be unreliable with varying numbers of decimal places.
+- So to ensure consistent sorting, Tasks will round non-integer numbers to a fixed 5 decimal places, returning the value as a string.
+- This still sorts consistently even when some of the group's values are integers.
+
 <!-- placeholder to force blank line after included text --><!-- endInclude -->
 
 ### File property examples

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -283,6 +283,14 @@ export function groupByFunction(task: Task, arg: GroupingArg, queryContext?: Que
             return [];
         }
 
+        if (typeof result === 'number' && !Number.isInteger(result)) {
+            // Guard against #3371: order of groups, when grouping by "function task.urgency" without specifying precision, is confusing.
+            // Sorting has been found to be unreliable with varying numbers of decimal places.
+            // So to ensure consistent sorting, we round the value to a fixed number of decimals and return it as a string.
+            // This still sorts consistently even when some of the group's values are integers.
+            return [result.toFixed(5)];
+        }
+
         // If there was an error in the expression, like it referred to
         // an unknown task field, result will be undefined, and the call
         // on undefined.toString() will give an exception and a useful error

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -522,7 +522,7 @@ describe('FunctionField - grouping return types', () => {
         ['1', ['1']],
         ['0', ['0']],
         ['0 || "No value"', ['No value']],
-        ['1.0765456', ['1.0765456']],
+        ['1.0765456', ['1.07655']],
         ['1.0765456.toFixed(3)', ['1.077']],
         ['["heading1", "heading2"]', ['heading1', 'heading2']], // return two headings, indicating that this task should be displayed twice, once in each heading
         ['[1, 2]', ['1', '2']], // return two headings, that need to be converted to strings

--- a/tests/Query/Group/TaskGroups.test.ts
+++ b/tests/Query/Group/TaskGroups.test.ts
@@ -243,9 +243,12 @@ describe('Grouping tasks', () => {
         jest.setSystemTime(new Date('2025-03-07'));
 
         const lines = [
+            '- [ ] 0 📅 2025-02-28 🔺           ', // urgency: 21
             '- [ ] 1 📅 2025-03-07 ⏳ 2025-03-07', // urgency: 15.75
             '- [ ] 2 📅 2025-03-08 ⏳ 2025-03-07', // urgency: 15.292857142857141
             '- [ ] 3 📅 2025-03-09 ⏳ 2025-03-07', // urgency: 14.835714285714285
+            '- [ ] 4 ⏫  🛫 2025-03-18          ', // urgency: 3
+            '- [ ] 5 🔽                         ', // urgency: 0
         ];
         const tasks = fromLines({ lines });
 
@@ -257,7 +260,7 @@ describe('Grouping tasks', () => {
 
         const groups: TaskGroups = makeTasksGroups(grouping, tasks);
         const groupHeadings = groups.groups.map((group: TaskGroup) => group.groups[0]);
-        expect(groupHeadings).toEqual(['14.83571', '15.29286', '15.75000']);
+        expect(groupHeadings).toEqual(['0', '3', '14.83571', '15.29286', '15.75000', '21']);
     });
 
     it('handles tasks matching multiple groups correctly', () => {

--- a/tests/Query/Group/TaskGroups.test.ts
+++ b/tests/Query/Group/TaskGroups.test.ts
@@ -238,7 +238,7 @@ describe('Grouping tasks', () => {
         `);
     });
 
-    it.failing('sorts raw urgency value groups correctly', () => {
+    it('sorts raw urgency value groups correctly', () => {
         jest.useFakeTimers();
         jest.setSystemTime(new Date('2025-03-07'));
 
@@ -256,10 +256,8 @@ describe('Grouping tasks', () => {
         const grouping = [new FunctionField().createGrouperFromLine('group by function task.urgency')!];
 
         const groups: TaskGroups = makeTasksGroups(grouping, tasks);
-        const groupHeadings = groups.groups.map((group: TaskGroup) => group.groups[0].slice(0, 7));
-
-        expect(groupHeadings).toEqual(['14.8357', '15.75', '15.2928']); // This passes: it shows that the order is illogical (non-ascending).
-        expect(groupHeadings).toEqual(['14.8357', '15.2928', '15.75']); // This fails: it is what users would expect.
+        const groupHeadings = groups.groups.map((group: TaskGroup) => group.groups[0]);
+        expect(groupHeadings).toEqual(['14.83571', '15.29286', '15.75000']);
     });
 
     it('handles tasks matching multiple groups correctly', () => {

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.urgency_docs.approved.md
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.urgency_docs.approved.md
@@ -7,5 +7,14 @@ group by function task.urgency.toFixed(3)
 
 - Show the urgency to 3 decimal places, unlike the built-in "group by urgency" which uses 2.
 
+```javascript
+group by function task.urgency
+```
+
+- Show non-integer urgency values to 5 decimal places, and integer ones to 0 decimal places.
+- Sorting of groups by name has been found to be unreliable with varying numbers of decimal places.
+- So to ensure consistent sorting, Tasks will round non-integer numbers to a fixed 5 decimal places, returning the value as a string.
+- This still sorts consistently even when some of the group's values are integers.
+
 
 <!-- placeholder to force blank line after included text -->

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.urgency_results.approved.txt
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.other_properties_task.urgency_results.approved.txt
@@ -13,3 +13,18 @@ Show the urgency to 3 decimal places, unlike the built-in "group by urgency" whi
 9.000
 ====================================================================================
 
+
+group by function task.urgency
+Show non-integer urgency values to 5 decimal places, and integer ones to 0 decimal places.
+Sorting of groups by name has been found to be unreliable with varying numbers of decimal places.
+So to ensure consistent sorting, Tasks will round non-integer numbers to a fixed 5 decimal places, returning the value as a string.
+This still sorts consistently even when some of the group's values are integers.
+=>
+-1.80000
+0
+1.95000
+3.90000
+6
+9
+====================================================================================
+

--- a/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.ts
+++ b/tests/Scripting/ScriptingReference/CustomGrouping/CustomGroupingExamples.test.ts
@@ -704,6 +704,13 @@ describe('other properties', () => {
                     'group by function task.urgency.toFixed(3)',
                     'Show the urgency to 3 decimal places, unlike the built-in "group by urgency" which uses 2',
                 ],
+                [
+                    'group by function task.urgency',
+                    'Show non-integer urgency values to 5 decimal places, and integer ones to 0 decimal places',
+                    'Sorting of groups by name has been found to be unreliable with varying numbers of decimal places.',
+                    'So to ensure consistent sorting, Tasks will round non-integer numbers to a fixed 5 decimal places, returning the value as a string.',
+                    "This still sorts consistently even when some of the group's values are integers.",
+                ],
             ],
             SampleTasks.withAllPriorities(),
         ],


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3371
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

If custom group labels are floating point numbers, round them to a fixed 5 decimal places, to prevent observed problems of the sort order appearing random, if floating point group labels have different numbers of decimal places.

## Motivation and Context

Fix #3371:

- https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3371

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- New tests
- Exploratory testing

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
