### PR TITLE
fix: Suppress Tasks Auto-Suggest in Task-Board plugin modal (#3475)

### DIFF
--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -47,7 +47,7 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
         if (!this.settings.autoSuggestInEditor) return null;
 
         if (_file === undefined) {
-            // We won't be able to save any changes, tell Obsidian that we cannot make suggestions.
+            // We won't be able to save any changes, so tell Obsidian that we cannot make suggestions.
             // This allows other plugins, such as Natural Language Dates, to have the opportunity
             // to make suggestions.
             return null;

--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -45,6 +45,14 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
 
     onTrigger(cursor: EditorPosition, editor: Editor, _file: TFile): EditorSuggestTriggerInfo | null {
         if (!this.settings.autoSuggestInEditor) return null;
+
+        if (_file === undefined) {
+            // We won't be able to save any changes, tell Obsidian that we cannot make suggestions.
+            // This allows other plugins, such as Natural Language Dates, to have the opportunity
+            // to make suggestions.
+            return null;
+        }
+
         const line = editor.getLine(cursor.line);
         if (canSuggestForLine(line, cursor, editor)) {
             return {

--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -60,6 +60,13 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
     }
 
     getSuggestions(context: EditorSuggestContext): SuggestInfoWithContext[] {
+        if (context.file === undefined) {
+            // If the editor isn't a real file, we won't be able to locate
+            // the task line where the cursor is, so won't be able to make any
+            // suggestions:
+            return [] as SuggestInfoWithContext[];
+        }
+
         const line = context.query;
         const currentCursor = context.editor.getCursor();
         const allTasks = this.plugin.getTasks();


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
  - Issue/discussion: #3475

## Description

1. Fix issue #3475, that Tasks caused a console error message in the Task Board plugin's 'Add new task' modal
2. Fix related issue, found in testing: 
    - If the other plugin does not supply a `TFile` to `onTrigger()`, then confirm that Tasks cannot offer suggestions.
    - This enables the Natural Language Dates plugin's `@today` and similar to work inside the Task-Board plugin's `Add new task` modal when Tasks is installed.

## Motivation and Context

Fix #3475.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

- By following the reproduction steps in #3475
- By confirming that Auto-Suggest still works in the test vault
- By testing that the Natural Language Dates plugin works inside the Task-Board plugin's 'Add New Task' modal when Tasks is installed, with suggestions enabled.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
