### PR TITLE
feat!!: Rename 'include' facility to 'preset'

### DIFF
--- a/contributing/Architecture Decisions/ADR-001 - Nomenclature for Reusable Instruction Blocks Feature.md
+++ b/contributing/Architecture Decisions/ADR-001 - Nomenclature for Reusable Instruction Blocks Feature.md
@@ -1,0 +1,92 @@
+---
+publish: true
+---
+
+# ADR-001 - Nomenclature for Reusable Instruction Blocks Feature
+
+## Status
+
+**ACCEPTED** - Decision made on 2025-05-29
+
+## Context
+
+The Tasks plugin introduced a feature allowing users to define reusable blocks of Tasks instructions in settings and reference them in queries. This feature was initially named "Includes" with the following syntax:
+
+- Direct instruction: `include standard_options`  
+- Placeholder syntax: `{{includes.standard_options}}`
+
+However, during pre-release testing, a significant naming collision was identified with the existing text search functionality:
+
+- Existing: `description includes blah` (searches for text containing "blah")
+- New feature: `include standard_options` (imports predefined instruction block)
+
+This collision creates cognitive overhead and potential user confusion, necessitating a nomenclature change before public release.
+
+## Decision
+
+We will rename the feature from "Includes" to "Presets" with the following syntax:
+
+- **Direct instruction:** `preset standard_options`
+- **Placeholder syntax:** `{{preset.standard_options}}` (singular for consistency)
+
+## Alternatives Considered
+
+The following alternatives were evaluated in priority order:
+
+| Priority | Direct Syntax                 | Placeholder Syntax                 | Assessment                                      |
+| -------- | ----------------------------- | ---------------------------------- | ----------------------------------------------- |
+| **1**    | `preset standard_options`     | `{{presets.standard_options}}`     | ✅ No conflicts, user-friendly                  |
+| 2        | `macro standard_options`      | `{{macros.standard_options}}`      | ✅ No conflicts, technical precision            |
+| 3        | `def standard_options`        | `{{defs.standard_options}}`        | ✅ No conflicts, programming-friendly           |
+| 4        | `definition standard_options` | `{{definitions.standard_options}}` | ✅ No conflicts, verbose                        |
+| 5        | `import standard_options`     | `{{imports.standard_options}}`     | ✅ No conflicts, developer-oriented             |
+| 6        | `block standard_options`      | `{{blocks.standard_options}}`      | ⚠️ Potential confusion with Obsidian block refs |
+| 7        | `reference standard_options`  | `{{references.standard_options}}`  | ⚠️ Potential confusion with Obsidian links      |
+| 8        | `ref standard_options`        | `{{refs.standard_options}}`        | ⚠️ Potential confusion with Obsidian links      |
+| 9        | `include standard_options`    | `{{includes.standard_options}}`    | ❌ Conflicts with `description includes text`   |
+| 10       | `snippet standard_options`    | `{{snippets.standard_options}}`    | ❌ Conflicts with Obsidian CSS snippets         |
+| 11       | `template standard_options`   | `{{templates.standard_options}}`   | ❌ Strong conflict with Obsidian Templates      |
+
+## Rationale
+
+"Preset" was selected as the optimal choice because:
+
+1. **Zero Conflicts:** No collision with existing Tasks functionality or Obsidian features
+2. **User Accessibility:** Least programmer-centric terminology among viable options
+3. **Familiar Concept:** Widely used across many software applications (camera presets, filter presets, etc.)
+4. **Clear Intent:** Immediately conveys the concept of predefined configurations
+5. **Broad Appeal:** Accessible to users across all technical levels
+
+The decision to use singular form in placeholder syntax (`{{preset.name}}` instead of `{{presets.name}}`) maintains consistency with other Tasks placeholder patterns.
+
+## Consequences
+
+### Positive
+
+- Eliminates user confusion from naming collision
+- Provides clear, accessible terminology
+- Maintains feature functionality while improving usability
+- Establishes consistent naming pattern for future features
+
+### Negative
+
+- Requires updating developer's own test configurations (feature is pre-release)
+- Documentation and examples need updating before public release
+
+### Neutral
+
+- No user impact since feature is unreleased
+- Error messages and validation logic require updates
+
+## Implementation Notes
+
+- Update all pre-release documentation and examples to use new terminology
+- No user migration needed since feature is unreleased
+- Error messages and validation logic should use "preset" terminology
+- Release feature publicly with "preset" nomenclature
+
+---
+
+**Decision made by:** Clare Macrae
+**Date:** 2025-05-29  
+**ADR Number:** 001

--- a/contributing/Architecture Decisions/About Architecture Decisions.md
+++ b/contributing/Architecture Decisions/About Architecture Decisions.md
@@ -1,0 +1,13 @@
+---
+publish: true
+---
+
+# About Architecture Decisions
+
+## Introduction
+
+This a collection of [Architecture decision records (ADRs)](https://github.com/joelparkerhenderson/architecture-decision-record) for the Tasks plugin.
+
+If a design decision was non-obvious, we will record the thought process here.
+
+- [[ADR-001 - Nomenclature for Reusable Instruction Blocks Feature]]

--- a/contributing/Welcome.md
+++ b/contributing/Welcome.md
@@ -20,6 +20,7 @@ Getting the most from this documentation:
 - See [[About Testing]] to learn about automated and manual testing of the plugin
 - See [[About Debugging]] for tips to debug the plugin
 - See [[About Code]] for descriptions of the project's source code
+- See [[About Architecture Decisions]] for Architecture Decision Records
 - See [[About Documentation]] if you would like to improve and test the user docs
 - See [[About Translation]] if you are adding new text the plugin, and to help translate it
 

--- a/docs/Scripting/Placeholders.md
+++ b/docs/Scripting/Placeholders.md
@@ -80,7 +80,7 @@ It is now possible to use properties in the query file. See [[Obsidian Propertie
 You can do the following:
 
 ```text
-{{includes.my_snippet_from_settings}}
+{{preset.my_snippet_from_settings}}
 ```
 
 See also [[Includes]].

--- a/docs/Scripting/Placeholders.md
+++ b/docs/Scripting/Placeholders.md
@@ -75,7 +75,7 @@ Explanation of this Tasks code block query:
 
 It is now possible to use properties in the query file. See [[Obsidian Properties#Using Query Properties in Searches]]
 
-## Using includes.xxx
+## Using preset.xxx
 
 You can do the following:
 
@@ -83,7 +83,7 @@ You can do the following:
 {{preset.my_snippet_from_settings}}
 ```
 
-See also [[Includes]].
+See also [[Presets]].
 
 ## Error checking: invalid variables
 

--- a/docs/Scripting/Presets.md
+++ b/docs/Scripting/Presets.md
@@ -2,12 +2,12 @@
 publish: true
 ---
 
-# Includes
+# Presets
 
 <span class="related-pages">#feature/scripting</span>
 
 ```text
-include my_snippet_from_settings
+preset my_snippet_from_settings
 ```
 
 You can only include full lines (valid instructions).

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
@@ -1,5 +1,5 @@
 {
-  "includes": {
+  "presets": {
     "hide_all_dates": "# Hide any values for all 6 date fields\nhide due date\nhide scheduled date\nhide start date\nhide created date\nhide done date\nhide cancelled date",
     "hide_buttons": "# Hide postpone, edit and backinks\nhide postpone button\nhide edit button\nhide backlinks",
     "hide_other_fields": "# Hide all the non-date fields, keep tags\nhide id\nhide depends on\nhide recurrence rule\nhide on completion\nhide priority",

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
@@ -3,8 +3,8 @@
     "hide_all_dates": "# Hide any values for all 6 date fields\nhide due date\nhide scheduled date\nhide start date\nhide created date\nhide done date\nhide cancelled date",
     "hide_buttons": "# Hide postpone, edit and backinks\nhide postpone button\nhide edit button\nhide backlinks",
     "hide_other_fields": "# Hide all the non-date fields, keep tags\nhide id\nhide depends on\nhide recurrence rule\nhide on completion\nhide priority",
-    "just_the_description_and_tags": "# Show only description and any tags\ninclude hide_all_dates\ninclude hide_other_fields\ninclude hide_buttons",
-    "just_the_description": "# Show only description, not even the tags\ninclude just_the_description_and_tags\nhide tags",
+    "just_the_description_and_tags": "# Show only description and any tags\npreset hide_all_dates\npreset hide_other_fields\npreset hide_buttons",
+    "just_the_description": "# Show only description, not even the tags\npreset just_the_description_and_tags\nhide tags",
     "filter_by_context": "filter by function let fn = (ctx) => task.tags.includes(`#context/${ctx}`); return fn",
     "extract_contexts_1": "ctx => task.tags.includes(`#context/${ctx}`)",
     "extract_contexts_2": "(ctx => task.tags.includes(`#context/${ctx}`))"

--- a/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
@@ -106,17 +106,17 @@ explain: `INPUT[toggle:TQ_explain]`
 ````text
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:
-group by function const x = "{{includes.filter_by_context}}"; return x
+group by function const x = "{{preset.filter_by_context}}"; return x
 
-{{includes.filter_by_context}}('home')
+{{preset.filter_by_context}}('home')
 ```
 ````
 
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:
-group by function const x = "{{includes.filter_by_context}}"; return x
+group by function const x = "{{preset.filter_by_context}}"; return x
 
-{{includes.filter_by_context}}('home')
+{{preset.filter_by_context}}('home')
 ```
 
 ### Has context 'home' - and group by the Include text - version 2
@@ -126,19 +126,19 @@ explain: `INPUT[toggle:TQ_explain]`
 ````text
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:
-group by function const x = "{{includes.extract_contexts_1}}"; return x
+group by function const x = "{{preset.extract_contexts_1}}"; return x
 
 # includes.extract_contexts_1 value needs to be surrounded by parentheses ():
-filter by function return ({{includes.extract_contexts_1}})('home')
+filter by function return ({{preset.extract_contexts_1}})('home')
 ```
 ````
 
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:
-group by function const x = "{{includes.extract_contexts_1}}"; return x
+group by function const x = "{{preset.extract_contexts_1}}"; return x
 
 # includes.extract_contexts_1 value needs to be surrounded by parentheses ():
-filter by function return ({{includes.extract_contexts_1}})('home')
+filter by function return ({{preset.extract_contexts_1}})('home')
 ```
 
 ### Has context 'home' - and group by the Include text - version 3
@@ -148,17 +148,17 @@ explain: `INPUT[toggle:TQ_explain]`
 ````text
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:
-group by function const x = "{{includes.extract_contexts_2}}"; return x
+group by function const x = "{{preset.extract_contexts_2}}"; return x
 
 # includes.extract_contexts_1 value has the parentheses, to simplify use:
-filter by function {{includes.extract_contexts_2}}('home')
+filter by function {{preset.extract_contexts_2}}('home')
 ```
 ````
 
 ```tasks
 # For debug/explanatory purposes, show the source of the Include as a group name:
-group by function const x = "{{includes.extract_contexts_2}}"; return x
+group by function const x = "{{preset.extract_contexts_2}}"; return x
 
 # includes.extract_contexts_1 value has the parentheses, to simplify use:
-filter by function {{includes.extract_contexts_2}}('home')
+filter by function {{preset.extract_contexts_2}}('home')
 ```

--- a/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md
@@ -9,7 +9,7 @@ TQ_extra_instructions: |-
 
 These searches are for experimenting with, and understanding, the new "Includes" facility, which was released in Tasks X.Y.Z.
 
-Includes values can be defined in the Tasks settings.
+presets values can be defined in the Tasks settings.
 
 explain: `INPUT[toggle:TQ_explain]`
 
@@ -19,12 +19,12 @@ explain: `INPUT[toggle:TQ_explain]`
 
 ````text
 ```tasks
-include xxxx
+preset xxxx
 ```
 ````
 
 ```tasks
-include xxxx
+preset xxxx
 ```
 
 ## Show all the fields
@@ -45,14 +45,14 @@ explain: `INPUT[toggle:TQ_explain]`
 
 ````text
 ```tasks
-include hide_all_dates
-include hide_other_fields
+preset hide_all_dates
+preset hide_other_fields
 ```
 ````
 
 ```tasks
-include hide_all_dates
-include hide_other_fields
+preset hide_all_dates
+preset hide_other_fields
 ```
 
 ## Hide all the Tasks user interface elements
@@ -61,12 +61,12 @@ explain: `INPUT[toggle:TQ_explain]`
 
 ````text
 ```tasks
-include hide_buttons
+preset hide_buttons
 ```
 ````
 
 ```tasks
-include hide_buttons
+preset hide_buttons
 ```
 
 ## Show only the description and any tags
@@ -75,12 +75,12 @@ explain: `INPUT[toggle:TQ_explain]`
 
 ````text
 ```tasks
-include just_the_description_and_tags
+preset just_the_description_and_tags
 ```
 ````
 
 ```tasks
-include just_the_description_and_tags
+preset just_the_description_and_tags
 ```
 
 ## Just show the description, without tags
@@ -89,12 +89,12 @@ explain: `INPUT[toggle:TQ_explain]`
 
 ````text
 ```tasks
-include just_the_description
+preset just_the_description
 ```
 ````
 
 ```tasks
-include just_the_description
+preset just_the_description
 ```
 
 ## Advanced use: return a function, that takes a parameter from the query source

--- a/src/Config/IncludesSettingsUI.ts
+++ b/src/Config/IncludesSettingsUI.ts
@@ -41,7 +41,7 @@ export class IncludesSettingsUI {
             // Clear the input map when re-rendering
             this.nameFields.clear();
 
-            Object.entries(settings.includes).forEach(([key, value]) => {
+            Object.entries(settings.presets).forEach(([key, value]) => {
                 this.renderIncludeItem(includesContainer, settings, key, value, renderIncludes);
             });
         };
@@ -94,7 +94,7 @@ export class IncludesSettingsUI {
             // Handle renaming an include
             const commitRename = async () => {
                 if (newKey && newKey !== key) {
-                    const updatedIncludes = this.includesSettingsService.renameInclude(settings.includes, key, newKey);
+                    const updatedIncludes = this.includesSettingsService.renameInclude(settings.presets, key, newKey);
                     if (updatedIncludes) {
                         await this.saveIncludesSettings(updatedIncludes, settings, refreshView);
                     }
@@ -119,7 +119,7 @@ export class IncludesSettingsUI {
 
             return textArea.onChange(async (newValue) => {
                 const updatedIncludes = this.includesSettingsService.updateIncludeValue(
-                    settings.includes,
+                    settings.presets,
                     key,
                     newValue,
                 );
@@ -147,7 +147,7 @@ export class IncludesSettingsUI {
             btn.setIcon('cross')
                 .setTooltip('Delete')
                 .onClick(async () => {
-                    const updatedIncludes = this.includesSettingsService.deleteInclude(settings.includes, key);
+                    const updatedIncludes = this.includesSettingsService.deleteInclude(settings.presets, key);
                     await this.saveIncludesSettings(updatedIncludes, settings, refreshView);
                 });
         });
@@ -225,7 +225,7 @@ export class IncludesSettingsUI {
 
             // Perform the reorder
             const updatedIncludes = this.includesSettingsService.reorderInclude(
-                settings.includes,
+                settings.presets,
                 draggedKey,
                 targetIndex,
             );
@@ -246,7 +246,7 @@ export class IncludesSettingsUI {
      */
     private getTargetIndex(targetKey: string, position: 'above' | 'below'): number {
         const settings = getSettings();
-        const keys = Object.keys(settings.includes);
+        const keys = Object.keys(settings.presets);
         const targetIndex = keys.indexOf(targetKey);
 
         if (position === 'above') {
@@ -361,7 +361,7 @@ export class IncludesSettingsUI {
             btn.setButtonText('Add new include')
                 .setCta()
                 .onClick(async () => {
-                    const { includes: updatedIncludes } = this.includesSettingsService.addInclude(settings.includes);
+                    const { includes: updatedIncludes } = this.includesSettingsService.addInclude(settings.presets);
                     await this.saveIncludesSettings(updatedIncludes, settings, refreshView);
                 });
         });
@@ -380,11 +380,11 @@ export class IncludesSettingsUI {
     ) {
         // TODO Consider how this relates to the validation code - should it refuse to save settings if validation fails?
         // Update the settings in storage
-        updateSettings({ includes: updatedIncludes });
+        updateSettings({ presets: updatedIncludes });
         await this.plugin.saveSettings();
 
         // Update the local settings object to reflect the changes
-        settings.includes = { ...updatedIncludes };
+        settings.presets = { ...updatedIncludes };
 
         // Refresh the view if a callback was provided
         if (refreshView) {

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -196,7 +196,8 @@ export const updateSettings = (newSettings: Partial<Settings>): Settings => {
 };
 
 export const resetSettings = (): Settings => {
-    return updateSettings(defaultSettings);
+    settings = JSON.parse(JSON.stringify(defaultSettings));
+    return settings;
 };
 
 export const updateGeneralSetting = (name: string, value: string | boolean): Settings => {

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -254,6 +254,8 @@ export function getUserSelectedTaskFormat(): TaskFormat {
 /**
  * Migrates old settings structure to new structure.
  * This handles backwards compatibility when settings property names change.
+ *
+ * Note: The vault's 'data.json' file is only updated when the user opens the Tasks settings UI.
  */
 function migrateSettings(loadedSettings: any): Partial<Settings> {
     const migratedSettings = { ...loadedSettings };

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -62,7 +62,7 @@ export type TASK_FORMATS = typeof TASK_FORMATS; // For convenience to make some 
 export type IncludesMap = Record<string, string>;
 
 export interface Settings {
-    includes: IncludesMap;
+    presets: IncludesMap;
     globalQuery: string;
     globalFilter: string;
     removeGlobalFilter: boolean;
@@ -98,7 +98,7 @@ export interface Settings {
 }
 
 const defaultSettings: Settings = {
-    includes: {},
+    presets: {},
     globalQuery: '',
     globalFilter: '',
     removeGlobalFilter: false,

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -97,7 +97,7 @@ export interface Settings {
     loggingOptions: LogOptions;
 }
 
-const defaultSettings: Settings = {
+const defaultSettings: Readonly<Settings> = {
     presets: {},
     globalQuery: '',
     globalFilter: '',
@@ -190,7 +190,10 @@ export const getSettings = (): Settings => {
 };
 
 export const updateSettings = (newSettings: Partial<Settings>): Settings => {
-    settings = { ...settings, ...newSettings };
+    // Apply migrations before updating settings
+    const migratedSettings = migrateSettings(newSettings);
+
+    settings = { ...settings, ...migratedSettings };
 
     return getSettings();
 };
@@ -246,4 +249,22 @@ export const toggleFeature = (internalName: string, enabled: boolean): FeatureFl
  */
 export function getUserSelectedTaskFormat(): TaskFormat {
     return TASK_FORMATS[getSettings().taskFormat];
+}
+
+/**
+ * Migrates old settings structure to new structure.
+ * This handles backwards compatibility when settings property names change.
+ */
+function migrateSettings(loadedSettings: any): Partial<Settings> {
+    const migratedSettings = { ...loadedSettings };
+
+    // Migrate 'includes' to 'presets' if present
+    if ('includes' in migratedSettings && !('presets' in migratedSettings)) {
+        migratedSettings.presets = migratedSettings.includes;
+        delete migratedSettings.includes;
+    }
+
+    // Add future migrations here as needed
+
+    return migratedSettings;
 }

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -158,10 +158,10 @@ export class SettingsTab extends PluginSettingTab {
 
         // ---------------------------------------------------------------------------
         new Setting(containerEl)
-            .setName('Includes')
+            .setName('Presets')
             .setHeading()
             .setDesc(
-                'You can define named instructions here, that you can re-use in multiple queries. They can be used with "{{includes.name}}" and "include name".',
+                'You can define named instructions here, that you can re-use in multiple queries. They can be used with "{{preset.name}}" and "preset name".',
             );
         // ---------------------------------------------------------------------------
         this.includesSettingsUI.renderIncludesSettings(containerEl);

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -474,10 +474,10 @@ ${statement.explainStatement('    ')}
         const include = this.includeRegexp.exec(line);
         if (include) {
             const includeName = include[1].trim();
-            const { includes } = getSettings();
-            const includeValue = includes[includeName];
+            const { presets } = getSettings();
+            const includeValue = presets[includeName];
             if (!includeValue) {
-                this.setError(unknownIncludeErrorMessage(includeName, includes), statement);
+                this.setError(unknownIncludeErrorMessage(includeName, presets), statement);
                 return;
             }
 

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -59,7 +59,7 @@ export class Query implements IQuery {
     private readonly limitRegexp = /^limit (groups )?(to )?(\d+)( tasks?)?/i;
 
     private readonly commentRegexp = /^#.*/;
-    private readonly includeRegexp = /^include +(.*)/i;
+    private readonly includeRegexp = /^preset +(.*)/i;
 
     constructor(source: string, tasksFile: OptionalTasksFile = undefined) {
         this._queryId = this.generateQueryId(10);

--- a/src/Scripting/Includes.ts
+++ b/src/Scripting/Includes.ts
@@ -25,7 +25,7 @@ function summariseInstruction(instructions: string) {
 }
 
 export function unknownIncludeErrorMessage(includeName: string, includes: IncludesMap) {
-    let message = `Cannot find include "${includeName}" in the Tasks settings`;
+    let message = `Cannot find preset "${includeName}" in the Tasks settings`;
 
     const isIncludesEmpty = Object.keys(includes).length === 0;
     if (isIncludesEmpty) {
@@ -36,7 +36,7 @@ export function unknownIncludeErrorMessage(includeName: string, includes: Includ
             .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
             .map(([key, value]) => `${key.padEnd(maxKeyLength)}: ${summariseInstruction(value)}`)
             .join('\n  ');
-        message += `\nThe following includes are defined in the Tasks settings:\n  ${availableNames}`;
+        message += `\nThe following presets are defined in the Tasks settings:\n  ${availableNames}`;
     }
 
     return message;

--- a/src/Scripting/QueryContext.ts
+++ b/src/Scripting/QueryContext.ts
@@ -59,6 +59,6 @@ export function makeQueryContextWithTasks(tasksFile: TasksFile, allTasks: Readon
             allTasks: allTasks,
             searchCache: {}, // Added for caching
         },
-        preset: { ...getSettings().includes },
+        preset: { ...getSettings().presets },
     };
 }

--- a/src/Scripting/QueryContext.ts
+++ b/src/Scripting/QueryContext.ts
@@ -25,7 +25,7 @@ export interface QueryContext {
         allTasks: Readonly<Task[]>;
         searchCache: Record<string, any>; // Added caching capability
     };
-    includes: IncludesMap;
+    preset: IncludesMap;
 }
 
 /**
@@ -59,6 +59,6 @@ export function makeQueryContextWithTasks(tasksFile: TasksFile, allTasks: Readon
             allTasks: allTasks,
             searchCache: {}, // Added for caching
         },
-        includes: { ...getSettings().includes },
+        preset: { ...getSettings().includes },
     };
 }

--- a/tests/Config/Settings.test.ts
+++ b/tests/Config/Settings.test.ts
@@ -56,7 +56,7 @@ describe('resetSettings behaviour', () => {
         expect(getSettings().setCancelledDate).toEqual(true);
     });
 
-    it.failing('should completely remove properties not in defaultSettings', () => {
+    it('should completely remove properties not in defaultSettings', () => {
         // Arrange: Add an extra property that isn't in defaultSettings
         updateSettings({
             extraProperty: 'should be removed',

--- a/tests/Config/Settings.test.ts
+++ b/tests/Config/Settings.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { getSettings, isFeatureEnabled, toggleFeature, updateSettings } from '../../src/Config/Settings';
+import { getSettings, isFeatureEnabled, resetSettings, toggleFeature, updateSettings } from '../../src/Config/Settings';
 
 describe('settings-usage', () => {
     it('load default settings and validate features', () => {
@@ -42,5 +42,34 @@ describe('settings-usage', () => {
 
         // Assert:
         expect(loggingOptions.loggingOptions.minLevels['tasks.Query']).toBeDefined();
+    });
+});
+
+describe('resetSettings behaviour', () => {
+    it('should reset a setting to default values', () => {
+        expect(getSettings().setCancelledDate).toEqual(true);
+
+        updateSettings({ setCancelledDate: false });
+        expect(getSettings().setCancelledDate).toEqual(false);
+
+        resetSettings();
+        expect(getSettings().setCancelledDate).toEqual(true);
+    });
+
+    it.failing('should completely remove properties not in defaultSettings', () => {
+        // Arrange: Add an extra property that isn't in defaultSettings
+        updateSettings({
+            extraProperty: 'should be removed',
+        } as any);
+
+        // Verify the extra property exists
+        const settingsBeforeReset = getSettings();
+        expect((settingsBeforeReset as any).extraProperty).toBe('should be removed');
+
+        // Act: Reset settings
+        const resetResult = resetSettings();
+
+        // Assert: Extra property should be completely gone
+        expect((resetResult as any).extraProperty).toBeUndefined();
     });
 });

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -123,7 +123,7 @@ describe('QueryResultsRenderer - responding to file edits', () => {
     it('should be able to reread the query when query settings are changed', () => {
         // Arrange
         updateSettings({ includes: { CurrentGrouping: 'group by PATH' } });
-        const source = 'include CurrentGrouping';
+        const source = 'preset CurrentGrouping';
         const renderer = makeQueryResultsRenderer(source, new TasksFile('any file.md'));
         expect(renderer.query.explainQuery()).toContain('group by PATH');
 

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -122,13 +122,13 @@ describe('QueryResultsRenderer - responding to file edits', () => {
 
     it('should be able to reread the query when query settings are changed', () => {
         // Arrange
-        updateSettings({ includes: { CurrentGrouping: 'group by PATH' } });
+        updateSettings({ presets: { CurrentGrouping: 'group by PATH' } });
         const source = 'preset CurrentGrouping';
         const renderer = makeQueryResultsRenderer(source, new TasksFile('any file.md'));
         expect(renderer.query.explainQuery()).toContain('group by PATH');
 
         // Act
-        updateSettings({ includes: { CurrentGrouping: 'group by DUE' } });
+        updateSettings({ presets: { CurrentGrouping: 'group by DUE' } });
         renderer.rereadQueryFromFile();
 
         // Assert

--- a/tests/Scripting/Includes.test.ts
+++ b/tests/Scripting/Includes.test.ts
@@ -66,25 +66,25 @@ describe('include tests', () => {
         });
 
         it('should accept whole-line include filter instruction', () => {
-            const source = 'include not_done';
+            const source = 'preset not_done';
             const query = createValidQuery(source, includes);
             expectFiltersToBe(query, ['not done']);
             expect(query.explainQuery()).toMatchInlineSnapshot(`
-                "include not_done =>
+                "preset not_done =>
                 not done
                 "
             `);
         });
 
         it('should accept whole-line include filter instruction, continued over two lines', () => {
-            const source = 'include \\\nnot_done';
+            const source = 'preset \\\nnot_done';
             const query = createValidQuery(source, includes);
             expectFiltersToBe(query, ['not done']);
             expect(query.explainQuery()).toMatchInlineSnapshot(`
-                "include \\
+                "preset \\
                 not_done
                  =>
-                include not_done =>
+                preset not_done =>
                 not done
                 "
             `);
@@ -93,7 +93,7 @@ describe('include tests', () => {
 
     it('should accept whole-line include layout instruction', () => {
         const includes = makeIncludes(['show_tree', 'show tree']);
-        const source = 'include show_tree';
+        const source = 'preset show_tree';
 
         const query = createValidQuery(source, includes);
 
@@ -103,7 +103,7 @@ describe('include tests', () => {
 
     it('should accept multi-line include', () => {
         const includes = makeIncludes(['multi_line', 'scheduled tomorrow\nhide backlink']);
-        const source = 'include multi_line';
+        const source = 'preset multi_line';
 
         const query = createValidQuery(source, includes);
 
@@ -117,9 +117,9 @@ describe('include tests', () => {
         const includes = makeIncludes(
             // Force line break
             ['inside', 'not done'],
-            ['out', 'include inside\nhide edit button'],
+            ['out', 'preset inside\nhide edit button'],
         );
-        const source = 'include out';
+        const source = 'preset out';
 
         const query = createValidQuery(source, includes);
 
@@ -139,7 +139,7 @@ describe('include tests', () => {
         });
 
         it('include instruction should expand placeholder in include value', () => {
-            const source = 'include this_path';
+            const source = 'preset this_path';
             const query = createValidQuery(source, includes);
             expectFiltersToBe(query, ['path includes root/folder/stuff.md']);
         });
@@ -148,7 +148,7 @@ describe('include tests', () => {
     describe('multi-line placeholders inside includes', () => {
         const includes = makeIncludes(
             ['two_lines', 'has due date\nhas created date'],
-            ['two_lines_as_include', 'include two_lines'],
+            ['two_lines_as_include', 'preset two_lines'],
             ['two_lines_as_placeholder', '{{preset.two_lines}}'],
         );
 
@@ -165,19 +165,19 @@ describe('include tests', () => {
         });
 
         it('include another include instruction should detect both lines in included value', () => {
-            const source = 'include two_lines_as_include';
+            const source = 'preset two_lines_as_include';
             const query = createValidQuery(source, includes);
             expectFiltersToBe(query, ['has due date', 'has created date']);
         });
 
         it('include a placeholder include should detect both lines in included value BUT DOES NOT', () => {
             // TODO Handle expanding multi-line placeholders
-            const source = 'include two_lines_as_placeholder';
+            const source = 'preset two_lines_as_placeholder';
             const query = createQuery(source, includes);
             expect(query.error).toMatchInlineSnapshot(`
                 "do not understand query
                 Problem statement:
-                    include two_lines_as_placeholder =>
+                    preset two_lines_as_placeholder =>
                     has due date
                 has created date
                 "
@@ -269,7 +269,7 @@ return "Hello World";`;
         });
 
         it('include instruction supports line continuations in include value', () => {
-            const source = 'include instruction_with_continuation_lines';
+            const source = 'preset instruction_with_continuation_lines';
             const query = createValidQuery(source, includes);
             expectExpandedStatementToBe(query.grouping[0].statement, expectedStatement);
         });
@@ -335,7 +335,7 @@ describe('include - explain output', () => {
     describe('explain two levels of nested includes', () => {
         const includes = makeIncludes(
             ['inside', '(happens this week) AND (starts before today)'],
-            ['out', 'include inside\nnot done'],
+            ['out', 'preset inside\nnot done'],
         );
 
         it('includes placeholder should explain two levels of nested includes', () => {
@@ -360,11 +360,11 @@ describe('include - explain output', () => {
         });
 
         it('include instruction should explain two levels of nested includes', () => {
-            const query = createValidQuery('include out', includes);
+            const query = createValidQuery('preset out', includes);
             // With the repeated output 'include out =>', it is less obvious than in
             // the previous test that some text was expanded in to more than one line.
             expect(query.explainQuery()).toMatchInlineSnapshot(`
-                "include out =>
+                "preset out =>
                 (happens this week) AND (starts before today) =>
                   AND (All of):
                     happens this week =>
@@ -374,7 +374,7 @@ describe('include - explain output', () => {
                     starts before today =>
                       start date is before 2025-04-28 (Monday 28th April 2025) OR no start date
 
-                include out =>
+                preset out =>
                 not done
                 "
             `);
@@ -400,11 +400,11 @@ describe('include - error messages', () => {
         });
 
         it('include instruction should give a meaningful error for non-existent include', () => {
-            const query = createQuery('include not_existent', includes);
+            const query = createQuery('preset not_existent', includes);
             expect(query.error).toMatchInlineSnapshot(`
                 "Cannot find include "not_existent" in the Tasks settings
                 You can define the instruction(s) for "not_existent" in the Tasks settings.
-                Problem line: "include not_existent""
+                Problem line: "preset not_existent""
             `);
         });
     });
@@ -439,7 +439,7 @@ describe('include - error messages', () => {
         });
 
         it('include instruction should give a meaningful error for non-existent include', () => {
-            const query = createQuery('include not_existent', includes);
+            const query = createQuery('preset not_existent', includes);
             expect(query.error).toMatchInlineSnapshot(`
                 "Cannot find include "not_existent" in the Tasks settings
                 The following includes are defined in the Tasks settings:
@@ -447,7 +447,7 @@ describe('include - error messages', () => {
                   include2            : task.due.format("YYYY")
                   include3            : (filename includes File 1) AND ( (heading includes...
                   include4_longer_name: (filename includes File 1) AND \\...
-                Problem line: "include not_existent""
+                Problem line: "preset not_existent""
             `);
         });
     });
@@ -456,7 +456,7 @@ describe('include - error messages', () => {
         const includes = makeIncludes(
             // Force line break
             ['inside', 'apple sauce'],
-            ['out', 'include inside'],
+            ['out', 'preset inside'],
         );
 
         it('includes placeholder should give meaningful error message about included text', () => {
@@ -471,11 +471,11 @@ describe('include - error messages', () => {
         });
 
         it('include instruction should give meaningful error message about included text', () => {
-            const query = createQuery('include out', includes);
+            const query = createQuery('preset out', includes);
             expect(query.error).toMatchInlineSnapshot(`
                 "do not understand query
                 Problem statement:
-                    include out =>
+                    preset out =>
                     apple sauce
                 "
             `);
@@ -485,7 +485,7 @@ describe('include - error messages', () => {
     describe('infinite recursion of instruction', () => {
         const includes = makeIncludes(
             ['self_reference_1', '{{preset.self_reference_1}}'],
-            ['self_reference_2', 'include self_reference_2'],
+            ['self_reference_2', 'preset self_reference_2'],
         );
 
         it('includes placeholder should give meaningful error message about self-referencing instructions BUT DOES NOT', () => {
@@ -514,11 +514,11 @@ describe('include - error messages', () => {
         });
 
         it('include instruction should give meaningful error message about self-referencing instructions BUT DOES NOT', () => {
-            // TODO Better error error message for 'include self_reference'
-            const query = createQuery('include self_reference_2', includes);
+            // TODO Better error error message for 'preset self_reference'
+            const query = createQuery('preset self_reference_2', includes);
             expect(query.error).toMatchInlineSnapshot(`
                 "Maximum call stack size exceeded
-                Problem line: "include self_reference_2""
+                Problem line: "preset self_reference_2""
             `);
         });
     });

--- a/tests/Scripting/Includes.test.ts
+++ b/tests/Scripting/Includes.test.ts
@@ -402,7 +402,7 @@ describe('include - error messages', () => {
         it('include instruction should give a meaningful error for non-existent include', () => {
             const query = createQuery('preset not_existent', includes);
             expect(query.error).toMatchInlineSnapshot(`
-                "Cannot find include "not_existent" in the Tasks settings
+                "Cannot find preset "not_existent" in the Tasks settings
                 You can define the instruction(s) for "not_existent" in the Tasks settings.
                 Problem line: "preset not_existent""
             `);
@@ -441,8 +441,8 @@ describe('include - error messages', () => {
         it('include instruction should give a meaningful error for non-existent include', () => {
             const query = createQuery('preset not_existent', includes);
             expect(query.error).toMatchInlineSnapshot(`
-                "Cannot find include "not_existent" in the Tasks settings
-                The following includes are defined in the Tasks settings:
+                "Cannot find preset "not_existent" in the Tasks settings
+                The following presets are defined in the Tasks settings:
                   include1            : sort by function task.lineNumber
                   include2            : task.due.format("YYYY")
                   include3            : (filename includes File 1) AND ( (heading includes...

--- a/tests/Scripting/Includes.test.ts
+++ b/tests/Scripting/Includes.test.ts
@@ -55,11 +55,11 @@ describe('include tests', () => {
         const includes = makeIncludes(['not_done', 'not done']);
 
         it('should accept whole-line include placeholder', () => {
-            const source = '{{includes.not_done}}';
+            const source = '{{preset.not_done}}';
             const query = createValidQuery(source, includes);
             expectFiltersToBe(query, ['not done']);
             expect(query.explainQuery()).toMatchInlineSnapshot(`
-                "{{includes.not_done}} =>
+                "{{preset.not_done}} =>
                 not done
                 "
             `);
@@ -133,7 +133,7 @@ describe('include tests', () => {
         const includes = makeIncludes(['this_path', 'path includes {{query.file.path}}']);
 
         it('includes placeholder should expand placeholder in include value', () => {
-            const source = '{{includes.this_path}}';
+            const source = '{{preset.this_path}}';
             const query = createValidQuery(source, includes);
             expectFiltersToBe(query, ['path includes root/folder/stuff.md']);
         });
@@ -149,17 +149,17 @@ describe('include tests', () => {
         const includes = makeIncludes(
             ['two_lines', 'has due date\nhas created date'],
             ['two_lines_as_include', 'include two_lines'],
-            ['two_lines_as_placeholder', '{{includes.two_lines}}'],
+            ['two_lines_as_placeholder', '{{preset.two_lines}}'],
         );
 
         it('includes placeholder should detect both lines in included value', () => {
-            const source = '{{includes.two_lines_as_placeholder}}';
+            const source = '{{preset.two_lines_as_placeholder}}';
             const query = createValidQuery(source, includes);
             expectFiltersToBe(query, ['has due date', 'has created date']);
         });
 
         it('includes placeholders should be ignored in comments', () => {
-            const source = '# {{includes.two_lines_as_placeholder}}';
+            const source = '# {{preset.two_lines_as_placeholder}}';
             const query = createValidQuery(source, includes);
             expectFiltersToBe(query, []);
         });
@@ -192,9 +192,9 @@ describe('include tests', () => {
             ['this_folder', 'folder includes {{query.file.folder}}'],
             ['this_root', 'root includes {{query.file.root}}'],
             // 2-level include:
-            ['this_everything', '{{includes.this_path}}\n{{includes.this_folder}}\n{{includes.this_root}}'],
+            ['this_everything', '{{preset.this_path}}\n{{preset.this_folder}}\n{{preset.this_root}}'],
             // 3-level include:
-            ['this_everything_indirect', '{{includes.this_everything}}'],
+            ['this_everything_indirect', '{{preset.this_everything}}'],
         );
 
         const expectedFilterLines = [
@@ -204,51 +204,51 @@ describe('include tests', () => {
         ];
 
         it('includes placeholder should support placeholders inside simple instructions', () => {
-            const source = '{{includes.this_path}}\n{{includes.this_folder}}\n{{includes.this_root}}';
+            const source = '{{preset.this_path}}\n{{preset.this_folder}}\n{{preset.this_root}}';
             const query = createValidQuery(source, includes);
             expectFiltersToBe(query, expectedFilterLines);
             expect(query.explainQuery()).toMatchInlineSnapshot(`
-                "{{includes.this_path}} =>
+                "{{preset.this_path}} =>
                 path includes root/folder/stuff.md
 
-                {{includes.this_folder}} =>
+                {{preset.this_folder}} =>
                 folder includes root/folder/
 
-                {{includes.this_root}} =>
+                {{preset.this_root}} =>
                 root includes root/
                 "
             `);
         });
 
         it('includes placeholder should support one-level nested placeholders', () => {
-            const source = '{{includes.this_everything}}';
+            const source = '{{preset.this_everything}}';
             const query = createValidQuery(source, includes);
             expectFiltersToBe(query, expectedFilterLines);
             expect(query.explainQuery()).toMatchInlineSnapshot(`
-                "{{includes.this_everything}}: statement 1 after expansion of placeholder =>
+                "{{preset.this_everything}}: statement 1 after expansion of placeholder =>
                 path includes root/folder/stuff.md
 
-                {{includes.this_everything}}: statement 2 after expansion of placeholder =>
+                {{preset.this_everything}}: statement 2 after expansion of placeholder =>
                 folder includes root/folder/
 
-                {{includes.this_everything}}: statement 3 after expansion of placeholder =>
+                {{preset.this_everything}}: statement 3 after expansion of placeholder =>
                 root includes root/
                 "
             `);
         });
 
         it('includes placeholder should support two-level nested placeholders', () => {
-            const source = '{{includes.this_everything_indirect}}';
+            const source = '{{preset.this_everything_indirect}}';
             const query = createValidQuery(source, includes);
             expectFiltersToBe(query, expectedFilterLines);
             expect(query.explainQuery()).toMatchInlineSnapshot(`
-                "{{includes.this_everything_indirect}}: statement 1 after expansion of placeholder =>
+                "{{preset.this_everything_indirect}}: statement 1 after expansion of placeholder =>
                 path includes root/folder/stuff.md
 
-                {{includes.this_everything_indirect}}: statement 2 after expansion of placeholder =>
+                {{preset.this_everything_indirect}}: statement 2 after expansion of placeholder =>
                 folder includes root/folder/
 
-                {{includes.this_everything_indirect}}: statement 3 after expansion of placeholder =>
+                {{preset.this_everything_indirect}}: statement 3 after expansion of placeholder =>
                 root includes root/
                 "
             `);
@@ -263,7 +263,7 @@ return "Hello World";`;
         const expectedStatement = 'group by function return "Hello World";';
 
         it('includes placeholder supports line continuations in include value', () => {
-            const source = '{{includes.instruction_with_continuation_lines}}';
+            const source = '{{preset.instruction_with_continuation_lines}}';
             const query = createValidQuery(source, includes);
             expectExpandedStatementToBe(query.grouping[0].statement, expectedStatement);
         });
@@ -276,7 +276,7 @@ return "Hello World";`;
     });
 
     describe('includes inside Boolean combinations', () => {
-        // ( {{includes.filter1}} ) AND ( {{includes.filter2}} )
+        // ( {{preset.filter1}} ) AND ( {{preset.filter2}} )
         // ( include filter1 ) AND ( include filter2 )
         const includes = makeIncludes(
             // Force line break
@@ -286,12 +286,12 @@ return "Hello World";`;
         const expectedStatement = '( not done ) AND ( due 2025-05-01 )';
 
         it('should allow Boolean instructions to use includes placeholders', () => {
-            const source = '( {{includes.filter1}} ) AND ( {{includes.filter2}} )';
+            const source = '( {{preset.filter1}} ) AND ( {{preset.filter2}} )';
             const query = createValidQuery(source, includes);
 
             expectFiltersToBe(query, [expectedStatement]);
             expect(query.explainQuery()).toMatchInlineSnapshot(`
-                "( {{includes.filter1}} ) AND ( {{includes.filter2}} ) =>
+                "( {{preset.filter1}} ) AND ( {{preset.filter2}} ) =>
                 ( not done ) AND ( due 2025-05-01 ) =>
                   AND (All of):
                     not done
@@ -339,11 +339,11 @@ describe('include - explain output', () => {
         );
 
         it('includes placeholder should explain two levels of nested includes', () => {
-            const query = createValidQuery('{{includes.out}}', includes);
+            const query = createValidQuery('{{preset.out}}', includes);
             // The 'statement 1', 'statement 2' text is useful in clarifying that
             // some text was expanded in to more than one line.
             expect(query.explainQuery()).toMatchInlineSnapshot(`
-                "{{includes.out}}: statement 1 after expansion of placeholder =>
+                "{{preset.out}}: statement 1 after expansion of placeholder =>
                 (happens this week) AND (starts before today) =>
                   AND (All of):
                     happens this week =>
@@ -353,7 +353,7 @@ describe('include - explain output', () => {
                     starts before today =>
                       start date is before 2025-04-28 (Monday 28th April 2025) OR no start date
 
-                {{includes.out}}: statement 2 after expansion of placeholder =>
+                {{preset.out}}: statement 2 after expansion of placeholder =>
                 not done
                 "
             `);
@@ -387,15 +387,15 @@ describe('include - error messages', () => {
         const includes = {};
 
         it('includes placeholder should give a meaningful error for non-existent include', () => {
-            const query = createQuery('{{includes.not_existent}}', includes);
+            const query = createQuery('{{preset.not_existent}}', includes);
             expect(query.error).toMatchInlineSnapshot(`
                 "There was an error expanding one or more placeholders.
 
                 The error message was:
-                    Unknown property: includes.not_existent
+                    Unknown property: preset.not_existent
 
                 The problem is in:
-                    {{includes.not_existent}}"
+                    {{preset.not_existent}}"
             `);
         });
 
@@ -426,15 +426,15 @@ describe('include - error messages', () => {
         );
 
         it('includes placeholder should give a meaningful error for non-existent include', () => {
-            const query = createQuery('{{includes.not_existent}}', includes);
+            const query = createQuery('{{preset.not_existent}}', includes);
             expect(query.error).toMatchInlineSnapshot(`
                 "There was an error expanding one or more placeholders.
 
                 The error message was:
-                    Unknown property: includes.not_existent
+                    Unknown property: preset.not_existent
 
                 The problem is in:
-                    {{includes.not_existent}}"
+                    {{preset.not_existent}}"
             `);
         });
 
@@ -460,11 +460,11 @@ describe('include - error messages', () => {
         );
 
         it('includes placeholder should give meaningful error message about included text', () => {
-            const query = createQuery('{{includes.out}}', includes);
+            const query = createQuery('{{preset.out}}', includes);
             expect(query.error).toMatchInlineSnapshot(`
                 "do not understand query
                 Problem statement:
-                    {{includes.out}} =>
+                    {{preset.out}} =>
                     apple sauce
                 "
             `);
@@ -484,32 +484,32 @@ describe('include - error messages', () => {
 
     describe('infinite recursion of instruction', () => {
         const includes = makeIncludes(
-            ['self_reference_1', '{{includes.self_reference_1}}'],
+            ['self_reference_1', '{{preset.self_reference_1}}'],
             ['self_reference_2', 'include self_reference_2'],
         );
 
         it('includes placeholder should give meaningful error message about self-referencing instructions BUT DOES NOT', () => {
-            // TODO Better error error message for '{{includes.self_reference}}'
-            const query = createQuery('{{includes.self_reference_1}}', includes);
+            // TODO Better error error message for '{{preset.self_reference}}'
+            const query = createQuery('{{preset.self_reference_1}}', includes);
             expect(query.error).toMatchInlineSnapshot(`
                 "Could not interpret the following instruction as a Boolean combination:
-                    {{includes.self_reference_1}}
+                    {{preset.self_reference_1}}
 
                 The error message is:
-                    couldn't parse sub-expression 'includes.self_reference_1'
+                    couldn't parse sub-expression 'preset.self_reference_1'
 
                 The instruction was converted to the following simplified line:
                     ((f1))
 
                 Where the sub-expressions in the simplified line are:
-                    'f1': 'includes.self_reference_1'
+                    'f1': 'preset.self_reference_1'
                         => ERROR:
                            do not understand query
 
                 For help, see:
                     https://publish.obsidian.md/tasks/Queries/Combining+Filters
 
-                Problem line: "{{includes.self_reference_1}}""
+                Problem line: "{{preset.self_reference_1}}""
             `);
         });
 

--- a/tests/Scripting/Includes.test.ts
+++ b/tests/Scripting/Includes.test.ts
@@ -26,7 +26,7 @@ export function makeIncludes(...entries: [string, string][]): IncludesMap {
 const tasksFile = new TasksFile('root/folder/stuff.md');
 
 function createQuery(source: string, includes: IncludesMap) {
-    updateSettings({ includes });
+    updateSettings({ presets: includes });
     const query = new Query(source, tasksFile);
 
     expect(query.source).toEqual(source);
@@ -528,6 +528,6 @@ describe('include settings tests', () => {
     it('should have an empty include field', () => {
         const settings = getSettings();
 
-        expect(settings.includes).toEqual({});
+        expect(settings.presets).toEqual({});
     });
 });


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
    - #2443 
    - #2267
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [x] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

### How practically breaking a change is it?

Note: I am labelling this a **breaking change** because it does **rename an unreleased feature**.

I believe that I am likely the only person who is using the feature, so in practice it will not require a major-version-number bump.

### The changes

Done:

1. Write an Architecture Decision Record (ADR) recording the names I considered, and why I chose the name I did.
2. Rename the `include` facility to `preset`, to avoid confusion with the `includes/does not include` text search instructions.
    - `include my_lovely_filters` => `preset my_lovely_filters`
    - `{{includes.my_lovely_filters}}`=> `{{preset.my_lovely_filters}}`
        - Note the change from plural to singular
3. Automatically migrate any `includes` values in the vault's Tasks settings to `presets`
    - for the unlikely event that any users other than me have run a development version of this feature
    - note that the `data.json` file is only actually modified the first time the user opens the Tasks settings UI in their vault.
4. Update the minimal docs I had started writing for this feature
5. Update files in the test vault that showed this feature.

### Later work

Will be done later:

- Update all code symbols and CSS names for the new `preset`/`presets` vocab.
- Update test names and their data.

## Motivation and Context

I was a bit nervous about the possible source of confusion, so asked for feedback on the `#tasks` channel in Obsidian discord, and the message was clear: `include`/`includes` is confusing.

## How has this been tested?

- Automated tests
- Exploratory testing

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/11618422-c47f-47f8-8112-201d01a1497d)


## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
