### PR TITLE
feat: Editing any Includes setting redraws open Tasks searches

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
@@ -69,7 +69,7 @@ include hide_buttons
 include hide_buttons
 ```
 
-## Hide everything, including tags
+## Show only the description and any tags
 
 explain: `INPUT[toggle:TQ_explain]`
 
@@ -81,6 +81,20 @@ include just_the_description_and_tags
 
 ```tasks
 include just_the_description_and_tags
+```
+
+## Just show the description, without tags
+
+explain: `INPUT[toggle:TQ_explain]`
+
+````text
+```tasks
+include just_the_description
+```
+````
+
+```tasks
+include just_the_description
 ```
 
 ## Advanced use: return a function, that takes a parameter from the query source

--- a/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
@@ -17,6 +17,12 @@ explain: `INPUT[toggle:TQ_explain]`
 
 (assuming there is not one called `xxxx`!)
 
+````text
+```tasks
+include xxxx
+```
+````
+
 ```tasks
 include xxxx
 ```
@@ -25,12 +31,24 @@ include xxxx
 
 explain: `INPUT[toggle:TQ_explain]`
 
+````text
+```tasks
+```
+````
+
 ```tasks
 ```
 
 ## Hide all the fields
 
 explain: `INPUT[toggle:TQ_explain]`
+
+````text
+```tasks
+include hide_all_dates
+include hide_other_fields
+```
+````
 
 ```tasks
 include hide_all_dates
@@ -41,6 +59,12 @@ include hide_other_fields
 
 explain: `INPUT[toggle:TQ_explain]`
 
+````text
+```tasks
+include hide_buttons
+```
+````
+
 ```tasks
 include hide_buttons
 ```
@@ -48,6 +72,12 @@ include hide_buttons
 ## Hide everything, including tags
 
 explain: `INPUT[toggle:TQ_explain]`
+
+````text
+```tasks
+include just_the_description_and_tags
+```
+````
 
 ```tasks
 include just_the_description_and_tags
@@ -58,6 +88,15 @@ include just_the_description_and_tags
 ### Has context 'home' - and group by the Include text - version 1
 
 explain: `INPUT[toggle:TQ_explain]`
+
+````text
+```tasks
+# For debug/explanatory purposes, show the source of the Include as a group name:
+group by function const x = "{{includes.filter_by_context}}"; return x
+
+{{includes.filter_by_context}}('home')
+```
+````
 
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:
@@ -70,6 +109,16 @@ group by function const x = "{{includes.filter_by_context}}"; return x
 
 explain: `INPUT[toggle:TQ_explain]`
 
+````text
+```tasks
+# For debug/explanatory purposes, show the source of the Include as a group name:
+group by function const x = "{{includes.extract_contexts_1}}"; return x
+
+# includes.extract_contexts_1 value needs to be surrounded by parentheses ():
+filter by function return ({{includes.extract_contexts_1}})('home')
+```
+````
+
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:
 group by function const x = "{{includes.extract_contexts_1}}"; return x
@@ -81,6 +130,16 @@ filter by function return ({{includes.extract_contexts_1}})('home')
 ### Has context 'home' - and group by the Include text - version 3
 
 explain: `INPUT[toggle:TQ_explain]`
+
+````text
+```tasks
+# For debug/explanatory purposes, show the source of the Include as a group name:
+group by function const x = "{{includes.extract_contexts_2}}"; return x
+
+# includes.extract_contexts_1 value has the parentheses, to simplify use:
+filter by function {{includes.extract_contexts_2}}('home')
+```
+````
 
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:

--- a/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
@@ -1,8 +1,9 @@
 ---
 TQ_explain: false
 TQ_extra_instructions: |-
+  (filename includes Tasks Format) OR (tag includes #context)
   ignore global query
-  limit 10
+  limit 20
 ---
 # Reuse instructions across the vault
 

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -13,7 +13,6 @@ type RefreshViewCallback = () => void;
  */
 export class IncludesSettingsUI {
     private readonly plugin: TasksPlugin;
-    // @ts-expect-error: TS6133: events is declared but its value is never read.
     private readonly events: TasksEvents;
     private readonly includesSettingsService = new IncludesSettingsService();
     private readonly nameFields: Map<string, { inputEl: HTMLInputElement; originalKey: string }> = new Map();
@@ -223,5 +222,7 @@ export class IncludesSettingsUI {
         if (refreshView) {
             refreshView();
         }
+
+        this.events.triggerReloadOpenSearchResults();
     }
 }

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -20,6 +20,7 @@ export class IncludesSettingsUI {
     /**
      * Creates a new instance of IncludesSettingsUI
      * @param plugin The Tasks plugin instance
+     * @param events The plugin's events object
      */
     constructor(plugin: TasksPlugin, events: TasksEvents) {
         this.plugin = plugin;

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -1,5 +1,6 @@
 import { Setting, TextAreaComponent } from 'obsidian';
 import type TasksPlugin from '../main';
+import type { TasksEvents } from '../Obsidian/TasksEvents';
 import { IncludesSettingsService, type RenamesInProgress } from './IncludesSettingsService';
 import { type IncludesMap, type Settings, getSettings, updateSettings } from './Settings';
 
@@ -12,6 +13,8 @@ type RefreshViewCallback = () => void;
  */
 export class IncludesSettingsUI {
     private readonly plugin: TasksPlugin;
+    // @ts-expect-error: TS6133: events is declared but its value is never read.
+    private readonly events: TasksEvents;
     private readonly includesSettingsService = new IncludesSettingsService();
     private readonly nameFields: Map<string, { inputEl: HTMLInputElement; originalKey: string }> = new Map();
 
@@ -19,8 +22,9 @@ export class IncludesSettingsUI {
      * Creates a new instance of IncludesSettingsUI
      * @param plugin The Tasks plugin instance
      */
-    constructor(plugin: TasksPlugin) {
+    constructor(plugin: TasksPlugin, events: TasksEvents) {
         this.plugin = plugin;
+        this.events = events;
     }
 
     /**

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -6,6 +6,7 @@ import { Status } from '../Statuses/Status';
 import type { StatusCollection } from '../Statuses/StatusCollection';
 import { createStatusRegistryReport } from '../Statuses/StatusRegistryReport';
 import { i18n } from '../i18n/i18n';
+import type { TasksEvents } from '../Obsidian/TasksEvents';
 import * as Themes from './Themes';
 import {
     type HeadingState,
@@ -34,11 +35,11 @@ export class SettingsTab extends PluginSettingTab {
     private readonly plugin: TasksPlugin;
     private readonly includesSettingsUI;
 
-    constructor({ plugin }: { plugin: TasksPlugin }) {
+    constructor({ plugin, events }: { plugin: TasksPlugin; events: TasksEvents }) {
         super(plugin.app, plugin);
 
         this.plugin = plugin;
-        this.includesSettingsUI = new IncludesSettingsUI(plugin);
+        this.includesSettingsUI = new IncludesSettingsUI(plugin, events);
     }
 
     private static createFragmentWithHTML = (html: string) =>

--- a/src/Obsidian/TasksEvents.ts
+++ b/src/Obsidian/TasksEvents.ts
@@ -22,6 +22,9 @@ export class TasksEvents {
         this.obsidianEvents = obsidianEvents;
     }
 
+    // ------------------------------------------------------------------------
+    // CacheUpdate event
+
     public onCacheUpdate(handler: (cacheData: CacheUpdateData) => void): EventRef {
         this.logger.debug('TasksEvents.onCacheUpdate()');
         const name = Event.CacheUpdate;
@@ -34,6 +37,9 @@ export class TasksEvents {
         this.logger.debug('TasksEvents.triggerCacheUpdate()');
         this.obsidianEvents.trigger(Event.CacheUpdate, cacheData);
     }
+
+    // ------------------------------------------------------------------------
+    // RequestCacheUpdate event
 
     public onRequestCacheUpdate(handler: (fn: (cacheData: CacheUpdateData) => void) => void): EventRef {
         this.logger.debug('TasksEvents.onRequestCacheUpdate()');

--- a/src/Obsidian/TasksEvents.ts
+++ b/src/Obsidian/TasksEvents.ts
@@ -24,9 +24,10 @@ export class TasksEvents {
 
     public onCacheUpdate(handler: (cacheData: CacheUpdateData) => void): EventRef {
         this.logger.debug('TasksEvents.onCacheUpdate()');
+        const name = Event.CacheUpdate;
         // @ts-expect-error: error TS2345: Argument of type '(cacheData: CacheUpdateData) => void'
         // is not assignable to parameter of type '(...data: unknown[]) => unknown'.
-        return this.obsidianEvents.on(Event.CacheUpdate, handler);
+        return this.obsidianEvents.on(name, handler);
     }
 
     public triggerCacheUpdate(cacheData: CacheUpdateData): void {
@@ -36,9 +37,10 @@ export class TasksEvents {
 
     public onRequestCacheUpdate(handler: (fn: (cacheData: CacheUpdateData) => void) => void): EventRef {
         this.logger.debug('TasksEvents.onRequestCacheUpdate()');
+        const name = Event.RequestCacheUpdate;
         // @ts-expect-error: error TS2345: Argument of type '(cacheData: CacheUpdateData) => void'
         // is not assignable to parameter of type '(...data: unknown[]) => unknown'.
-        return this.obsidianEvents.on(Event.RequestCacheUpdate, handler);
+        return this.obsidianEvents.on(name, handler);
     }
 
     public triggerRequestCacheUpdate(fn: (cacheData: CacheUpdateData) => void): void {

--- a/src/Obsidian/TasksEvents.ts
+++ b/src/Obsidian/TasksEvents.ts
@@ -7,6 +7,7 @@ import type { State } from './Cache';
 enum Event {
     CacheUpdate = 'obsidian-tasks-plugin:cache-update',
     RequestCacheUpdate = 'obsidian-tasks-plugin:request-cache-update',
+    ReloadOpenSearchResults = 'obsidian-tasks-plugin:reload-open-search-results',
 }
 
 interface CacheUpdateData {
@@ -52,6 +53,20 @@ export class TasksEvents {
     public triggerRequestCacheUpdate(fn: (cacheData: CacheUpdateData) => void): void {
         this.logger.debug('TasksEvents.triggerRequestCacheUpdate()');
         this.obsidianEvents.trigger(Event.RequestCacheUpdate, fn);
+    }
+
+    // ------------------------------------------------------------------------
+    // ReloadOpenSearchResults event
+
+    public onReloadOpenSearchResults(handler: () => void): EventRef {
+        this.logger.debug('TasksEvents.onReloadOpenSearchResults()');
+        const name = Event.ReloadOpenSearchResults;
+        return this.obsidianEvents.on(name, handler);
+    }
+
+    public triggerReloadOpenSearchResults(): void {
+        this.logger.debug('TasksEvents.triggerReloadOpenSearchResults()');
+        this.obsidianEvents.trigger(Event.ReloadOpenSearchResults);
     }
 
     public off(eventRef: EventRef): void {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -112,6 +112,20 @@ export class QueryResultsRenderer {
      */
     public setTasksFile(newFile: TasksFile) {
         this._tasksFile = newFile;
+        this.rereadQueryFromFile();
+    }
+
+    /**
+     * Reads the query from the source file and tasks file.
+     *
+     * This is for when some change in the vault invalidates the current
+     * Query object, and so it needs to be reloaded.
+     *
+     * For example, the user edited their Tasks plugin settings in some
+     * way that changes how the query is interpreted, such as changing an
+     * 'includes' definition.
+     */
+    public rereadQueryFromFile() {
         this.query = this.makeQueryFromSourceAndTasksFile();
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,9 @@ export default class TasksPlugin extends Plugin {
         const { loggingOptions } = getSettings();
         logging.configure(loggingOptions);
 
-        this.addSettingTab(new SettingsTab({ plugin: this }));
+        const events = new TasksEvents({ obsidianEvents: this.app.workspace });
+
+        this.addSettingTab(new SettingsTab({ plugin: this, events }));
 
         initializeFile({
             metadataCache: this.app.metadataCache,
@@ -52,7 +54,6 @@ export default class TasksPlugin extends Plugin {
         // Load configured status types.
         await this.loadTaskStatuses();
 
-        const events = new TasksEvents({ obsidianEvents: this.app.workspace });
         this.cache = new Cache({
             metadataCache: this.app.metadataCache,
             vault: this.app.vault,

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -16,6 +16,7 @@ import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
 import { prettifyHTML } from '../TestingTools/HTMLHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { toMarkdown } from '../TestingTools/TestHelpers';
+import { resetSettings, updateSettings } from '../../src/Config/Settings';
 import { mockHTMLRenderer } from './RenderingTestHelpers';
 
 window.moment = moment;
@@ -28,6 +29,7 @@ beforeEach(() => {
 afterEach(() => {
     jest.useRealTimers();
     GlobalFilter.getInstance().reset();
+    resetSettings();
 });
 
 function makeQueryResultsRenderer(source: string, tasksFile: TasksFile) {
@@ -116,6 +118,21 @@ describe('QueryResultsRenderer - responding to file edits', () => {
 
         // Assert
         expect(renderer.query.explainQuery()).toContain('path includes newPath.md');
+    });
+
+    it('should be able to reread the query when query settings are changed', () => {
+        // Arrange
+        updateSettings({ includes: { CurrentGrouping: 'group by PATH' } });
+        const source = 'include CurrentGrouping';
+        const renderer = makeQueryResultsRenderer(source, new TasksFile('any file.md'));
+        expect(renderer.query.explainQuery()).toContain('group by PATH');
+
+        // Act
+        updateSettings({ includes: { CurrentGrouping: 'group by DUE' } });
+        renderer.rereadQueryFromFile();
+
+        // Assert
+        expect(renderer.query.explainQuery()).toContain('group by DUE');
     });
 });
 

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -105,7 +105,7 @@ ${toMarkdown(allTasks)}
 });
 
 describe('QueryResultsRenderer - responding to file edits', () => {
-    it('should update the query its file path is changed', () => {
+    it('should update the query when its file path is changed', () => {
         // Arrange
         const source = 'path includes {{query.file.path}}';
         const renderer = makeQueryResultsRenderer(source, new TasksFile('oldPath.md'));


### PR DESCRIPTION
_From @claremacrae: This is a recreation of #3462, which I squashed by mistake._

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
    - #2443 
    - #2267
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

1. This is a major improvement to the usability of the Includes feature:
    - Editing its settings now does a debounced refresh of any open search results.
    - The debounce time is currently 300ms.
2. It works by adding a new event: `'obsidian-tasks-plugin:reload-open-search-results'`
    - This may be useful later, for example in updating search results if the Global Query is edited in settings.
3. It also makes a demo file a bit easier to understand and use:
    - `resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md`.

## Motivation and Context

Wanting to release these features:

- #2443 
- #2267

See also the following, which is an earlier commit of this code, accidentally squashed, and so reverted:

- #3462

## How has this been tested?

- Added a new test for part of the change.
- Lots of manual exploratory testing in the test vault.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
