### PR TITLE
fix: Includes settings now work on mobile and narrow windows

### DIFF
--- a/src/Config/IncludesSettingsUI.scss
+++ b/src/Config/IncludesSettingsUI.scss
@@ -51,10 +51,15 @@
                 border-radius: 4px !important;
 
                 .tasks-includes-key {
+                    // Make the Name input field full-width.
+                    // The value textarea will take up most of the width, with the Delete button to its right.
                     width: 100%;
                 }
+            }
 
+            @container (max-width: 500px) {
                 .tasks-includes-value {
+                    // Make the Value textarea full-width, forcing the Delete button on to the third row.
                     width: 100%;
                     min-width: 0;
                 }

--- a/src/Config/IncludesSettingsUI.scss
+++ b/src/Config/IncludesSettingsUI.scss
@@ -48,12 +48,4 @@
             align-items: unset;
         }
     }
-
-    // Responsive: Stack vertically on narrow screens (does not work)
-    @media (max-width: 600px) {
-        .tasks-includes-setting.setting-item {
-            flex-direction: column;
-            align-items: stretch;
-        }
-    }
 }

--- a/src/Config/IncludesSettingsUI.scss
+++ b/src/Config/IncludesSettingsUI.scss
@@ -46,6 +46,20 @@
         // Control alignment adjustment
         .setting-item-control {
             align-items: unset;
+
+            // Force wrapping behavior on narrow screens
+            @container (max-width: 600px) {
+                flex-wrap: wrap;
+
+                .tasks-includes-key {
+                    width: 100%;
+                }
+
+                .tasks-includes-value {
+                    width: 100%;
+                    min-width: 0;
+                }
+            }
         }
     }
 }

--- a/src/Config/IncludesSettingsUI.scss
+++ b/src/Config/IncludesSettingsUI.scss
@@ -10,15 +10,6 @@
 
     // Individual setting row
     .tasks-includes-setting {
-        &.setting-item {
-            // Layout: horizontal flex with wrap
-            display: flex;
-            align-items: flex-start;
-            gap: 1em;
-            flex-wrap: wrap;
-            width: 100%;
-        }
-
         // Name input field (left column)
         .tasks-includes-key {
             width: 200px;

--- a/src/Config/IncludesSettingsUI.scss
+++ b/src/Config/IncludesSettingsUI.scss
@@ -36,13 +36,6 @@
             white-space: pre;        // Preserve formatting
         }
 
-        // Hide empty info sections
-        .setting-item-info {
-            &:has(.setting-item-name:empty):has(.setting-item-description:empty) {
-                display: none;
-            }
-        }
-
         // Control alignment adjustment
         .setting-item-control {
             align-items: unset;

--- a/src/Config/IncludesSettingsUI.scss
+++ b/src/Config/IncludesSettingsUI.scss
@@ -51,6 +51,12 @@
             @container (max-width: 500px) {
                 flex-wrap: wrap;
 
+                // Put a border around the elements for each Include, to make structure easier
+                // to see when in single-column mode.
+                border: 1px solid var(--background-modifier-border) !important;
+                padding: 0.5em !important;
+                border-radius: 4px !important;
+
                 .tasks-includes-key {
                     width: 100%;
                 }

--- a/src/Config/IncludesSettingsUI.scss
+++ b/src/Config/IncludesSettingsUI.scss
@@ -48,7 +48,7 @@
             align-items: unset;
 
             // Force wrapping behavior on narrow screens
-            @container (max-width: 600px) {
+            @container (max-width: 500px) {
                 flex-wrap: wrap;
 
                 .tasks-includes-key {

--- a/src/Config/IncludesSettingsUI.scss
+++ b/src/Config/IncludesSettingsUI.scss
@@ -48,7 +48,7 @@
             align-items: unset;
 
             // Force wrapping behavior on narrow screens
-            @container (max-width: 500px) {
+            @container (max-width: 600px) {
                 flex-wrap: wrap;
 
                 // Put a border around the elements for each Include, to make structure easier

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -134,6 +134,10 @@ export class IncludesSettingsUI {
                     await this.saveIncludesSettings(updatedIncludes, settings, refreshView);
                 });
         });
+
+        // We are not providing any information about this setting, so delete it to prevent
+        // using up screen width.
+        setting.infoEl.remove();
     }
 
     /**


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: Preparing to release features for:
    - #2443 
    - #2267

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

Adjust the Includes settings to work on narrow screens.

## Motivation and Context

Trying to get the code releasable for:

- #2443 
- #2267

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

- By building and running the plugin locally on Mac
- By using device emulation on the Dev tools, using the Theme Design Utility Plugin's 'Toggle mobile emulation' command

## Screenshots (if appropriate)

### iPhone 12 Pro

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/80ad4702-e642-4f2f-94b5-45b0032b4c82)  |     ![image](https://github.com/user-attachments/assets/b02ae09e-62c0-4835-aee3-61831fb40b29) | 

### iPad mini

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ed6b1957-26b4-4df6-97f9-4002f9e3896c) |  ![image](https://github.com/user-attachments/assets/88619a35-6775-45c1-a497-285a44252c2c)   | 



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
