### PR TITLE
fix: {{query.file...}} no longer broken when renaming other files (#3335, #3428)

### DIFF
--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -150,7 +150,11 @@ class QueryRenderChild extends MarkdownRenderChild {
         );
 
         this.registerEvent(
-            this.app.vault.on('rename', (tFile: TAbstractFile, _oldPath: string) => {
+            this.app.vault.on('rename', (tFile: TAbstractFile, oldPath: string) => {
+                if (oldPath !== this.queryResultsRenderer.filePath) {
+                    return;
+                }
+
                 let fileCache: CachedMetadata | null = null;
                 if (tFile && tFile instanceof TFile) {
                     fileCache = this.app.metadataCache.getFileCache(tFile);


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
      - #3335
      - #3428

## Description

QueryRenderer now only listens out for renames to the file containing the query, rather than to any file in the vault.

## Motivation and Context

- Fixes https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3335
- Fixes https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3428

## How has this been tested?

Exploratory testing, using the reproduction steps in the two linked issues.

Cases tested:

- That it no longer updates queries in files other than the one that was renamed
- That it does still update queries in the one that is renamed

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
