### PR TITLE
fix: Allow text selection with mouse in Preset settings

### DIFF
--- a/src/Config/PresetsSettingsUI.ts
+++ b/src/Config/PresetsSettingsUI.ts
@@ -71,8 +71,6 @@ export class PresetsSettingsUI {
         const setting = new Setting(wrapper);
         setting.settingEl.addClass('tasks-presets-setting');
 
-        // Make the wrapper draggable
-        wrapper.draggable = true;
         wrapper.setAttribute('data-preset-key', key);
 
         // Add name input field
@@ -131,6 +129,8 @@ export class PresetsSettingsUI {
 
             btn.extraSettingsEl.style.cursor = 'grab';
             btn.extraSettingsEl.addEventListener('mousedown', (_e) => {
+                // Enable dragging only when mousedown starts on the handle
+                wrapper.draggable = true;
                 btn.extraSettingsEl.style.cursor = 'grabbing';
             });
             btn.extraSettingsEl.addEventListener('mouseup', (_e) => {
@@ -181,6 +181,8 @@ export class PresetsSettingsUI {
 
         // Drag end
         wrapper.addEventListener('dragend', (_e) => {
+            // Disable dragging after drag ends
+            wrapper.draggable = false;
             wrapper.removeClass('tasks-presets-dragging');
             this.clearDropIndicators();
         });


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3510

## Description

Make drag-and-drop in the Presets section of settings only act upon the drag handle.

This allows users to click and drag to select text for editing.

## Motivation and Context

Fix #3510.

## How has this been tested?

Manually, in the sample vault.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
