### PR TITLE
refactor: Rename `outLinks` getters to `outlinks` - changing unreleased code

### DIFF
--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -53,7 +53,7 @@ export class TasksFile {
     /**
      * Return an array of {@link Link} in the body of the file.
      */
-    get outLinks(): Link[] {
+    get outlinks(): Link[] {
         return this.cachedMetadata?.links?.map((link) => new Link(link, this.filenameWithoutExtension)) ?? [];
     }
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -200,7 +200,7 @@ export class ListItem {
      * The data contest is documented here:
      * https://docs.obsidian.md/Reference/TypeScript+API/LinkCache
      */
-    get rawLinksInFileBody(): LinkCache[] {
+    private get rawLinksInFileBody(): LinkCache[] {
         return this.file.cachedMetadata?.links ?? [];
     }
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -207,7 +207,7 @@ export class ListItem {
     /**
      * Return a list of links in the task or list item's line.
      */
-    public get outLinks(): Link[] {
+    public get outlinks(): Link[] {
         return this.rawLinksInFileBody
             .filter((link) => link.position.start.line === this.lineNumber)
             .map((link) => new Link(link, this.file.filenameWithoutExtension));

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -241,13 +241,13 @@ describe('TasksFile - reading frontmatter', () => {
 describe('TasksFile - accessing links', () => {
     it('should return all links in the file body', () => {
         const tasksFile = getTasksFileFromMockData(links_everywhere);
-        expect(tasksFile.outLinks.length).toEqual(3);
-        expect(tasksFile.outLinks[0].originalMarkdown).toEqual('[[link_in_file_body]]');
+        expect(tasksFile.outlinks.length).toEqual(3);
+        expect(tasksFile.outlinks[0].originalMarkdown).toEqual('[[link_in_file_body]]');
     });
 
     it('should return no yaml links', () => {
         const tasksFile = getTasksFileFromMockData(link_in_yaml);
-        expect(tasksFile.outLinks.length).toEqual(0);
+        expect(tasksFile.outlinks.length).toEqual(0);
     });
 });
 

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -208,12 +208,6 @@ describe('related items', () => {
     });
 });
 describe('outLinks', () => {
-    it('should return all links in the task file', () => {
-        const tasks = readTasksFromSimulatedFile(links_everywhere);
-
-        expect(tasks[0].rawLinksInFileBody.length).toEqual(3);
-    });
-
     it('should return all links in the task line', () => {
         const tasks = readTasksFromSimulatedFile(links_everywhere);
 

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -211,13 +211,13 @@ describe('outLinks', () => {
     it('should return all links in the task line', () => {
         const tasks = readTasksFromSimulatedFile(links_everywhere);
 
-        expect(tasks[0].outLinks.length).toEqual(1);
-        expect(tasks[0].outLinks[0].originalMarkdown).toEqual('[[link_in_task_wikilink]]');
+        expect(tasks[0].outlinks.length).toEqual(1);
+        expect(tasks[0].outlinks[0].originalMarkdown).toEqual('[[link_in_task_wikilink]]');
     });
 
     it('should return [] when no links in the task line', () => {
         const tasks = readTasksFromSimulatedFile(multi_line_task_and_list_item);
-        expect(tasks[0].outLinks).toEqual([]);
+        expect(tasks[0].outlinks).toEqual([]);
     });
 });
 

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -207,7 +207,7 @@ describe('related items', () => {
         expect(grandChild.findClosestParentTask()).toEqual(parentTask);
     });
 });
-describe('outLinks', () => {
+describe('outlinks', () => {
     it('should return all links in the task line', () => {
         const tasks = readTasksFromSimulatedFile(links_everywhere);
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Improve method names, from `outLinks` to `outlinks` for easier typing, and consistency with a lot of references online.

## Motivation and Context

This is getting #3466 ready for release.

## How has this been tested?

In the test vault, and by updating user tests.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
