### PR TITLE
i18n: Add German translation of settings UI

### DIFF
--- a/docs/What is New/Changelog.md
+++ b/docs/What is New/Changelog.md
@@ -15,8 +15,11 @@ _In recent [Tasks releases](https://github.com/obsidian-tasks-group/obsidian-tas
 - X.Y.Z:
   - [[Line Continuations]] can now be used in the [[Query File Defaults]] property `TQ_extra_instructions`.
   - [[Check your Statuses]] report now contains samples of each status, and a convenient search to test them.
+  - Add German translation of [[Settings]], [[Editing a Status]] and [[Check your Statuses]].
 - 7.19.0:
   - New setting to [[Recurring Tasks#Remove scheduled date on recurrence|remove scheduled date on recurrence]].
+- 7.17.0:
+  - Add Belarusian, Russian, and Ukrainian translations of [[Settings]], [[Editing a Status]] and [[Check your Statuses]].
 - 7.16.0:
   - Add `task.lineNumber`.
     - This enables `sort by function task.lineNumber` to override the [[Sorting#Default sort order|default sort order]].

--- a/i18next-parser.config.js
+++ b/i18next-parser.config.js
@@ -4,6 +4,7 @@ module.exports = {
     locales: [
         // Supported locales, in alphabetical order
         'be',
+        'de',
         'en',
         'ru',
         'uk',

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,5 +1,6 @@
 import i18next from 'i18next';
 import be from './locales/be.json';
+import de from './locales/de.json';
 import en from './locales/en.json';
 import ru from './locales/ru.json';
 import uk from './locales/uk.json';
@@ -26,6 +27,7 @@ export const initializeI18n = async () => {
             resources: {
                 // alphabetical order:
                 be: { translation: be }, // Belarusian
+                de: { translation: de }, // German
                 en: { translation: en }, // English
                 ru: { translation: ru }, // Russian
                 uk: { translation: uk }, // Ukrainian

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -223,7 +223,7 @@
       "coreStatuses": {
         "buttons": {
           "checkStatuses": {
-            "name": "Überprüfen und Status kontrollieren",
+            "name": "Überprüfen und einsehen Sie Ihre Status-Einträge",
             "tooltip": "Erstellen Sie eine neue Datei im Hauptverzeichnis des Tresors, die ein Mermaid-Diagramm der aktuellen Statuseinstellungen enthält."
           }
         },

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1,259 +1,259 @@
 {
   "main": {
-    "loadingPlugin": "",
-    "unloadingPlugin": ""
+    "loadingPlugin": "Lade Plugin: {{name}} v{{version}}",
+    "unloadingPlugin": "Entlade Plugin: {{name}} v{{version}}"
   },
   "modals": {
     "customStatusModal": {
       "editAvailableAsCommand": {
-        "description": "",
-        "name": ""
+        "description": "WennBei Aktivierung können Sie diesen Status als Befehl nutzen und ihm eine Tastenkombination zuordnen, um den Status umzuschalten.",
+        "name": "Verfügbar als Befehl"
       },
       "editNextStatusSymbol": {
-        "description": "",
-        "name": ""
+        "description": "Bei Klick verwenden Sie dies als das nächstverwendete Symbol.",
+        "name": "Symbol für nächsten Status"
       },
       "editStatusName": {
-        "description": "",
-        "name": ""
+        "description": "Der Anzeigename des Aufgabenstatus.",
+        "name": "Name des Aufgabenstatus"
       },
       "editStatusSymbol": {
-        "description": "",
-        "name": ""
+        "description": "Das Zeichen zwischen den eckigen Klammern. (Sie können es nur für benutzerdefinierte Status bearbeiten, nicht für Kernstatus.)",
+        "name": "Symbol des Aufgabenstatus"
       },
       "editStatusType": {
-        "description": "",
-        "name": ""
+        "description": "Kontrollieren Sie, wie der Status beim Suchen und Umschalten funktioniert.",
+        "name": "Typ des Aufgabenstatus"
       },
-      "fixErrorsBeforeSaving": ""
+      "fixErrorsBeforeSaving": "Fehler vor dem Speichern beheben."
     }
   },
   "reports": {
     "statusRegistry": {
       "about": {
-        "createdBy": "",
-        "deleteFileAnyTime": "",
-        "title": "",
+        "createdBy": "Ich habe diese Datei mit dem Obsidian Tasks-Plugin (Version {{version}}) erstellt, um die Aufgabenstatus in diesem Vault zu visualisieren.",
+        "deleteFileAnyTime": "Sie können diese Datei jederzeit löschen.",
+        "title": "Über diese Datei",
         "updateReport": {
-          "line1": "",
-          "line2": "",
-          "line3": ""
+          "line1": "Wenn Sie die Tasks-Status-Einstellungen ändern, erhalten Sie einen aktualisierten Bericht, indem Sie:",
+          "line2": "Zu `Einstellungen` -> `Tasks` gehen.",
+          "line3": "Auf `Überprüfen und Status kontrollieren` klicken."
         }
       },
       "columnHeadings": {
-        "nextStatusSymbol": "",
-        "problems": "",
-        "statusName": "",
-        "statusSymbol": "",
-        "statusType": ""
+        "nextStatusSymbol": "Nächstes Status-Symbol",
+        "problems": "Probleme (falls vorhanden)",
+        "statusName": "Statusname",
+        "statusSymbol": "Statussymbol",
+        "statusType": "Statustyp"
       },
       "loadedSettings": {
-        "settingsActuallyUsed": "",
-        "switchToLivePreview": "",
-        "title": ""
+        "settingsActuallyUsed": "Dies sind die aktuellen Einstellungen, die Tasks verwendet.",
+        "switchToLivePreview": "Wechseln Sie zur Live-Vorschau oder zum Lesemodus, um das Diagramm zu sehen.",
+        "title": "Geladene Einstellungen"
       },
       "messages": {
-        "cannotFindNextStatus": "",
-        "duplicateSymbol": "",
-        "emptySymbol": "",
-        "nextSymbolUnknown": "",
-        "notConventionalType": "",
+        "cannotFindNextStatus": "Ich konnte den nächsten Status nicht finden.",
+        "duplicateSymbol": "Doppeltes Symbol '{{symbol}}': Plugin ignoriert diesen Status.",
+        "emptySymbol": "Leeres Symbol: Plugin ignoriert diesen Status.",
+        "nextSymbolUnknown": "Nächstes Symbol {{symbol}} ist unbekannt: Erstellen Sie einen Status mit dem Symbol {{symbol}}.",
+        "notConventionalType": "Zur Information: Der übliche Typ für das Status-Symbol {{symbol}} ist {{type}}. Überprüfen Sie diesen Typ gegebenenfalls.",
         "wrongTypeAfterDone": {
-          "line1": "",
-          "line2": "",
-          "line3": ""
+          "line1": "Dieser `ERLEDIGT`-Status folgt {{nextType}}, nicht `TODO` oder `IN_PROGRESS`.",
+          "line2": "Wenn Sie diesen Status verwenden, um eine wiederkehrende Aufgabe abzuschließen, folgt darauf `TODO` oder `IN_PROGRESS`, um sicherzustellen, dass die nächste Aufgabe dem `nicht erledigt`-Filter entspricht.",
+          "line3": "Siehe [Wiederkehrende Aufgaben und benutzerdefinierte Status]({{helpURL}})."
         }
       },
       "sampleTasks": {
-        "line1": "",
-        "line2": "",
-        "line3": "",
+        "line1": "Hier ist eine Beispiel-Aufgabenzeile für jeden von Tasks tatsächlich genutzten Status, mit der Sie experimentieren können.",
+        "line2": "Zu dem Zeitpunkt, zu dem ich diese Datei erstellt habe, waren die Status-Symbole und Namen in den Aufgabentexten korrekt.",
+        "line3": "Wenn Sie die Beispielaufgaben geändert haben, sehen Sie die aktuellen Statustypen und Namen in den Gruppenüberschriften in der Tasks-Suche unten.",
         "tip": {
-          "line1": "",
-          "line2": ""
+          "line1": "Tipp: Wenn alle Ihre Kontrollkästchen gleich aussehen...",
+          "line2": "Wenn Ihre Kontrollkästchen im Lesemodus oder in der Live-Vorschau gleich aussehen, informieren Sie sich unter [Benutzerdefinierte Statusstile]({{url}}), wie Sie ein Theme oder ein CSS-Snippet auswählen können, um Ihre Status zu formatieren."
         },
-        "title": ""
+        "title": "Beispielaufgaben"
       },
       "searchSampleTasks": {
-        "line1": "",
-        "title": ""
+        "line1": "Diese Tasks-Suche zeigt alle Aufgaben in dieser Datei an, gruppiert nach ihrem Statustyp und Statusnamen.",
+        "title": "Suche in den Beispielaufgaben"
       },
       "statusSettings": {
         "comment": {
-          "line1": "",
-          "line2": "",
-          "line3": ""
+          "line1": "Wechseln Sie zur Live-Vorschau oder zum Lesemodus, um die Tabelle zu sehen.",
+          "line2": "Wenn in Statusnamen Markdown-Formatierungszeichen wie '*' oder '_' enthalten sind,",
+          "line3": "stellt Obsidian die Tabelle möglicherweise nur im Lesemodus korrekt dar."
         },
-        "theseAreStatusValues": "",
-        "title": ""
+        "theseAreStatusValues": "Diese Statuswerte finden Sie in den Abschnitten Kern- und Benutzerdefinierte Status.",
+        "title": "Status-Einstellungen"
       }
     }
   },
   "settings": {
     "autoSuggest": {
-      "heading": "",
+      "heading": "Autosuggest",
       "maxSuggestions": {
-        "description": "",
-        "name": ""
+        "description": "Wie viele Vorschläge möchten Sie anzeigen, wenn ein Autosuggest-Menü aufgeht (einschließlich der \"⏎\"-Option).",
+        "name": "Maximale Anzahl von Autosuggest-Vorschlägen anzeigen"
       },
       "minLength": {
-        "description": "",
-        "name": ""
+        "description": "Wenn größer als 0, löst Autosuggest nur aus, wenn Sie den Beginn eines unterstützten Schlüsselwortes erkennen.",
+        "name": "Minimale Übereinstimmungslänge für Autosuggest"
       },
       "toggle": {
-        "description": "",
-        "name": ""
+        "description": "Durch Aktivierung öffnet sich ein intelligentes Vorschlagsmenü, während Sie innerhalb einer erkannten Aufgabenzeile tippen.",
+        "name": "Aufgabentext automatisch vorschlagen"
       }
     },
-    "changeRequiresRestart": "",
+    "changeRequiresRestart": "Das Ändern von Einstellungen erfordert einen Neustart von Obsidian.",
     "dates": {
       "cancelledDate": {
-        "description": "",
-        "name": ""
+        "description": "Wenn aktiviert, füge beim Umschalten auf 'abgebrochen' automatisch ein Datum ❌ YYYY-MM-DD am Ende hinzu.",
+        "name": "Abbruch-Datum bei jeder abgebrochenen Aufgabe festlegen"
       },
       "createdDate": {
-        "description": "",
-        "name": ""
+        "description": "Füge bei Aktivierung beim Erstellen einer Aufgabe mit 'Erstellen oder Bearbeiten einer Aufgabe' oder beim Abschluss einer wiederkehrenden Aufgabe ein Datum ➕ YYYY-MM-DD vor anderen Datumswerten hinzu.",
+        "name": "Erstellungsdatum bei jeder hinzugefügten Aufgabe festlegen"
       },
       "doneDate": {
-        "description": "",
-        "name": ""
+        "description": "Bei Aktivierung wird beim Umschalten auf 'erledigt' automatisch ein Datum ✅ YYYY-MM-DD am Ende hinzugefügt.",
+        "name": "Erledigungsdatum bei jeder abgeschlossenen Aufgabe festlegen"
       },
-      "heading": ""
+      "heading": "Daten"
     },
     "datesFromFileNames": {
-      "heading": "",
+      "heading": "Daten aus Dateinamen",
       "scheduledDate": {
         "extraFormat": {
           "description": {
-            "line1": "",
-            "line2": ""
+            "line1": "Ein zusätzliches Datumsformat, das das Tasks-Plugin beim Verwenden des Dateinamens als geplantes Datum für undatierte Aufgaben erkennt.",
+            "line2": "Syntax-Referenz"
           },
-          "name": "",
-          "placeholder": ""
+          "name": "Zusätzliches Datumsformat für Dateinamen als geplantes Datum für undatierte Aufgaben",
+          "placeholder": "Beispiel: MMM DD YYYY"
         },
         "folders": {
-          "description": "",
-          "name": ""
+          "description": "Lassen Sie dieses Feld leer, wenn Sie standardmäßige geplante Datumsangaben überall verwenden wollen, oder geben Sie eine durch Kommas getrennte Liste von Ordnern ein.",
+          "name": "Ordner mit standardmäßigen geplanten Datumsangaben"
         },
         "toggle": {
           "description": {
-            "line1": "",
-            "line2": "",
-            "line3": "",
-            "line4": ""
+            "line1": "Sparen Sie Zeit beim Eingeben geplanter (⏳) Daten.",
+            "line2": "Bei Aktivierung erhalten alle undatierten Aufgaben ein geplantes Datum, das aus ihrem Dateinamen extrahiert wird.",
+            "line3": "Standardmäßig erkennt das Tasks-Plugin sowohl <code>YYYY-MM-DD</code> als auch <code>YYYYMMDD</code> Datumsformate.",
+            "line4": "Undatierte Aufgaben haben weder ein Fälligkeitsdatum (📅 ), geplantes (⏳) noch Start-(🛫)datum."
           },
-          "name": ""
+          "name": "Dateinamen als geplantes Datum für undatierte Aufgaben verwenden"
         }
       }
     },
     "dialogs": {
       "accessKeys": {
-        "description": "",
-        "name": ""
+        "description": "Wenn die Zugriffsschlüssel (Tastenkombinationen) für verschiedene Steuerelemente in Dialogfeldern in Konflikt mit System-Tastenkombinationen oder wichtigen assistiven Funktionen stehen, deaktivieren Sie sie hier.",
+        "name": "Zugriffsschlüssel in Dialogen bereitstellen"
       },
-      "heading": ""
+      "heading": "Dialoge"
     },
     "format": {
       "description": {
-        "line1": "",
-        "line2": ""
+        "line1": "Das Format, das Tasks zum Lesen und Schreiben von Aufgaben verwendet.",
+        "line2": "<b>Wichtig:</b> Tasks unterstützt gleichzeitig nur ein Format. Wenn Sie Dataview auswählen, hindert dies Tasks daran, seine eigenen Emoji-Anzeiger zu verwenden."
       },
       "displayName": {
-        "dataview": "",
-        "tasksEmojiFormat": ""
+        "dataview": "Dataview",
+        "tasksEmojiFormat": "Tasks Emoji Format"
       },
-      "name": ""
+      "name": "Aufgabenformat"
     },
     "globalFilter": {
       "filter": {
         "description": {
-          "line1": "",
-          "line2": "",
-          "line3": "",
-          "line4": ""
+          "line1": "Empfehlung: Lassen Sie dieses Feld leer, damit das Plugin alle Kontrollkästchen in Ihrem Tresor als Aufgaben verwalten kann.",
+          "line2": "Verwenden Sie einen globalen Filter, wenn Tasks nur auf einen Teil Ihrer \"<code>- [ ]</code>\" Kontrollkästchenitems wirken soll. Sorgen Sie dafür, dass ein Kontrollkästchenitem die angegebene Zeichenfolge in seiner Beschreibung enthält, um als Aufgabe betrachtet zu werden.",
+          "line3": "Setzen Sie den globalen Filter z. B. auf <code>#task</code>, verwaltet Tasks nur die mit <code>#task</code> gekennzeichneten Kontrollkästchenitems.",
+          "line4": "Andere Kontrollkästchenitems bleiben normale Kontrollkästchen und erscheinen nicht in Abfragen und erhalten kein Erledigungsdatum."
         },
-        "name": "",
-        "placeholder": ""
+        "name": "Globaler Filter",
+        "placeholder": "z.B. #task oder TODO"
       },
-      "heading": "",
+      "heading": "Globaler Aufgabenfilter",
       "removeFilter": {
-        "description": "",
-        "name": ""
+        "description": "Aktiviert entfernt die Zeichenfolge, die Sie als globalen Filter gesetzt haben, aus der Aufgabenbeschreibung, wenn die Aufgabe angezeigt wird.",
+        "name": "Globalen Filter aus Beschreibung entfernen"
       }
     },
     "globalQuery": {
-      "heading": "",
+      "heading": "Globale Abfrage",
       "query": {
-        "description": "",
-        "placeholder": ""
+        "description": "Fügen Sie automatisch eine Abfrage am Anfang jedes Tasks-Blocks im Tresor hinzu. Nützlich für Standardfilter oder Layout-Optionen.",
+        "placeholder": "Zum Beispiel...\npath does not include _templates/\nlimit 300\nshow urgency"
       }
     },
     "recurringTasks": {
-      "heading": "",
+      "heading": "Wiederkehrende Aufgaben",
       "nextLine": {
-        "description": "",
-        "name": ""
+        "description": "Aktivieren Sie dies, damit das nächste Auftreten einer Aufgabe in der Zeile unterhalb der abgeschlossenen Aufgabe erscheint. Ansonsten erscheint es vor der abgeschlossenen Aufgabe.",
+        "name": "Nächste Wiederholung erscheint in Zeile darunter"
       },
       "removeScheduledDate": {
         "description": {
-          "line1": "",
-          "line2": ""
+          "line1": "Aktiviert, damit das nächste Auftreten einer Aufgabe keinen geplanten (⏳) Termin hat, wenn mindestens Start-(🛫) oder Fälligkeitsdaten (📅) vorhanden sind.",
+          "line2": "Dies gilt, wenn Sie möchten, dass Start- und Fälligkeitsdaten beim nächsten Auftreten beibehalten werden, aber das geplante Datum später festgelegt wird, sobald Sie planen, daran zu arbeiten."
         },
-        "name": ""
+        "name": "Geplantes Datum bei Wiederholung entfernen"
       }
     },
-    "seeTheDocumentation": "",
+    "seeTheDocumentation": "Vgl. die Dokumentation",
     "statuses": {
       "collections": {
-        "anuppuccinTheme": "",
-        "auraTheme": "",
-        "borderTheme": "",
+        "anuppuccinTheme": "AnuPpuccin Theme",
+        "auraTheme": "Aura Theme",
+        "borderTheme": "Border Theme",
         "buttons": {
           "addCollection": {
-            "name": ""
+            "name": "{{themeName}}: Füge {{numberOfStatuses}} unterstützte Status hinzu"
           }
         },
-        "ebullientworksTheme": "",
-        "itsThemeAndSlrvbCheckboxes": "",
-        "lytModeTheme": "",
-        "minimalTheme": "",
-        "thingsTheme": ""
+        "ebullientworksTheme": "Ebullientworks Theme",
+        "itsThemeAndSlrvbCheckboxes": "ITS Theme & SlRvb Kontrollkästchen",
+        "lytModeTheme": "LYT Mode Theme (nur Dunkelmodus)",
+        "minimalTheme": "Minimal Theme",
+        "thingsTheme": "Things Theme"
       },
       "coreStatuses": {
         "buttons": {
           "checkStatuses": {
-            "name": "",
-            "tooltip": ""
+            "name": "Überprüfen und Status kontrollieren",
+            "tooltip": "Erstellen Sie eine neue Datei im Hauptverzeichnis des Tresors, die ein Mermaid-Diagramm der aktuellen Statuseinstellungen enthält."
           }
         },
         "description": {
-          "line1": "",
-          "line2": ""
+          "line1": "Diese Kern-Status unterstützt Tasks nativ ohne benutzerdefiniertes CSS-Styling oder Themes.",
+          "line2": "Hinzufügen und Bearbeiten Ihrer eigenen benutzerdefinierten Status können Sie im unteren Abschnitt."
         },
-        "heading": ""
+        "heading": "Kern-Status"
       },
       "customStatuses": {
         "buttons": {
           "addAllUnknown": {
-            "name": ""
+            "name": "Alle unbekannten Statustypen hinzufügen"
           },
           "addNewStatus": {
-            "name": ""
+            "name": "Neuen Aufgabenstatus hinzufügen"
           },
           "resetCustomStatuses": {
-            "name": ""
+            "name": "Benutzerdefinierte Statustypen auf Standard zurücksetzen"
           }
         },
         "description": {
-          "line1": "",
-          "line2": "",
-          "line3": "",
-          "line4": ""
+          "line1": "Zuerst wählen und installieren Sie ein CSS-Snippet oder Theme, um benutzerdefinierte Kontrollkästchen zu formatieren.",
+          "line2": "Verwenden Sie dann die untenstehenden Schaltflächen, um Ihre benutzerdefinierten Status zu erstellen, sodass sie mit Ihren ausgewählten CSS-Kontrollkästchen übereinstimmen.",
+          "line3": "Hinweis: Status mit dem gleichen Symbol wie ein früherer Status ignorieren wir. Bestätigen Sie die tatsächlich geladenen Status, indem Sie den 'Aufgabe erstellen oder bearbeiten'-Befehl ausführen und das Status-Dropdown anschauen.",
+          "line4": "Nutzen Sie die Dokumentation, um loszulegen!"
         },
-        "heading": ""
+        "heading": "Benutzerdefinierte Status"
       },
-      "heading": ""
+      "heading": "Aufgabenstatus"
     }
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1,0 +1,259 @@
+{
+  "main": {
+    "loadingPlugin": "",
+    "unloadingPlugin": ""
+  },
+  "modals": {
+    "customStatusModal": {
+      "editAvailableAsCommand": {
+        "description": "",
+        "name": ""
+      },
+      "editNextStatusSymbol": {
+        "description": "",
+        "name": ""
+      },
+      "editStatusName": {
+        "description": "",
+        "name": ""
+      },
+      "editStatusSymbol": {
+        "description": "",
+        "name": ""
+      },
+      "editStatusType": {
+        "description": "",
+        "name": ""
+      },
+      "fixErrorsBeforeSaving": ""
+    }
+  },
+  "reports": {
+    "statusRegistry": {
+      "about": {
+        "createdBy": "",
+        "deleteFileAnyTime": "",
+        "title": "",
+        "updateReport": {
+          "line1": "",
+          "line2": "",
+          "line3": ""
+        }
+      },
+      "columnHeadings": {
+        "nextStatusSymbol": "",
+        "problems": "",
+        "statusName": "",
+        "statusSymbol": "",
+        "statusType": ""
+      },
+      "loadedSettings": {
+        "settingsActuallyUsed": "",
+        "switchToLivePreview": "",
+        "title": ""
+      },
+      "messages": {
+        "cannotFindNextStatus": "",
+        "duplicateSymbol": "",
+        "emptySymbol": "",
+        "nextSymbolUnknown": "",
+        "notConventionalType": "",
+        "wrongTypeAfterDone": {
+          "line1": "",
+          "line2": "",
+          "line3": ""
+        }
+      },
+      "sampleTasks": {
+        "line1": "",
+        "line2": "",
+        "line3": "",
+        "tip": {
+          "line1": "",
+          "line2": ""
+        },
+        "title": ""
+      },
+      "searchSampleTasks": {
+        "line1": "",
+        "title": ""
+      },
+      "statusSettings": {
+        "comment": {
+          "line1": "",
+          "line2": "",
+          "line3": ""
+        },
+        "theseAreStatusValues": "",
+        "title": ""
+      }
+    }
+  },
+  "settings": {
+    "autoSuggest": {
+      "heading": "",
+      "maxSuggestions": {
+        "description": "",
+        "name": ""
+      },
+      "minLength": {
+        "description": "",
+        "name": ""
+      },
+      "toggle": {
+        "description": "",
+        "name": ""
+      }
+    },
+    "changeRequiresRestart": "",
+    "dates": {
+      "cancelledDate": {
+        "description": "",
+        "name": ""
+      },
+      "createdDate": {
+        "description": "",
+        "name": ""
+      },
+      "doneDate": {
+        "description": "",
+        "name": ""
+      },
+      "heading": ""
+    },
+    "datesFromFileNames": {
+      "heading": "",
+      "scheduledDate": {
+        "extraFormat": {
+          "description": {
+            "line1": "",
+            "line2": ""
+          },
+          "name": "",
+          "placeholder": ""
+        },
+        "folders": {
+          "description": "",
+          "name": ""
+        },
+        "toggle": {
+          "description": {
+            "line1": "",
+            "line2": "",
+            "line3": "",
+            "line4": ""
+          },
+          "name": ""
+        }
+      }
+    },
+    "dialogs": {
+      "accessKeys": {
+        "description": "",
+        "name": ""
+      },
+      "heading": ""
+    },
+    "format": {
+      "description": {
+        "line1": "",
+        "line2": ""
+      },
+      "displayName": {
+        "dataview": "",
+        "tasksEmojiFormat": ""
+      },
+      "name": ""
+    },
+    "globalFilter": {
+      "filter": {
+        "description": {
+          "line1": "",
+          "line2": "",
+          "line3": "",
+          "line4": ""
+        },
+        "name": "",
+        "placeholder": ""
+      },
+      "heading": "",
+      "removeFilter": {
+        "description": "",
+        "name": ""
+      }
+    },
+    "globalQuery": {
+      "heading": "",
+      "query": {
+        "description": "",
+        "placeholder": ""
+      }
+    },
+    "recurringTasks": {
+      "heading": "",
+      "nextLine": {
+        "description": "",
+        "name": ""
+      },
+      "removeScheduledDate": {
+        "description": {
+          "line1": "",
+          "line2": ""
+        },
+        "name": ""
+      }
+    },
+    "seeTheDocumentation": "",
+    "statuses": {
+      "collections": {
+        "anuppuccinTheme": "",
+        "auraTheme": "",
+        "borderTheme": "",
+        "buttons": {
+          "addCollection": {
+            "name": ""
+          }
+        },
+        "ebullientworksTheme": "",
+        "itsThemeAndSlrvbCheckboxes": "",
+        "lytModeTheme": "",
+        "minimalTheme": "",
+        "thingsTheme": ""
+      },
+      "coreStatuses": {
+        "buttons": {
+          "checkStatuses": {
+            "name": "",
+            "tooltip": ""
+          }
+        },
+        "description": {
+          "line1": "",
+          "line2": ""
+        },
+        "heading": ""
+      },
+      "customStatuses": {
+        "buttons": {
+          "addAllUnknown": {
+            "name": ""
+          },
+          "addNewStatus": {
+            "name": ""
+          },
+          "resetCustomStatuses": {
+            "name": ""
+          }
+        },
+        "description": {
+          "line1": "",
+          "line2": "",
+          "line3": "",
+          "line4": ""
+        },
+        "heading": ""
+      },
+      "heading": ""
+    }
+  }
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -59,7 +59,7 @@
         "nextSymbolUnknown": "Nächstes Symbol {{symbol}} ist unbekannt: Erstellen Sie einen Status mit dem Symbol {{symbol}}.",
         "notConventionalType": "Zur Information: Der übliche Typ für das Status-Symbol {{symbol}} ist {{type}}. Überprüfen Sie diesen Typ gegebenenfalls.",
         "wrongTypeAfterDone": {
-          "line1": "Dieser `ERLEDIGT`-Status folgt {{nextType}}, nicht `TODO` oder `IN_PROGRESS`.",
+          "line1": "Nach diesem `ERLEDIGT`-Status folgt {{nextType}}, nicht `TODO` oder `IN_PROGRESS`.",
           "line2": "Wenn Sie diesen Status verwenden, um eine wiederkehrende Aufgabe abzuschließen, folgt darauf `TODO` oder `IN_PROGRESS`, um sicherzustellen, dass die nächste Aufgabe dem `nicht erledigt`-Filter entspricht.",
           "line3": "Siehe [Wiederkehrende Aufgaben und benutzerdefinierte Status]({{helpURL}})."
         }


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Translation** (prefix: `i18n` - additions or improvements to the translations - see [Support a new language](https://publish.obsidian.md/tasks-contributing/Translation/Support+a+new+language))

## Description

Add German translation of settings UI.

This translation was contributed by @i-am-the-slime - thank you!

## Motivation and Context

Help German users edit their Tasks settings

## How has this been tested?

I got Claude.ai to translate it back to English, and did a quick visual inspection of the differences from the original English strings.

I also built the plugin and set Obsidian to German, to confirm that the settings were displayed in German.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
