### PR TITLE
docs: Link Sorting.md to related section in Grouping.md

### DIFF
--- a/docs/Queries/Sorting.md
+++ b/docs/Queries/Sorting.md
@@ -697,6 +697,8 @@ If given, the sort order will be reverse for that property.
 Note that `reverse` will reverse the entire result set.
 For example, when you `sort by done reverse` and your query results contain tasks that do not have a done date, then those tasks without a done date will be listed first.
 
+Refer to [[Grouping#Reversing groups]] to specify the sort order of groups when using the `GROUP BY` clause.
+
 ## Examples
 
 ### Sort tasks by due date, from oldest to newest


### PR DESCRIPTION
Create a link to Grouping.md from Sorting.md to support readers who want to reverse the order of groups in grouped queries

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

## Description

This change introduces a link between two documentation pages having to do with reversing the sort direction when ordering Tasks or Groups.

## Motivation and Context

In attempting to create a "captain's log" of tasks already done, sorted reverse chronologically, I discovered that `SORT BY` does not effect the order of groups when using a `GROUP BY` clause. I began opening a bug report and, while doing so, discovered Tasks supports reversing the order of groups via the `GROUP BY` clause, rather than the `SORT BY` (which is different than SQL, where I'm more familiar). Rather than opening a bug against `SORT BY`, this PR simply intends on making future readers' lives a bit easier in discovering this nuance.

## How has this been tested?

Documentation update. Non-operative code. Opened `docs/` in Obsidian to confirm correct rendering of markdown and linkage functionality.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project and passes `yarn run lint`.
  - not applicable
- [x] My change requires a change to the documentation.
   - exclusively a documentation change
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
   - exclusively a documentation change
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - not applicable

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
