### PR TITLE
feat: arrange the delete button in the includes settings

### DIFF
--- a/src/Config/IncludesSettingsUI.scss
+++ b/src/Config/IncludesSettingsUI.scss
@@ -12,8 +12,7 @@
     .tasks-includes-setting {
         // Name input field (left column)
         .tasks-includes-key {
-            width: 200px;
-            flex-shrink: 0;
+            grid-column: 1;
 
             // Error state styling
             &.has-error {
@@ -24,7 +23,7 @@
 
         // Value textarea (right column)
         .tasks-includes-value {
-            flex-grow: 1;
+            grid-column: 2;
             min-width: 300px;
             min-height: 3em;
             font-family: var(--font-monospace);
@@ -36,14 +35,20 @@
             white-space: pre;        // Preserve formatting
         }
 
+        .tasks-includes-delete-button {
+            grid-column: 3;
+        }
+
         // Control alignment adjustment
         .setting-item-control {
+            justify-content: start;
+            display: grid;
+            grid-template-columns: 200px 1fr auto;
+
             align-items: unset;
 
             // Force wrapping behavior on narrow screens
             @container (max-width: 600px) {
-                flex-wrap: wrap;
-
                 // Put a border around the elements for each Include, to make structure easier
                 // to see when in single-column mode.
                 border: 1px solid var(--background-modifier-border) !important;

--- a/src/Config/IncludesSettingsUI.scss
+++ b/src/Config/IncludesSettingsUI.scss
@@ -12,7 +12,7 @@
     .tasks-includes-setting {
         // Name input field (left column)
         .tasks-includes-key {
-            grid-column: 1;
+            grid-area: key;
 
             // Error state styling
             &.has-error {
@@ -23,7 +23,8 @@
 
         // Value textarea (right column)
         .tasks-includes-value {
-            grid-column: 2;
+            grid-area: value;
+
             min-width: 300px;
             min-height: 3em;
             font-family: var(--font-monospace);
@@ -36,7 +37,7 @@
         }
 
         .tasks-includes-delete-button {
-            grid-column: 3;
+            grid-area: delete;
         }
 
         // Control alignment adjustment
@@ -44,11 +45,17 @@
             justify-content: start;
             display: grid;
             grid-template-columns: 200px 1fr auto;
+            grid-template-areas: "key value delete";
 
             align-items: unset;
 
             // Force wrapping behavior on narrow screens
             @container (max-width: 600px) {
+                grid-template-columns: 5fr 1fr;
+                grid-template-areas:
+                  "key delete"
+                  "value value";
+
                 // Put a border around the elements for each Include, to make structure easier
                 // to see when in single-column mode.
                 border: 1px solid var(--background-modifier-border) !important;

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -127,6 +127,7 @@ export class IncludesSettingsUI {
 
         // Add delete button
         setting.addExtraButton((btn) => {
+            btn.extraSettingsEl.addClass('tasks-includes-delete-button');
             btn.setIcon('cross')
                 .setTooltip('Delete')
                 .onClick(async () => {


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: settings for #2443 

## Description

- Delete button is now well positioned on all screen sizes (always on the right, even on smaller screen sizes, where the position of the key-value inputs is vertical

## Motivation and Context

- Improve UI for #2443

## How has this been tested?

- Build + manual test in demo vault

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - CSS and settings code not covered by tests

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
