### PR TITLE
fix: Inline attachment previews are now visible in Live Preview and Reading modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ yarn-error.log
 
 # VS code config
 .vscode/
+
+# Obsidian's hot reload plugin marker file
+.hotreload

--- a/src/Obsidian/InlineRenderer.ts
+++ b/src/Obsidian/InlineRenderer.ts
@@ -1,4 +1,4 @@
-import type { MarkdownPostProcessorContext, Plugin } from 'obsidian';
+import type { App, MarkdownPostProcessorContext, Plugin } from 'obsidian';
 import { MarkdownRenderChild } from 'obsidian';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { TaskLayoutOptions } from '../Layout/TaskLayoutOptions';
@@ -23,7 +23,11 @@ import { TaskLocation } from '../Task/TaskLocation';
  * See also {@link LivePreviewExtension} which handles Markdown task lines in Obsidian's Live Preview mode.
  */
 export class InlineRenderer {
-    constructor({ plugin }: { plugin: Plugin }) {
+    private readonly app: App;
+
+    constructor({ plugin, app }: { plugin: Plugin; app: App }) {
+        this.app = app;
+
         plugin.registerMarkdownPostProcessor((el, ctx) => {
             plugin.app.workspace.onLayoutReady(() => {
                 this.markdownPostProcessor(el, ctx);
@@ -114,6 +118,7 @@ export class InlineRenderer {
         }
 
         const taskLineRenderer = new TaskLineRenderer({
+            obsidianApp: this.app,
             obsidianComponent: childComponent,
             parentUlElement: element,
             taskLayoutOptions: new TaskLayoutOptions(),

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -120,17 +120,19 @@ class QueryRenderChild extends MarkdownRenderChild {
     }) {
         super(container);
 
+        this.app = app;
+
         this.queryResultsRenderer = new QueryResultsRenderer(
             this.containerEl.className,
             source,
             tasksFile,
-            MarkdownRenderer.renderMarkdown,
+            MarkdownRenderer.render,
             this,
+            this.app,
         );
 
         this.queryResultsRenderer.query.debug('[render] QueryRenderChild.constructor() entered');
 
-        this.app = app;
         this.plugin = plugin;
         this.events = events;
 

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -1,4 +1,4 @@
-import type { Component, TFile } from 'obsidian';
+import type { App, Component, TFile } from 'obsidian';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import { postponeButtonTitle, shouldShowPostponeButton } from '../DateTime/Postponer';
@@ -67,19 +67,28 @@ export class QueryResultsRenderer {
     // Renders the group heading in this class:
     private readonly renderMarkdown;
     private readonly obsidianComponent: Component | null;
+    private readonly obsidianApp: App;
 
     constructor(
         className: string,
         source: string,
         tasksFile: TasksFile,
-        renderMarkdown: (markdown: string, el: HTMLElement, sourcePath: string, component: Component) => Promise<void>,
+        renderMarkdown: (
+            app: App,
+            markdown: string,
+            el: HTMLElement,
+            sourcePath: string,
+            component: Component,
+        ) => Promise<void>,
         obsidianComponent: Component | null,
+        obsidianApp: App,
         textRenderer: TextRenderer = TaskLineRenderer.obsidianMarkdownRenderer,
     ) {
         this.source = source;
         this._tasksFile = tasksFile;
         this.renderMarkdown = renderMarkdown;
         this.obsidianComponent = obsidianComponent;
+        this.obsidianApp = obsidianApp;
         this.textRenderer = textRenderer;
 
         // The engine is chosen on the basis of the code block language. Currently,
@@ -257,6 +266,7 @@ export class QueryResultsRenderer {
 
         const taskLineRenderer = new TaskLineRenderer({
             textRenderer: this.textRenderer,
+            obsidianApp: this.obsidianApp,
             obsidianComponent: this.obsidianComponent,
             parentUlElement: taskList,
             taskLayoutOptions: this.query.taskLayoutOptions,
@@ -469,7 +479,13 @@ export class QueryResultsRenderer {
         if (this.obsidianComponent === null) {
             return;
         }
-        await this.renderMarkdown(group.displayName, headerEl, this.tasksFile.path, this.obsidianComponent);
+        await this.renderMarkdown(
+            this.obsidianApp,
+            group.displayName,
+            headerEl,
+            this.tasksFile.path,
+            this.obsidianComponent,
+        );
     }
 
     private addBacklinks(

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -1,5 +1,5 @@
 import type { Moment } from 'moment';
-import { App, Component, MarkdownRenderer } from 'obsidian';
+import { type App, Component, MarkdownRenderer } from 'obsidian';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { TASK_FORMATS, getSettings } from '../Config/Settings';
 import type { QueryLayoutOptions } from '../Layout/QueryLayoutOptions';

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -1,5 +1,5 @@
 import type { Moment } from 'moment';
-import { Component, MarkdownRenderer } from 'obsidian';
+import { App, Component, MarkdownRenderer } from 'obsidian';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { TASK_FORMATS, getSettings } from '../Config/Settings';
 import type { QueryLayoutOptions } from '../Layout/QueryLayoutOptions';
@@ -21,6 +21,7 @@ import { TaskFieldRenderer } from './TaskFieldRenderer';
  * The function used to render a Markdown task line into an existing HTML element.
  */
 export type TextRenderer = (
+    app: App,
     text: string,
     element: HTMLSpanElement,
     path: string,
@@ -65,12 +66,14 @@ export function createAndAppendElement<K extends keyof HTMLElementTagNameMap>(
  */
 export class TaskLineRenderer {
     private readonly textRenderer: TextRenderer;
+    private readonly obsidianApp: App;
     private readonly obsidianComponent: Component | null;
     private readonly parentUlElement: HTMLElement;
     private readonly taskLayoutOptions: TaskLayoutOptions;
     private readonly queryLayoutOptions: QueryLayoutOptions;
 
     public static async obsidianMarkdownRenderer(
+        app: App,
         text: string,
         element: HTMLSpanElement,
         path: string,
@@ -79,7 +82,8 @@ export class TaskLineRenderer {
         if (!obsidianComponent) {
             return;
         }
-        await MarkdownRenderer.renderMarkdown(text, element, path, obsidianComponent);
+
+        await MarkdownRenderer.render(app, text, element, path, obsidianComponent);
     }
 
     /**
@@ -99,18 +103,21 @@ export class TaskLineRenderer {
      */
     constructor({
         textRenderer = TaskLineRenderer.obsidianMarkdownRenderer,
+        obsidianApp,
         obsidianComponent,
         parentUlElement,
         taskLayoutOptions,
         queryLayoutOptions,
     }: {
         textRenderer?: TextRenderer;
+        obsidianApp: App;
         obsidianComponent: Component | null;
         parentUlElement: HTMLElement;
         taskLayoutOptions: TaskLayoutOptions;
         queryLayoutOptions: QueryLayoutOptions;
     }) {
         this.textRenderer = textRenderer;
+        this.obsidianApp = obsidianApp;
         this.obsidianComponent = obsidianComponent;
         this.parentUlElement = parentUlElement;
         this.taskLayoutOptions = taskLayoutOptions;
@@ -301,7 +308,7 @@ export class TaskLineRenderer {
             // Add some debug output to enable hidden information in the task to be inspected.
             description += `<br>🐛 <b>${task.lineNumber}</b> . ${task.sectionStart} . ${task.sectionIndex} . '<code>${task.originalMarkdown}</code>'<br>'<code>${task.path}</code>' > '<code>${task.precedingHeader}</code>'<br>`;
         }
-        await this.textRenderer(description, span, task.path, this.obsidianComponent);
+        await this.textRenderer(this.obsidianApp, description, span, task.path, this.obsidianComponent);
 
         // If the task is a block quote, the block quote wraps the p-tag that contains the content.
         // In that case, we need to unwrap the p-tag *inside* the surrounding block quote.
@@ -495,6 +502,7 @@ export class TaskLineRenderer {
 
         const span = createAndAppendElement('span', li);
         await this.textRenderer(
+            this.obsidianApp,
             listItem.description,
             span,
             listItem.findClosestParentTask()?.path ?? '',

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,7 @@ export default class TasksPlugin extends Plugin {
             events,
         });
 
-        this.inlineRenderer = new InlineRenderer({ plugin: this });
+        this.inlineRenderer = new InlineRenderer({ plugin: this, app: this.app });
         this.queryRenderer = new QueryRenderer({ plugin: this, events });
 
         // Update types.json.

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -3,7 +3,6 @@
  */
 import moment from 'moment';
 import type { Task } from 'Task/Task';
-import type { App } from 'obsidian';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { State } from '../../src/Obsidian/Cache';
 import { QueryResultsRenderer } from '../../src/Renderer/QueryResultsRenderer';
@@ -18,6 +17,7 @@ import { prettifyHTML } from '../TestingTools/HTMLHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { toMarkdown } from '../TestingTools/TestHelpers';
 import { resetSettings, updateSettings } from '../../src/Config/Settings';
+import { mockApp } from '../__mocks__/obsidian';
 import { mockHTMLRenderer } from './RenderingTestHelpers';
 
 window.moment = moment;
@@ -32,13 +32,6 @@ afterEach(() => {
     GlobalFilter.getInstance().reset();
     resetSettings();
 });
-
-/**
- * Since we don't use the app object's method or properties directly,
- * and just treat it as an "opaque object" for markdown rendering, there is
- * not a lot to mock in particular.
- */
-const mockApp = {} as unknown as App;
 
 function makeQueryResultsRenderer(source: string, tasksFile: TasksFile) {
     return new QueryResultsRenderer(

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -3,6 +3,7 @@
  */
 import moment from 'moment';
 import type { Task } from 'Task/Task';
+import type { App } from 'obsidian';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { State } from '../../src/Obsidian/Cache';
 import { QueryResultsRenderer } from '../../src/Renderer/QueryResultsRenderer';
@@ -32,6 +33,13 @@ afterEach(() => {
     resetSettings();
 });
 
+/**
+ * Since we don't use the app object's method or properties directly,
+ * and just treat it as an "opaque object" for markdown rendering, there is
+ * not a lot to mock in particular.
+ */
+const mockApp = {} as unknown as App;
+
 function makeQueryResultsRenderer(source: string, tasksFile: TasksFile) {
     return new QueryResultsRenderer(
         'block-language-tasks',
@@ -39,6 +47,7 @@ function makeQueryResultsRenderer(source: string, tasksFile: TasksFile) {
         tasksFile,
         () => Promise.resolve(),
         null,
+        mockApp,
         mockHTMLRenderer,
     );
 }

--- a/tests/Renderer/RenderingTestHelpers.ts
+++ b/tests/Renderer/RenderingTestHelpers.ts
@@ -1,4 +1,6 @@
-export const mockHTMLRenderer = async (text: string, element: HTMLSpanElement, _path: string) => {
+import type { App } from 'obsidian';
+
+export const mockHTMLRenderer = async (_obsidianApp: App, text: string, element: HTMLSpanElement, _path: string) => {
     // Contrary to the default mockTextRenderer(),
     // instead of the rendered HTMLSpanElement.innerText,
     // we need the plain HTML here like in TaskLineRenderer.renderComponentText(),
@@ -6,6 +8,6 @@ export const mockHTMLRenderer = async (text: string, element: HTMLSpanElement, _
     element.innerHTML = text;
 };
 
-export const mockTextRenderer = async (text: string, element: HTMLSpanElement, _path: string) => {
+export const mockTextRenderer = async (_obsidianApp: App, text: string, element: HTMLSpanElement, _path: string) => {
     element.innerText = text;
 };

--- a/tests/Renderer/TaskLineRenderer.test.ts
+++ b/tests/Renderer/TaskLineRenderer.test.ts
@@ -3,7 +3,6 @@
  */
 import moment from 'moment';
 
-import type { App } from 'obsidian';
 import { DebugSettings } from '../../src/Config/DebugSettings';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { resetSettings, updateSettings } from '../../src/Config/Settings';
@@ -18,17 +17,11 @@ import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
 import { prettifyHTML } from '../TestingTools/HTMLHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { fromLine } from '../TestingTools/TestHelpers';
+import { mockApp } from '../__mocks__/obsidian';
 import { mockHTMLRenderer, mockTextRenderer } from './RenderingTestHelpers';
 
 jest.mock('obsidian');
 window.moment = moment;
-
-/**
- * Since we don't use the app object's method or properties directly,
- * and just treat it as an "opaque object" for markdown rendering, there is
- * not a lot to mock in particular.
- */
-const mockApp = {} as unknown as App;
 
 /**
  * Renders a task for test purposes and returns the rendered ListItem.

--- a/tests/Renderer/TaskLineRenderer.test.ts
+++ b/tests/Renderer/TaskLineRenderer.test.ts
@@ -3,6 +3,7 @@
  */
 import moment from 'moment';
 
+import type { App } from 'obsidian';
 import { DebugSettings } from '../../src/Config/DebugSettings';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { resetSettings, updateSettings } from '../../src/Config/Settings';
@@ -23,6 +24,13 @@ jest.mock('obsidian');
 window.moment = moment;
 
 /**
+ * Since we don't use the app object's method or properties directly,
+ * and just treat it as an "opaque object" for markdown rendering, there is
+ * not a lot to mock in particular.
+ */
+const mockApp = {} as unknown as App;
+
+/**
  * Renders a task for test purposes and returns the rendered ListItem.
  *
  * @param task to be rendered
@@ -41,6 +49,7 @@ async function renderListItem(
 ) {
     const taskLineRenderer = new TaskLineRenderer({
         textRenderer: testRenderer ?? mockTextRenderer,
+        obsidianApp: mockApp,
         obsidianComponent: null,
         parentUlElement: document.createElement('div'),
         taskLayoutOptions: taskLayoutOptions ?? new TaskLayoutOptions(),
@@ -84,6 +93,7 @@ describe('task line rendering - HTML', () => {
         const ulElement = document.createElement('ul');
         const taskLineRenderer = new TaskLineRenderer({
             textRenderer: mockTextRenderer,
+            obsidianApp: mockApp,
             obsidianComponent: null,
             parentUlElement: ulElement,
             taskLayoutOptions: new TaskLayoutOptions(),

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -1,6 +1,13 @@
-import type { CachedMetadata } from 'obsidian';
+import type { App, CachedMetadata } from 'obsidian';
 
 export {};
+
+/**
+ * Since we don't use the app object's method or properties directly,
+ * and just treat it as an "opaque object" for markdown rendering, there is
+ * not a lot to mock in particular.
+ */
+export const mockApp = {} as unknown as App;
 
 export class MenuItem {
     public title: string | DocumentFragment = '';


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3151#issuecomment-3014283469

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

Currently the tasks plugin is using the following API to render markdown: https://docs.obsidian.md/Reference/TypeScript+API/MarkdownRenderer/renderMarkdown

Said API is deprecated in favor of https://docs.obsidian.md/Reference/TypeScript+API/MarkdownRenderer/render

I didn't find any confirmation after a quick search, but my theory of why this fixes the issue with Live Preview attachments preview is that it allows the markdown renderer mechanism to access information related to the app settings, such as the attachments folder for example.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Motivation is to be able to render the attachments I added to my tasks for context, when using queries :) 

- Fixes https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3151#issuecomment-3014293928

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- All suite of tests were run and are passing
- I tested it manually on my own vault

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - Note from the author: On this topic, I am not sure how much can be unit tested in this case, since the markdown renderer is just an opaque API, and so far all other tests are passing. Open to discussions of course :)

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
