### PR TITLE
Refactor add includes settings service

### DIFF
--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -19,23 +19,23 @@ export class IncludesSettingsService {
     /**
      * Checks if a new key would create a duplicate in the includes map
      * @param includes The current includes map (will not be modified)
-     * @param originalKey The original key (to exclude from comparison)
+     * @param keyBeingRenamed The original key (to exclude from comparison)
      * @param newKey The new key to check
      * @returns True if the key would be a duplicate, false otherwise
      */
-    public wouldCreateDuplicateKey(includes: Readonly<IncludesMap>, originalKey: string, newKey: string): boolean {
+    public wouldCreateDuplicateKey(includes: Readonly<IncludesMap>, keyBeingRenamed: string, newKey: string): boolean {
         // Normalize the newKey once
         const normalizedNewKey = newKey.trim();
 
         // Check if it's the same as the original key (after trimming)
-        if (originalKey.trim() === newKey) {
+        if (keyBeingRenamed.trim() === newKey) {
             return false; // Same key, not a duplicate
         }
 
         // Check against all existing keys
         for (const existingKey of Object.keys(includes)) {
             // Skip the original key
-            if (existingKey !== originalKey && existingKey === normalizedNewKey) {
+            if (existingKey !== keyBeingRenamed && existingKey === normalizedNewKey) {
                 return true; // Found a duplicate
             }
         }

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -29,6 +29,19 @@ export class IncludesSettingsService {
     }
 
     /**
+     * Updates the value of an include
+     * @param includes The current includes map (will not be modified)
+     * @param key The key to update
+     * @param value The new value
+     * @returns The updated includes map
+     */
+    public updateIncludeValue(includes: Readonly<IncludesMap>, key: string, value: string): IncludesMap {
+        const newIncludes = { ...includes };
+        newIncludes[key] = value;
+        return newIncludes;
+    }
+
+    /**
      * Checks if renaming a key would create a duplicate in the includes map
      * @param includes The includes map to check against
      * @param keyBeingRenamed The existing key that would be renamed

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -24,6 +24,9 @@ export class IncludesSettingsService {
      * @returns True if the key would be a duplicate, false otherwise
      */
     public isDuplicateKey(includes: Readonly<IncludesMap>, originalKey: string, newKey: string): boolean {
+        // Normalize the newKey once
+        const normalizedNewKey = newKey.trim();
+
         // Check if it's the same as the original key (after trimming)
         if (originalKey === newKey) {
             return false; // Same key, not a duplicate
@@ -32,7 +35,7 @@ export class IncludesSettingsService {
         // Check against all existing keys
         for (const existingKey of Object.keys(includes)) {
             // Skip the original key
-            if (existingKey !== originalKey && existingKey === newKey) {
+            if (existingKey !== originalKey && existingKey === normalizedNewKey) {
                 return true; // Found a duplicate
             }
         }

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -17,6 +17,18 @@ export class IncludesSettingsService {
     }
 
     /**
+     * Deletes an include from the map
+     * @param includes The current includes map (will not be modified)
+     * @param key The key to delete
+     * @returns The updated includes map
+     */
+    public deleteInclude(includes: Readonly<IncludesMap>, key: string): IncludesMap {
+        const newIncludes = { ...includes };
+        delete newIncludes[key];
+        return newIncludes;
+    }
+
+    /**
      * Checks if renaming a key would create a duplicate in the includes map
      * @param includes The includes map to check against
      * @param keyBeingRenamed The existing key that would be renamed

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -34,6 +34,8 @@ export class IncludesSettingsService {
             return null; // Empty keys are not allowed
         }
 
+        proposedNewName = proposedNewName.trim();
+
         // Check if this would create a duplicate
         if (this.wouldCreateDuplicateKey(includes, keyBeingRenamed, proposedNewName)) {
             return null;

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -38,8 +38,8 @@ export class IncludesSettingsService {
 
         // Check against all existing keys
         for (const existingKey of Object.keys(includes)) {
-            // Skip the original key
-            if (existingKey !== keyBeingRenamed && existingKey === normalizedNewName) {
+            // Skip the key being renamed (exact reference check)
+            if (existingKey !== keyBeingRenamed && existingKey.trim() === normalizedNewName) {
                 return true; // Found a duplicate
             }
         }

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -20,17 +20,17 @@ export class IncludesSettingsService {
     /**
      * Renames a key in the includes map, preserving order
      * @param includes The current includes map (will not be modified)
-     * @param oldKey The key to rename
+     * @param keyBeingRenamed The existing key that would be renamed
      * @param newKey The new key name
      * @returns The updated includes map, or null if the operation failed (for example, duplicate key)
      */
-    public renameInclude(includes: Readonly<IncludesMap>, oldKey: string, newKey: string): IncludesMap | null {
+    public renameInclude(includes: Readonly<IncludesMap>, keyBeingRenamed: string, newKey: string): IncludesMap | null {
         // Check if this would create a duplicate
-        if (this.wouldCreateDuplicateKey(includes, oldKey, newKey)) {
+        if (this.wouldCreateDuplicateKey(includes, keyBeingRenamed, newKey)) {
             return null;
         }
 
-        return renameKeyInRecordPreservingOrder(includes, oldKey, newKey);
+        return renameKeyInRecordPreservingOrder(includes, keyBeingRenamed, newKey);
     }
 
     /**

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -52,7 +52,7 @@ export class IncludesSettingsService {
      * @param includes The current includes map
      * @returns A unique key string
      */
-    private generateUniqueKey(includes: IncludesMap): string {
+    private generateUniqueKey(includes: Readonly<IncludesMap>): string {
         const baseKey = 'new_key';
         let suffix = 1;
         while (Object.prototype.hasOwnProperty.call(includes, `${baseKey}_${suffix}`)) {

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -17,11 +17,11 @@ export class IncludesSettingsService {
     }
 
     /**
-     * Checks if a new key would create a duplicate in the includes map
-     * @param includes The current includes map (will not be modified)
-     * @param keyBeingRenamed The original key (to exclude from comparison)
-     * @param proposedNewName The new key to check
-     * @returns True if the key would be a duplicate, false otherwise
+     * Checks if renaming a key would create a duplicate in the includes map
+     * @param includes The includes map to check against
+     * @param keyBeingRenamed The existing key that would be renamed
+     * @param proposedNewName The new name being considered
+     * @returns True if the proposed new name would conflict with an existing key
      */
     public wouldCreateDuplicateKey(
         includes: Readonly<IncludesMap>,

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -1,0 +1,32 @@
+import type { IncludesMap } from './Settings';
+
+export class IncludesSettingsService {
+    /**
+     * Adds a new include to the map with a unique key
+     * @param includes The current includes map
+     * @returns An object with the updated includes map and the new key
+     */
+    public addInclude(includes: IncludesMap): { includes: IncludesMap; newKey: string } {
+        const newKey = this.generateUniqueKey(includes);
+        const newIncludes = { ...includes };
+        newIncludes[newKey] = '';
+        return {
+            includes: newIncludes,
+            newKey,
+        };
+    }
+
+    /**
+     * Generates a unique key for a new include
+     * @param includes The current includes map
+     * @returns A unique key string
+     */
+    private generateUniqueKey(includes: IncludesMap): string {
+        const baseKey = 'new_key';
+        let suffix = 1;
+        while (Object.prototype.hasOwnProperty.call(includes, `${baseKey}_${suffix}`)) {
+            suffix++;
+        }
+        return `${baseKey}_${suffix}`;
+    }
+}

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -20,15 +20,19 @@ export class IncludesSettingsService {
      * Checks if a new key would create a duplicate in the includes map
      * @param includes The current includes map (will not be modified)
      * @param keyBeingRenamed The original key (to exclude from comparison)
-     * @param newKey The new key to check
+     * @param proposedNewName The new key to check
      * @returns True if the key would be a duplicate, false otherwise
      */
-    public wouldCreateDuplicateKey(includes: Readonly<IncludesMap>, keyBeingRenamed: string, newKey: string): boolean {
-        // Normalize the newKey once
-        const normalizedNewKey = newKey.trim();
+    public wouldCreateDuplicateKey(
+        includes: Readonly<IncludesMap>,
+        keyBeingRenamed: string,
+        proposedNewName: string,
+    ): boolean {
+        // Normalize the proposedNewName once
+        const normalizedNewKey = proposedNewName.trim();
 
         // Check if it's the same as the original key (after trimming)
-        if (keyBeingRenamed.trim() === newKey) {
+        if (keyBeingRenamed.trim() === proposedNewName) {
             return false; // Same key, not a duplicate
         }
 

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -28,7 +28,7 @@ export class IncludesSettingsService {
         const normalizedNewKey = newKey.trim();
 
         // Check if it's the same as the original key (after trimming)
-        if (originalKey === newKey) {
+        if (originalKey.trim() === newKey) {
             return false; // Same key, not a duplicate
         }
 

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -21,16 +21,20 @@ export class IncludesSettingsService {
      * Renames a key in the includes map, preserving order
      * @param includes The current includes map (will not be modified)
      * @param keyBeingRenamed The existing key that would be renamed
-     * @param newKey The new key name
+     * @param proposedNewName The new name being considered
      * @returns The updated includes map, or null if the operation failed (for example, duplicate key)
      */
-    public renameInclude(includes: Readonly<IncludesMap>, keyBeingRenamed: string, newKey: string): IncludesMap | null {
+    public renameInclude(
+        includes: Readonly<IncludesMap>,
+        keyBeingRenamed: string,
+        proposedNewName: string,
+    ): IncludesMap | null {
         // Check if this would create a duplicate
-        if (this.wouldCreateDuplicateKey(includes, keyBeingRenamed, newKey)) {
+        if (this.wouldCreateDuplicateKey(includes, keyBeingRenamed, proposedNewName)) {
             return null;
         }
 
-        return renameKeyInRecordPreservingOrder(includes, keyBeingRenamed, newKey);
+        return renameKeyInRecordPreservingOrder(includes, keyBeingRenamed, proposedNewName);
     }
 
     /**

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -3,10 +3,10 @@ import type { IncludesMap } from './Settings';
 export class IncludesSettingsService {
     /**
      * Adds a new include to the map with a unique key
-     * @param includes The current includes map
+     * @param includes The current includes map (will not be modified)
      * @returns An object with the updated includes map and the new key
      */
-    public addInclude(includes: IncludesMap): { includes: IncludesMap; newKey: string } {
+    public addInclude(includes: Readonly<IncludesMap>): { includes: IncludesMap; newKey: string } {
         const newKey = this.generateUniqueKey(includes);
         const newIncludes = { ...includes };
         newIncludes[newKey] = '';

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -29,6 +29,11 @@ export class IncludesSettingsService {
         keyBeingRenamed: string,
         proposedNewName: string,
     ): IncludesMap | null {
+        // Validate inputs
+        if (!proposedNewName) {
+            return null; // Empty keys are not allowed
+        }
+
         // Check if this would create a duplicate
         if (this.wouldCreateDuplicateKey(includes, keyBeingRenamed, proposedNewName)) {
             return null;

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -31,9 +31,9 @@ export class IncludesSettingsService {
         // Normalize the proposedNewName once
         const normalizedNewName = proposedNewName.trim();
 
-        // Check if it's the same as the original key (after trimming)
-        if (keyBeingRenamed.trim() === proposedNewName) {
-            return false; // Same key, not a duplicate
+        // If it's the same key (after trimming), it's not a duplicate
+        if (keyBeingRenamed.trim() === normalizedNewName) {
+            return false;
         }
 
         // Check against all existing keys

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -30,7 +30,7 @@ export class IncludesSettingsService {
         proposedNewName: string,
     ): IncludesMap | null {
         // Validate inputs
-        if (!proposedNewName) {
+        if (!proposedNewName || proposedNewName.trim() === '') {
             return null; // Empty keys are not allowed
         }
 

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -29,7 +29,7 @@ export class IncludesSettingsService {
         proposedNewName: string,
     ): boolean {
         // Normalize the proposedNewName once
-        const normalizedNewKey = proposedNewName.trim();
+        const normalizedNewName = proposedNewName.trim();
 
         // Check if it's the same as the original key (after trimming)
         if (keyBeingRenamed.trim() === proposedNewName) {
@@ -39,7 +39,7 @@ export class IncludesSettingsService {
         // Check against all existing keys
         for (const existingKey of Object.keys(includes)) {
             // Skip the original key
-            if (existingKey !== keyBeingRenamed && existingKey === normalizedNewKey) {
+            if (existingKey !== keyBeingRenamed && existingKey === normalizedNewName) {
                 return true; // Found a duplicate
             }
         }

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -23,7 +23,7 @@ export class IncludesSettingsService {
      * @param newKey The new key to check
      * @returns True if the key would be a duplicate, false otherwise
      */
-    public isDuplicateKey(includes: Readonly<IncludesMap>, originalKey: string, newKey: string): boolean {
+    public wouldCreateDuplicateKey(includes: Readonly<IncludesMap>, originalKey: string, newKey: string): boolean {
         // Normalize the newKey once
         const normalizedNewKey = newKey.trim();
 

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -17,6 +17,30 @@ export class IncludesSettingsService {
     }
 
     /**
+     * Checks if a new key would create a duplicate in the includes map
+     * @param includes The current includes map (will not be modified)
+     * @param originalKey The original key (to exclude from comparison)
+     * @param newKey The new key to check
+     * @returns True if the key would be a duplicate, false otherwise
+     */
+    public isDuplicateKey(includes: Readonly<IncludesMap>, originalKey: string, newKey: string): boolean {
+        // Check if it's the same as the original key (after trimming)
+        if (originalKey === newKey) {
+            return false; // Same key, not a duplicate
+        }
+
+        // Check against all existing keys
+        for (const existingKey of Object.keys(includes)) {
+            // Skip the original key
+            if (existingKey !== originalKey && existingKey === newKey) {
+                return true; // Found a duplicate
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Generates a unique key for a new include
      * @param includes The current includes map
      * @returns A unique key string

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -1,3 +1,4 @@
+import { renameKeyInRecordPreservingOrder } from '../lib/RecordHelpers';
 import type { IncludesMap } from './Settings';
 
 export class IncludesSettingsService {
@@ -14,6 +15,22 @@ export class IncludesSettingsService {
             includes: newIncludes,
             newKey,
         };
+    }
+
+    /**
+     * Renames a key in the includes map, preserving order
+     * @param includes The current includes map (will not be modified)
+     * @param oldKey The key to rename
+     * @param newKey The new key name
+     * @returns The updated includes map, or null if the operation failed (for example, duplicate key)
+     */
+    public renameInclude(includes: Readonly<IncludesMap>, oldKey: string, newKey: string): IncludesMap | null {
+        // Check if this would create a duplicate
+        if (this.wouldCreateDuplicateKey(includes, oldKey, newKey)) {
+            return null;
+        }
+
+        return renameKeyInRecordPreservingOrder(includes, oldKey, newKey);
     }
 
     /**

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -734,15 +734,22 @@ export class SettingsTab extends PluginSettingTab {
         });
     }
 
+    /**
+     * Updates settings with new includes and refreshes UI
+     * @param updatedIncludes The new includes map
+     * @param settings The current settings object to update
+     * @param refreshView Callback to refresh the view
+     */
     private async saveIncludesSettings(
         updatedIncludes: IncludesMap,
         settings: Settings,
         refreshView: () => void,
     ): Promise<void> {
+        // Update the settings in storage
         updateSettings({ includes: updatedIncludes });
         await this.plugin.saveSettings();
 
-        // Update the local settings object to reflect the change
+        // Update the local settings object to reflect the changes
         settings.includes = { ...updatedIncludes };
         refreshView();
     }

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -728,12 +728,12 @@ export class SettingsTab extends PluginSettingTab {
             btn.setButtonText('Add new include')
                 .setCta()
                 .onClick(async () => {
-                    const { includes } = this.includesSettingsService.addInclude(settings.includes);
-                    updateSettings({ includes: includes });
+                    const { includes: updatedIncludes } = this.includesSettingsService.addInclude(settings.includes);
+                    updateSettings({ includes: updatedIncludes });
                     await this.plugin.saveSettings();
 
                     // Update the local settings object to reflect the change
-                    settings.includes = { ...includes };
+                    settings.includes = { ...updatedIncludes };
                     renderIncludes();
                 });
         });

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -6,7 +6,6 @@ import { Status } from '../Statuses/Status';
 import type { StatusCollection } from '../Statuses/StatusCollection';
 import { createStatusRegistryReport } from '../Statuses/StatusRegistryReport';
 import { i18n } from '../i18n/i18n';
-import { renameKeyInRecordPreservingOrder } from '../lib/RecordHelpers';
 import * as Themes from './Themes';
 import { type HeadingState, type IncludesMap, type Settings, TASK_FORMATS } from './Settings';
 import { getSettings, isFeatureEnabled, updateGeneralSetting, updateSettings } from './Settings';
@@ -664,13 +663,10 @@ export class SettingsTab extends PluginSettingTab {
             // Handle renaming an include
             const commitRename = async () => {
                 if (newKey && newKey !== key) {
-                    const newIncludes = renameKeyInRecordPreservingOrder(settings.includes, key, newKey);
-                    updateSettings({ includes: newIncludes });
-                    await this.plugin.saveSettings();
-
-                    // Refresh settings after replacing the includes object to avoid stale data in the next render.
-                    Object.assign(settings, getSettings());
-                    renderIncludes();
+                    const updatedIncludes = this.includesSettingsService.renameInclude(settings.includes, key, newKey);
+                    if (updatedIncludes) {
+                        await this.saveIncludesSettings(updatedIncludes, settings, renderIncludes);
+                    }
                 }
             };
 

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -15,6 +15,7 @@ import { StatusSettings } from './StatusSettings';
 
 import { CustomStatusModal } from './CustomStatusModal';
 import { GlobalQuery } from './GlobalQuery';
+import { IncludesSettingsService } from './IncludesSettingsService';
 
 export class SettingsTab extends PluginSettingTab {
     // If the UI needs a more complex setting you can create a
@@ -726,22 +727,14 @@ export class SettingsTab extends PluginSettingTab {
             btn.setButtonText('Add new include')
                 .setCta()
                 .onClick(async () => {
-                    const newKey = this.generateUniqueIncludeKey(settings);
+                    const includesSettingsService = new IncludesSettingsService();
+                    const { newKey } = includesSettingsService.addInclude(settings.includes);
                     settings.includes[newKey] = '';
                     updateSettings({ includes: settings.includes });
                     await this.plugin.saveSettings();
                     renderIncludes();
                 });
         });
-    }
-
-    private generateUniqueIncludeKey(settings: Settings) {
-        const baseKey = 'new_key';
-        let suffix = 1;
-        while (Object.prototype.hasOwnProperty.call(settings.includes, `${baseKey}_${suffix}`)) {
-            suffix++;
-        }
-        return `${baseKey}_${suffix}`;
     }
 
     private static renderFolderArray(folders: string[]): string {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -691,9 +691,12 @@ export class SettingsTab extends PluginSettingTab {
             this.setupAutoResizingTextarea(textArea);
 
             return textArea.onChange(async (newValue) => {
-                settings.includes[key] = newValue;
-                updateSettings({ includes: settings.includes });
-                await this.plugin.saveSettings();
+                const updatedIncludes = this.includesSettingsService.updateIncludeValue(
+                    settings.includes,
+                    key,
+                    newValue,
+                );
+                await this.saveIncludesSettings(updatedIncludes, settings, null);
             });
         });
 
@@ -733,15 +736,15 @@ export class SettingsTab extends PluginSettingTab {
     }
 
     /**
-     * Updates settings with new includes and refreshes UI
+     * Updates settings with new includes and refreshes UI if needed
      * @param updatedIncludes The new includes map
      * @param settings The current settings object to update
-     * @param refreshView Callback to refresh the view
+     * @param refreshView Callback to refresh the view (pass null if no refresh is needed)
      */
     private async saveIncludesSettings(
         updatedIncludes: IncludesMap,
         settings: Settings,
-        refreshView: () => void,
+        refreshView: (() => void) | null,
     ): Promise<void> {
         // Update the settings in storage
         updateSettings({ includes: updatedIncludes });
@@ -749,7 +752,11 @@ export class SettingsTab extends PluginSettingTab {
 
         // Update the local settings object to reflect the changes
         settings.includes = { ...updatedIncludes };
-        refreshView();
+
+        // Refresh the view if a callback was provided
+        if (refreshView) {
+            refreshView();
+        }
     }
 
     private static renderFolderArray(folders: string[]): string {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -702,10 +702,8 @@ export class SettingsTab extends PluginSettingTab {
             btn.setIcon('cross')
                 .setTooltip('Delete')
                 .onClick(async () => {
-                    delete settings.includes[key];
-                    updateSettings({ includes: settings.includes });
-                    await this.plugin.saveSettings();
-                    renderIncludes();
+                    const updatedIncludes = this.includesSettingsService.deleteInclude(settings.includes, key);
+                    await this.saveIncludesSettings(updatedIncludes, settings, renderIncludes);
                 });
         });
     }

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -27,6 +27,7 @@ export class SettingsTab extends PluginSettingTab {
     };
 
     private readonly plugin: TasksPlugin;
+    private readonly includesSettingsService = new IncludesSettingsService();
 
     constructor({ plugin }: { plugin: TasksPlugin }) {
         super(plugin.app, plugin);
@@ -727,8 +728,7 @@ export class SettingsTab extends PluginSettingTab {
             btn.setButtonText('Add new include')
                 .setCta()
                 .onClick(async () => {
-                    const includesSettingsService = new IncludesSettingsService();
-                    const { newKey } = includesSettingsService.addInclude(settings.includes);
+                    const { newKey } = this.includesSettingsService.addInclude(settings.includes);
                     settings.includes[newKey] = '';
                     updateSettings({ includes: settings.includes });
                     await this.plugin.saveSettings();

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -8,7 +8,7 @@ import { createStatusRegistryReport } from '../Statuses/StatusRegistryReport';
 import { i18n } from '../i18n/i18n';
 import { renameKeyInRecordPreservingOrder } from '../lib/RecordHelpers';
 import * as Themes from './Themes';
-import { type HeadingState, type Settings, TASK_FORMATS } from './Settings';
+import { type HeadingState, type IncludesMap, type Settings, TASK_FORMATS } from './Settings';
 import { getSettings, isFeatureEnabled, updateGeneralSetting, updateSettings } from './Settings';
 import { GlobalFilter } from './GlobalFilter';
 import { StatusSettings } from './StatusSettings';
@@ -729,14 +729,18 @@ export class SettingsTab extends PluginSettingTab {
                 .setCta()
                 .onClick(async () => {
                     const { includes: updatedIncludes } = this.includesSettingsService.addInclude(settings.includes);
-                    updateSettings({ includes: updatedIncludes });
-                    await this.plugin.saveSettings();
-
-                    // Update the local settings object to reflect the change
-                    settings.includes = { ...updatedIncludes };
-                    renderIncludes();
+                    await this.saveIncludesSettings(updatedIncludes, settings, renderIncludes);
                 });
         });
+    }
+
+    private async saveIncludesSettings(updatedIncludes: IncludesMap, settings: Settings, renderIncludes: () => void) {
+        updateSettings({ includes: updatedIncludes });
+        await this.plugin.saveSettings();
+
+        // Update the local settings object to reflect the change
+        settings.includes = { ...updatedIncludes };
+        renderIncludes();
     }
 
     private static renderFolderArray(folders: string[]): string {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -734,7 +734,11 @@ export class SettingsTab extends PluginSettingTab {
         });
     }
 
-    private async saveIncludesSettings(updatedIncludes: IncludesMap, settings: Settings, refreshView: () => void) {
+    private async saveIncludesSettings(
+        updatedIncludes: IncludesMap,
+        settings: Settings,
+        refreshView: () => void,
+    ): Promise<void> {
         updateSettings({ includes: updatedIncludes });
         await this.plugin.saveSettings();
 

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -728,10 +728,12 @@ export class SettingsTab extends PluginSettingTab {
             btn.setButtonText('Add new include')
                 .setCta()
                 .onClick(async () => {
-                    const { newKey } = this.includesSettingsService.addInclude(settings.includes);
-                    settings.includes[newKey] = '';
-                    updateSettings({ includes: settings.includes });
+                    const { includes } = this.includesSettingsService.addInclude(settings.includes);
+                    updateSettings({ includes: includes });
                     await this.plugin.saveSettings();
+
+                    // Update the local settings object to reflect the change
+                    settings.includes = { ...includes };
                     renderIncludes();
                 });
         });

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -734,13 +734,13 @@ export class SettingsTab extends PluginSettingTab {
         });
     }
 
-    private async saveIncludesSettings(updatedIncludes: IncludesMap, settings: Settings, renderIncludes: () => void) {
+    private async saveIncludesSettings(updatedIncludes: IncludesMap, settings: Settings, refreshView: () => void) {
         updateSettings({ includes: updatedIncludes });
         await this.plugin.saveSettings();
 
         // Update the local settings object to reflect the change
         settings.includes = { ...updatedIncludes };
-        renderIncludes();
+        refreshView();
     }
 
     private static renderFolderArray(folders: string[]): string {

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -20,4 +20,12 @@ describe('IncludesSettingsService', () => {
         expect(result.includes['new_key_1']).toBe('');
         expect(Object.keys(result.includes).length).toBe(3);
     });
+
+    it('should detect duplicates', () => {
+        // Checks if a new key would create a duplicate in the includes map
+        expect(service.isDuplicateKey(testIncludes, 'key1', 'key2')).toBe(true);
+        expect(service.isDuplicateKey(testIncludes, 'key1', 'key3')).toBe(false);
+        expect(service.isDuplicateKey(testIncludes, 'key1', 'key1')).toBe(false);
+        expect(service.isDuplicateKey(testIncludes, 'key1', ' key2 ')).toBe(false); // White space counts as different
+    });
 });

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -26,6 +26,6 @@ describe('IncludesSettingsService', () => {
         expect(service.isDuplicateKey(testIncludes, 'key1', 'key2')).toBe(true);
         expect(service.isDuplicateKey(testIncludes, 'key1', 'key3')).toBe(false);
         expect(service.isDuplicateKey(testIncludes, 'key1', 'key1')).toBe(false);
-        expect(service.isDuplicateKey(testIncludes, 'key1', ' key2 ')).toBe(false); // White space counts as different
+        expect(service.isDuplicateKey(testIncludes, 'key1', ' key2 ')).toBe(true); // Trim test
     });
 });

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -33,6 +33,14 @@ describe('IncludesSettingsService', () => {
             expect(Object.keys(result!).length).toBe(2);
         });
 
+        it.failing('should trim spaces from a unique new name', () => {
+            const result = service.renameInclude(testIncludes, 'key2', '  renamed_key2  ');
+            expect(result).not.toBeNull();
+            expect(Object.keys(result!)[1]).toBe('renamed_key2');
+            expect(result!['renamed_key2']).toBe('value2');
+            expect(Object.keys(result!).length).toBe(2);
+        });
+
         it('should return null for duplicate keys', () => {
             const result = service.renameInclude(testIncludes, 'key1', 'key2');
 

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -76,7 +76,7 @@ describe('IncludesSettingsService', () => {
             expect(service.wouldCreateDuplicateKey(testIncludes, 'key1', '  key1  ')).toBe(false);
         });
 
-        it.failing('should identify a rename as non-duplicate when only whitespace differs', () => {
+        it('should identify a rename as non-duplicate when only whitespace differs', () => {
             // Should be considered the same key (not a duplicate)
             expect(service.wouldCreateDuplicateKey(testIncludes, 'key1  ', '  key1')).toBe(false);
         });

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -12,6 +12,7 @@ describe('IncludesSettingsService', () => {
             key2: 'value2',
         };
     });
+
     describe('IncludesSettingsService - addInclude', () => {
         it('should add a new include with a unique key', () => {
             const result = service.addInclude(testIncludes);
@@ -19,6 +20,16 @@ describe('IncludesSettingsService', () => {
             expect(result.newKey).toBe('new_key_1');
             expect(result.includes['new_key_1']).toBe('');
             expect(Object.keys(result.includes).length).toBe(3);
+        });
+    });
+
+    describe('IncludesSettingsService - deleteInclude', () => {
+        it('should remove a key', () => {
+            const result = service.deleteInclude(testIncludes, 'key1');
+
+            expect(Object.keys(result).length).toBe(1);
+            expect(result['key1']).toBeUndefined();
+            expect(result['key2']).toBe('value2');
         });
     });
 

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -71,6 +71,28 @@ describe('IncludesSettingsService', () => {
             expect(service.wouldCreateDuplicateKey(includesWithSpacedKey, 'key1', 'spacedKey')).toBe(true);
         });
 
+        it('should normalize the proposed new name before comparison', () => {
+            // We're renaming 'key1' to '  key1  ' which should be considered the same key after trimming
+            expect(service.wouldCreateDuplicateKey(testIncludes, 'key1', '  key1  ')).toBe(false);
+        });
+
+        it.failing('should identify a rename as non-duplicate when only whitespace differs', () => {
+            // Should be considered the same key (not a duplicate)
+            expect(service.wouldCreateDuplicateKey(testIncludes, 'key1  ', '  key1')).toBe(false);
+        });
+
+        it('should not consider keys the same if there are actual differences beyond whitespace', () => {
+            // Add a key with a similar name
+            const extendedIncludes = {
+                ...testIncludes,
+                key1a: 'value3',
+            };
+
+            // Should NOT consider 'key1' and 'key1a' the same after trimming
+            expect(service.wouldCreateDuplicateKey(extendedIncludes, 'key1', '  key1a  ')).toBe(true);
+            expect(service.wouldCreateDuplicateKey(extendedIncludes, 'key1  ', '  key1a')).toBe(true);
+        });
+
         // Tests for the conditional logic
 
         it('should ignore the key being renamed when checking for duplicates', () => {

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -60,7 +60,7 @@ describe('IncludesSettingsService', () => {
             expect(service.wouldCreateDuplicateKey(testIncludes, 'key1', '  key2  ')).toBe(true);
         });
 
-        it.failing('should normalize both new key and existing keys by trimming whitespace', () => {
+        it('should normalize both new key and existing keys by trimming whitespace', () => {
             // Add a key with leading/trailing whitespace to the includes map
             const includesWithSpacedKey = {
                 ...testIncludes,
@@ -99,7 +99,7 @@ describe('IncludesSettingsService', () => {
             expect(service.wouldCreateDuplicateKey(includesWithEmptyKey, 'key1', '')).toBe(true);
         });
 
-        it.failing('should handle keys containing only whitespace', () => {
+        it('should handle keys containing only whitespace', () => {
             const includesWithWhitespaceKey = {
                 ...testIncludes,
                 '   ': 'whitespace value',

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -45,7 +45,7 @@ describe('IncludesSettingsService', () => {
             expect(result).toBeNull();
         });
 
-        it.failing('should return null for empty key containing only whitespace', () => {
+        it('should return null for empty key containing only whitespace', () => {
             const result = service.renameInclude(testIncludes, 'key1', '\t ');
 
             expect(result).toBeNull();

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -23,10 +23,10 @@ describe('IncludesSettingsService', () => {
 
     it('should detect duplicates', () => {
         // Checks if a new key would create a duplicate in the includes map
-        expect(service.isDuplicateKey(testIncludes, 'key1', 'key2')).toBe(true);
-        expect(service.isDuplicateKey(testIncludes, 'key1', 'key3')).toBe(false);
-        expect(service.isDuplicateKey(testIncludes, 'key1', 'key1')).toBe(false);
-        expect(service.isDuplicateKey(testIncludes, ' key1 ', 'key1')).toBe(false); // Trim test
-        expect(service.isDuplicateKey(testIncludes, 'key1', ' key2 ')).toBe(true); // Trim test
+        expect(service.wouldCreateDuplicateKey(testIncludes, 'key1', 'key2')).toBe(true);
+        expect(service.wouldCreateDuplicateKey(testIncludes, 'key1', 'key3')).toBe(false);
+        expect(service.wouldCreateDuplicateKey(testIncludes, 'key1', 'key1')).toBe(false);
+        expect(service.wouldCreateDuplicateKey(testIncludes, ' key1 ', 'key1')).toBe(false); // Trim test
+        expect(service.wouldCreateDuplicateKey(testIncludes, 'key1', ' key2 ')).toBe(true); // Trim test
     });
 });

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -60,6 +60,17 @@ describe('IncludesSettingsService', () => {
             expect(service.wouldCreateDuplicateKey(testIncludes, 'key1', '  key2  ')).toBe(true);
         });
 
+        it.failing('should normalize both new key and existing keys by trimming whitespace', () => {
+            // Add a key with leading/trailing whitespace to the includes map
+            const includesWithSpacedKey = {
+                ...testIncludes,
+                '  spacedKey  ': 'value4',
+            };
+
+            // Should detect when we try to rename to a key that matches after trimming
+            expect(service.wouldCreateDuplicateKey(includesWithSpacedKey, 'key1', 'spacedKey')).toBe(true);
+        });
+
         // Tests for the conditional logic
 
         it('should ignore the key being renamed when checking for duplicates', () => {
@@ -86,6 +97,19 @@ describe('IncludesSettingsService', () => {
 
             // Should detect when we try to rename to an empty key that already exists
             expect(service.wouldCreateDuplicateKey(includesWithEmptyKey, 'key1', '')).toBe(true);
+        });
+
+        it.failing('should handle keys containing only whitespace', () => {
+            const includesWithWhitespaceKey = {
+                ...testIncludes,
+                '   ': 'whitespace value',
+            };
+
+            // Should detect when we try to rename to a whitespace-only key that matches after trimming
+            expect(service.wouldCreateDuplicateKey(includesWithWhitespaceKey, 'key1', '  ')).toBe(true);
+
+            // Should handle comparing empty string (after trim) with whitespace-only key
+            expect(service.wouldCreateDuplicateKey(includesWithWhitespaceKey, '   ', 'newKey')).toBe(false);
         });
 
         it('should handle case sensitivity correctly', () => {

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -26,6 +26,7 @@ describe('IncludesSettingsService', () => {
         expect(service.isDuplicateKey(testIncludes, 'key1', 'key2')).toBe(true);
         expect(service.isDuplicateKey(testIncludes, 'key1', 'key3')).toBe(false);
         expect(service.isDuplicateKey(testIncludes, 'key1', 'key1')).toBe(false);
+        expect(service.isDuplicateKey(testIncludes, ' key1 ', 'key1')).toBe(false); // Trim test
         expect(service.isDuplicateKey(testIncludes, 'key1', ' key2 ')).toBe(true); // Trim test
     });
 });

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -35,6 +35,7 @@ describe('IncludesSettingsService', () => {
 
         it('should trim spaces from a unique new name', () => {
             const result = service.renameInclude(testIncludes, 'key2', '  renamed_key2  ');
+
             expect(result).not.toBeNull();
             expect(Object.keys(result!)[1]).toBe('renamed_key2');
             expect(result!['renamed_key2']).toBe('value2');

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -1,0 +1,23 @@
+import { IncludesSettingsService } from '../../src/Config/IncludesSettingsService';
+import type { IncludesMap } from '../../src/Config/Settings';
+
+describe('IncludesSettingsService', () => {
+    let service: IncludesSettingsService;
+    let testIncludes: IncludesMap;
+
+    beforeEach(() => {
+        service = new IncludesSettingsService();
+        testIncludes = {
+            key1: 'value1',
+            key2: 'value2',
+        };
+    });
+
+    it('should add a new include with a unique key', () => {
+        const result = service.addInclude(testIncludes);
+
+        expect(result.newKey).toBe('new_key_1');
+        expect(result.includes['new_key_1']).toBe('');
+        expect(Object.keys(result.includes).length).toBe(3);
+    });
+});

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -23,6 +23,23 @@ describe('IncludesSettingsService', () => {
         });
     });
 
+    describe('IncludesSettingsService - renameInclude', () => {
+        it('should rename a key and preserve order', () => {
+            const result = service.renameInclude(testIncludes, 'key1', 'newName');
+
+            expect(result).not.toBeNull();
+            expect(Object.keys(result!)[0]).toBe('newName');
+            expect(result!['newName']).toBe('value1');
+            expect(Object.keys(result!).length).toBe(2);
+        });
+
+        it('should return null for duplicate keys', () => {
+            const result = service.renameInclude(testIncludes, 'key1', 'key2');
+
+            expect(result).toBeNull();
+        });
+    });
+
     describe('IncludesSettingsService - deleteInclude', () => {
         it('should remove a key', () => {
             const result = service.deleteInclude(testIncludes, 'key1');

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -38,6 +38,12 @@ describe('IncludesSettingsService', () => {
 
             expect(result).toBeNull();
         });
+
+        it.failing('should return null for empty new key', () => {
+            const result = service.renameInclude(testIncludes, 'key1', '');
+
+            expect(result).toBeNull();
+        });
     });
 
     describe('IncludesSettingsService - deleteInclude', () => {

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -33,6 +33,14 @@ describe('IncludesSettingsService', () => {
         });
     });
 
+    describe('IncludesSettingsService - updateIncludeValue', () => {
+        it('should update the value of an include', () => {
+            const result = service.updateIncludeValue(testIncludes, 'key1', 'new value');
+
+            expect(result['key1']).toBe('new value');
+        });
+    });
+
     describe('IncludesSettingsService - wouldCreateDuplicateKey', () => {
         let service: IncludesSettingsService;
         let testIncludes: IncludesMap;

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -39,7 +39,7 @@ describe('IncludesSettingsService', () => {
             expect(result).toBeNull();
         });
 
-        it.failing('should return null for empty new key', () => {
+        it('should return null for empty new key', () => {
             const result = service.renameInclude(testIncludes, 'key1', '');
 
             expect(result).toBeNull();

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -33,7 +33,7 @@ describe('IncludesSettingsService', () => {
             expect(Object.keys(result!).length).toBe(2);
         });
 
-        it.failing('should trim spaces from a unique new name', () => {
+        it('should trim spaces from a unique new name', () => {
             const result = service.renameInclude(testIncludes, 'key2', '  renamed_key2  ');
             expect(result).not.toBeNull();
             expect(Object.keys(result!)[1]).toBe('renamed_key2');

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -12,13 +12,14 @@ describe('IncludesSettingsService', () => {
             key2: 'value2',
         };
     });
+    describe('IncludesSettingsService - addInclude', () => {
+        it('should add a new include with a unique key', () => {
+            const result = service.addInclude(testIncludes);
 
-    it('should add a new include with a unique key', () => {
-        const result = service.addInclude(testIncludes);
-
-        expect(result.newKey).toBe('new_key_1');
-        expect(result.includes['new_key_1']).toBe('');
-        expect(Object.keys(result.includes).length).toBe(3);
+            expect(result.newKey).toBe('new_key_1');
+            expect(result.includes['new_key_1']).toBe('');
+            expect(Object.keys(result.includes).length).toBe(3);
+        });
     });
 
     describe('IncludesSettingsService - wouldCreateDuplicateKey', () => {

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -44,6 +44,12 @@ describe('IncludesSettingsService', () => {
 
             expect(result).toBeNull();
         });
+
+        it.failing('should return null for empty key containing only whitespace', () => {
+            const result = service.renameInclude(testIncludes, 'key1', '\t ');
+
+            expect(result).toBeNull();
+        });
     });
 
     describe('IncludesSettingsService - deleteInclude', () => {


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- Refactor a lot of the Includes UI logic out to a new class, `IncludesSettingsService`
- Extract `SettingsTab.saveIncludesSettings()` to remove a lot of repetition.

## Motivation and Context

Goal: Make the Includes settings UI code easier to understand, maintain and test:


## How has this been tested?

- New tests added
- Manual exploratory testing

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
