### PR TITLE
fix: Support line continuations in TQ_extra_instructions & placeholders

### DIFF
--- a/docs/Queries/Query File Defaults.md
+++ b/docs/Queries/Query File Defaults.md
@@ -60,6 +60,7 @@ When editing `TQ_extra_instructions` in Obsidian's File properties editor, you c
 > - `TQ_extra_instructions` is especially useful when you have more than one Tasks search block in a file, and you want the same instructions to be present in all the searches.
 > - Before this feature, if those standard instructions changed, you had to remember to update every search.
 > - Now you can put those standard instructions in `TQ_extra_instructions`, and only update them in one place.
+> - Since Tasks X.Y.Z, `TQ_extra_instructions` does support [[Line Continuations]].
 
 > [!note]
 > The `TQ_extra_instructions` property isn't an array. It's a single string value, and the `|-` allows it to span multiple lines.
@@ -248,6 +249,3 @@ The `type` values are explained in the [Property types](https://help.obsidian.md
 - Tasks searches in **Canvas cards** cannot use [[Query File Defaults]], because the [Canvas format](https://jsoncanvas.org) does not support frontmatter/properties.
   - The workaround is to use the Canvas [Convert to file](https://help.obsidian.md/Plugins/Canvas#Add+text+cards) facility to convert cards which contain Tasks queries to a separate Markdown note, embedded in the canvas.
   - You can then add Query File Defaults to the new note.
-- The property `TQ_extra_instructions` can contain any kind of Tasks instruction, including placeholders.
-  - But it does not work with [[Line Continuations]].
-  - The workaround is to write any long instructions all on one line when placed in `TQ_extra_instructions`.

--- a/docs/What is New/Changelog.md
+++ b/docs/What is New/Changelog.md
@@ -13,6 +13,7 @@ _In recent [Tasks releases](https://github.com/obsidian-tasks-group/obsidian-tas
 ## 7.x releases
 
 - X.Y.Z:
+  - [[Line Continuations]] can now be used in the [[Query File Defaults]] property `TQ_extra_instructions`.
   - [[Check your Statuses]] report now contains samples of each status, and a convenient search to test them.
 - 7.19.0:
   - New setting to [[Recurring Tasks#Remove scheduled date on recurrence|remove scheduled date on recurrence]].

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -184,6 +184,11 @@ ${source}`;
             const queryContext = makeQueryContext(tasksFile);
             try {
                 expandedSource = expandPlaceholders(source, queryContext);
+                if (expandedSource !== source) {
+                    expandedSource = continueLines(expandedSource)
+                        .map((statement) => statement.anyContinuationLinesRemoved)
+                        .join('\n');
+                }
             } catch (error) {
                 if (error instanceof Error) {
                     this._error = error.message;

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -876,18 +876,16 @@ group by folder
                 `);
             });
 
-            it('does not work with continuation lines in multi-line property with query.file.property via placeholder', () => {
+            it('should work with continuation lines in multi-line property with query.file.property via placeholder', () => {
                 const propertyValue = `path \\
   includes query_using_properties
 `;
                 const query = makeQueryFromPropertyWithValue('task_instructions_with_continuation_line', propertyValue);
 
-                expect(query.error).not.toBeUndefined();
-                expect(query.error).toMatchInlineSnapshot(`
-                    "do not understand query
-                    Problem statement:
-                        {{query.file.property('task_instructions_with_continuation_line')}}: statement 1 after expansion of placeholder =>
-                        path \\
+                expect(query.error).toBeUndefined();
+                expect(query.explainQuery()).toMatchInlineSnapshot(`
+                    "{{query.file.property('task_instructions_with_continuation_line')}} =>
+                    path includes query_using_properties
                     "
                 `);
             });

--- a/tests/Scripting/Includes.test.ts
+++ b/tests/Scripting/Includes.test.ts
@@ -155,26 +155,10 @@ return "Hello World";`;
 
         const expectedStatement = 'group by function return "Hello World";';
 
-        it('includes placeholder DOES NOT YET SUPPORT line continuations in include value', () => {
-            // TODO Teach '{{includes.x}}' to support line continuations
-            // Just as TQ_extra_instructions (in Query File Defaults) does not work with line continuations,
-            // so includes in placeholders do not.
-            // This is because line continuations are applied only once, before the placeholders
-            // are expanded.
-
+        it('includes placeholder supports line continuations in include value', () => {
             const source = '{{includes.instruction_with_continuation_lines}}';
-            const query = createQuery(source, includes);
-            expect(query.error).toMatchInlineSnapshot(`
-                "Could not interpret the following instruction as a Boolean combination:
-                    return "Hello World";
-
-                The error message is:
-                    All filters in a Boolean instruction must be inside one of these pairs of delimiter characters: (...) or [...] or {...} or "...". Combinations of those delimiters are no longer supported.
-                Problem statement:
-                    {{includes.instruction_with_continuation_lines}}: statement 2 after expansion of placeholder =>
-                    return "Hello World";
-                "
-            `);
+            const query = createValidQuery(source, includes);
+            expectExpandedStatementToBe(query.grouping[0].statement, expectedStatement);
         });
 
         it('include instruction supports line continuations in include value', () => {


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: None, but it fixes a limitation that was mentioned in the `TQ_extra_instructions` docs
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Fix a documented limitation that instructions in `TQ_extra_instructions` and in multi-line placeholders did not support line continuations.

## Motivation and Context

I am addressing limitations in the forthcoming "includes" feature (that is its current working name - I don't yet know what the finale name will be.)


## How has this been tested?

- Updating existing unit tests
- Manual exploratory testing

## Screenshots (if appropriate)

Here is an example Markdown file that now works:

~~~
---
task_instructions_with_continuation_line: |-
  path \
    includes query_using_properties
---
# Test

```tasks
explain
{{query.file.property('task_instructions_with_continuation_line')}}
```
~~~

Before, it gave an error:

![image](https://github.com/user-attachments/assets/f431edb3-06b4-4289-8cf6-ab0582a2b369)

Now it works:

![image](https://github.com/user-attachments/assets/2ddb93a2-8e76-4cda-a656-c69df25c8c43)

That used a placeholder, but the same improvements improve the behaviour of `TQ_extra_instructions`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
