### PR TITLE
fix: Stop onCompletion: delete leaving blank lines for non-recurring tasks

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Task Toggling Scenarios/On Completion Delete.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Task Toggling Scenarios/On Completion Delete.md
@@ -13,7 +13,7 @@
 - [ ] #task Complete in **Source Mode** with `Tasks: Toggle task done` command 🏁 delete
 - Line after
 
-==❌ This shows \#3342 - blank line remains, as of Tasks `7.18.4`.==
+✅ Whole line is removed.
 
 ## Live Preview
 
@@ -23,7 +23,7 @@
 - [ ] #task Complete in **Live Preview** with `Tasks: Toggle task done` command 🏁 delete
 - Line after
 
-==❌ This shows \#3342 - blank line remains, as of Tasks `7.18.4`.==
+✅ Whole line is removed.
 
 ### Complete in Live Preview clicking checkbox
 

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Task Toggling Scenarios/On Completion Delete.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Task Toggling Scenarios/On Completion Delete.md
@@ -61,9 +61,19 @@
 
 ✅ Whole line is removed.
 
+### Complete in Search results right-clicking checkbox
+
+- Line before
+- [ ] #task Complete in **Search result**s right-clicking checkbox 🏁 delete
+- Line after
+
+✅ Whole line is removed.
+
+### Search
+
 ```tasks
 path includes {{query.file.path}}
-heading includes Complete in Search results clicking checkbox
+heading includes Complete in Search results
 short mode
 ```
 

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Task Toggling Scenarios/On Completion Delete.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Task Toggling Scenarios/On Completion Delete.md
@@ -31,7 +31,7 @@
 - [ ] #task Complete in **Live Preview** clicking checkbox 🏁 delete
 - Line after
 
-==❌ This shows \#3342 - blank line remains, as of Tasks `7.18.4`.==
+✅ Whole line is removed.
 
 ## Reading Mode
 

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Task Toggling Scenarios/On Completion Delete.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Task Toggling Scenarios/On Completion Delete.md
@@ -43,6 +43,14 @@
 
 ✅ Whole line is removed.
 
+### Complete in Reading Mode right-clicking checkbox
+
+- Line before
+- [ ] #task Complete in **Reading Mode** right-clicking checkbox 🏁 delete
+- Line after
+
+✅ Whole line is removed.
+
 ## Search results
 
 ### Complete in Search results clicking checkbox

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Task Toggling Scenarios/On Completion Delete.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Task Toggling Scenarios/On Completion Delete.md
@@ -59,13 +59,13 @@
 - [ ] #task Complete in **Search result**s clicking checkbox 🏁 delete
 - Line after
 
+✅ Whole line is removed.
+
 ```tasks
 path includes {{query.file.path}}
 heading includes Complete in Search results clicking checkbox
 short mode
 ```
-
-✅ Whole line is removed.
 
 ## Remaining steps
 

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -42,19 +42,16 @@ export const toggleDone = (checking: boolean, editor: Editor, view: MarkdownView
     const taskIsOnLastLine = !taskWasNotOnLastLine;
     if (replacementTextIsNonEmpty) {
         editor.setLine(lineNumber, insertion.text);
-    } else {
+    } else if (taskIsOnLastLine) {
         // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3342
-        // If insertion.text is empty, delete the line instead, so we don't leave a trailing end-of-line character around.
-        if (taskIsOnLastLine) {
-            // There is no end-of-line character on our line, which is the last line in the file.
-            // console.log(`Deleting line "${editor.getLine(lineNumber)}", because insertion.text is empty.`);
-            editor.setLine(lineNumber, insertion.text);
-        } else {
-            const from = { line: lineNumber, ch: 0 };
-            const to = { line: lineNumber + 1, ch: 0 };
-            // console.log(`Deleting line+EOL "${editor.getRange(from, to)}", because insertion.text is empty.`);
-            editor.replaceRange('', from, to);
-        }
+        // There is no end-of-line character on our line, which is the last line in the file.
+        // console.log(`Deleting line "${editor.getLine(lineNumber)}", because insertion.text is empty.`);
+        editor.setLine(lineNumber, insertion.text);
+    } else {
+        const from = { line: lineNumber, ch: 0 };
+        const to = { line: lineNumber + 1, ch: 0 };
+        // console.log(`Deleting line+EOL "${editor.getRange(from, to)}", because insertion.text is empty.`);
+        editor.replaceRange('', from, to);
     }
 
     /* Cursor positions are 0-based for both "line" and "ch" offsets.

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -37,7 +37,8 @@ export const toggleDone = (checking: boolean, editor: Editor, view: MarkdownView
 
     const insertion = toggleLine(line, path);
 
-    if (insertion.text.length > 0) {
+    const replacementTextIsNonEmpty = insertion.text.length > 0;
+    if (replacementTextIsNonEmpty) {
         editor.setLine(lineNumber, insertion.text);
     } else {
         // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3342

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -44,15 +44,15 @@ export const toggleDone = (checking: boolean, editor: Editor, view: MarkdownView
     } else {
         // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3342
         // If insertion.text is empty, delete the line instead, so we don't leave a trailing end-of-line character around.
-        if (taskWasNotOnLastLine) {
+        if (!taskWasNotOnLastLine) {
+            // There is no end-of-line character on our line, which is the last line in the file.
+            // console.log(`Deleting line "${editor.getLine(lineNumber)}", because insertion.text is empty.`);
+            editor.setLine(lineNumber, insertion.text);
+        } else {
             const from = { line: lineNumber, ch: 0 };
             const to = { line: lineNumber + 1, ch: 0 };
             // console.log(`Deleting line+EOL "${editor.getRange(from, to)}", because insertion.text is empty.`);
             editor.replaceRange('', from, to);
-        } else {
-            // There is no end-of-line character on our line, which is the last line in the file.
-            // console.log(`Deleting line "${editor.getLine(lineNumber)}", because insertion.text is empty.`);
-            editor.setLine(lineNumber, insertion.text);
         }
     }
 

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -42,11 +42,16 @@ export const toggleDone = (checking: boolean, editor: Editor, view: MarkdownView
     } else {
         // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3342
         // If insertion.text is empty, delete the line instead, so we don't leave a trailing end-of-line character around.
-        // This behaves gracefully even if there is no end-of-line character on the last line in the file.
-        const from = { line: lineNumber, ch: 0 };
-        const to = { line: lineNumber + 1, ch: 0 };
-        // console.log(`Deleting line+EOL "${editor.getRange(from, to)}", because insertion.text is empty.`);
-        editor.replaceRange('', from, to);
+        if (lineNumber < editor.lineCount() - 1) {
+            const from = { line: lineNumber, ch: 0 };
+            const to = { line: lineNumber + 1, ch: 0 };
+            // console.log(`Deleting line+EOL "${editor.getRange(from, to)}", because insertion.text is empty.`);
+            editor.replaceRange('', from, to);
+        } else {
+            // There is no end-of-line character on our line, which is the last line in the file.
+            // console.log(`Deleting line "${editor.getLine(lineNumber)}", because insertion.text is empty.`);
+            editor.setLine(lineNumber, insertion.text);
+        }
     }
 
     /* Cursor positions are 0-based for both "line" and "ch" offsets.

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -42,9 +42,10 @@ export const toggleDone = (checking: boolean, editor: Editor, view: MarkdownView
     if (replacementTextIsNonEmpty || taskIsOnLastLine) {
         editor.setLine(lineNumber, insertion.text);
     } else {
+        // The replacement text is empty, and our line was followed by a new line character,
+        // so we delete the line and the new-line, to avoid leaving a blank line in the file.
         const from = { line: lineNumber, ch: 0 };
         const to = { line: lineNumber + 1, ch: 0 };
-        // console.log(`Deleting line+EOL "${editor.getRange(from, to)}", because insertion.text is empty.`);
         editor.replaceRange('', from, to);
     }
 

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -39,12 +39,13 @@ export const toggleDone = (checking: boolean, editor: Editor, view: MarkdownView
 
     const replacementTextIsNonEmpty = insertion.text.length > 0;
     const taskWasNotOnLastLine = lineNumber < editor.lineCount() - 1;
+    const taskIsOnLastLine = !taskWasNotOnLastLine;
     if (replacementTextIsNonEmpty) {
         editor.setLine(lineNumber, insertion.text);
     } else {
         // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3342
         // If insertion.text is empty, delete the line instead, so we don't leave a trailing end-of-line character around.
-        if (!taskWasNotOnLastLine) {
+        if (taskIsOnLastLine) {
             // There is no end-of-line character on our line, which is the last line in the file.
             // console.log(`Deleting line "${editor.getLine(lineNumber)}", because insertion.text is empty.`);
             editor.setLine(lineNumber, insertion.text);

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -36,7 +36,18 @@ export const toggleDone = (checking: boolean, editor: Editor, view: MarkdownView
     const line = editor.getLine(lineNumber);
 
     const insertion = toggleLine(line, path);
-    editor.setLine(lineNumber, insertion.text);
+
+    if (insertion.text.length > 0) {
+        editor.setLine(lineNumber, insertion.text);
+    } else {
+        // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3342
+        // If insertion.text is empty, delete the line instead, so we don't leave a trailing end-of-line character around.
+        // This behaves gracefully even if there is no end-of-line character on the last line in the file.
+        const from = { line: lineNumber, ch: 0 };
+        const to = { line: lineNumber + 1, ch: 0 };
+        // console.log(`Deleting line+EOL "${editor.getRange(from, to)}", because insertion.text is empty.`);
+        editor.replaceRange('', from, to);
+    }
 
     /* Cursor positions are 0-based for both "line" and "ch" offsets.
      * If "ch" offset bigger than the line length, will just continue to next line(s).

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -38,8 +38,7 @@ export const toggleDone = (checking: boolean, editor: Editor, view: MarkdownView
     const insertion = toggleLine(line, path);
 
     const replacementTextIsNonEmpty = insertion.text.length > 0;
-    const taskWasNotOnLastLine = lineNumber < editor.lineCount() - 1;
-    const taskIsOnLastLine = !taskWasNotOnLastLine;
+    const taskIsOnLastLine = !(lineNumber < editor.lineCount() - 1);
     if (replacementTextIsNonEmpty || taskIsOnLastLine) {
         editor.setLine(lineNumber, insertion.text);
     } else {

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -38,12 +38,13 @@ export const toggleDone = (checking: boolean, editor: Editor, view: MarkdownView
     const insertion = toggleLine(line, path);
 
     const replacementTextIsNonEmpty = insertion.text.length > 0;
+    const taskWasNotOnLastLine = lineNumber < editor.lineCount() - 1;
     if (replacementTextIsNonEmpty) {
         editor.setLine(lineNumber, insertion.text);
     } else {
         // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3342
         // If insertion.text is empty, delete the line instead, so we don't leave a trailing end-of-line character around.
-        if (lineNumber < editor.lineCount() - 1) {
+        if (taskWasNotOnLastLine) {
             const from = { line: lineNumber, ch: 0 };
             const to = { line: lineNumber + 1, ch: 0 };
             // console.log(`Deleting line+EOL "${editor.getRange(from, to)}", because insertion.text is empty.`);

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -38,7 +38,7 @@ export const toggleDone = (checking: boolean, editor: Editor, view: MarkdownView
     const insertion = toggleLine(line, path);
 
     const replacementTextIsNonEmpty = insertion.text.length > 0;
-    const taskIsOnLastLine = !(lineNumber < editor.lineCount() - 1);
+    const taskIsOnLastLine = lineNumber >= editor.lineCount() - 1;
     if (replacementTextIsNonEmpty || taskIsOnLastLine) {
         editor.setLine(lineNumber, insertion.text);
     } else {

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -40,12 +40,7 @@ export const toggleDone = (checking: boolean, editor: Editor, view: MarkdownView
     const replacementTextIsNonEmpty = insertion.text.length > 0;
     const taskWasNotOnLastLine = lineNumber < editor.lineCount() - 1;
     const taskIsOnLastLine = !taskWasNotOnLastLine;
-    if (replacementTextIsNonEmpty) {
-        editor.setLine(lineNumber, insertion.text);
-    } else if (taskIsOnLastLine) {
-        // https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3342
-        // There is no end-of-line character on our line, which is the last line in the file.
-        // console.log(`Deleting line "${editor.getLine(lineNumber)}", because insertion.text is empty.`);
+    if (replacementTextIsNonEmpty || taskIsOnLastLine) {
         editor.setLine(lineNumber, insertion.text);
     } else {
         const from = { line: lineNumber, ch: 0 };

--- a/src/Obsidian/LivePreviewExtension.ts
+++ b/src/Obsidian/LivePreviewExtension.ts
@@ -91,11 +91,22 @@ class LivePreviewExtension implements PluginValue {
         const toggled = task.toggleWithRecurrenceInUsersOrder();
         const toggledString = toggled.map((t) => t.toFileLineString()).join(state.lineBreak);
 
+        let to = line.to;
+
+        if (toggledString === '') {
+            // We also need to remove any line break at the end of the line.
+            const nextLine = line.number < state.doc.lines ? state.doc.line(line.number + 1) : null;
+            if (nextLine) {
+                // If not the last line, delete up to the start of the next line, including the line break
+                to = nextLine.from;
+            }
+        }
+
         // Creates a CodeMirror transaction in order to update the document.
         const transaction = state.update({
             changes: {
                 from: line.from,
-                to: line.to,
+                to,
                 insert: toggledString,
             },
         });


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3342
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

Prevent 'On completion: Delete' leaving blank lines in the file, when completing non-recurring, self-deleting tasks via:

- Live Preview, clicking on the checkbox
- The `Tasks: Toggle task done` command

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #3342 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Exploratory testing, including using content of the file `On Completion Delete.md`

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
