### PR TITLE
fix: Improve performance when multiple files are edited quickly

### DIFF
--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -111,6 +111,11 @@ export class Cache {
 
     private notifySubscribers(): void {
         this.logger.debug('Cache.notifySubscribers()');
+        this.notifySubscribersNotDebounced();
+    }
+
+    private notifySubscribersNotDebounced(): void {
+        this.logger.debug('Cache.notifySubscribersNotDebounced()');
         this.events.triggerCacheUpdate({
             tasks: this.tasks,
             state: this.state,

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -1,4 +1,12 @@
-import type { CachedMetadata, EventRef, HeadingCache, ListItemCache, SectionCache, Workspace } from 'obsidian';
+import {
+    type CachedMetadata,
+    type EventRef,
+    type HeadingCache,
+    type ListItemCache,
+    type SectionCache,
+    type Workspace,
+    debounce,
+} from 'obsidian';
 import { MetadataCache, Notice, TAbstractFile, TFile, Vault } from 'obsidian';
 import { Mutex } from 'async-mutex';
 import { TasksFile } from '../Scripting/TasksFile';
@@ -32,6 +40,12 @@ export class Cache {
     private readonly tasksMutex: Mutex;
     private state: State;
     private tasks: Task[];
+
+    private readonly notifySubscribersDebounced = debounce(
+        () => this.notifySubscribersNotDebounced(),
+        100, // Long enough to prevent successive redraws slowing performance; short enough for edits via context menus to appear snappy
+        true,
+    );
 
     /**
      * We cannot know if this class will be instantiated because obsidian started
@@ -111,7 +125,7 @@ export class Cache {
 
     private notifySubscribers(): void {
         this.logger.debug('Cache.notifySubscribers()');
-        this.notifySubscribersNotDebounced();
+        this.notifySubscribersDebounced();
     }
 
     private notifySubscribersNotDebounced(): void {


### PR DESCRIPTION
# Types of changes

Done by pairing with @ilandikov.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: 
      - Relates to #3283

## Description

### The change

This adds a small delay between successive redraws of Tasks search results.

This speeds up situations where more than one file containing tests is modified within that 0.1 second window, which can happen with things like:

- Changes being synced in from another device
- Bulk edits being made in the vault, for example:
    - Renaming a property
    - Doing multi-file find-and-replace in a text editor
    - Running the Lint plugin on a folder or folders
    - A folder being renamed

Previously, Tasks would redraw all open queries on every individual file edit, for files that contain lines it considers to be tasks.

This also eliminates some double redraws that I have not previously been able to track down.

### Example improvement

Time taken to delete 76 files with tasks in, in the test vault, on a _very_ fast Mac.

| Code | Time (in seconds) |
|--------|-------:|
| Before this PR | 8.6 |
| After this PR | 0.5 | 

### What is not (yet) changed

Because the  0.1 secs delay is small compared to the Obsidian 2-second auto-save interval, this probably will not have much benefit to typing speed, whilst the Tasks plugin is rendering many searches.

That will be improved in a future PR.

## Motivation and Context

- Save user time
- Save device battery power

This is the first of a series of improvements to Tasks performance.

## How has this been tested?

Thorough exploratory testing in the Tasks test vault.

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/30d8ae21-b8be-4502-8b1c-67eef9d1fbe9)

Screenshot showing the size of debug-log files from Tasks, when deleting 64 files containing tasks, with 5 queries open.

The size of the output reflects the number of redraws done.

| Code | Log Size (in KB) |
|--------|-------:|
| Before this PR | 482 |
| After this PR | 92 | 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
