### PR TITLE
refactor: Minor refactoring of links code and tests

### DIFF
--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -51,7 +51,7 @@ export class TasksFile {
     }
 
     /**
-     * Return a array of Link in the body of the file.
+     * Return an array of {@link Link} in the body of the file.
      */
     get outLinks(): Link[] {
         return this.cachedMetadata?.links?.map((link) => new Link(link, this.filenameWithoutExtension)) ?? [];

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -24,7 +24,7 @@ export class Link {
     /**
      * Returns the filename of the link destination without the path or alias
      * Removes the .md extension if present leaves other extensions intact.
-     * No accomodation for empty links.
+     * No accommodation for empty links.
      * @returns {string}
      */
     public get destinationFilename() {

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -29,7 +29,7 @@ export class Link {
      */
     public get destinationFilename() {
         // Handle internal links (starting with '#')
-        if (this.destination[0] === '#') return this.filename;
+        if (this.destination.startsWith('#')) return this.filename;
 
         // Extract filename from path (handles both path and optional hash fragment)
         const pathPart = this.destination.split('#', 1)[0];

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -1,8 +1,8 @@
 import type { LinkCache } from 'obsidian';
 
 export class Link {
-    private rawLink: LinkCache;
-    private filename: string;
+    private readonly rawLink: LinkCache;
+    private readonly filename: string;
 
     /**
      * @param {LinkCache} rawLink - The raw link from Obsidian cache.

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -13,11 +13,11 @@ export class Link {
         this.filenameContainingLink = filenameContainingLink;
     }
 
-    public get originalMarkdown() {
+    public get originalMarkdown(): string {
         return this.rawLink.original;
     }
 
-    public get destination() {
+    public get destination(): string {
         return this.rawLink.link;
     }
 
@@ -27,7 +27,7 @@ export class Link {
      * No accommodation for empty links.
      * @returns {string}
      */
-    public get destinationFilename() {
+    public get destinationFilename(): string {
         // Handle internal links (starting with '#')
         if (this.destination.startsWith('#')) {
             return this.filenameContainingLink;
@@ -41,7 +41,7 @@ export class Link {
         return destFilename.endsWith('.md') ? destFilename.slice(0, -3) : destFilename;
     }
 
-    public get displayText() {
+    public get displayText(): string | undefined {
         return this.rawLink.displayText;
     }
 }

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -29,7 +29,9 @@ export class Link {
      */
     public get destinationFilename() {
         // Handle internal links (starting with '#')
-        if (this.destination.startsWith('#')) return this.filename;
+        if (this.destination.startsWith('#')) {
+            return this.filename;
+        }
 
         // Extract filename from path (handles both path and optional hash fragment)
         const pathPart = this.destination.split('#', 1)[0];

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -6,11 +6,11 @@ export class Link {
 
     /**
      * @param {LinkCache} rawLink - The raw link from Obsidian cache.
-     * @param {string} filename - The name of the file where this link is located.
+     * @param {string} filenameContainingLink - The name of the file where this link is located.
      */
-    constructor(rawLink: LinkCache, filename: string) {
+    constructor(rawLink: LinkCache, filenameContainingLink: string) {
         this.rawLink = rawLink;
-        this.filenameContainingLink = filename;
+        this.filenameContainingLink = filenameContainingLink;
     }
 
     public get originalMarkdown() {

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -2,7 +2,7 @@ import type { LinkCache } from 'obsidian';
 
 export class Link {
     private readonly rawLink: LinkCache;
-    private readonly filename: string;
+    private readonly filenameContainingLink: string;
 
     /**
      * @param {LinkCache} rawLink - The raw link from Obsidian cache.
@@ -10,7 +10,7 @@ export class Link {
      */
     constructor(rawLink: LinkCache, filename: string) {
         this.rawLink = rawLink;
-        this.filename = filename;
+        this.filenameContainingLink = filename;
     }
 
     public get originalMarkdown() {
@@ -30,7 +30,7 @@ export class Link {
     public get destinationFilename() {
         // Handle internal links (starting with '#')
         if (this.destination.startsWith('#')) {
-            return this.filename;
+            return this.filenameContainingLink;
         }
 
         // Extract filename from path (handles both path and optional hash fragment)

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -14,9 +14,7 @@ function getLink(data: any, index: number) {
 
 describe('linkClass', () => {
     it('should construct a Link object', () => {
-        const data = links_everywhere;
-        const index = 0;
-        const link = getLink(data, index);
+        const link = getLink(links_everywhere, 0);
 
         expect(link).toBeDefined();
         expect(link.originalMarkdown).toEqual('[[link_in_file_body]]');

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -8,8 +8,7 @@ import link_in_task_markdown_link from '../Obsidian/__test_data__/link_in_task_m
 
 function getLink(data: any, index: number) {
     const rawLink = data.cachedMetadata.links[index];
-    const link = new Link(rawLink, new TasksFile(data.filePath).filenameWithoutExtension);
-    return link;
+    return new Link(rawLink, new TasksFile(data.filePath).filenameWithoutExtension);
 }
 
 describe('linkClass', () => {

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -6,12 +6,17 @@ import internal_heading_links from '../Obsidian/__test_data__/internal_heading_l
 import link_in_task_wikilink from '../Obsidian/__test_data__/link_in_task_wikilink.json';
 import link_in_task_markdown_link from '../Obsidian/__test_data__/link_in_task_markdown_link.json';
 
+function getLink(data: any, index: number) {
+    const rawLink = data.cachedMetadata.links[index];
+    const link = new Link(rawLink, new TasksFile(data.filePath).filenameWithoutExtension);
+    return link;
+}
+
 describe('linkClass', () => {
     it('should construct a Link object', () => {
         const data = links_everywhere;
         const index = 0;
-        const rawLink = data.cachedMetadata.links[index];
-        const link = new Link(rawLink, new TasksFile(data.filePath).filenameWithoutExtension);
+        const link = getLink(data, index);
 
         expect(link).toBeDefined();
         expect(link.originalMarkdown).toEqual('[[link_in_file_body]]');

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -8,8 +8,10 @@ import link_in_task_markdown_link from '../Obsidian/__test_data__/link_in_task_m
 
 describe('linkClass', () => {
     it('should construct a Link object', () => {
-        const rawLink = links_everywhere.cachedMetadata.links[0];
-        const link = new Link(rawLink, new TasksFile(links_everywhere.filePath).filenameWithoutExtension);
+        const data = links_everywhere;
+        const index = 0;
+        const rawLink = data.cachedMetadata.links[index];
+        const link = new Link(rawLink, new TasksFile(data.filePath).filenameWithoutExtension);
 
         expect(link).toBeDefined();
         expect(link.originalMarkdown).toEqual('[[link_in_file_body]]');

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -29,16 +29,14 @@ describe('linkClass', () => {
 
         // Tests checking against __internal_heading_links__
         it('should return the filename of the containing note if the link is internal [[#heading]]', () => {
-            const rawLink = internal_heading_links.cachedMetadata.links[0];
-            const link = new Link(rawLink, new TasksFile(internal_heading_links.filePath).filenameWithoutExtension);
+            const link = getLink(internal_heading_links, 0);
 
             expect(link.originalMarkdown).toEqual('[[#Basic Internal Links]]');
             expect(link.destinationFilename).toEqual('internal_heading_links');
         });
 
         it('should return the filename of the containing note if the link is internal and has an alias [[#heading|display text]]', () => {
-            const rawLink = internal_heading_links.cachedMetadata.links[6];
-            const link = new Link(rawLink, new TasksFile(internal_heading_links.filePath).filenameWithoutExtension);
+            const link = getLink(internal_heading_links, 6);
 
             expect(link.originalMarkdown).toEqual('[[#Header Links With File Reference]]');
             expect(link.destinationFilename).toEqual('internal_heading_links');
@@ -46,40 +44,35 @@ describe('linkClass', () => {
 
         // Tests checking against __link_in_task_wikilink__
         it('should return the filename if simple [[filename]]', () => {
-            const rawLink = link_in_task_wikilink.cachedMetadata.links[0];
-            const link = new Link(rawLink, new TasksFile(link_in_task_wikilink.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_wikilink, 0);
 
             expect(link.originalMarkdown).toEqual('[[link_in_task_wikilink]]');
             expect(link.destinationFilename).toEqual('link_in_task_wikilink');
         });
 
         it('should return the filename if link has a path [[path/filename]]', () => {
-            const rawLink = link_in_task_wikilink.cachedMetadata.links[2];
-            const link = new Link(rawLink, new TasksFile(link_in_task_wikilink.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_wikilink, 2);
 
             expect(link.originalMarkdown).toEqual('[[path/link_in_task_wikilink]]');
             expect(link.destinationFilename).toEqual('link_in_task_wikilink');
         });
 
         it('should return the filename if link has a path and a heading link [[path/filename#heading]]', () => {
-            const rawLink = link_in_task_wikilink.cachedMetadata.links[3];
-            const link = new Link(rawLink, new TasksFile(link_in_task_wikilink.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_wikilink, 3);
 
             expect(link.originalMarkdown).toEqual('[[path/link_in_task_wikilink#heading_link]]');
             expect(link.destinationFilename).toEqual('link_in_task_wikilink');
         });
 
         it('should return the filename if link has an alias [[filename|alias]]', () => {
-            const rawLink = link_in_task_wikilink.cachedMetadata.links[4];
-            const link = new Link(rawLink, new TasksFile(link_in_task_wikilink.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_wikilink, 4);
 
             expect(link.originalMarkdown).toEqual('[[link_in_task_wikilink|alias]]');
             expect(link.destinationFilename).toEqual('link_in_task_wikilink');
         });
 
         it('should return the filename if link has a path and an alias [[path/path/filename|alias]]', () => {
-            const rawLink = link_in_task_wikilink.cachedMetadata.links[5];
-            const link = new Link(rawLink, new TasksFile(link_in_task_wikilink.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_wikilink, 5);
 
             expect(link.originalMarkdown).toEqual('[[path/path/link_in_task_wikilink|alias]]');
             expect(link.destinationFilename).toEqual('link_in_task_wikilink');
@@ -87,8 +80,7 @@ describe('linkClass', () => {
 
         // # is a valid character in a filename or a path but Obsidian does not support it in links
         it('should return the filename if path contains a # [[pa#th/path/filename]]', () => {
-            const rawLink = link_in_task_wikilink.cachedMetadata.links[6];
-            const link = new Link(rawLink, new TasksFile(link_in_task_wikilink.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_wikilink, 6);
 
             expect(link.originalMarkdown).toEqual('[[pa#th/path/link_in_task_wikilink]]');
             expect(link.destinationFilename).toEqual('pa');
@@ -96,16 +88,14 @@ describe('linkClass', () => {
 
         // When grouping a Wikilink link expect [[file.md]] to be grouped with [[file]].
         it('should return a filename with no file extension if suffixed with .md [[link_in_task_wikilink.md]]', () => {
-            const rawLink = link_in_task_wikilink.cachedMetadata.links[7];
-            const link = new Link(rawLink, new TasksFile(link_in_task_wikilink.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_wikilink, 7);
 
             expect(link.originalMarkdown).toEqual('[[link_in_task_wikilink.md]]');
             expect(link.destinationFilename).toEqual('link_in_task_wikilink');
         });
 
         it('should return a filename with corresponding file extension if not markdown [[a_pdf_file.pdf]]', () => {
-            const rawLink = link_in_task_wikilink.cachedMetadata.links[8];
-            const link = new Link(rawLink, new TasksFile(link_in_task_wikilink.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_wikilink, 8);
 
             expect(link.originalMarkdown).toEqual('[[a_pdf_file.pdf]]');
             expect(link.destinationFilename).toEqual('a_pdf_file.pdf');
@@ -115,24 +105,21 @@ describe('linkClass', () => {
         // [[]] is not detected by the obsidian parser as a link
 
         it('should provide no special functionality for [[|]]; returns "|")', () => {
-            const rawLink = link_in_task_wikilink.cachedMetadata.links[9];
-            const link = new Link(rawLink, new TasksFile(link_in_task_wikilink.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_wikilink, 9);
 
             expect(link.originalMarkdown).toEqual('[[|]]');
             expect(link.destinationFilename).toEqual('|');
         });
 
         it('should provide no special functionality for [[|alias]]; returns "|alias".)', () => {
-            const rawLink = link_in_task_wikilink.cachedMetadata.links[10];
-            const link = new Link(rawLink, new TasksFile(link_in_task_wikilink.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_wikilink, 10);
 
             expect(link.originalMarkdown).toEqual('[[|alias]]');
             expect(link.destinationFilename).toEqual('|alias');
         });
 
         it('should provide no special functionality for [[|#alias]]; returns "|".)', () => {
-            const rawLink = link_in_task_wikilink.cachedMetadata.links[11];
-            const link = new Link(rawLink, new TasksFile(link_in_task_wikilink.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_wikilink, 11);
 
             expect(link.originalMarkdown).toEqual('[[|#alias]]');
             expect(link.destinationFilename).toEqual('|');
@@ -145,48 +132,42 @@ describe('linkClass', () => {
         // Tests checking against __link_in_task_markdown_link__
 
         it('should return the filename if the link is internal [display name](#heading)', () => {
-            const rawLink = link_in_task_markdown_link.cachedMetadata.links[8];
-            const link = new Link(rawLink, new TasksFile(link_in_task_markdown_link.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_markdown_link, 8);
 
             expect(link.originalMarkdown).toEqual('[heading](#heading)');
             expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
         });
 
         it('should return the filename when a simple markdown link [display name](filename)', () => {
-            const rawLink = link_in_task_markdown_link.cachedMetadata.links[2];
-            const link = new Link(rawLink, new TasksFile(link_in_task_markdown_link.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_markdown_link, 2);
 
             expect(link.originalMarkdown).toEqual('[link_in_task_markdown_link](link_in_task_markdown_link.md)');
             expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
         });
 
         it('should return the filename if link has a path [link_in_task_markdown_link](path/filename.md)', () => {
-            const rawLink = link_in_task_markdown_link.cachedMetadata.links[3];
-            const link = new Link(rawLink, new TasksFile(link_in_task_markdown_link.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_markdown_link, 3);
 
             expect(link.originalMarkdown).toEqual('[link_in_task_markdown_link](path/link_in_task_markdown_link.md)');
             expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
         });
 
         it('should return the filename if link has a path and a heading link [heading_link](path/filename.md#heading)', () => {
-            const rawLink = link_in_task_markdown_link.cachedMetadata.links[4];
-            const link = new Link(rawLink, new TasksFile(link_in_task_markdown_link.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_markdown_link, 4);
 
             expect(link.originalMarkdown).toEqual('[heading_link](path/link_in_task_markdown_link.md#heading_link)');
             expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
         });
 
         it('should return the filename if link has an alias [alias](filename.md)', () => {
-            const rawLink = link_in_task_markdown_link.cachedMetadata.links[5];
-            const link = new Link(rawLink, new TasksFile(link_in_task_markdown_link.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_markdown_link, 5);
 
             expect(link.originalMarkdown).toEqual('[alias](link_in_task_markdown_link.md)');
             expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
         });
 
         it('should return the filename if link has a path and an alias [alias](path/path/filename.md)', () => {
-            const rawLink = link_in_task_markdown_link.cachedMetadata.links[6];
-            const link = new Link(rawLink, new TasksFile(link_in_task_markdown_link.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_markdown_link, 6);
 
             expect(link.originalMarkdown).toEqual('[alias](path/path/link_in_task_markdown_link.md)');
             expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
@@ -194,8 +175,7 @@ describe('linkClass', () => {
 
         // # is a valid character in a filename or a path but Obsidian does not support it in links
         it('should return the string before the # [link_in_task_markdown_link](pa#th/path/filename.md)', () => {
-            const rawLink = link_in_task_markdown_link.cachedMetadata.links[7];
-            const link = new Link(rawLink, new TasksFile(link_in_task_markdown_link.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_markdown_link, 7);
 
             expect(link.originalMarkdown).toEqual(
                 '[link_in_task_markdown_link](pa#th/path/link_in_task_markdown_link.md)',
@@ -205,24 +185,21 @@ describe('linkClass', () => {
 
         // When grouping a Wikilink link expect [[file.md]] to be grouped with [[file]].
         it('should return a filename when no .md extension if the .md exists in markdown link [alias](filename)', () => {
-            const rawLink = link_in_task_markdown_link.cachedMetadata.links[9];
-            const link = new Link(rawLink, new TasksFile(link_in_task_markdown_link.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_markdown_link, 9);
 
             expect(link.originalMarkdown).toEqual('[link_in_task_markdown_link](link_in_task_markdown_link)');
             expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
         });
 
         it('should return a filename with corresponding file extension if not markdown [a_pdf_file](a_pdf_file.pdf)', () => {
-            const rawLink = link_in_task_markdown_link.cachedMetadata.links[10];
-            const link = new Link(rawLink, new TasksFile(link_in_task_markdown_link.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_markdown_link, 10);
 
             expect(link.originalMarkdown).toEqual('[a_pdf_file](a_pdf_file.pdf)');
             expect(link.destinationFilename).toEqual('a_pdf_file.pdf');
         });
 
         it('should handle spaces in the path, filename, and heading link [heading link](path/filename with spaces.md#heading link)', () => {
-            const rawLink = link_in_task_markdown_link.cachedMetadata.links[11];
-            const link = new Link(rawLink, new TasksFile(link_in_task_markdown_link.filePath).filenameWithoutExtension);
+            const link = getLink(link_in_task_markdown_link, 11);
 
             expect(link.originalMarkdown).toEqual(
                 '[spaces everywhere](Test%20Data/spaced%20filename%20link.md#spaced%20heading)',


### PR DESCRIPTION
_This replaces the following PR, which I squashed by mistake and so reverted:_

- https://github.com/obsidian-tasks-group/obsidian-tasks/pull/3494

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
    - #2443 
    - #2267
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

1. This is a major improvement to the usability of the Includes feature:
    - Editing its settings now does a debounced refresh of any open search results.
    - The debounce time is currently 300ms.
2. It works by adding a new event: `'obsidian-tasks-plugin:reload-open-search-results'`
    - This may be useful later, for example in updating search results if the Global Query is edited in settings.
3. It also makes a demo file a bit easier to understand and use:
    - `resources/sample_vaults/Tasks-Demo/How To/Reuse instructions across the vault.md`.

## Motivation and Context

Wanting to release these features:

- #2443 
- #2267

## How has this been tested?

- Added a new test for part of the change.
- Lots of manual exploratory testing in the test vault.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
