### PR TITLE
feat: Add error-checking of duplicate names of "Includes"

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
@@ -1,5 +1,11 @@
 {
-  "includes": {},
+  "includes": {
+    "hide_all_dates": "hide due date\nhide scheduled date\nhide start date\nhide created date\nhide done date\nhide cancelled date",
+    "hide_buttons": "hide postpone button\nhide edit button\nhide backlinks",
+    "hide_other_fields": "hide id\nhide depends on\nhide recurrence rule\nhide on completion\nhide priority",
+    "just_the_description_and_tags": "include hide_all_dates\ninclude hide_other_fields\ninclude hide_buttons",
+    "just_the_description": "include just_the_description_and_tags\nhide tags"
+  },
   "globalQuery": "# Exclude templates files:\nroot does not include _meta\n\n# Ignore the sample tasks that demonstrate Theme and Snippet support:\npath does not include Manual Testing/SlrVb's Alternative Checkboxes\npath does not include Styling/Snippet -\npath does not include Styling/Theme -\n",
   "globalFilter": "#task",
   "removeGlobalFilter": true,

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
@@ -1,10 +1,10 @@
 {
   "includes": {
-    "hide_all_dates": "hide due date\nhide scheduled date\nhide start date\nhide created date\nhide done date\nhide cancelled date",
-    "hide_buttons": "hide postpone button\nhide edit button\nhide backlinks",
-    "hide_other_fields": "hide id\nhide depends on\nhide recurrence rule\nhide on completion\nhide priority",
-    "just_the_description_and_tags": "include hide_all_dates\ninclude hide_other_fields\ninclude hide_buttons",
-    "just_the_description": "include just_the_description_and_tags\nhide tags"
+    "hide_all_dates": "# Hide any values for all 6 date fields\nhide due date\nhide scheduled date\nhide start date\nhide created date\nhide done date\nhide cancelled date",
+    "hide_buttons": "# Hide postpone, edit and backinks\nhide postpone button\nhide edit button\nhide backlinks",
+    "hide_other_fields": "# Hide all the non-date fields, keep tags\nhide id\nhide depends on\nhide recurrence rule\nhide on completion\nhide priority",
+    "just_the_description_and_tags": "# Show only description and any tags\ninclude hide_all_dates\ninclude hide_other_fields\ninclude hide_buttons",
+    "just_the_description": "# Show only description, not even the tags\ninclude just_the_description_and_tags\nhide tags"
   },
   "globalQuery": "# Exclude templates files:\nroot does not include _meta\n\n# Ignore the sample tasks that demonstrate Theme and Snippet support:\npath does not include Manual Testing/SlrVb's Alternative Checkboxes\npath does not include Styling/Snippet -\npath does not include Styling/Theme -\n",
   "globalFilter": "#task",

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
@@ -4,7 +4,10 @@
     "hide_buttons": "# Hide postpone, edit and backinks\nhide postpone button\nhide edit button\nhide backlinks",
     "hide_other_fields": "# Hide all the non-date fields, keep tags\nhide id\nhide depends on\nhide recurrence rule\nhide on completion\nhide priority",
     "just_the_description_and_tags": "# Show only description and any tags\ninclude hide_all_dates\ninclude hide_other_fields\ninclude hide_buttons",
-    "just_the_description": "# Show only description, not even the tags\ninclude just_the_description_and_tags\nhide tags"
+    "just_the_description": "# Show only description, not even the tags\ninclude just_the_description_and_tags\nhide tags",
+    "filter_by_context": "filter by function const myFunction = (context) => task.tags.includes(`#context/${context}`); return myFunction",
+    "extract_contents_1": "context => task.tags.includes(`#context/${context}`)",
+    "extract_contents_2": "(context => task.tags.includes(`#context/${context}`))"
   },
   "globalQuery": "# Exclude templates files:\nroot does not include _meta\n\n# Ignore the sample tasks that demonstrate Theme and Snippet support:\npath does not include Manual Testing/SlrVb's Alternative Checkboxes\npath does not include Styling/Snippet -\npath does not include Styling/Theme -\n",
   "globalFilter": "#task",

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
@@ -5,9 +5,9 @@
     "hide_other_fields": "# Hide all the non-date fields, keep tags\nhide id\nhide depends on\nhide recurrence rule\nhide on completion\nhide priority",
     "just_the_description_and_tags": "# Show only description and any tags\ninclude hide_all_dates\ninclude hide_other_fields\ninclude hide_buttons",
     "just_the_description": "# Show only description, not even the tags\ninclude just_the_description_and_tags\nhide tags",
-    "filter_by_context": "filter by function const myFunction = (context) => task.tags.includes(`#context/${context}`); return myFunction",
-    "extract_contents_1": "context => task.tags.includes(`#context/${context}`)",
-    "extract_contents_2": "(context => task.tags.includes(`#context/${context}`))"
+    "filter_by_context": "filter by function let fn = (ctx) => task.tags.includes(`#context/${ctx}`); return fn",
+    "extract_contents_1": "ctx => task.tags.includes(`#context/${ctx}`)",
+    "extract_contents_2": "(ctx => task.tags.includes(`#context/${ctx}`))"
   },
   "globalQuery": "# Exclude templates files:\nroot does not include _meta\n\n# Ignore the sample tasks that demonstrate Theme and Snippet support:\npath does not include Manual Testing/SlrVb's Alternative Checkboxes\npath does not include Styling/Snippet -\npath does not include Styling/Theme -\n",
   "globalFilter": "#task",

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
@@ -6,8 +6,8 @@
     "just_the_description_and_tags": "# Show only description and any tags\ninclude hide_all_dates\ninclude hide_other_fields\ninclude hide_buttons",
     "just_the_description": "# Show only description, not even the tags\ninclude just_the_description_and_tags\nhide tags",
     "filter_by_context": "filter by function let fn = (ctx) => task.tags.includes(`#context/${ctx}`); return fn",
-    "extract_contents_1": "ctx => task.tags.includes(`#context/${ctx}`)",
-    "extract_contents_2": "(ctx => task.tags.includes(`#context/${ctx}`))"
+    "extract_contexts_1": "ctx => task.tags.includes(`#context/${ctx}`)",
+    "extract_contexts_2": "(ctx => task.tags.includes(`#context/${ctx}`))"
   },
   "globalQuery": "# Exclude templates files:\nroot does not include _meta\n\n# Ignore the sample tasks that demonstrate Theme and Snippet support:\npath does not include Manual Testing/SlrVb's Alternative Checkboxes\npath does not include Styling/Snippet -\npath does not include Styling/Theme -\n",
   "globalFilter": "#task",

--- a/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
@@ -69,18 +69,18 @@ group by function const x = "{{includes.filter_by_context}}"; return x
 
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:
-group by function const x = "{{includes.extract_contents_1}}"; return x
+group by function const x = "{{includes.extract_contexts_1}}"; return x
 
-# includes.extract_contents_1 value needs to be surrounded by parentheses (): 
-filter by function return ({{includes.extract_contents_1}})('home')
+# includes.extract_contexts_1 value needs to be surrounded by parentheses (): 
+filter by function return ({{includes.extract_contexts_1}})('home')
 ```
 
 ### Has context 'home' - and group by the Include text - version 3
 
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:
-group by function const x = "{{includes.extract_contents_2}}"; return x
+group by function const x = "{{includes.extract_contexts_2}}"; return x
 
-# includes.extract_contents_1 value has the parentheses, to simplify use:
-filter by function {{includes.extract_contents_2}}('home')
+# includes.extract_contexts_1 value has the parentheses, to simplify use:
+filter by function {{includes.extract_contexts_2}}('home')
 ```

--- a/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
@@ -1,0 +1,50 @@
+---
+TQ_explain: false
+---
+# Reuse instructions across the vault
+
+These searches are for experimenting with, and understanding, the new "Includes" facility, which was released in Tasks X.Y.Z.
+
+Includes values can be defined in the Tasks settings.
+
+## List all the known 'include' values in settings
+
+(assuming there is not one called `xxxx`!)
+
+```tasks
+include xxxx
+```
+
+## Show all the fields
+
+explain: `INPUT[toggle:TQ_explain]`
+
+```tasks
+limit 10
+```
+
+## Hide all the fields
+
+explain: `INPUT[toggle:TQ_explain]`
+
+```tasks
+include hide_all_dates
+include hide_other_fields
+limit 10
+```
+
+## Hide all the Tasks user interface elements
+
+explain: `INPUT[toggle:TQ_explain]`
+
+```tasks
+include hide_buttons
+limit 10
+```
+
+## Hide everything, including tags
+
+```tasks
+include just_the_description_and_tags
+limit 10
+```

--- a/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
@@ -1,11 +1,16 @@
 ---
 TQ_explain: false
+TQ_extra_instructions: |-
+  ignore global query
+  limit 10
 ---
 # Reuse instructions across the vault
 
 These searches are for experimenting with, and understanding, the new "Includes" facility, which was released in Tasks X.Y.Z.
 
 Includes values can be defined in the Tasks settings.
+
+explain: `INPUT[toggle:TQ_explain]`
 
 ## List all the known 'include' values in settings
 
@@ -47,4 +52,35 @@ limit 10
 ```tasks
 include just_the_description_and_tags
 limit 10
+```
+
+## Advanced use: return a function, that takes a parameter from the query source
+
+### Has context 'home' - and group by the Include text - version 1
+
+```tasks
+# For debug/explanatory purposes, show the source of the Include as a group name:
+group by function const x = "{{includes.filter_by_context}}"; return x
+
+{{includes.filter_by_context}}('home')
+```
+
+### Has context 'home' - and group by the Include text - version 2
+
+```tasks
+# For debug/explanatory purposes, show the source of the Include as a group name:
+group by function const x = "{{includes.extract_contents_1}}"; return x
+
+filter by function const f = {{includes.extract_contents_1}}; return f('home');
+filter by function return ({{includes.extract_contents_1}})('home')
+```
+
+### Has context 'home' - and group by the Include text - version 3
+
+```tasks
+# For debug/explanatory purposes, show the source of the Include as a group name:
+group by function const x = "{{includes.extract_contents_2}}"; return x
+
+filter by function const f = {{includes.extract_contents_2}}; return f('home');
+filter by function {{includes.extract_contents_2}}('home')
 ```

--- a/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
@@ -25,7 +25,6 @@ include xxxx
 explain: `INPUT[toggle:TQ_explain]`
 
 ```tasks
-limit 10
 ```
 
 ## Hide all the fields
@@ -35,7 +34,6 @@ explain: `INPUT[toggle:TQ_explain]`
 ```tasks
 include hide_all_dates
 include hide_other_fields
-limit 10
 ```
 
 ## Hide all the Tasks user interface elements
@@ -44,14 +42,12 @@ explain: `INPUT[toggle:TQ_explain]`
 
 ```tasks
 include hide_buttons
-limit 10
 ```
 
 ## Hide everything, including tags
 
 ```tasks
 include just_the_description_and_tags
-limit 10
 ```
 
 ## Advanced use: return a function, that takes a parameter from the query source
@@ -71,7 +67,7 @@ group by function const x = "{{includes.filter_by_context}}"; return x
 # For debug/explanatory purposes, show the source of the Include as a group name:
 group by function const x = "{{includes.extract_contexts_1}}"; return x
 
-# includes.extract_contexts_1 value needs to be surrounded by parentheses (): 
+# includes.extract_contexts_1 value needs to be surrounded by parentheses ():
 filter by function return ({{includes.extract_contexts_1}})('home')
 ```
 

--- a/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
@@ -46,6 +46,8 @@ include hide_buttons
 
 ## Hide everything, including tags
 
+explain: `INPUT[toggle:TQ_explain]`
+
 ```tasks
 include just_the_description_and_tags
 ```
@@ -53,6 +55,8 @@ include just_the_description_and_tags
 ## Advanced use: return a function, that takes a parameter from the query source
 
 ### Has context 'home' - and group by the Include text - version 1
+
+explain: `INPUT[toggle:TQ_explain]`
 
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:
@@ -63,6 +67,8 @@ group by function const x = "{{includes.filter_by_context}}"; return x
 
 ### Has context 'home' - and group by the Include text - version 2
 
+explain: `INPUT[toggle:TQ_explain]`
+
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:
 group by function const x = "{{includes.extract_contexts_1}}"; return x
@@ -72,6 +78,8 @@ filter by function return ({{includes.extract_contexts_1}})('home')
 ```
 
 ### Has context 'home' - and group by the Include text - version 3
+
+explain: `INPUT[toggle:TQ_explain]`
 
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:

--- a/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
@@ -71,7 +71,7 @@ group by function const x = "{{includes.filter_by_context}}"; return x
 # For debug/explanatory purposes, show the source of the Include as a group name:
 group by function const x = "{{includes.extract_contents_1}}"; return x
 
-filter by function const f = {{includes.extract_contents_1}}; return f('home');
+# includes.extract_contents_1 value needs to be surrounded by parentheses (): 
 filter by function return ({{includes.extract_contents_1}})('home')
 ```
 
@@ -81,6 +81,6 @@ filter by function return ({{includes.extract_contents_1}})('home')
 # For debug/explanatory purposes, show the source of the Include as a group name:
 group by function const x = "{{includes.extract_contents_2}}"; return x
 
-filter by function const f = {{includes.extract_contents_2}}; return f('home');
+# includes.extract_contents_1 value has the parentheses, to simplify use:
 filter by function {{includes.extract_contents_2}}('home')
 ```

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -26,11 +26,7 @@ export class IncludesSettingsService {
         const results: CrossValidatedNameEditResults = {};
 
         // First, normalise all input names
-        const normalisedNames: OriginalToCurrentNameMap = {};
-        for (const [originalName, currentName] of Object.entries(names)) {
-            // Store the normalised (trimmed) version of each name
-            normalisedNames[originalName] = currentName.trim();
-        }
+        const normalisedNames: OriginalToCurrentNameMap = names;
 
         // Check each key against all others using the normalised names
         for (const [originalName, normalisedName] of Object.entries(normalisedNames)) {

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -13,7 +13,7 @@ export interface OriginalToCurrentIncludeNameMap {
  * Result of validating multiple include values at once
  */
 export interface CrossValidatedNameEditResults {
-    [key: string]: { isValid: boolean; errorMessage: string | null };
+    [originalName: string]: { isValid: boolean; errorMessage: string | null };
 }
 
 export class IncludesSettingsService {

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -21,7 +21,7 @@ export class NewResult {
     }
 }
 
-type RenameResult = { isValid: boolean; errorMessage: string | null; newResult: NewResult };
+export type RenameResult = { isValid: boolean; errorMessage: string | null; newResult: NewResult };
 
 /**
  * Result of validating multiple include values at once

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -84,7 +84,7 @@ export class IncludesSettingsService {
                 continue;
             }
 
-            if (existingKey === proposedName.trim()) {
+            if (existingKey.trim() === proposedName.trim()) {
                 return {
                     isValid: false,
                     errorMessage: 'An include with this name already exists',

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -37,10 +37,7 @@ export class IncludesSettingsService {
             }
 
             // Pass empty string as keyBeingRenamed since we're not excluding any key from duplicate check
-            const result = this.validateRename(includesWithOtherPendingRenames, '', newName);
-
-            // Store the validation result
-            results[originalName] = result;
+            results[originalName] = this.validateRename(includesWithOtherPendingRenames, '', newName);
         }
 
         return results;

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -23,6 +23,8 @@ export class IncludesSettingsService {
      * @returns Object mapping each key to its validation result
      */
     public validateMultipleIncludeNames(originalKeys: IncludeKeyValueMap): MultiValidationResult {
+        // TODO Reuse validateIncludeName()? Or at least unify the logic.
+        // TODO Two keys differing only in trailing spaces are considered as different - they should match.
         const results: MultiValidationResult = {};
 
         // Check each key against all others

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -5,40 +5,40 @@ import type { IncludesMap } from './Settings';
  * Represents a map of include keys and their current values
  * used during validation
  */
-export interface OriginalToCurrentNameMap {
+export interface RenamesInProgress {
     [originalName: string]: string;
 }
 
 /**
  * Result of validating multiple include values at once
  */
-export interface CrossValidatedNameEditResults {
+export interface RenameResults {
     [originalName: string]: { isValid: boolean; errorMessage: string | null };
 }
 
 export class IncludesSettingsService {
     /**
      * Validates multiple include names against each other
-     * @param names Map of original keys to their current values in UI
+     * @param renames Map of original keys to their current values in UI
      * @returns Object mapping each key to its validation result
      */
-    public validateMultipleIncludeNames(names: OriginalToCurrentNameMap): CrossValidatedNameEditResults {
-        const results: CrossValidatedNameEditResults = {};
+    public validateRenames(renames: RenamesInProgress): RenameResults {
+        const results: RenameResults = {};
 
         // Check each key against all others
-        for (const [originalName, currentName] of Object.entries(names)) {
+        for (const [originalName, newName] of Object.entries(renames)) {
             // Create a temporary map to simulate the situation
             const simulatedIncludes: IncludesMap = {};
 
-            for (const [otherOriginalName, otherNormalisedName] of Object.entries(names)) {
+            for (const [otherOriginalName, otherNewName] of Object.entries(renames)) {
                 // Skip the name being validated
                 if (otherOriginalName !== originalName) {
-                    simulatedIncludes[otherNormalisedName] = '';
+                    simulatedIncludes[otherNewName] = '';
                 }
             }
 
             // Pass empty string as keyBeingRenamed since we're not excluding any key from duplicate check
-            const result = this.validateIncludeName(simulatedIncludes, '', currentName);
+            const result = this.validateRename(simulatedIncludes, '', newName);
 
             // Store the validation result
             results[originalName] = result;
@@ -54,7 +54,7 @@ export class IncludesSettingsService {
      * @param proposedName The proposed name to validate
      * @returns An object with validation result and error message if any
      */
-    public validateIncludeName(
+    public validateRename(
         includes: Readonly<IncludesMap>,
         keyBeingRenamed: string,
         proposedName: string,

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -5,7 +5,7 @@ import type { IncludesMap } from './Settings';
  * Represents a map of include keys and their current values
  * used during validation
  */
-export interface OriginalToCurrentIncludeNameMap {
+export interface OriginalToCurrentNameMap {
     [originalName: string]: string;
 }
 
@@ -22,7 +22,7 @@ export class IncludesSettingsService {
      * @param originalKeys Map of original keys to their current values in UI
      * @returns Object mapping each key to its validation result
      */
-    public validateMultipleIncludeNames(originalKeys: OriginalToCurrentIncludeNameMap): CrossValidatedNameEditResults {
+    public validateMultipleIncludeNames(originalKeys: OriginalToCurrentNameMap): CrossValidatedNameEditResults {
         // TODO Reuse validateIncludeName()? Or at least unify the logic.
         // TODO Two keys differing only in trailing spaces are considered as different - they should match.
         const results: CrossValidatedNameEditResults = {};

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -25,24 +25,20 @@ export class IncludesSettingsService {
     public validateMultipleIncludeNames(names: OriginalToCurrentNameMap): CrossValidatedNameEditResults {
         const results: CrossValidatedNameEditResults = {};
 
-        // Check each key against all others using the normalised names
-        for (const [originalName, normalisedName] of Object.entries(names)) {
+        // Check each key against all others
+        for (const [originalName, currentName] of Object.entries(names)) {
             // Create a temporary map to simulate the situation
             const simulatedIncludes: IncludesMap = {};
 
-            // Add all other normalised names to the map
             for (const [otherOriginalName, otherNormalisedName] of Object.entries(names)) {
                 // Skip the name being validated
                 if (otherOriginalName !== originalName) {
-                    // Use normalised names in the map
                     simulatedIncludes[otherNormalisedName] = '';
                 }
             }
 
-            // Use validateIncludeName to check against the normalised map
             // Pass empty string as keyBeingRenamed since we're not excluding any key from duplicate check
-            // validateIncludeName will trim normalisedName again, which is redundant but harmless
-            const result = this.validateIncludeName(simulatedIncludes, '', normalisedName);
+            const result = this.validateIncludeName(simulatedIncludes, '', currentName);
 
             // Store the validation result
             results[originalName] = result;

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -23,25 +23,33 @@ export class IncludesSettingsService {
      * @returns Object mapping each key to its validation result
      */
     public validateMultipleIncludeNames(names: OriginalToCurrentNameMap): CrossValidatedNameEditResults {
-        // TODO Two keys differing only in trailing spaces are considered as different - they should match.
         const results: CrossValidatedNameEditResults = {};
 
-        // Check each key against all others
+        // First, normalise all input names
+        const normalisedNames: OriginalToCurrentNameMap = {};
         for (const [originalName, currentName] of Object.entries(names)) {
-            // Create a temporary map simulating the situation if this rename were to happen
+            // Store the normalised (trimmed) version of each name
+            normalisedNames[originalName] = currentName.trim();
+        }
+
+        // Check each key against all others using the normalised names
+        for (const [originalName, normalisedName] of Object.entries(normalisedNames)) {
+            // Create a temporary map to simulate the situation
             const simulatedIncludes: IncludesMap = {};
 
-            // Collect all other current name values to check against
-            for (const [otherOriginalName, otherCurrentName] of Object.entries(names)) {
+            // Add all other normalised names to the map
+            for (const [otherOriginalName, otherNormalisedName] of Object.entries(normalisedNames)) {
                 // Skip the name being validated
                 if (otherOriginalName !== originalName) {
-                    // Use other current names as keys in the map
-                    simulatedIncludes[otherCurrentName] = '';
+                    // Use normalised names in the map
+                    simulatedIncludes[otherNormalisedName] = '';
                 }
             }
 
-            // Use validateIncludeName to validate against all other names
-            const result = this.validateIncludeName(simulatedIncludes, '', currentName);
+            // Use validateIncludeName to check against the normalised map
+            // Pass empty string as keyBeingRenamed since we're not excluding any key from duplicate check
+            // validateIncludeName will trim normalisedName again, which is redundant but harmless
+            const result = this.validateIncludeName(simulatedIncludes, '', normalisedName);
 
             // Store the validation result
             results[originalName] = result;

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -9,7 +9,7 @@ export interface RenamesInProgress {
     [originalName: string]: string;
 }
 
-export class NewResult {
+export class RenameResult {
     public readonly originalName: string;
     public readonly isValid: boolean;
     public readonly errorMessage: string | null;
@@ -20,8 +20,6 @@ export class NewResult {
         this.errorMessage = errorMessage;
     }
 }
-
-export type RenameResult = NewResult;
 
 /**
  * Result of validating multiple include values at once
@@ -67,7 +65,7 @@ export class IncludesSettingsService {
     public validateRename(includes: Readonly<IncludesMap>, keyBeingRenamed: string, newName: string): RenameResult {
         // Check for empty name
         if (!newName || newName.trim() === '') {
-            return new NewResult(keyBeingRenamed, false, 'Include name cannot be empty or all whitespace');
+            return new RenameResult(keyBeingRenamed, false, 'Include name cannot be empty or all whitespace');
         }
 
         for (const existingKey of Object.keys(includes)) {
@@ -77,11 +75,11 @@ export class IncludesSettingsService {
             }
 
             if (existingKey.trim() === newName.trim()) {
-                return new NewResult(keyBeingRenamed, false, 'An include with this name already exists');
+                return new RenameResult(keyBeingRenamed, false, 'An include with this name already exists');
             }
         }
 
-        return new NewResult(keyBeingRenamed, true, null);
+        return new RenameResult(keyBeingRenamed, true, null);
     }
 
     /**

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -47,16 +47,16 @@ export class IncludesSettingsService {
      * Validates if an include name is valid
      * @param includes The current includes map
      * @param keyBeingRenamed The key being renamed
-     * @param proposedName The proposed name to validate
+     * @param newName The proposed name to validate
      * @returns An object with validation result and error message if any
      */
     public validateRename(
         includes: Readonly<IncludesMap>,
         keyBeingRenamed: string,
-        proposedName: string,
+        newName: string,
     ): { isValid: boolean; errorMessage: string | null } {
         // Check for empty name
-        if (!proposedName || proposedName.trim() === '') {
+        if (!newName || newName.trim() === '') {
             return {
                 isValid: false,
                 errorMessage: 'Include name cannot be empty or all whitespace',
@@ -69,7 +69,7 @@ export class IncludesSettingsService {
                 continue;
             }
 
-            if (existingKey.trim() === proposedName.trim()) {
+            if (existingKey.trim() === newName.trim()) {
                 return {
                     isValid: false,
                     errorMessage: 'An include with this name already exists',

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -21,7 +21,7 @@ export class NewResult {
     }
 }
 
-export type RenameResult = { isValid: boolean; newResult: NewResult };
+export type RenameResult = { newResult: NewResult };
 
 /**
  * Result of validating multiple include values at once
@@ -68,7 +68,6 @@ export class IncludesSettingsService {
         // Check for empty name
         if (!newName || newName.trim() === '') {
             return {
-                isValid: false,
                 newResult: new NewResult(keyBeingRenamed, false, 'Include name cannot be empty or all whitespace'),
             };
         }
@@ -81,13 +80,12 @@ export class IncludesSettingsService {
 
             if (existingKey.trim() === newName.trim()) {
                 return {
-                    isValid: false,
                     newResult: new NewResult(keyBeingRenamed, false, 'An include with this name already exists'),
                 };
             }
         }
 
-        return { isValid: true, newResult: new NewResult(keyBeingRenamed, true, null) };
+        return { newResult: new NewResult(keyBeingRenamed, true, null) };
     }
 
     /**

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -6,7 +6,7 @@ import type { IncludesMap } from './Settings';
  * used during validation
  */
 export interface OriginalToCurrentIncludeNameMap {
-    [key: string]: string;
+    [originalName: string]: string;
 }
 
 /**

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -28,10 +28,10 @@ export class IncludesSettingsService {
         const results: CrossValidatedNameEditResults = {};
 
         // Check each key against all others
-        for (const [originalKey, currentValue] of Object.entries(names)) {
+        for (const [originalName, currentName] of Object.entries(names)) {
             // Skip validation if empty (handled separately)
-            if (!currentValue || currentValue.trim() === '') {
-                results[originalKey] = {
+            if (!currentName || currentName.trim() === '') {
+                results[originalName] = {
                     isValid: false,
                     errorMessage: 'Include name cannot be empty or all whitespace',
                 };
@@ -44,8 +44,8 @@ export class IncludesSettingsService {
 
             for (const [otherKey, otherValue] of Object.entries(names)) {
                 // Skip comparing to self
-                if (otherKey !== originalKey) {
-                    if (otherValue === currentValue) {
+                if (otherKey !== originalName) {
+                    if (otherValue === currentName) {
                         isDuplicate = true;
                         duplicateKey = otherKey;
                         break;
@@ -54,12 +54,12 @@ export class IncludesSettingsService {
             }
 
             if (isDuplicate) {
-                results[originalKey] = {
+                results[originalName] = {
                     isValid: false,
                     errorMessage: `Duplicate of include "${duplicateKey}"`,
                 };
             } else {
-                results[originalKey] = { isValid: true, errorMessage: null };
+                results[originalName] = { isValid: true, errorMessage: null };
             }
         }
 

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -27,18 +27,17 @@ export class IncludesSettingsService {
 
         // Check each key against all others
         for (const [originalName, newName] of Object.entries(renames)) {
-            // Create a temporary map to simulate the situation
-            const simulatedIncludes: IncludesMap = {};
+            const includesWithOtherPendingRenames: IncludesMap = {};
 
             for (const [otherOriginalName, otherNewName] of Object.entries(renames)) {
-                // Skip the name being validated
+                // Skip the name being validated to avoid false duplicate matches.
                 if (otherOriginalName !== originalName) {
-                    simulatedIncludes[otherNewName] = '';
+                    includesWithOtherPendingRenames[otherNewName] = '';
                 }
             }
 
             // Pass empty string as keyBeingRenamed since we're not excluding any key from duplicate check
-            const result = this.validateRename(simulatedIncludes, '', newName);
+            const result = this.validateRename(includesWithOtherPendingRenames, '', newName);
 
             // Store the validation result
             results[originalName] = result;

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -25,16 +25,13 @@ export class IncludesSettingsService {
     public validateMultipleIncludeNames(names: OriginalToCurrentNameMap): CrossValidatedNameEditResults {
         const results: CrossValidatedNameEditResults = {};
 
-        // First, normalise all input names
-        const normalisedNames: OriginalToCurrentNameMap = names;
-
         // Check each key against all others using the normalised names
-        for (const [originalName, normalisedName] of Object.entries(normalisedNames)) {
+        for (const [originalName, normalisedName] of Object.entries(names)) {
             // Create a temporary map to simulate the situation
             const simulatedIncludes: IncludesMap = {};
 
             // Add all other normalised names to the map
-            for (const [otherOriginalName, otherNormalisedName] of Object.entries(normalisedNames)) {
+            for (const [otherOriginalName, otherNormalisedName] of Object.entries(names)) {
                 // Skip the name being validated
                 if (otherOriginalName !== originalName) {
                     // Use normalised names in the map

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -84,7 +84,7 @@ export class IncludesSettingsService {
                 continue;
             }
 
-            if (existingKey === proposedName) {
+            if (existingKey === proposedName.trim()) {
                 return {
                     isValid: false,
                     errorMessage: 'An include with this name already exists',

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -21,11 +21,13 @@ export class NewResult {
     }
 }
 
+type RenameResult = { isValid: boolean; errorMessage: string | null; newResult: NewResult };
+
 /**
  * Result of validating multiple include values at once
  */
 export interface RenameResults {
-    [originalName: string]: { isValid: boolean; errorMessage: string | null; newResult: NewResult };
+    [originalName: string]: RenameResult;
 }
 
 export class IncludesSettingsService {
@@ -62,11 +64,7 @@ export class IncludesSettingsService {
      * @param newName The proposed name to validate
      * @returns An object with validation result and error message if any
      */
-    public validateRename(
-        includes: Readonly<IncludesMap>,
-        keyBeingRenamed: string,
-        newName: string,
-    ): { isValid: boolean; errorMessage: string | null; newResult: NewResult } {
+    public validateRename(includes: Readonly<IncludesMap>, keyBeingRenamed: string, newName: string): RenameResult {
         // Check for empty name
         if (!newName || newName.trim() === '') {
             return {

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -19,16 +19,16 @@ export interface CrossValidatedNameEditResults {
 export class IncludesSettingsService {
     /**
      * Validates multiple include names against each other
-     * @param originalKeys Map of original keys to their current values in UI
+     * @param names Map of original keys to their current values in UI
      * @returns Object mapping each key to its validation result
      */
-    public validateMultipleIncludeNames(originalKeys: OriginalToCurrentNameMap): CrossValidatedNameEditResults {
+    public validateMultipleIncludeNames(names: OriginalToCurrentNameMap): CrossValidatedNameEditResults {
         // TODO Reuse validateIncludeName()? Or at least unify the logic.
         // TODO Two keys differing only in trailing spaces are considered as different - they should match.
         const results: CrossValidatedNameEditResults = {};
 
         // Check each key against all others
-        for (const [originalKey, currentValue] of Object.entries(originalKeys)) {
+        for (const [originalKey, currentValue] of Object.entries(names)) {
             // Skip validation if empty (handled separately)
             if (!currentValue || currentValue.trim() === '') {
                 results[originalKey] = {
@@ -42,7 +42,7 @@ export class IncludesSettingsService {
             let isDuplicate = false;
             let duplicateKey = '';
 
-            for (const [otherKey, otherValue] of Object.entries(originalKeys)) {
+            for (const [otherKey, otherValue] of Object.entries(names)) {
                 // Skip comparing to self
                 if (otherKey !== originalKey) {
                     if (otherValue === currentValue) {

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -21,7 +21,7 @@ export class NewResult {
     }
 }
 
-export type RenameResult = { isValid: boolean; errorMessage: string | null; newResult: NewResult };
+export type RenameResult = { isValid: boolean; newResult: NewResult };
 
 /**
  * Result of validating multiple include values at once
@@ -69,7 +69,6 @@ export class IncludesSettingsService {
         if (!newName || newName.trim() === '') {
             return {
                 isValid: false,
-                errorMessage: 'Include name cannot be empty or all whitespace',
                 newResult: new NewResult(keyBeingRenamed, false, 'Include name cannot be empty or all whitespace'),
             };
         }
@@ -83,13 +82,12 @@ export class IncludesSettingsService {
             if (existingKey.trim() === newName.trim()) {
                 return {
                     isValid: false,
-                    errorMessage: 'An include with this name already exists',
                     newResult: new NewResult(keyBeingRenamed, false, 'An include with this name already exists'),
                 };
             }
         }
 
-        return { isValid: true, errorMessage: null, newResult: new NewResult(keyBeingRenamed, true, null) };
+        return { isValid: true, newResult: new NewResult(keyBeingRenamed, true, null) };
     }
 
     /**

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -12,7 +12,7 @@ export interface OriginalToCurrentIncludeNameMap {
 /**
  * Result of validating multiple include values at once
  */
-export interface MultiValidationResult {
+export interface CrossValidatedNameEditResults {
     [key: string]: { isValid: boolean; errorMessage: string | null };
 }
 
@@ -22,10 +22,10 @@ export class IncludesSettingsService {
      * @param originalKeys Map of original keys to their current values in UI
      * @returns Object mapping each key to its validation result
      */
-    public validateMultipleIncludeNames(originalKeys: OriginalToCurrentIncludeNameMap): MultiValidationResult {
+    public validateMultipleIncludeNames(originalKeys: OriginalToCurrentIncludeNameMap): CrossValidatedNameEditResults {
         // TODO Reuse validateIncludeName()? Or at least unify the logic.
         // TODO Two keys differing only in trailing spaces are considered as different - they should match.
-        const results: MultiValidationResult = {};
+        const results: CrossValidatedNameEditResults = {};
 
         // Check each key against all others
         for (const [originalKey, currentValue] of Object.entries(originalKeys)) {

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -42,12 +42,12 @@ export class IncludesSettingsService {
             let isDuplicate = false;
             let duplicateKey = '';
 
-            for (const [otherKey, otherValue] of Object.entries(names)) {
+            for (const [otherRowOriginalName, otherRowCurrentName] of Object.entries(names)) {
                 // Skip comparing to self
-                if (otherKey !== originalName) {
-                    if (otherValue === currentName) {
+                if (otherRowOriginalName !== originalName) {
+                    if (otherRowCurrentName === currentName) {
                         isDuplicate = true;
-                        duplicateKey = otherKey;
+                        duplicateKey = otherRowOriginalName;
                         break;
                     }
                 }

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -9,11 +9,23 @@ export interface RenamesInProgress {
     [originalName: string]: string;
 }
 
+export class NewResult {
+    public readonly originalName: string;
+    public readonly isValid: boolean;
+    public readonly errorMessage: string | null;
+
+    constructor(originalName: string, isValid: boolean, errorMessage: string | null) {
+        this.originalName = originalName;
+        this.isValid = isValid;
+        this.errorMessage = errorMessage;
+    }
+}
+
 /**
  * Result of validating multiple include values at once
  */
 export interface RenameResults {
-    [originalName: string]: { isValid: boolean; errorMessage: string | null };
+    [originalName: string]: { isValid: boolean; errorMessage: string | null; newResult: NewResult };
 }
 
 export class IncludesSettingsService {
@@ -54,12 +66,13 @@ export class IncludesSettingsService {
         includes: Readonly<IncludesMap>,
         keyBeingRenamed: string,
         newName: string,
-    ): { isValid: boolean; errorMessage: string | null } {
+    ): { isValid: boolean; errorMessage: string | null; newResult: NewResult } {
         // Check for empty name
         if (!newName || newName.trim() === '') {
             return {
                 isValid: false,
                 errorMessage: 'Include name cannot be empty or all whitespace',
+                newResult: new NewResult(keyBeingRenamed, false, 'Include name cannot be empty or all whitespace'),
             };
         }
 
@@ -73,11 +86,12 @@ export class IncludesSettingsService {
                 return {
                     isValid: false,
                     errorMessage: 'An include with this name already exists',
+                    newResult: new NewResult(keyBeingRenamed, false, 'An include with this name already exists'),
                 };
             }
         }
 
-        return { isValid: true, errorMessage: null };
+        return { isValid: true, errorMessage: null, newResult: new NewResult(keyBeingRenamed, true, null) };
     }
 
     /**

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -21,7 +21,7 @@ export class NewResult {
     }
 }
 
-export type RenameResult = { newResult: NewResult };
+export type RenameResult = NewResult;
 
 /**
  * Result of validating multiple include values at once
@@ -67,9 +67,7 @@ export class IncludesSettingsService {
     public validateRename(includes: Readonly<IncludesMap>, keyBeingRenamed: string, newName: string): RenameResult {
         // Check for empty name
         if (!newName || newName.trim() === '') {
-            return {
-                newResult: new NewResult(keyBeingRenamed, false, 'Include name cannot be empty or all whitespace'),
-            };
+            return new NewResult(keyBeingRenamed, false, 'Include name cannot be empty or all whitespace');
         }
 
         for (const existingKey of Object.keys(includes)) {
@@ -79,13 +77,11 @@ export class IncludesSettingsService {
             }
 
             if (existingKey.trim() === newName.trim()) {
-                return {
-                    newResult: new NewResult(keyBeingRenamed, false, 'An include with this name already exists'),
-                };
+                return new NewResult(keyBeingRenamed, false, 'An include with this name already exists');
             }
         }
 
-        return { newResult: new NewResult(keyBeingRenamed, true, null) };
+        return new NewResult(keyBeingRenamed, true, null);
     }
 
     /**

--- a/src/Config/IncludesSettingsService.ts
+++ b/src/Config/IncludesSettingsService.ts
@@ -5,7 +5,7 @@ import type { IncludesMap } from './Settings';
  * Represents a map of include keys and their current values
  * used during validation
  */
-export interface IncludeKeyValueMap {
+export interface OriginalToCurrentIncludeNameMap {
     [key: string]: string;
 }
 
@@ -22,7 +22,7 @@ export class IncludesSettingsService {
      * @param originalKeys Map of original keys to their current values in UI
      * @returns Object mapping each key to its validation result
      */
-    public validateMultipleIncludeNames(originalKeys: IncludeKeyValueMap): MultiValidationResult {
+    public validateMultipleIncludeNames(originalKeys: OriginalToCurrentIncludeNameMap): MultiValidationResult {
         // TODO Reuse validateIncludeName()? Or at least unify the logic.
         // TODO Two keys differing only in trailing spaces are considered as different - they should match.
         const results: MultiValidationResult = {};

--- a/src/Config/IncludesSettingsUI.scss
+++ b/src/Config/IncludesSettingsUI.scss
@@ -51,3 +51,9 @@
         align-items: unset;
     }
 }
+
+/* Error state for invalid input */
+.tasks-settings .tasks-includes-setting .tasks-includes-key.has-error {
+    border-color: var(--text-error);
+    border-width: 2px;
+}

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -1,6 +1,6 @@
 import { Setting, TextAreaComponent } from 'obsidian';
 import type TasksPlugin from '../main';
-import { type IncludeKeyValueMap, IncludesSettingsService } from './IncludesSettingsService';
+import { IncludesSettingsService, type OriginalToCurrentIncludeNameMap } from './IncludesSettingsService';
 import { type IncludesMap, type Settings, getSettings, updateSettings } from './Settings';
 
 type RefreshViewCallback = () => void;
@@ -135,7 +135,7 @@ export class IncludesSettingsUI {
      */
     private validateAllInputs() {
         // Build the current key-value map for validation
-        const currentValues: IncludeKeyValueMap = {};
+        const currentValues: OriginalToCurrentIncludeNameMap = {};
 
         this.nameFields.forEach(({ inputEl, originalKey }) => {
             currentValues[originalKey] = inputEl.value;

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -1,6 +1,6 @@
 import { Setting, TextAreaComponent } from 'obsidian';
 import type TasksPlugin from '../main';
-import { IncludesSettingsService, type OriginalToCurrentNameMap } from './IncludesSettingsService';
+import { IncludesSettingsService, type RenamesInProgress } from './IncludesSettingsService';
 import { type IncludesMap, type Settings, getSettings, updateSettings } from './Settings';
 
 type RefreshViewCallback = () => void;
@@ -137,14 +137,14 @@ export class IncludesSettingsUI {
      */
     private validateAllInputs() {
         // Build the current key-value map for validation
-        const currentValues: OriginalToCurrentNameMap = {};
+        const currentValues: RenamesInProgress = {};
 
         this.nameFields.forEach(({ inputEl, originalKey }) => {
             currentValues[originalKey] = inputEl.value;
         });
 
         // Get validation results from the service
-        const validationResults = this.includesSettingsService.validateMultipleIncludeNames(currentValues);
+        const validationResults = this.includesSettingsService.validateRenames(currentValues);
 
         // Apply styling based on validation results
         this.nameFields.forEach(({ inputEl, originalKey }) => {

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -13,7 +13,7 @@ type RefreshViewCallback = () => void;
 export class IncludesSettingsUI {
     private readonly plugin: TasksPlugin;
     private readonly includesSettingsService = new IncludesSettingsService();
-    private inputElements: Map<string, { inputEl: HTMLInputElement; originalKey: string }> = new Map();
+    private readonly inputElements: Map<string, { inputEl: HTMLInputElement; originalKey: string }> = new Map();
 
     /**
      * Creates a new instance of IncludesSettingsUI

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -119,6 +119,8 @@ export class IncludesSettingsUI {
             });
         });
 
+        // TODO Add reorder button or facility to drag and drop items
+
         // Add delete button
         setting.addExtraButton((btn) => {
             btn.setIcon('cross')

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -205,6 +205,7 @@ export class IncludesSettingsUI {
         settings: Settings,
         refreshView: RefreshViewCallback | null,
     ) {
+        // TODO Consider how this relates to the validation code - should it refuse to save settings if validation fails?
         // Update the settings in storage
         updateSettings({ includes: updatedIncludes });
         await this.plugin.saveSettings();

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -150,7 +150,7 @@ export class IncludesSettingsUI {
         this.nameFields.forEach(({ inputEl, originalKey }) => {
             const result = validationResults[originalKey];
 
-            if (result && !result.isValid) {
+            if (result && !result.newResult.isValid) {
                 inputEl.addClass('has-error');
 
                 // Optionally, you could add a title attribute to show the error message on hover

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -13,7 +13,7 @@ type RefreshViewCallback = () => void;
 export class IncludesSettingsUI {
     private readonly plugin: TasksPlugin;
     private readonly includesSettingsService = new IncludesSettingsService();
-    private readonly inputElements: Map<string, { inputEl: HTMLInputElement; originalKey: string }> = new Map();
+    private readonly nameFields: Map<string, { inputEl: HTMLInputElement; originalKey: string }> = new Map();
 
     /**
      * Creates a new instance of IncludesSettingsUI
@@ -35,7 +35,7 @@ export class IncludesSettingsUI {
             includesContainer.empty();
 
             // Clear the input map when re-rendering
-            this.inputElements.clear();
+            this.nameFields.clear();
 
             Object.entries(settings.includes).forEach(([key, value]) => {
                 this.renderIncludeItem(includesContainer, settings, key, value, renderIncludes);
@@ -72,7 +72,7 @@ export class IncludesSettingsUI {
             text.inputEl.addClass('tasks-includes-key');
 
             // Store reference to this input with its original key
-            this.inputElements.set(key, { inputEl: text.inputEl, originalKey: key });
+            this.nameFields.set(key, { inputEl: text.inputEl, originalKey: key });
 
             let newKey = key;
 
@@ -137,7 +137,7 @@ export class IncludesSettingsUI {
         // Build the current key-value map for validation
         const currentValues: IncludeKeyValueMap = {};
 
-        this.inputElements.forEach(({ inputEl, originalKey }) => {
+        this.nameFields.forEach(({ inputEl, originalKey }) => {
             currentValues[originalKey] = inputEl.value;
         });
 
@@ -145,7 +145,7 @@ export class IncludesSettingsUI {
         const validationResults = this.includesSettingsService.validateMultipleIncludeNames(currentValues);
 
         // Apply styling based on validation results
-        this.inputElements.forEach(({ inputEl, originalKey }) => {
+        this.nameFields.forEach(({ inputEl, originalKey }) => {
             const result = validationResults[originalKey];
 
             if (result && !result.isValid) {

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -71,6 +71,17 @@ export class IncludesSettingsUI {
 
             text.inputEl.addEventListener('input', (e) => {
                 newKey = (e.target as HTMLInputElement).value;
+
+                // Validate the name as the user types
+                // TODO This does not remove the red if the user renames the Include
+                //      this one matched.
+                const validation = this.includesSettingsService.validateIncludeName(settings.includes, key, newKey);
+
+                if (!validation.isValid) {
+                    text.inputEl.addClass('has-error');
+                } else {
+                    text.inputEl.removeClass('has-error');
+                }
             });
 
             // Handle renaming an include

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -150,11 +150,11 @@ export class IncludesSettingsUI {
         this.nameFields.forEach(({ inputEl, originalKey }) => {
             const result = validationResults[originalKey];
 
-            if (result && !result.newResult.isValid) {
+            if (result && !result.isValid) {
                 inputEl.addClass('has-error');
 
                 // Optionally, you could add a title attribute to show the error message on hover
-                inputEl.title = result.newResult.errorMessage || '';
+                inputEl.title = result.errorMessage || '';
             } else {
                 inputEl.removeClass('has-error');
                 inputEl.title = '';

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -154,7 +154,7 @@ export class IncludesSettingsUI {
                 inputEl.addClass('has-error');
 
                 // Optionally, you could add a title attribute to show the error message on hover
-                inputEl.title = result.errorMessage || '';
+                inputEl.title = result.newResult.errorMessage || '';
             } else {
                 inputEl.removeClass('has-error');
                 inputEl.title = '';

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -1,6 +1,6 @@
 import { Setting, TextAreaComponent } from 'obsidian';
 import type TasksPlugin from '../main';
-import { IncludesSettingsService, type OriginalToCurrentIncludeNameMap } from './IncludesSettingsService';
+import { IncludesSettingsService, type OriginalToCurrentNameMap } from './IncludesSettingsService';
 import { type IncludesMap, type Settings, getSettings, updateSettings } from './Settings';
 
 type RefreshViewCallback = () => void;
@@ -135,7 +135,7 @@ export class IncludesSettingsUI {
      */
     private validateAllInputs() {
         // Build the current key-value map for validation
-        const currentValues: OriginalToCurrentIncludeNameMap = {};
+        const currentValues: OriginalToCurrentNameMap = {};
 
         this.nameFields.forEach(({ inputEl, originalKey }) => {
             currentValues[originalKey] = inputEl.value;

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -133,6 +133,11 @@ describe('IncludesSettingsService', () => {
             expectIsNotValid(result, 'An include with this name already exists');
         });
 
+        it.failing('should reject a new name if it already exists, without ending spaces', () => {
+            const result = service.validateIncludeName(testIncludes, 'key1', 'key2  ');
+            expectIsNotValid(result, 'An include with this name already exists');
+        });
+
         it('should treat renaming to self as valid', () => {
             expectIsValid(service.validateIncludeName(testIncludes, 'key1', 'key1'));
         });

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -5,6 +5,16 @@ import {
 } from '../../src/Config/IncludesSettingsService';
 import type { IncludesMap } from '../../src/Config/Settings';
 
+function expectToBeValid(result: RenameResult) {
+    expect(result.isValid).toBe(true);
+    expect(result.errorMessage).toBe(null);
+}
+
+function expectToGiveError(result: RenameResult, errorMessage: string) {
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).toBe(errorMessage);
+}
+
 describe('IncludesSettingsService', () => {
     let service: IncludesSettingsService;
     let testIncludes: IncludesMap;
@@ -23,16 +33,6 @@ describe('IncludesSettingsService', () => {
         beforeEach(() => {
             service = new IncludesSettingsService();
         });
-
-        function expectToBeValid(resultForOriginalName: RenameResult) {
-            expect(resultForOriginalName.isValid).toBe(true);
-            expect(resultForOriginalName.errorMessage).toBe(null);
-        }
-
-        function expectToGiveError(resultForOriginalName: RenameResult, expectedErrorMessage: string) {
-            expect(resultForOriginalName.isValid).toBe(false);
-            expect(resultForOriginalName.errorMessage).toBe(expectedErrorMessage);
-        }
 
         it('should validate all keys as valid when there are no duplicates', () => {
             const keyMap: RenamesInProgress = {
@@ -106,16 +106,6 @@ describe('IncludesSettingsService', () => {
     });
 
     describe('IncludesSettingsService - validateIncludeName', () => {
-        function expectToBeValid(result: RenameResult) {
-            expect(result.isValid).toBe(true);
-            expect(result.errorMessage).toBe(null);
-        }
-
-        function expectToGiveError(result: RenameResult, errorMessage: string) {
-            expect(result.isValid).toBe(false);
-            expect(result.errorMessage).toBe(errorMessage);
-        }
-
         it('should recognise valid new name', () => {
             expectToBeValid(service.validateRename(testIncludes, 'key1', 'new-name'));
         });

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -34,8 +34,8 @@ describe('IncludesSettingsService', () => {
             const result = service.validateMultipleIncludeNames(keyMap);
 
             expectToBeValid(result['original_key_1']);
-            expect(result['original_key_2'].isValid).toBe(true);
-            expect(result['original_key_3'].isValid).toBe(true);
+            expectToBeValid(result['original_key_2']);
+            expectToBeValid(result['original_key_3']);
         });
 
         it('should mark duplicate keys as invalid', () => {
@@ -53,7 +53,7 @@ describe('IncludesSettingsService', () => {
             expect(result['original_key_2'].isValid).toBe(false);
             expect(result['original_key_2'].errorMessage).toBe('Duplicate of include "original_key_1"');
 
-            expect(result['original_key_3'].isValid).toBe(true);
+            expectToBeValid(result['original_key_3']);
         });
 
         it('should mark empty keys as invalid', () => {
@@ -71,7 +71,7 @@ describe('IncludesSettingsService', () => {
             expect(result['original_key_2'].isValid).toBe(false);
             expect(result['original_key_2'].errorMessage).toBe('Include name cannot be empty or all whitespace');
 
-            expect(result['original_key_3'].isValid).toBe(true);
+            expectToBeValid(result['original_key_3']);
         });
 
         it('should handle the case when all keys are identical', () => {

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -20,6 +20,10 @@ describe('IncludesSettingsService', () => {
             service = new IncludesSettingsService();
         });
 
+        function expectToBeValid(resultForOriginalName: { isValid: boolean; errorMessage: string | null }) {
+            expect(resultForOriginalName.isValid).toBe(true);
+        }
+
         it('should validate all keys as valid when there are no duplicates', () => {
             const keyMap: OriginalToCurrentNameMap = {
                 original_key_1: 'unique_value_1',
@@ -29,7 +33,7 @@ describe('IncludesSettingsService', () => {
 
             const result = service.validateMultipleIncludeNames(keyMap);
 
-            expect(result['original_key_1'].isValid).toBe(true);
+            expectToBeValid(result['original_key_1']);
             expect(result['original_key_2'].isValid).toBe(true);
             expect(result['original_key_3'].isValid).toBe(true);
         });

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -1,4 +1,4 @@
-import { IncludesSettingsService, type OriginalToCurrentNameMap } from '../../src/Config/IncludesSettingsService';
+import { IncludesSettingsService, type RenamesInProgress } from '../../src/Config/IncludesSettingsService';
 import type { IncludesMap } from '../../src/Config/Settings';
 
 describe('IncludesSettingsService', () => {
@@ -33,13 +33,13 @@ describe('IncludesSettingsService', () => {
         }
 
         it('should validate all keys as valid when there are no duplicates', () => {
-            const keyMap: OriginalToCurrentNameMap = {
+            const keyMap: RenamesInProgress = {
                 original_key_1: 'unique_value_1',
                 original_key_2: 'unique_value_2',
                 original_key_3: 'unique_value_3',
             };
 
-            const result = service.validateMultipleIncludeNames(keyMap);
+            const result = service.validateRenames(keyMap);
 
             expectToBeValid(result['original_key_1']);
             expectToBeValid(result['original_key_2']);
@@ -47,13 +47,13 @@ describe('IncludesSettingsService', () => {
         });
 
         it('should mark duplicate keys as invalid', () => {
-            const keyMap: OriginalToCurrentNameMap = {
+            const keyMap: RenamesInProgress = {
                 original_key_1: 'duplicate_value',
                 original_key_2: 'duplicate_value', // Duplicate
                 original_key_3: 'unique_value',
             };
 
-            const result = service.validateMultipleIncludeNames(keyMap);
+            const result = service.validateRenames(keyMap);
 
             expectToGiveError(result['original_key_1'], 'An include with this name already exists');
             expectToGiveError(result['original_key_2'], 'An include with this name already exists');
@@ -61,13 +61,13 @@ describe('IncludesSettingsService', () => {
         });
 
         it('should mark names differing only in whitespace as identical', () => {
-            const keyMap: OriginalToCurrentNameMap = {
+            const keyMap: RenamesInProgress = {
                 original_key_1: 'duplicate_value',
                 original_key_2: 'duplicate_value  ', // Duplicate
                 original_key_3: 'unique_value',
             };
 
-            const result = service.validateMultipleIncludeNames(keyMap);
+            const result = service.validateRenames(keyMap);
 
             expectToGiveError(result['original_key_1'], 'An include with this name already exists');
             expectToGiveError(result['original_key_2'], 'An include with this name already exists');
@@ -75,13 +75,13 @@ describe('IncludesSettingsService', () => {
         });
 
         it('should mark empty keys as invalid', () => {
-            const keyMap: OriginalToCurrentNameMap = {
+            const keyMap: RenamesInProgress = {
                 original_key_1: '',
                 original_key_2: '  ', // Whitespace only
                 original_key_3: 'valid_key',
             };
 
-            const result = service.validateMultipleIncludeNames(keyMap);
+            const result = service.validateRenames(keyMap);
 
             expectToGiveError(result['original_key_1'], 'Include name cannot be empty or all whitespace');
             expectToGiveError(result['original_key_2'], 'Include name cannot be empty or all whitespace');
@@ -89,13 +89,13 @@ describe('IncludesSettingsService', () => {
         });
 
         it('should handle the case when all keys are identical', () => {
-            const keyMap: OriginalToCurrentNameMap = {
+            const keyMap: RenamesInProgress = {
                 original_key_1: 'same_value',
                 original_key_2: 'same_value',
                 original_key_3: 'same_value',
             };
 
-            const result = service.validateMultipleIncludeNames(keyMap);
+            const result = service.validateRenames(keyMap);
 
             // None should be valid
             const validCount = Object.values(result).filter((r) => r.isValid).length;
@@ -115,26 +115,26 @@ describe('IncludesSettingsService', () => {
         }
 
         it('should recognise valid new name', () => {
-            expectIsValid(service.validateIncludeName(testIncludes, 'key1', 'new-name'));
+            expectIsValid(service.validateRename(testIncludes, 'key1', 'new-name'));
         });
 
         it('should reject an empty new name', () => {
-            const result = service.validateIncludeName(testIncludes, 'key1', '');
+            const result = service.validateRename(testIncludes, 'key1', '');
             expectIsNotValid(result, 'Include name cannot be empty or all whitespace');
         });
 
         it('should reject an new name with only whitespaces', () => {
-            const result = service.validateIncludeName(testIncludes, 'key1', ' \t');
+            const result = service.validateRename(testIncludes, 'key1', ' \t');
             expectIsNotValid(result, 'Include name cannot be empty or all whitespace');
         });
 
         it('should reject a new name if it already exists', () => {
-            const result = service.validateIncludeName(testIncludes, 'key1', 'key2');
+            const result = service.validateRename(testIncludes, 'key1', 'key2');
             expectIsNotValid(result, 'An include with this name already exists');
         });
 
         it('should reject a new name if it already exists, without ending spaces', () => {
-            const result = service.validateIncludeName(testIncludes, 'key1', 'key2  ');
+            const result = service.validateRename(testIncludes, 'key1', 'key2  ');
             expectIsNotValid(result, 'An include with this name already exists');
         });
 
@@ -144,12 +144,12 @@ describe('IncludesSettingsService', () => {
                 ' key2 ': 'value2',
             };
 
-            const result = service.validateIncludeName(testIncludes, 'key1', 'key2');
+            const result = service.validateRename(testIncludes, 'key1', 'key2');
             expectIsNotValid(result, 'An include with this name already exists');
         });
 
         it('should treat renaming to self as valid', () => {
-            expectIsValid(service.validateIncludeName(testIncludes, 'key1', 'key1'));
+            expectIsValid(service.validateRename(testIncludes, 'key1', 'key1'));
         });
     });
 

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -25,13 +25,11 @@ describe('IncludesSettingsService', () => {
         });
 
         function expectToBeValid(resultForOriginalName: RenameResult) {
-            expect(resultForOriginalName.isValid).toBe(true);
             expect(resultForOriginalName.newResult.isValid).toBe(true);
             expect(resultForOriginalName.newResult.errorMessage).toBe(null);
         }
 
         function expectToGiveError(resultForOriginalName: RenameResult, expectedErrorMessage: string) {
-            expect(resultForOriginalName.isValid).toBe(false);
             expect(resultForOriginalName.newResult.isValid).toBe(false);
             expect(resultForOriginalName.newResult.errorMessage).toBe(expectedErrorMessage);
         }
@@ -102,19 +100,17 @@ describe('IncludesSettingsService', () => {
             const result = service.validateRenames(keyMap);
 
             // None should be valid
-            const validCount = Object.values(result).filter((r) => r.isValid).length;
+            const validCount = Object.values(result).filter((r) => r.newResult.isValid).length;
             expect(validCount).toBe(0);
         });
     });
 
     describe('IncludesSettingsService - validateIncludeName', () => {
         function expectIsValid(result: RenameResult) {
-            expect(result.isValid).toBe(true);
             expect(result.newResult.errorMessage).toBe(null);
         }
 
         function expectIsNotValid(result: RenameResult, errorMessage: string) {
-            expect(result.isValid).toBe(false);
             expect(result.newResult.errorMessage).toBe(errorMessage);
         }
 

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -25,13 +25,13 @@ describe('IncludesSettingsService', () => {
         });
 
         function expectToBeValid(resultForOriginalName: RenameResult) {
-            expect(resultForOriginalName.newResult.isValid).toBe(true);
-            expect(resultForOriginalName.newResult.errorMessage).toBe(null);
+            expect(resultForOriginalName.isValid).toBe(true);
+            expect(resultForOriginalName.errorMessage).toBe(null);
         }
 
         function expectToGiveError(resultForOriginalName: RenameResult, expectedErrorMessage: string) {
-            expect(resultForOriginalName.newResult.isValid).toBe(false);
-            expect(resultForOriginalName.newResult.errorMessage).toBe(expectedErrorMessage);
+            expect(resultForOriginalName.isValid).toBe(false);
+            expect(resultForOriginalName.errorMessage).toBe(expectedErrorMessage);
         }
 
         it('should validate all keys as valid when there are no duplicates', () => {
@@ -100,18 +100,18 @@ describe('IncludesSettingsService', () => {
             const result = service.validateRenames(keyMap);
 
             // None should be valid
-            const validCount = Object.values(result).filter((r) => r.newResult.isValid).length;
+            const validCount = Object.values(result).filter((r) => r.isValid).length;
             expect(validCount).toBe(0);
         });
     });
 
     describe('IncludesSettingsService - validateIncludeName', () => {
         function expectIsValid(result: RenameResult) {
-            expect(result.newResult.errorMessage).toBe(null);
+            expect(result.errorMessage).toBe(null);
         }
 
         function expectIsNotValid(result: RenameResult, errorMessage: string) {
-            expect(result.newResult.errorMessage).toBe(errorMessage);
+            expect(result.errorMessage).toBe(errorMessage);
         }
 
         it('should recognise valid new name', () => {

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -44,7 +44,11 @@ describe('IncludesSettingsService', () => {
             const result = service.validateMultipleIncludeNames(keyMap);
 
             expect(result['original_key_1'].isValid).toBe(false);
+            expect(result['original_key_1'].errorMessage).toBe('Duplicate of include "original_key_2"');
+
             expect(result['original_key_2'].isValid).toBe(false);
+            expect(result['original_key_2'].errorMessage).toBe('Duplicate of include "original_key_1"');
+
             expect(result['original_key_3'].isValid).toBe(true);
         });
 
@@ -58,8 +62,11 @@ describe('IncludesSettingsService', () => {
             const result = service.validateMultipleIncludeNames(keyMap);
 
             expect(result['original_key_1'].isValid).toBe(false);
-            expect(result['original_key_1'].errorMessage).toContain('empty');
+            expect(result['original_key_1'].errorMessage).toBe('Include name cannot be empty or all whitespace');
+
             expect(result['original_key_2'].isValid).toBe(false);
+            expect(result['original_key_2'].errorMessage).toBe('Include name cannot be empty or all whitespace');
+
             expect(result['original_key_3'].isValid).toBe(true);
         });
 

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -107,10 +107,12 @@ describe('IncludesSettingsService', () => {
 
     describe('IncludesSettingsService - validateIncludeName', () => {
         function expectIsValid(result: RenameResult) {
+            expect(result.isValid).toBe(true);
             expect(result.errorMessage).toBe(null);
         }
 
         function expectIsNotValid(result: RenameResult, errorMessage: string) {
+            expect(result.isValid).toBe(false);
             expect(result.errorMessage).toBe(errorMessage);
         }
 

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -27,14 +27,12 @@ describe('IncludesSettingsService', () => {
         function expectToBeValid(resultForOriginalName: RenameResult) {
             expect(resultForOriginalName.isValid).toBe(true);
             expect(resultForOriginalName.newResult.isValid).toBe(true);
-            expect(resultForOriginalName.errorMessage).toBe(null);
             expect(resultForOriginalName.newResult.errorMessage).toBe(null);
         }
 
         function expectToGiveError(resultForOriginalName: RenameResult, expectedErrorMessage: string) {
             expect(resultForOriginalName.isValid).toBe(false);
             expect(resultForOriginalName.newResult.isValid).toBe(false);
-            expect(resultForOriginalName.errorMessage).toBe(expectedErrorMessage);
             expect(resultForOriginalName.newResult.errorMessage).toBe(expectedErrorMessage);
         }
 
@@ -112,13 +110,11 @@ describe('IncludesSettingsService', () => {
     describe('IncludesSettingsService - validateIncludeName', () => {
         function expectIsValid(result: RenameResult) {
             expect(result.isValid).toBe(true);
-            expect(result.errorMessage).toBe(null);
             expect(result.newResult.errorMessage).toBe(null);
         }
 
         function expectIsNotValid(result: RenameResult, errorMessage: string) {
             expect(result.isValid).toBe(false);
-            expect(result.errorMessage).toBe(errorMessage);
             expect(result.newResult.errorMessage).toBe(errorMessage);
         }
 

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -56,10 +56,7 @@ describe('IncludesSettingsService', () => {
             const result = service.validateMultipleIncludeNames(keyMap);
 
             expectToGiveError(result['original_key_1'], 'Duplicate of include "original_key_2"');
-
-            expect(result['original_key_2'].isValid).toBe(false);
-            expect(result['original_key_2'].errorMessage).toBe('Duplicate of include "original_key_1"');
-
+            expectToGiveError(result['original_key_2'], 'Duplicate of include "original_key_1"');
             expectToBeValid(result['original_key_3']);
         });
 
@@ -72,12 +69,8 @@ describe('IncludesSettingsService', () => {
 
             const result = service.validateMultipleIncludeNames(keyMap);
 
-            expect(result['original_key_1'].isValid).toBe(false);
-            expect(result['original_key_1'].errorMessage).toBe('Include name cannot be empty or all whitespace');
-
-            expect(result['original_key_2'].isValid).toBe(false);
-            expect(result['original_key_2'].errorMessage).toBe('Include name cannot be empty or all whitespace');
-
+            expectToGiveError(result['original_key_1'], 'Include name cannot be empty or all whitespace');
+            expectToGiveError(result['original_key_2'], 'Include name cannot be empty or all whitespace');
             expectToBeValid(result['original_key_3']);
         });
 

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -106,38 +106,38 @@ describe('IncludesSettingsService', () => {
     });
 
     describe('IncludesSettingsService - validateIncludeName', () => {
-        function expectIsValid(result: RenameResult) {
+        function expectToBeValid(result: RenameResult) {
             expect(result.isValid).toBe(true);
             expect(result.errorMessage).toBe(null);
         }
 
-        function expectIsNotValid(result: RenameResult, errorMessage: string) {
+        function expectToGiveError(result: RenameResult, errorMessage: string) {
             expect(result.isValid).toBe(false);
             expect(result.errorMessage).toBe(errorMessage);
         }
 
         it('should recognise valid new name', () => {
-            expectIsValid(service.validateRename(testIncludes, 'key1', 'new-name'));
+            expectToBeValid(service.validateRename(testIncludes, 'key1', 'new-name'));
         });
 
         it('should reject an empty new name', () => {
             const result = service.validateRename(testIncludes, 'key1', '');
-            expectIsNotValid(result, 'Include name cannot be empty or all whitespace');
+            expectToGiveError(result, 'Include name cannot be empty or all whitespace');
         });
 
         it('should reject an new name with only whitespaces', () => {
             const result = service.validateRename(testIncludes, 'key1', ' \t');
-            expectIsNotValid(result, 'Include name cannot be empty or all whitespace');
+            expectToGiveError(result, 'Include name cannot be empty or all whitespace');
         });
 
         it('should reject a new name if it already exists', () => {
             const result = service.validateRename(testIncludes, 'key1', 'key2');
-            expectIsNotValid(result, 'An include with this name already exists');
+            expectToGiveError(result, 'An include with this name already exists');
         });
 
         it('should reject a new name if it already exists, without ending spaces', () => {
             const result = service.validateRename(testIncludes, 'key1', 'key2  ');
-            expectIsNotValid(result, 'An include with this name already exists');
+            expectToGiveError(result, 'An include with this name already exists');
         });
 
         it('should reject a new name if it already exists, with surrounding spaces', () => {
@@ -147,11 +147,11 @@ describe('IncludesSettingsService', () => {
             };
 
             const result = service.validateRename(testIncludes, 'key1', 'key2');
-            expectIsNotValid(result, 'An include with this name already exists');
+            expectToGiveError(result, 'An include with this name already exists');
         });
 
         it('should treat renaming to self as valid', () => {
-            expectIsValid(service.validateRename(testIncludes, 'key1', 'key1'));
+            expectToBeValid(service.validateRename(testIncludes, 'key1', 'key1'));
         });
     });
 

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -1,6 +1,6 @@
 import {
     IncludesSettingsService,
-    type RenameResult,
+    RenameResult,
     type RenamesInProgress,
 } from '../../src/Config/IncludesSettingsService';
 import type { IncludesMap } from '../../src/Config/Settings';

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -1,4 +1,7 @@
-import { type IncludeKeyValueMap, IncludesSettingsService } from '../../src/Config/IncludesSettingsService';
+import {
+    IncludesSettingsService,
+    type OriginalToCurrentIncludeNameMap,
+} from '../../src/Config/IncludesSettingsService';
 import type { IncludesMap } from '../../src/Config/Settings';
 
 describe('IncludesSettingsService', () => {
@@ -21,7 +24,7 @@ describe('IncludesSettingsService', () => {
         });
 
         it('should validate all keys as valid when there are no duplicates', () => {
-            const keyMap: IncludeKeyValueMap = {
+            const keyMap: OriginalToCurrentIncludeNameMap = {
                 original_key_1: 'unique_value_1',
                 original_key_2: 'unique_value_2',
                 original_key_3: 'unique_value_3',
@@ -35,7 +38,7 @@ describe('IncludesSettingsService', () => {
         });
 
         it('should mark duplicate keys as invalid', () => {
-            const keyMap: IncludeKeyValueMap = {
+            const keyMap: OriginalToCurrentIncludeNameMap = {
                 original_key_1: 'duplicate_value',
                 original_key_2: 'duplicate_value', // Duplicate
                 original_key_3: 'unique_value',
@@ -49,7 +52,7 @@ describe('IncludesSettingsService', () => {
         });
 
         it('should mark empty keys as invalid', () => {
-            const keyMap: IncludeKeyValueMap = {
+            const keyMap: OriginalToCurrentIncludeNameMap = {
                 original_key_1: '',
                 original_key_2: '  ', // Whitespace only
                 original_key_3: 'valid_key',
@@ -64,7 +67,7 @@ describe('IncludesSettingsService', () => {
         });
 
         it('should handle the case when all keys are identical', () => {
-            const keyMap: IncludeKeyValueMap = {
+            const keyMap: OriginalToCurrentIncludeNameMap = {
                 original_key_1: 'same_value',
                 original_key_2: 'same_value',
                 original_key_3: 'same_value',

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -55,8 +55,8 @@ describe('IncludesSettingsService', () => {
 
             const result = service.validateMultipleIncludeNames(keyMap);
 
-            expectToGiveError(result['original_key_1'], 'Duplicate of include "original_key_2"');
-            expectToGiveError(result['original_key_2'], 'Duplicate of include "original_key_1"');
+            expectToGiveError(result['original_key_1'], 'An include with this name already exists');
+            expectToGiveError(result['original_key_2'], 'An include with this name already exists');
             expectToBeValid(result['original_key_3']);
         });
 

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -1,7 +1,4 @@
-import {
-    IncludesSettingsService,
-    type OriginalToCurrentIncludeNameMap,
-} from '../../src/Config/IncludesSettingsService';
+import { IncludesSettingsService, type OriginalToCurrentNameMap } from '../../src/Config/IncludesSettingsService';
 import type { IncludesMap } from '../../src/Config/Settings';
 
 describe('IncludesSettingsService', () => {
@@ -24,7 +21,7 @@ describe('IncludesSettingsService', () => {
         });
 
         it('should validate all keys as valid when there are no duplicates', () => {
-            const keyMap: OriginalToCurrentIncludeNameMap = {
+            const keyMap: OriginalToCurrentNameMap = {
                 original_key_1: 'unique_value_1',
                 original_key_2: 'unique_value_2',
                 original_key_3: 'unique_value_3',
@@ -38,7 +35,7 @@ describe('IncludesSettingsService', () => {
         });
 
         it('should mark duplicate keys as invalid', () => {
-            const keyMap: OriginalToCurrentIncludeNameMap = {
+            const keyMap: OriginalToCurrentNameMap = {
                 original_key_1: 'duplicate_value',
                 original_key_2: 'duplicate_value', // Duplicate
                 original_key_3: 'unique_value',
@@ -52,7 +49,7 @@ describe('IncludesSettingsService', () => {
         });
 
         it('should mark empty keys as invalid', () => {
-            const keyMap: OriginalToCurrentIncludeNameMap = {
+            const keyMap: OriginalToCurrentNameMap = {
                 original_key_1: '',
                 original_key_2: '  ', // Whitespace only
                 original_key_3: 'valid_key',
@@ -67,7 +64,7 @@ describe('IncludesSettingsService', () => {
         });
 
         it('should handle the case when all keys are identical', () => {
-            const keyMap: OriginalToCurrentIncludeNameMap = {
+            const keyMap: OriginalToCurrentNameMap = {
                 original_key_1: 'same_value',
                 original_key_2: 'same_value',
                 original_key_3: 'same_value',

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -138,6 +138,16 @@ describe('IncludesSettingsService', () => {
             expectIsNotValid(result, 'An include with this name already exists');
         });
 
+        it.failing('should reject a new name if it already exists, with surrounding spaces', () => {
+            testIncludes = {
+                key1: 'value1',
+                ' key2 ': 'value2',
+            };
+
+            const result = service.validateIncludeName(testIncludes, 'key1', 'key2');
+            expectIsNotValid(result, 'An include with this name already exists');
+        });
+
         it('should treat renaming to self as valid', () => {
             expectIsValid(service.validateIncludeName(testIncludes, 'key1', 'key1'));
         });

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -60,7 +60,7 @@ describe('IncludesSettingsService', () => {
             expectToBeValid(result['original_key_3']);
         });
 
-        it.failing('should mark names differing only in whitespace as identical', () => {
+        it('should mark names differing only in whitespace as identical', () => {
             const keyMap: OriginalToCurrentNameMap = {
                 original_key_1: 'duplicate_value',
                 original_key_2: 'duplicate_value  ', // Duplicate
@@ -69,8 +69,8 @@ describe('IncludesSettingsService', () => {
 
             const result = service.validateMultipleIncludeNames(keyMap);
 
-            expectToGiveError(result['original_key_1'], 'Duplicate of include "original_key_2"');
-            expectToGiveError(result['original_key_2'], 'Duplicate of include "original_key_1"');
+            expectToGiveError(result['original_key_1'], 'An include with this name already exists');
+            expectToGiveError(result['original_key_2'], 'An include with this name already exists');
             expectToBeValid(result['original_key_3']);
         });
 

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -60,6 +60,20 @@ describe('IncludesSettingsService', () => {
             expectToBeValid(result['original_key_3']);
         });
 
+        it.failing('should mark names differing only in whitespace as identical', () => {
+            const keyMap: OriginalToCurrentNameMap = {
+                original_key_1: 'duplicate_value',
+                original_key_2: 'duplicate_value  ', // Duplicate
+                original_key_3: 'unique_value',
+            };
+
+            const result = service.validateMultipleIncludeNames(keyMap);
+
+            expectToGiveError(result['original_key_1'], 'Duplicate of include "original_key_2"');
+            expectToGiveError(result['original_key_2'], 'Duplicate of include "original_key_1"');
+            expectToBeValid(result['original_key_3']);
+        });
+
         it('should mark empty keys as invalid', () => {
             const keyMap: OriginalToCurrentNameMap = {
                 original_key_1: '',

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -55,9 +55,7 @@ describe('IncludesSettingsService', () => {
 
             const result = service.validateMultipleIncludeNames(keyMap);
 
-            const r = result['original_key_1'];
-            const expectedErrorMessage = 'Duplicate of include "original_key_2"';
-            expectToGiveError(r, expectedErrorMessage);
+            expectToGiveError(result['original_key_1'], 'Duplicate of include "original_key_2"');
 
             expect(result['original_key_2'].isValid).toBe(false);
             expect(result['original_key_2'].errorMessage).toBe('Duplicate of include "original_key_1"');

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -133,7 +133,7 @@ describe('IncludesSettingsService', () => {
             expectIsNotValid(result, 'An include with this name already exists');
         });
 
-        it.failing('should reject a new name if it already exists, without ending spaces', () => {
+        it('should reject a new name if it already exists, without ending spaces', () => {
             const result = service.validateIncludeName(testIncludes, 'key1', 'key2  ');
             expectIsNotValid(result, 'An include with this name already exists');
         });

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -1,4 +1,8 @@
-import { IncludesSettingsService, type RenamesInProgress } from '../../src/Config/IncludesSettingsService';
+import {
+    IncludesSettingsService,
+    type RenameResult,
+    type RenamesInProgress,
+} from '../../src/Config/IncludesSettingsService';
 import type { IncludesMap } from '../../src/Config/Settings';
 
 describe('IncludesSettingsService', () => {
@@ -20,14 +24,11 @@ describe('IncludesSettingsService', () => {
             service = new IncludesSettingsService();
         });
 
-        function expectToBeValid(resultForOriginalName: { isValid: boolean; errorMessage: string | null }) {
+        function expectToBeValid(resultForOriginalName: RenameResult) {
             expect(resultForOriginalName.isValid).toBe(true);
         }
 
-        function expectToGiveError(
-            resultForOriginalName: { isValid: boolean; errorMessage: string | null },
-            expectedErrorMessage: string,
-        ) {
+        function expectToGiveError(resultForOriginalName: RenameResult, expectedErrorMessage: string) {
             expect(resultForOriginalName.isValid).toBe(false);
             expect(resultForOriginalName.errorMessage).toBe(expectedErrorMessage);
         }
@@ -104,12 +105,12 @@ describe('IncludesSettingsService', () => {
     });
 
     describe('IncludesSettingsService - validateIncludeName', () => {
-        function expectIsValid(result: { isValid: boolean; errorMessage: string | null }) {
+        function expectIsValid(result: RenameResult) {
             expect(result.isValid).toBe(true);
             expect(result.errorMessage).toBe(null);
         }
 
-        function expectIsNotValid(result: { isValid: boolean; errorMessage: string | null }, errorMessage: string) {
+        function expectIsNotValid(result: RenameResult, errorMessage: string) {
             expect(result.isValid).toBe(false);
             expect(result.errorMessage).toBe(errorMessage);
         }

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -26,11 +26,16 @@ describe('IncludesSettingsService', () => {
 
         function expectToBeValid(resultForOriginalName: RenameResult) {
             expect(resultForOriginalName.isValid).toBe(true);
+            expect(resultForOriginalName.newResult.isValid).toBe(true);
+            expect(resultForOriginalName.errorMessage).toBe(null);
+            expect(resultForOriginalName.newResult.errorMessage).toBe(null);
         }
 
         function expectToGiveError(resultForOriginalName: RenameResult, expectedErrorMessage: string) {
             expect(resultForOriginalName.isValid).toBe(false);
+            expect(resultForOriginalName.newResult.isValid).toBe(false);
             expect(resultForOriginalName.errorMessage).toBe(expectedErrorMessage);
+            expect(resultForOriginalName.newResult.errorMessage).toBe(expectedErrorMessage);
         }
 
         it('should validate all keys as valid when there are no duplicates', () => {
@@ -108,11 +113,13 @@ describe('IncludesSettingsService', () => {
         function expectIsValid(result: RenameResult) {
             expect(result.isValid).toBe(true);
             expect(result.errorMessage).toBe(null);
+            expect(result.newResult.errorMessage).toBe(null);
         }
 
         function expectIsNotValid(result: RenameResult, errorMessage: string) {
             expect(result.isValid).toBe(false);
             expect(result.errorMessage).toBe(errorMessage);
+            expect(result.newResult.errorMessage).toBe(errorMessage);
         }
 
         it('should recognise valid new name', () => {

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -83,9 +83,9 @@ describe('IncludesSettingsService', () => {
 
             const result = service.validateMultipleIncludeNames(keyMap);
 
-            // All should be invalid except potentially one
+            // None should be valid
             const validCount = Object.values(result).filter((r) => r.isValid).length;
-            expect(validCount).toBeLessThanOrEqual(1);
+            expect(validCount).toBe(0);
         });
     });
 

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -24,6 +24,14 @@ describe('IncludesSettingsService', () => {
             expect(resultForOriginalName.isValid).toBe(true);
         }
 
+        function expectToGiveError(
+            resultForOriginalName: { isValid: boolean; errorMessage: string | null },
+            expectedErrorMessage: string,
+        ) {
+            expect(resultForOriginalName.isValid).toBe(false);
+            expect(resultForOriginalName.errorMessage).toBe(expectedErrorMessage);
+        }
+
         it('should validate all keys as valid when there are no duplicates', () => {
             const keyMap: OriginalToCurrentNameMap = {
                 original_key_1: 'unique_value_1',
@@ -47,8 +55,9 @@ describe('IncludesSettingsService', () => {
 
             const result = service.validateMultipleIncludeNames(keyMap);
 
-            expect(result['original_key_1'].isValid).toBe(false);
-            expect(result['original_key_1'].errorMessage).toBe('Duplicate of include "original_key_2"');
+            const r = result['original_key_1'];
+            const expectedErrorMessage = 'Duplicate of include "original_key_2"';
+            expectToGiveError(r, expectedErrorMessage);
 
             expect(result['original_key_2'].isValid).toBe(false);
             expect(result['original_key_2'].errorMessage).toBe('Duplicate of include "original_key_1"');

--- a/tests/Config/IncludesSettingsService.test.ts
+++ b/tests/Config/IncludesSettingsService.test.ts
@@ -138,7 +138,7 @@ describe('IncludesSettingsService', () => {
             expectIsNotValid(result, 'An include with this name already exists');
         });
 
-        it.failing('should reject a new name if it already exists, with surrounding spaces', () => {
+        it('should reject a new name if it already exists, with surrounding spaces', () => {
             testIncludes = {
                 key1: 'value1',
                 ' key2 ': 'value2',


### PR DESCRIPTION
Mostly initially created with Claude.ai - with some help from @ilandikov cleaning up the code somewhat.

# Types of changes

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
    - #2443 
    - #2267
- [ ] **Translation** (prefix: `i18n` - additions or improvements to the translations - see [Support a new language](https://publish.obsidian.md/tasks-contributing/Translation/Support+a+new+language))
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

- **Settings:**
    - If two includes have the same name, ignoring surrounding spaces, display them in red
- **Sample vault:**
    - Add a few pre-defined instructions ("Includes") to the settings
    - Added page for manual testing: `resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md`

## Motivation and Context

Wanting to release these features:

- #2443 
- #2267

## How has this been tested?

- Automated tests
- Exploratory testing

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/75f2e497-e27c-4ea8-8a63-498c10cf2015)


## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
