### PR TITLE
feat: Add `Link.markdown` for reliable rendering of links

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/How To/Access links.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Access links.md
@@ -50,24 +50,6 @@ limit groups 1
 ```tasks
 # Task line has a link
 filter by function task.outlinks.length > 0
-group by function task.outlinks.map(link => link.originalMarkdown).sort().join(' · ')
-limit groups 1
-```
-
-### Group by task outlinks - task outlinks that give broken group headings
-
-- Hovering over these links **in the task lines** works because of [#3357](https://github.com/obsidian-tasks-group/obsidian-tasks/pull/3357).
-- Hovering over these links **in the group headings** gives things like **Unable to find “Basic Internal Links” in Access links**
-
-```tasks
-# Task line has a link
-filter by function task.outlinks.length > 0
-
-# Task's link goes to a heading in the same file
-description includes [[#
-
-filename includes internal_heading_links
-
-group by function task.outlinks.map(link => link.originalMarkdown).sort().join(' · ')
+group by function task.outlinks.map(link => link.markdown).sort().join(' · ')
 limit groups 1
 ```

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -61,14 +61,20 @@ export class TasksFile {
      * Return an array of {@link Link} in the file's properties/frontmatter.
      */
     get outlinksInProperties(): Link[] {
-        return this.cachedMetadata.frontmatterLinks?.map((link) => new Link(link, this.filenameWithoutExtension)) ?? [];
+        return (
+            this.cachedMetadata.frontmatterLinks?.map(
+                (link) => new Link(link, this.filenameWithoutExtension, this.path),
+            ) ?? []
+        );
     }
 
     /**
      * Return an array of {@link Link} in the body of the file.
      */
     get outlinksInBody(): Link[] {
-        return this.cachedMetadata?.links?.map((link) => new Link(link, this.filenameWithoutExtension)) ?? [];
+        return (
+            this.cachedMetadata?.links?.map((link) => new Link(link, this.filenameWithoutExtension, this.path)) ?? []
+        );
     }
 
     /**

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -61,20 +61,14 @@ export class TasksFile {
      * Return an array of {@link Link} in the file's properties/frontmatter.
      */
     get outlinksInProperties(): Link[] {
-        return (
-            this.cachedMetadata.frontmatterLinks?.map(
-                (link) => new Link(link, this.filenameWithoutExtension, this.path),
-            ) ?? []
-        );
+        return this.cachedMetadata.frontmatterLinks?.map((link) => new Link(link, this.path)) ?? [];
     }
 
     /**
      * Return an array of {@link Link} in the body of the file.
      */
     get outlinksInBody(): Link[] {
-        return (
-            this.cachedMetadata?.links?.map((link) => new Link(link, this.filenameWithoutExtension, this.path)) ?? []
-        );
+        return this.cachedMetadata?.links?.map((link) => new Link(link, this.path)) ?? [];
     }
 
     /**

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -29,7 +29,13 @@ export class Link {
      * See also {@link originalMarkdown}
      */
     public get markdown(): string {
-        return this.rawLink.original;
+        if (!this.destination.startsWith('#')) {
+            // The link already has a file name, so just return it
+            return this.originalMarkdown;
+        }
+
+        // We will need to construct a new link, containing the filename (later, the full path)
+        return `[[${this.destinationFilename}${this.destination}|${this.displayText}]]`;
     }
 
     public get destination(): string {

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -13,7 +13,22 @@ export class Link {
         this.filenameContainingLink = filenameContainingLink;
     }
 
+    /**
+     * Return the original Markdown.
+     *
+     * See also {@link markdown}
+     */
     public get originalMarkdown(): string {
+        return this.rawLink.original;
+    }
+
+    /**
+     * This is like {@link originalMarkdown}, but will also work for heading-only links
+     * when viewed in files other than the one containing the original link.
+     *
+     * See also {@link originalMarkdown}
+     */
+    public get markdown(): string {
         return this.rawLink.original;
     }
 

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -2,6 +2,7 @@ import type { Reference } from 'obsidian';
 
 export class Link {
     private readonly rawLink: Reference;
+    // @ts-expect-error: TS6133: filenameContainingLink is declared but its value is never read.
     private readonly filenameContainingLink: string;
     private readonly pathContainingLink: string;
 
@@ -43,26 +44,6 @@ export class Link {
 
     public get destination(): string {
         return this.rawLink.link;
-    }
-
-    /**
-     * Returns the filename of the link destination without the path or alias
-     * Removes the .md extension if present leaves other extensions intact.
-     * No accommodation for empty links.
-     * @returns {string}
-     */
-    public get destinationFilename(): string {
-        // Handle internal links (starting with '#')
-        if (this.destination.startsWith('#')) {
-            return this.filenameContainingLink;
-        }
-
-        // Extract filename from path (handles both path and optional hash fragment)
-        const pathPart = this.destination.split('#', 1)[0];
-        const destFilename = pathPart.substring(pathPart.lastIndexOf('/') + 1);
-
-        // Remove.md extension if present
-        return destFilename.endsWith('.md') ? destFilename.slice(0, -3) : destFilename;
     }
 
     public get displayText(): string | undefined {

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -3,14 +3,18 @@ import type { Reference } from 'obsidian';
 export class Link {
     private readonly rawLink: Reference;
     private readonly filenameContainingLink: string;
+    // @ts-expect-error: TS6133: pathContainingLink is declared but its value is never read.
+    private readonly pathContainingLink: string;
 
     /**
      * @param {Reference} rawLink - The raw link from Obsidian cache.
      * @param {string} filenameContainingLink - The name of the file where this link is located.
+     * @param {string} pathContainingLink - The path of the file where this link is located.
      */
-    constructor(rawLink: Reference, filenameContainingLink: string) {
+    constructor(rawLink: Reference, filenameContainingLink: string, pathContainingLink: string) {
         this.rawLink = rawLink;
         this.filenameContainingLink = filenameContainingLink;
+        this.pathContainingLink = pathContainingLink;
     }
 
     /**

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -3,7 +3,6 @@ import type { Reference } from 'obsidian';
 export class Link {
     private readonly rawLink: Reference;
     private readonly filenameContainingLink: string;
-    // @ts-expect-error: TS6133: pathContainingLink is declared but its value is never read.
     private readonly pathContainingLink: string;
 
     /**
@@ -39,7 +38,7 @@ export class Link {
         }
 
         // We will need to construct a new link, containing the filename (later, the full path)
-        return `[[${this.destinationFilename}${this.destination}|${this.displayText}]]`;
+        return `[[${this.pathContainingLink}${this.destination}|${this.displayText}]]`;
     }
 
     public get destination(): string {

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -2,18 +2,14 @@ import type { Reference } from 'obsidian';
 
 export class Link {
     private readonly rawLink: Reference;
-    // @ts-expect-error: TS6133: filenameContainingLink is declared but its value is never read.
-    private readonly filenameContainingLink: string;
     private readonly pathContainingLink: string;
 
     /**
      * @param {Reference} rawLink - The raw link from Obsidian cache.
-     * @param {string} filenameContainingLink - The name of the file where this link is located.
      * @param {string} pathContainingLink - The path of the file where this link is located.
      */
-    constructor(rawLink: Reference, filenameContainingLink: string, pathContainingLink: string) {
+    constructor(rawLink: Reference, pathContainingLink: string) {
         this.rawLink = rawLink;
-        this.filenameContainingLink = filenameContainingLink;
         this.pathContainingLink = pathContainingLink;
     }
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -210,7 +210,7 @@ export class ListItem {
     public get outlinks(): Link[] {
         return this.rawLinksInFileBody
             .filter((link) => link.position.start.line === this.lineNumber)
-            .map((link) => new Link(link, this.file.filenameWithoutExtension, this.file.path));
+            .map((link) => new Link(link, this.file.path));
     }
 
     /**

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -210,7 +210,7 @@ export class ListItem {
     public get outlinks(): Link[] {
         return this.rawLinksInFileBody
             .filter((link) => link.position.start.line === this.lineNumber)
-            .map((link) => new Link(link, this.file.filenameWithoutExtension));
+            .map((link) => new Link(link, this.file.filenameWithoutExtension, this.file.path));
     }
 
     /**

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -36,11 +36,14 @@ describe('linkClass', () => {
             expect(link.markdown).toEqual('[[link_in_task_wikilink]]');
         });
 
+        // For more test examples, see QueryResultsRenderer.test.ts
         it.failing('should return a working link to [[#heading]]', () => {
             const link = getLink(internal_heading_links, 0);
 
             expect(link.originalMarkdown).toEqual('[[#Basic Internal Links]]');
-            expect(link.markdown).toEqual('[[internal_heading_links#Basic Internal Links]]');
+            // Eventually we will want the result to include the path, so:
+            //      [[Test Data/internal_heading_links.md#Basic Internal Links|Basic Internal Links]]
+            expect(link.markdown).toEqual('[[internal_heading_links.md#Basic Internal Links|Basic Internal Links]]');
         });
     });
 

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -37,13 +37,13 @@ describe('linkClass', () => {
         });
 
         // For more test examples, see QueryResultsRenderer.test.ts
-        it.failing('should return a working link to [[#heading]]', () => {
+        it('should return a working link to [[#heading]]', () => {
             const link = getLink(internal_heading_links, 0);
 
             expect(link.originalMarkdown).toEqual('[[#Basic Internal Links]]');
             // Eventually we will want the result to include the path, so:
             //      [[Test Data/internal_heading_links.md#Basic Internal Links|Basic Internal Links]]
-            expect(link.markdown).toEqual('[[internal_heading_links.md#Basic Internal Links|Basic Internal Links]]');
+            expect(link.markdown).toEqual('[[internal_heading_links#Basic Internal Links|Basic Internal Links]]');
         });
     });
 

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -24,7 +24,6 @@ describe('linkClass', () => {
         expect(link.originalMarkdown).toEqual('[[link_in_file_body]]');
         expect(link.destination).toEqual('link_in_file_body');
         expect(link.displayText).toEqual('link_in_file_body');
-        expect(link.destinationFilename).toEqual('link_in_file_body');
         expect(link.markdown).toEqual(link.originalMarkdown);
     });
 
@@ -260,7 +259,6 @@ describe('visualise links', () => {
         outlinks.forEach((link) => {
             output += createRow('link.originalMarkdown', link.originalMarkdown);
             output += createRow('link.markdown', link.markdown);
-            output += createRow('link.destinationFilename', link.destinationFilename);
             output += createRow('link.destination', link.destination);
             output += createRow('link.displayText', link.displayText);
             output += '\n';

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -27,6 +27,23 @@ describe('linkClass', () => {
         expect(link.destinationFilename).toEqual('link_in_file_body');
     });
 
+    describe('return markdown to navigate to a link', () => {
+        // These links are useful
+        it('should return the filename if simple [[filename]]', () => {
+            const link = getLink(link_in_task_wikilink, 0);
+
+            expect(link.originalMarkdown).toEqual('[[link_in_task_wikilink]]');
+            expect(link.markdown).toEqual('[[link_in_task_wikilink]]');
+        });
+
+        it.failing('should return a working link to [[#heading]]', () => {
+            const link = getLink(internal_heading_links, 0);
+
+            expect(link.originalMarkdown).toEqual('[[#Basic Internal Links]]');
+            expect(link.markdown).toEqual('[[internal_heading_links#Basic Internal Links]]');
+        });
+    });
+
     describe('.destinationFilename()', () => {
         // ================================
         // WIKILINK TESTS

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -46,9 +46,7 @@ describe('linkClass', () => {
                 '[[Test Data/internal_heading_links.md#Basic Internal Links|Basic Internal Links]]',
             );
         });
-    });
 
-    describe('.markdown()', () => {
         // ================================
         // WIKILINK TESTS
         // ================================

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -41,9 +41,9 @@ describe('linkClass', () => {
             const link = getLink(internal_heading_links, 0);
 
             expect(link.originalMarkdown).toEqual('[[#Basic Internal Links]]');
-            // Eventually we will want the result to include the path, so:
-            //      [[Test Data/internal_heading_links.md#Basic Internal Links|Basic Internal Links]]
-            expect(link.markdown).toEqual('[[internal_heading_links#Basic Internal Links|Basic Internal Links]]');
+            expect(link.markdown).toEqual(
+                '[[Test Data/internal_heading_links.md#Basic Internal Links|Basic Internal Links]]',
+            );
         });
     });
 

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -25,6 +25,7 @@ describe('linkClass', () => {
         expect(link.destination).toEqual('link_in_file_body');
         expect(link.displayText).toEqual('link_in_file_body');
         expect(link.destinationFilename).toEqual('link_in_file_body');
+        expect(link.markdown).toEqual(link.originalMarkdown);
     });
 
     describe('return markdown to navigate to a link', () => {
@@ -47,7 +48,7 @@ describe('linkClass', () => {
         });
     });
 
-    describe('.destinationFilename()', () => {
+    describe('.markdown()', () => {
         // ================================
         // WIKILINK TESTS
         // ================================
@@ -57,14 +58,18 @@ describe('linkClass', () => {
             const link = getLink(internal_heading_links, 0);
 
             expect(link.originalMarkdown).toEqual('[[#Basic Internal Links]]');
-            expect(link.destinationFilename).toEqual('internal_heading_links');
+            expect(link.markdown).toEqual(
+                '[[Test Data/internal_heading_links.md#Basic Internal Links|Basic Internal Links]]',
+            );
         });
 
         it('should return the filename of the containing note if the link is internal and has an alias [[#heading|display text]]', () => {
             const link = getLink(internal_heading_links, 6);
 
             expect(link.originalMarkdown).toEqual('[[#Header Links With File Reference]]');
-            expect(link.destinationFilename).toEqual('internal_heading_links');
+            expect(link.markdown).toEqual(
+                '[[Test Data/internal_heading_links.md#Header Links With File Reference|Header Links With File Reference]]',
+            );
         });
 
         // Tests checking against __link_in_task_wikilink__
@@ -72,35 +77,35 @@ describe('linkClass', () => {
             const link = getLink(link_in_task_wikilink, 0);
 
             expect(link.originalMarkdown).toEqual('[[link_in_task_wikilink]]');
-            expect(link.destinationFilename).toEqual('link_in_task_wikilink');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should return the filename if link has a path [[path/filename]]', () => {
             const link = getLink(link_in_task_wikilink, 2);
 
             expect(link.originalMarkdown).toEqual('[[Test Data/link_in_task_wikilink]]');
-            expect(link.destinationFilename).toEqual('link_in_task_wikilink');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should return the filename if link has a path and a heading link [[path/filename#heading]]', () => {
             const link = getLink(link_in_task_wikilink, 3);
 
             expect(link.originalMarkdown).toEqual('[[Test Data/link_in_task_wikilink#heading_link]]');
-            expect(link.destinationFilename).toEqual('link_in_task_wikilink');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should return the filename if link has an alias [[filename|alias]]', () => {
             const link = getLink(link_in_task_wikilink, 4);
 
             expect(link.originalMarkdown).toEqual('[[link_in_task_wikilink|alias]]');
-            expect(link.destinationFilename).toEqual('link_in_task_wikilink');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should return the filename if link has a path and an alias [[path/path/filename|alias]]', () => {
             const link = getLink(link_in_task_wikilink, 5);
 
             expect(link.originalMarkdown).toEqual('[[Test Data/link_in_task_wikilink|alias]]');
-            expect(link.destinationFilename).toEqual('link_in_task_wikilink');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         // # is a valid character in a filename or a path but Obsidian does not support it in links
@@ -108,7 +113,7 @@ describe('linkClass', () => {
             const link = getLink(link_in_task_wikilink, 6);
 
             expect(link.originalMarkdown).toEqual('[[pa#th/path/link_in_task_wikilink]]');
-            expect(link.destinationFilename).toEqual('pa');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         // When grouping a Wikilink link expect [[file.md]] to be grouped with [[file]].
@@ -116,14 +121,14 @@ describe('linkClass', () => {
             const link = getLink(link_in_task_wikilink, 7);
 
             expect(link.originalMarkdown).toEqual('[[link_in_task_wikilink.md]]');
-            expect(link.destinationFilename).toEqual('link_in_task_wikilink');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should return a filename with corresponding file extension if not markdown [[a_pdf_file.pdf]]', () => {
             const link = getLink(link_in_task_wikilink, 8);
 
             expect(link.originalMarkdown).toEqual('[[a_pdf_file.pdf]]');
-            expect(link.destinationFilename).toEqual('a_pdf_file.pdf');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         // Empty Wikilink Tests
@@ -133,21 +138,21 @@ describe('linkClass', () => {
             const link = getLink(link_in_task_wikilink, 9);
 
             expect(link.originalMarkdown).toEqual('[[|]]');
-            expect(link.destinationFilename).toEqual('|');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should provide no special functionality for [[|alias]]; returns "|alias".)', () => {
             const link = getLink(link_in_task_wikilink, 10);
 
             expect(link.originalMarkdown).toEqual('[[|alias]]');
-            expect(link.destinationFilename).toEqual('|alias');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should provide no special functionality for [[|#alias]]; returns "|".)', () => {
             const link = getLink(link_in_task_wikilink, 11);
 
             expect(link.originalMarkdown).toEqual('[[|#alias]]');
-            expect(link.destinationFilename).toEqual('|');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         // ================================
@@ -160,14 +165,14 @@ describe('linkClass', () => {
             const link = getLink(link_in_task_markdown_link, 8);
 
             expect(link.originalMarkdown).toEqual('[heading](#heading)');
-            expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
+            expect(link.markdown).toEqual('[[Test Data/link_in_task_markdown_link.md#heading|heading]]');
         });
 
         it('should return the filename when a simple markdown link [display name](filename)', () => {
             const link = getLink(link_in_task_markdown_link, 2);
 
             expect(link.originalMarkdown).toEqual('[link_in_task_markdown_link](link_in_task_markdown_link.md)');
-            expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should return the filename if link has a path [link_in_task_markdown_link](path/filename.md)', () => {
@@ -176,28 +181,28 @@ describe('linkClass', () => {
             expect(link.originalMarkdown).toEqual(
                 '[link_in_task_markdown_link](Test%20Data/link_in_task_markdown_link.md)',
             );
-            expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should return the filename if link has a path and a heading link [heading_link](path/filename.md#heading)', () => {
             const link = getLink(link_in_task_markdown_link, 4);
 
             expect(link.originalMarkdown).toEqual('[heading_link](Test%20Data/link_in_task_markdown_link.md#heading)');
-            expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should return the filename if link has an alias [alias](filename.md)', () => {
             const link = getLink(link_in_task_markdown_link, 5);
 
             expect(link.originalMarkdown).toEqual('[alias](link_in_task_markdown_link.md)');
-            expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should return the filename if link has a path and an alias [alias](path/path/filename.md)', () => {
             const link = getLink(link_in_task_markdown_link, 6);
 
             expect(link.originalMarkdown).toEqual('[alias](Test%20Data/link_in_task_markdown_link.md)');
-            expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         // # is a valid character in a filename or a path but Obsidian does not support it in links
@@ -207,7 +212,7 @@ describe('linkClass', () => {
             expect(link.originalMarkdown).toEqual(
                 '[link_in_task_markdown_link](pa#th/path/link_in_task_markdown_link.md)',
             );
-            expect(link.destinationFilename).toEqual('pa');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         // When grouping a Wikilink link expect [[file.md]] to be grouped with [[file]].
@@ -215,14 +220,14 @@ describe('linkClass', () => {
             const link = getLink(link_in_task_markdown_link, 9);
 
             expect(link.originalMarkdown).toEqual('[link_in_task_markdown_link](link_in_task_markdown_link)');
-            expect(link.destinationFilename).toEqual('link_in_task_markdown_link');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should return a filename with corresponding file extension if not markdown [a_pdf_file](a_pdf_file.pdf)', () => {
             const link = getLink(link_in_task_markdown_link, 10);
 
             expect(link.originalMarkdown).toEqual('[a_pdf_file](a_pdf_file.pdf)');
-            expect(link.destinationFilename).toEqual('a_pdf_file.pdf');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         it('should handle spaces in the path, filename, and heading link [heading link](path/filename with spaces.md#heading link)', () => {
@@ -231,7 +236,7 @@ describe('linkClass', () => {
             expect(link.originalMarkdown).toEqual(
                 '[spaces everywhere](Manual%20Testing/Smoke%20Testing%20the%20Tasks%20Plugin#How%20the%20tests%20work)',
             );
-            expect(link.destinationFilename).toEqual('Smoke Testing the Tasks Plugin');
+            expect(link.markdown).toEqual(link.originalMarkdown);
         });
 
         // Empty Markdown Link Tests

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -13,7 +13,7 @@ import type { SimulatedFile } from '../Obsidian/SimulatedFile';
 
 function getLink(data: any, index: number) {
     const rawLink = data.cachedMetadata.links[index];
-    return new Link(rawLink, new TasksFile(data.filePath).filenameWithoutExtension);
+    return new Link(rawLink, new TasksFile(data.filePath).filenameWithoutExtension, data.filePath);
 }
 
 describe('linkClass', () => {

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -1,5 +1,4 @@
 import { Link } from '../../src/Task/Link';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 
 import links_everywhere from '../Obsidian/__test_data__/links_everywhere.json';
 import internal_heading_links from '../Obsidian/__test_data__/internal_heading_links.json';
@@ -13,7 +12,7 @@ import type { SimulatedFile } from '../Obsidian/SimulatedFile';
 
 function getLink(data: any, index: number) {
     const rawLink = data.cachedMetadata.links[index];
-    return new Link(rawLink, new TasksFile(data.filePath).filenameWithoutExtension, data.filePath);
+    return new Link(rawLink, data.filePath);
 }
 
 describe('linkClass', () => {

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -253,6 +253,7 @@ describe('visualise links', () => {
         output += `## ${file.filePath}\n\n`;
         outlinks.forEach((link) => {
             output += createRow('link.originalMarkdown', link.originalMarkdown);
+            output += createRow('link.markdown', link.markdown);
             output += createRow('link.destinationFilename', link.destinationFilename);
             output += createRow('link.destination', link.destination);
             output += createRow('link.displayText', link.displayText);

--- a/tests/Task/Link.test.visualise_links_note_bodies.approved.md
+++ b/tests/Task/Link.test.visualise_links_note_bodies.approved.md
@@ -9,19 +9,19 @@
 ## Test Data/internal_heading_links.md
 
 `link.originalMarkdown     `: `'[[#Basic Internal Links]]'`
-`link.markdown             `: `'[[#Basic Internal Links]]'`
+`link.markdown             `: `'[[internal_heading_links#Basic Internal Links|Basic Internal Links]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Basic Internal Links'`
 `link.displayText          `: `'Basic Internal Links'`
 
 `link.originalMarkdown     `: `'[[#Multiple Links In One Task]]'`
-`link.markdown             `: `'[[#Multiple Links In One Task]]'`
+`link.markdown             `: `'[[internal_heading_links#Multiple Links In One Task|Multiple Links In One Task]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Multiple Links In One Task'`
 `link.displayText          `: `'Multiple Links In One Task'`
 
 `link.originalMarkdown     `: `'[[#Simple Headers]]'`
-`link.markdown             `: `'[[#Simple Headers]]'`
+`link.markdown             `: `'[[internal_heading_links#Simple Headers|Simple Headers]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Simple Headers'`
 `link.displayText          `: `'Simple Headers'`
@@ -39,13 +39,13 @@
 `link.displayText          `: `'Other File'`
 
 `link.originalMarkdown     `: `'[[#Mixed Link Types]]'`
-`link.markdown             `: `'[[#Mixed Link Types]]'`
+`link.markdown             `: `'[[internal_heading_links#Mixed Link Types|Mixed Link Types]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Mixed Link Types'`
 `link.displayText          `: `'Mixed Link Types'`
 
 `link.originalMarkdown     `: `'[[#Header Links With File Reference]]'`
-`link.markdown             `: `'[[#Header Links With File Reference]]'`
+`link.markdown             `: `'[[internal_heading_links#Header Links With File Reference|Header Links With File Reference]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Header Links With File Reference'`
 `link.displayText          `: `'Header Links With File Reference'`
@@ -57,19 +57,19 @@
 `link.displayText          `: `'Other File > Some Header'`
 
 `link.originalMarkdown     `: `'[[#Another Header]]'`
-`link.markdown             `: `'[[#Another Header]]'`
+`link.markdown             `: `'[[internal_heading_links#Another Header|Another Header]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Another Header'`
 `link.displayText          `: `'Another Header'`
 
 `link.originalMarkdown     `: `'[[#Headers-With_Special Characters]]'`
-`link.markdown             `: `'[[#Headers-With_Special Characters]]'`
+`link.markdown             `: `'[[internal_heading_links#Headers-With_Special Characters|Headers-With_Special Characters]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Headers-With_Special Characters'`
 `link.displayText          `: `'Headers-With_Special Characters'`
 
 `link.originalMarkdown     `: `'[[#Aliased Links|I am an alias]]'`
-`link.markdown             `: `'[[#Aliased Links|I am an alias]]'`
+`link.markdown             `: `'[[internal_heading_links#Aliased Links|I am an alias]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Aliased Links'`
 `link.displayText          `: `'I am an alias'`
@@ -149,7 +149,7 @@
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[heading](#heading)'`
-`link.markdown             `: `'[heading](#heading)'`
+`link.markdown             `: `'[[link_in_task_markdown_link#heading|heading]]'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'#heading'`
 `link.displayText          `: `'heading'`

--- a/tests/Task/Link.test.visualise_links_note_bodies.approved.md
+++ b/tests/Task/Link.test.visualise_links_note_bodies.approved.md
@@ -9,19 +9,19 @@
 ## Test Data/internal_heading_links.md
 
 `link.originalMarkdown     `: `'[[#Basic Internal Links]]'`
-`link.markdown             `: `'[[internal_heading_links#Basic Internal Links|Basic Internal Links]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Basic Internal Links|Basic Internal Links]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Basic Internal Links'`
 `link.displayText          `: `'Basic Internal Links'`
 
 `link.originalMarkdown     `: `'[[#Multiple Links In One Task]]'`
-`link.markdown             `: `'[[internal_heading_links#Multiple Links In One Task|Multiple Links In One Task]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Multiple Links In One Task|Multiple Links In One Task]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Multiple Links In One Task'`
 `link.displayText          `: `'Multiple Links In One Task'`
 
 `link.originalMarkdown     `: `'[[#Simple Headers]]'`
-`link.markdown             `: `'[[internal_heading_links#Simple Headers|Simple Headers]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Simple Headers|Simple Headers]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Simple Headers'`
 `link.displayText          `: `'Simple Headers'`
@@ -39,13 +39,13 @@
 `link.displayText          `: `'Other File'`
 
 `link.originalMarkdown     `: `'[[#Mixed Link Types]]'`
-`link.markdown             `: `'[[internal_heading_links#Mixed Link Types|Mixed Link Types]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Mixed Link Types|Mixed Link Types]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Mixed Link Types'`
 `link.displayText          `: `'Mixed Link Types'`
 
 `link.originalMarkdown     `: `'[[#Header Links With File Reference]]'`
-`link.markdown             `: `'[[internal_heading_links#Header Links With File Reference|Header Links With File Reference]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Header Links With File Reference|Header Links With File Reference]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Header Links With File Reference'`
 `link.displayText          `: `'Header Links With File Reference'`
@@ -57,19 +57,19 @@
 `link.displayText          `: `'Other File > Some Header'`
 
 `link.originalMarkdown     `: `'[[#Another Header]]'`
-`link.markdown             `: `'[[internal_heading_links#Another Header|Another Header]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Another Header|Another Header]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Another Header'`
 `link.displayText          `: `'Another Header'`
 
 `link.originalMarkdown     `: `'[[#Headers-With_Special Characters]]'`
-`link.markdown             `: `'[[internal_heading_links#Headers-With_Special Characters|Headers-With_Special Characters]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Headers-With_Special Characters|Headers-With_Special Characters]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Headers-With_Special Characters'`
 `link.displayText          `: `'Headers-With_Special Characters'`
 
 `link.originalMarkdown     `: `'[[#Aliased Links|I am an alias]]'`
-`link.markdown             `: `'[[internal_heading_links#Aliased Links|I am an alias]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Aliased Links|I am an alias]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Aliased Links'`
 `link.displayText          `: `'I am an alias'`
@@ -149,7 +149,7 @@
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[heading](#heading)'`
-`link.markdown             `: `'[[link_in_task_markdown_link#heading|heading]]'`
+`link.markdown             `: `'[[Test Data/link_in_task_markdown_link.md#heading|heading]]'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'#heading'`
 `link.displayText          `: `'heading'`

--- a/tests/Task/Link.test.visualise_links_note_bodies.approved.md
+++ b/tests/Task/Link.test.visualise_links_note_bodies.approved.md
@@ -1,6 +1,7 @@
 ## Test Data/comments_markdown_style.md
 
 `link.originalMarkdown     `: `'[[comments_html_style]]'`
+`link.markdown             `: `'[[comments_html_style]]'`
 `link.destinationFilename  `: `'comments_html_style'`
 `link.destination          `: `'comments_html_style'`
 `link.displayText          `: `'comments_html_style'`
@@ -8,56 +9,67 @@
 ## Test Data/internal_heading_links.md
 
 `link.originalMarkdown     `: `'[[#Basic Internal Links]]'`
+`link.markdown             `: `'[[#Basic Internal Links]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Basic Internal Links'`
 `link.displayText          `: `'Basic Internal Links'`
 
 `link.originalMarkdown     `: `'[[#Multiple Links In One Task]]'`
+`link.markdown             `: `'[[#Multiple Links In One Task]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Multiple Links In One Task'`
 `link.displayText          `: `'Multiple Links In One Task'`
 
 `link.originalMarkdown     `: `'[[#Simple Headers]]'`
+`link.markdown             `: `'[[#Simple Headers]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Simple Headers'`
 `link.displayText          `: `'Simple Headers'`
 
 `link.originalMarkdown     `: `'[[Other File]]'`
+`link.markdown             `: `'[[Other File]]'`
 `link.destinationFilename  `: `'Other File'`
 `link.destination          `: `'Other File'`
 `link.displayText          `: `'Other File'`
 
 `link.originalMarkdown     `: `'[[Other File]]'`
+`link.markdown             `: `'[[Other File]]'`
 `link.destinationFilename  `: `'Other File'`
 `link.destination          `: `'Other File'`
 `link.displayText          `: `'Other File'`
 
 `link.originalMarkdown     `: `'[[#Mixed Link Types]]'`
+`link.markdown             `: `'[[#Mixed Link Types]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Mixed Link Types'`
 `link.displayText          `: `'Mixed Link Types'`
 
 `link.originalMarkdown     `: `'[[#Header Links With File Reference]]'`
+`link.markdown             `: `'[[#Header Links With File Reference]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Header Links With File Reference'`
 `link.displayText          `: `'Header Links With File Reference'`
 
 `link.originalMarkdown     `: `'[[Other File#Some Header]]'`
+`link.markdown             `: `'[[Other File#Some Header]]'`
 `link.destinationFilename  `: `'Other File'`
 `link.destination          `: `'Other File#Some Header'`
 `link.displayText          `: `'Other File > Some Header'`
 
 `link.originalMarkdown     `: `'[[#Another Header]]'`
+`link.markdown             `: `'[[#Another Header]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Another Header'`
 `link.displayText          `: `'Another Header'`
 
 `link.originalMarkdown     `: `'[[#Headers-With_Special Characters]]'`
+`link.markdown             `: `'[[#Headers-With_Special Characters]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Headers-With_Special Characters'`
 `link.displayText          `: `'Headers-With_Special Characters'`
 
 `link.originalMarkdown     `: `'[[#Aliased Links|I am an alias]]'`
+`link.markdown             `: `'[[#Aliased Links|I am an alias]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Aliased Links'`
 `link.displayText          `: `'I am an alias'`
@@ -65,6 +77,7 @@
 ## Test Data/link_in_file_body.md
 
 `link.originalMarkdown     `: `'[[yaml_tags_is_empty]]'`
+`link.markdown             `: `'[[yaml_tags_is_empty]]'`
 `link.destinationFilename  `: `'yaml_tags_is_empty'`
 `link.destination          `: `'yaml_tags_is_empty'`
 `link.displayText          `: `'yaml_tags_is_empty'`
@@ -72,6 +85,7 @@
 ## Test Data/link_in_file_body_with_custom_display_text.md
 
 `link.originalMarkdown     `: `'[[yaml_tags_is_empty|a file and use custom display text]]'`
+`link.markdown             `: `'[[yaml_tags_is_empty|a file and use custom display text]]'`
 `link.destinationFilename  `: `'yaml_tags_is_empty'`
 `link.destination          `: `'yaml_tags_is_empty'`
 `link.displayText          `: `'a file and use custom display text'`
@@ -79,6 +93,7 @@
 ## Test Data/link_in_heading.md
 
 `link.originalMarkdown     `: `'[[multiple_headings]]'`
+`link.markdown             `: `'[[multiple_headings]]'`
 `link.destinationFilename  `: `'multiple_headings'`
 `link.destination          `: `'multiple_headings'`
 `link.displayText          `: `'multiple_headings'`
@@ -86,61 +101,73 @@
 ## Test Data/link_in_task_markdown_link.md
 
 `link.originalMarkdown     `: `'[jason_properties](jason_properties.md)'`
+`link.markdown             `: `'[jason_properties](jason_properties.md)'`
 `link.destinationFilename  `: `'jason_properties'`
 `link.destination          `: `'jason_properties.md'`
 `link.displayText          `: `'jason_properties'`
 
 `link.originalMarkdown     `: `'[multiple_headings](multiple_headings.md)'`
+`link.markdown             `: `'[multiple_headings](multiple_headings.md)'`
 `link.destinationFilename  `: `'multiple_headings'`
 `link.destination          `: `'multiple_headings.md'`
 `link.displayText          `: `'multiple_headings'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](link_in_task_markdown_link.md)'`
+`link.markdown             `: `'[link_in_task_markdown_link](link_in_task_markdown_link.md)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'link_in_task_markdown_link.md'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](Test%20Data/link_in_task_markdown_link.md)'`
+`link.markdown             `: `'[link_in_task_markdown_link](Test%20Data/link_in_task_markdown_link.md)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'Test Data/link_in_task_markdown_link.md'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[heading_link](Test%20Data/link_in_task_markdown_link.md#heading)'`
+`link.markdown             `: `'[heading_link](Test%20Data/link_in_task_markdown_link.md#heading)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'Test Data/link_in_task_markdown_link.md#heading'`
 `link.displayText          `: `'heading_link'`
 
 `link.originalMarkdown     `: `'[alias](link_in_task_markdown_link.md)'`
+`link.markdown             `: `'[alias](link_in_task_markdown_link.md)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'link_in_task_markdown_link.md'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[alias](Test%20Data/link_in_task_markdown_link.md)'`
+`link.markdown             `: `'[alias](Test%20Data/link_in_task_markdown_link.md)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'Test Data/link_in_task_markdown_link.md'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](pa#th/path/link_in_task_markdown_link.md)'`
+`link.markdown             `: `'[link_in_task_markdown_link](pa#th/path/link_in_task_markdown_link.md)'`
 `link.destinationFilename  `: `'pa'`
 `link.destination          `: `'pa#th/path/link_in_task_markdown_link.md'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[heading](#heading)'`
+`link.markdown             `: `'[heading](#heading)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'#heading'`
 `link.displayText          `: `'heading'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](link_in_task_markdown_link)'`
+`link.markdown             `: `'[link_in_task_markdown_link](link_in_task_markdown_link)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'link_in_task_markdown_link'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[a_pdf_file](a_pdf_file.pdf)'`
+`link.markdown             `: `'[a_pdf_file](a_pdf_file.pdf)'`
 `link.destinationFilename  `: `'a_pdf_file.pdf'`
 `link.destination          `: `'a_pdf_file.pdf'`
 `link.displayText          `: `'a_pdf_file'`
 
 `link.originalMarkdown     `: `'[spaces everywhere](Manual%20Testing/Smoke%20Testing%20the%20Tasks%20Plugin#How%20the%20tests%20work)'`
+`link.markdown             `: `'[spaces everywhere](Manual%20Testing/Smoke%20Testing%20the%20Tasks%20Plugin#How%20the%20tests%20work)'`
 `link.destinationFilename  `: `'Smoke Testing the Tasks Plugin'`
 `link.destination          `: `'Manual Testing/Smoke Testing the Tasks Plugin#How the tests work'`
 `link.displayText          `: `'spaces everywhere'`
@@ -148,61 +175,73 @@
 ## Test Data/link_in_task_wikilink.md
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink]]'`
+`link.markdown             `: `'[[link_in_task_wikilink]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink'`
 `link.displayText          `: `'link_in_task_wikilink'`
 
 `link.originalMarkdown     `: `'[[multiple_headings]]'`
+`link.markdown             `: `'[[multiple_headings]]'`
 `link.destinationFilename  `: `'multiple_headings'`
 `link.destination          `: `'multiple_headings'`
 `link.displayText          `: `'multiple_headings'`
 
 `link.originalMarkdown     `: `'[[Test Data/link_in_task_wikilink]]'`
+`link.markdown             `: `'[[Test Data/link_in_task_wikilink]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'Test Data/link_in_task_wikilink'`
 `link.displayText          `: `'Test Data/link_in_task_wikilink'`
 
 `link.originalMarkdown     `: `'[[Test Data/link_in_task_wikilink#heading_link]]'`
+`link.markdown             `: `'[[Test Data/link_in_task_wikilink#heading_link]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'Test Data/link_in_task_wikilink#heading_link'`
 `link.displayText          `: `'Test Data/link_in_task_wikilink > heading_link'`
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink|alias]]'`
+`link.markdown             `: `'[[link_in_task_wikilink|alias]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[[Test Data/link_in_task_wikilink|alias]]'`
+`link.markdown             `: `'[[Test Data/link_in_task_wikilink|alias]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'Test Data/link_in_task_wikilink'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[[pa#th/path/link_in_task_wikilink]]'`
+`link.markdown             `: `'[[pa#th/path/link_in_task_wikilink]]'`
 `link.destinationFilename  `: `'pa'`
 `link.destination          `: `'pa#th/path/link_in_task_wikilink'`
 `link.displayText          `: `'pa > th/path/link_in_task_wikilink'`
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink.md]]'`
+`link.markdown             `: `'[[link_in_task_wikilink.md]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink.md'`
 `link.displayText          `: `'link_in_task_wikilink.md'`
 
 `link.originalMarkdown     `: `'[[a_pdf_file.pdf]]'`
+`link.markdown             `: `'[[a_pdf_file.pdf]]'`
 `link.destinationFilename  `: `'a_pdf_file.pdf'`
 `link.destination          `: `'a_pdf_file.pdf'`
 `link.displayText          `: `'a_pdf_file.pdf'`
 
 `link.originalMarkdown     `: `'[[|]]'`
+`link.markdown             `: `'[[|]]'`
 `link.destinationFilename  `: `'|'`
 `link.destination          `: `'|'`
 `link.displayText          `: `'|'`
 
 `link.originalMarkdown     `: `'[[|alias]]'`
+`link.markdown             `: `'[[|alias]]'`
 `link.destinationFilename  `: `'|alias'`
 `link.destination          `: `'|alias'`
 `link.displayText          `: `'|alias'`
 
 `link.originalMarkdown     `: `'[[|#alias]]'`
+`link.markdown             `: `'[[|#alias]]'`
 `link.destinationFilename  `: `'|'`
 `link.destination          `: `'|#alias'`
 `link.displayText          `: `'| > alias'`
@@ -210,6 +249,7 @@
 ## Test Data/link_is_broken.md
 
 `link.originalMarkdown     `: `'[[broken link - do not fix me]]'`
+`link.markdown             `: `'[[broken link - do not fix me]]'`
 `link.destinationFilename  `: `'broken link - do not fix me'`
 `link.destination          `: `'broken link - do not fix me'`
 `link.displayText          `: `'broken link - do not fix me'`
@@ -217,16 +257,19 @@
 ## Test Data/links_everywhere.md
 
 `link.originalMarkdown     `: `'[[link_in_file_body]]'`
+`link.markdown             `: `'[[link_in_file_body]]'`
 `link.destinationFilename  `: `'link_in_file_body'`
 `link.destination          `: `'link_in_file_body'`
 `link.displayText          `: `'link_in_file_body'`
 
 `link.originalMarkdown     `: `'[[link_in_heading]]'`
+`link.markdown             `: `'[[link_in_heading]]'`
 `link.destinationFilename  `: `'link_in_heading'`
 `link.destination          `: `'link_in_heading'`
 `link.displayText          `: `'link_in_heading'`
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink]]'`
+`link.markdown             `: `'[[link_in_task_wikilink]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink'`
 `link.displayText          `: `'link_in_task_wikilink'`
@@ -234,6 +277,7 @@
 ## Test Data/numbered_tasks_issue_3481.md
 
 `link.originalMarkdown     `: `'[[numbered_tasks_issue_3481_searches]]'`
+`link.markdown             `: `'[[numbered_tasks_issue_3481_searches]]'`
 `link.destinationFilename  `: `'numbered_tasks_issue_3481_searches'`
 `link.destination          `: `'numbered_tasks_issue_3481_searches'`
 `link.displayText          `: `'numbered_tasks_issue_3481_searches'`

--- a/tests/Task/Link.test.visualise_links_note_bodies.approved.md
+++ b/tests/Task/Link.test.visualise_links_note_bodies.approved.md
@@ -2,7 +2,6 @@
 
 `link.originalMarkdown     `: `'[[comments_html_style]]'`
 `link.markdown             `: `'[[comments_html_style]]'`
-`link.destinationFilename  `: `'comments_html_style'`
 `link.destination          `: `'comments_html_style'`
 `link.displayText          `: `'comments_html_style'`
 
@@ -10,67 +9,56 @@
 
 `link.originalMarkdown     `: `'[[#Basic Internal Links]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Basic Internal Links|Basic Internal Links]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Basic Internal Links'`
 `link.displayText          `: `'Basic Internal Links'`
 
 `link.originalMarkdown     `: `'[[#Multiple Links In One Task]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Multiple Links In One Task|Multiple Links In One Task]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Multiple Links In One Task'`
 `link.displayText          `: `'Multiple Links In One Task'`
 
 `link.originalMarkdown     `: `'[[#Simple Headers]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Simple Headers|Simple Headers]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Simple Headers'`
 `link.displayText          `: `'Simple Headers'`
 
 `link.originalMarkdown     `: `'[[Other File]]'`
 `link.markdown             `: `'[[Other File]]'`
-`link.destinationFilename  `: `'Other File'`
 `link.destination          `: `'Other File'`
 `link.displayText          `: `'Other File'`
 
 `link.originalMarkdown     `: `'[[Other File]]'`
 `link.markdown             `: `'[[Other File]]'`
-`link.destinationFilename  `: `'Other File'`
 `link.destination          `: `'Other File'`
 `link.displayText          `: `'Other File'`
 
 `link.originalMarkdown     `: `'[[#Mixed Link Types]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Mixed Link Types|Mixed Link Types]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Mixed Link Types'`
 `link.displayText          `: `'Mixed Link Types'`
 
 `link.originalMarkdown     `: `'[[#Header Links With File Reference]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Header Links With File Reference|Header Links With File Reference]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Header Links With File Reference'`
 `link.displayText          `: `'Header Links With File Reference'`
 
 `link.originalMarkdown     `: `'[[Other File#Some Header]]'`
 `link.markdown             `: `'[[Other File#Some Header]]'`
-`link.destinationFilename  `: `'Other File'`
 `link.destination          `: `'Other File#Some Header'`
 `link.displayText          `: `'Other File > Some Header'`
 
 `link.originalMarkdown     `: `'[[#Another Header]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Another Header|Another Header]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Another Header'`
 `link.displayText          `: `'Another Header'`
 
 `link.originalMarkdown     `: `'[[#Headers-With_Special Characters]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Headers-With_Special Characters|Headers-With_Special Characters]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Headers-With_Special Characters'`
 `link.displayText          `: `'Headers-With_Special Characters'`
 
 `link.originalMarkdown     `: `'[[#Aliased Links|I am an alias]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Aliased Links|I am an alias]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Aliased Links'`
 `link.displayText          `: `'I am an alias'`
 
@@ -78,7 +66,6 @@
 
 `link.originalMarkdown     `: `'[[yaml_tags_is_empty]]'`
 `link.markdown             `: `'[[yaml_tags_is_empty]]'`
-`link.destinationFilename  `: `'yaml_tags_is_empty'`
 `link.destination          `: `'yaml_tags_is_empty'`
 `link.displayText          `: `'yaml_tags_is_empty'`
 
@@ -86,7 +73,6 @@
 
 `link.originalMarkdown     `: `'[[yaml_tags_is_empty|a file and use custom display text]]'`
 `link.markdown             `: `'[[yaml_tags_is_empty|a file and use custom display text]]'`
-`link.destinationFilename  `: `'yaml_tags_is_empty'`
 `link.destination          `: `'yaml_tags_is_empty'`
 `link.displayText          `: `'a file and use custom display text'`
 
@@ -94,7 +80,6 @@
 
 `link.originalMarkdown     `: `'[[multiple_headings]]'`
 `link.markdown             `: `'[[multiple_headings]]'`
-`link.destinationFilename  `: `'multiple_headings'`
 `link.destination          `: `'multiple_headings'`
 `link.displayText          `: `'multiple_headings'`
 
@@ -102,73 +87,61 @@
 
 `link.originalMarkdown     `: `'[jason_properties](jason_properties.md)'`
 `link.markdown             `: `'[jason_properties](jason_properties.md)'`
-`link.destinationFilename  `: `'jason_properties'`
 `link.destination          `: `'jason_properties.md'`
 `link.displayText          `: `'jason_properties'`
 
 `link.originalMarkdown     `: `'[multiple_headings](multiple_headings.md)'`
 `link.markdown             `: `'[multiple_headings](multiple_headings.md)'`
-`link.destinationFilename  `: `'multiple_headings'`
 `link.destination          `: `'multiple_headings.md'`
 `link.displayText          `: `'multiple_headings'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](link_in_task_markdown_link.md)'`
 `link.markdown             `: `'[link_in_task_markdown_link](link_in_task_markdown_link.md)'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'link_in_task_markdown_link.md'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](Test%20Data/link_in_task_markdown_link.md)'`
 `link.markdown             `: `'[link_in_task_markdown_link](Test%20Data/link_in_task_markdown_link.md)'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'Test Data/link_in_task_markdown_link.md'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[heading_link](Test%20Data/link_in_task_markdown_link.md#heading)'`
 `link.markdown             `: `'[heading_link](Test%20Data/link_in_task_markdown_link.md#heading)'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'Test Data/link_in_task_markdown_link.md#heading'`
 `link.displayText          `: `'heading_link'`
 
 `link.originalMarkdown     `: `'[alias](link_in_task_markdown_link.md)'`
 `link.markdown             `: `'[alias](link_in_task_markdown_link.md)'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'link_in_task_markdown_link.md'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[alias](Test%20Data/link_in_task_markdown_link.md)'`
 `link.markdown             `: `'[alias](Test%20Data/link_in_task_markdown_link.md)'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'Test Data/link_in_task_markdown_link.md'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](pa#th/path/link_in_task_markdown_link.md)'`
 `link.markdown             `: `'[link_in_task_markdown_link](pa#th/path/link_in_task_markdown_link.md)'`
-`link.destinationFilename  `: `'pa'`
 `link.destination          `: `'pa#th/path/link_in_task_markdown_link.md'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[heading](#heading)'`
 `link.markdown             `: `'[[Test Data/link_in_task_markdown_link.md#heading|heading]]'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'#heading'`
 `link.displayText          `: `'heading'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](link_in_task_markdown_link)'`
 `link.markdown             `: `'[link_in_task_markdown_link](link_in_task_markdown_link)'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'link_in_task_markdown_link'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[a_pdf_file](a_pdf_file.pdf)'`
 `link.markdown             `: `'[a_pdf_file](a_pdf_file.pdf)'`
-`link.destinationFilename  `: `'a_pdf_file.pdf'`
 `link.destination          `: `'a_pdf_file.pdf'`
 `link.displayText          `: `'a_pdf_file'`
 
 `link.originalMarkdown     `: `'[spaces everywhere](Manual%20Testing/Smoke%20Testing%20the%20Tasks%20Plugin#How%20the%20tests%20work)'`
 `link.markdown             `: `'[spaces everywhere](Manual%20Testing/Smoke%20Testing%20the%20Tasks%20Plugin#How%20the%20tests%20work)'`
-`link.destinationFilename  `: `'Smoke Testing the Tasks Plugin'`
 `link.destination          `: `'Manual Testing/Smoke Testing the Tasks Plugin#How the tests work'`
 `link.displayText          `: `'spaces everywhere'`
 
@@ -176,73 +149,61 @@
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink]]'`
 `link.markdown             `: `'[[link_in_task_wikilink]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink'`
 `link.displayText          `: `'link_in_task_wikilink'`
 
 `link.originalMarkdown     `: `'[[multiple_headings]]'`
 `link.markdown             `: `'[[multiple_headings]]'`
-`link.destinationFilename  `: `'multiple_headings'`
 `link.destination          `: `'multiple_headings'`
 `link.displayText          `: `'multiple_headings'`
 
 `link.originalMarkdown     `: `'[[Test Data/link_in_task_wikilink]]'`
 `link.markdown             `: `'[[Test Data/link_in_task_wikilink]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'Test Data/link_in_task_wikilink'`
 `link.displayText          `: `'Test Data/link_in_task_wikilink'`
 
 `link.originalMarkdown     `: `'[[Test Data/link_in_task_wikilink#heading_link]]'`
 `link.markdown             `: `'[[Test Data/link_in_task_wikilink#heading_link]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'Test Data/link_in_task_wikilink#heading_link'`
 `link.displayText          `: `'Test Data/link_in_task_wikilink > heading_link'`
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink|alias]]'`
 `link.markdown             `: `'[[link_in_task_wikilink|alias]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[[Test Data/link_in_task_wikilink|alias]]'`
 `link.markdown             `: `'[[Test Data/link_in_task_wikilink|alias]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'Test Data/link_in_task_wikilink'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[[pa#th/path/link_in_task_wikilink]]'`
 `link.markdown             `: `'[[pa#th/path/link_in_task_wikilink]]'`
-`link.destinationFilename  `: `'pa'`
 `link.destination          `: `'pa#th/path/link_in_task_wikilink'`
 `link.displayText          `: `'pa > th/path/link_in_task_wikilink'`
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink.md]]'`
 `link.markdown             `: `'[[link_in_task_wikilink.md]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink.md'`
 `link.displayText          `: `'link_in_task_wikilink.md'`
 
 `link.originalMarkdown     `: `'[[a_pdf_file.pdf]]'`
 `link.markdown             `: `'[[a_pdf_file.pdf]]'`
-`link.destinationFilename  `: `'a_pdf_file.pdf'`
 `link.destination          `: `'a_pdf_file.pdf'`
 `link.displayText          `: `'a_pdf_file.pdf'`
 
 `link.originalMarkdown     `: `'[[|]]'`
 `link.markdown             `: `'[[|]]'`
-`link.destinationFilename  `: `'|'`
 `link.destination          `: `'|'`
 `link.displayText          `: `'|'`
 
 `link.originalMarkdown     `: `'[[|alias]]'`
 `link.markdown             `: `'[[|alias]]'`
-`link.destinationFilename  `: `'|alias'`
 `link.destination          `: `'|alias'`
 `link.displayText          `: `'|alias'`
 
 `link.originalMarkdown     `: `'[[|#alias]]'`
 `link.markdown             `: `'[[|#alias]]'`
-`link.destinationFilename  `: `'|'`
 `link.destination          `: `'|#alias'`
 `link.displayText          `: `'| > alias'`
 
@@ -250,7 +211,6 @@
 
 `link.originalMarkdown     `: `'[[broken link - do not fix me]]'`
 `link.markdown             `: `'[[broken link - do not fix me]]'`
-`link.destinationFilename  `: `'broken link - do not fix me'`
 `link.destination          `: `'broken link - do not fix me'`
 `link.displayText          `: `'broken link - do not fix me'`
 
@@ -258,19 +218,16 @@
 
 `link.originalMarkdown     `: `'[[link_in_file_body]]'`
 `link.markdown             `: `'[[link_in_file_body]]'`
-`link.destinationFilename  `: `'link_in_file_body'`
 `link.destination          `: `'link_in_file_body'`
 `link.displayText          `: `'link_in_file_body'`
 
 `link.originalMarkdown     `: `'[[link_in_heading]]'`
 `link.markdown             `: `'[[link_in_heading]]'`
-`link.destinationFilename  `: `'link_in_heading'`
 `link.destination          `: `'link_in_heading'`
 `link.displayText          `: `'link_in_heading'`
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink]]'`
 `link.markdown             `: `'[[link_in_task_wikilink]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink'`
 `link.displayText          `: `'link_in_task_wikilink'`
 
@@ -278,7 +235,6 @@
 
 `link.originalMarkdown     `: `'[[numbered_tasks_issue_3481_searches]]'`
 `link.markdown             `: `'[[numbered_tasks_issue_3481_searches]]'`
-`link.destinationFilename  `: `'numbered_tasks_issue_3481_searches'`
 `link.destination          `: `'numbered_tasks_issue_3481_searches'`
 `link.displayText          `: `'numbered_tasks_issue_3481_searches'`
 

--- a/tests/Task/Link.test.visualise_links_outlinks.approved.md
+++ b/tests/Task/Link.test.visualise_links_outlinks.approved.md
@@ -29,19 +29,19 @@
 ## Test Data/internal_heading_links.md
 
 `link.originalMarkdown     `: `'[[#Basic Internal Links]]'`
-`link.markdown             `: `'[[#Basic Internal Links]]'`
+`link.markdown             `: `'[[internal_heading_links#Basic Internal Links|Basic Internal Links]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Basic Internal Links'`
 `link.displayText          `: `'Basic Internal Links'`
 
 `link.originalMarkdown     `: `'[[#Multiple Links In One Task]]'`
-`link.markdown             `: `'[[#Multiple Links In One Task]]'`
+`link.markdown             `: `'[[internal_heading_links#Multiple Links In One Task|Multiple Links In One Task]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Multiple Links In One Task'`
 `link.displayText          `: `'Multiple Links In One Task'`
 
 `link.originalMarkdown     `: `'[[#Simple Headers]]'`
-`link.markdown             `: `'[[#Simple Headers]]'`
+`link.markdown             `: `'[[internal_heading_links#Simple Headers|Simple Headers]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Simple Headers'`
 `link.displayText          `: `'Simple Headers'`
@@ -59,13 +59,13 @@
 `link.displayText          `: `'Other File'`
 
 `link.originalMarkdown     `: `'[[#Mixed Link Types]]'`
-`link.markdown             `: `'[[#Mixed Link Types]]'`
+`link.markdown             `: `'[[internal_heading_links#Mixed Link Types|Mixed Link Types]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Mixed Link Types'`
 `link.displayText          `: `'Mixed Link Types'`
 
 `link.originalMarkdown     `: `'[[#Header Links With File Reference]]'`
-`link.markdown             `: `'[[#Header Links With File Reference]]'`
+`link.markdown             `: `'[[internal_heading_links#Header Links With File Reference|Header Links With File Reference]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Header Links With File Reference'`
 `link.displayText          `: `'Header Links With File Reference'`
@@ -77,19 +77,19 @@
 `link.displayText          `: `'Other File > Some Header'`
 
 `link.originalMarkdown     `: `'[[#Another Header]]'`
-`link.markdown             `: `'[[#Another Header]]'`
+`link.markdown             `: `'[[internal_heading_links#Another Header|Another Header]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Another Header'`
 `link.displayText          `: `'Another Header'`
 
 `link.originalMarkdown     `: `'[[#Headers-With_Special Characters]]'`
-`link.markdown             `: `'[[#Headers-With_Special Characters]]'`
+`link.markdown             `: `'[[internal_heading_links#Headers-With_Special Characters|Headers-With_Special Characters]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Headers-With_Special Characters'`
 `link.displayText          `: `'Headers-With_Special Characters'`
 
 `link.originalMarkdown     `: `'[[#Aliased Links|I am an alias]]'`
-`link.markdown             `: `'[[#Aliased Links|I am an alias]]'`
+`link.markdown             `: `'[[internal_heading_links#Aliased Links|I am an alias]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Aliased Links'`
 `link.displayText          `: `'I am an alias'`
@@ -169,7 +169,7 @@
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[heading](#heading)'`
-`link.markdown             `: `'[heading](#heading)'`
+`link.markdown             `: `'[[link_in_task_markdown_link#heading|heading]]'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'#heading'`
 `link.displayText          `: `'heading'`
@@ -291,7 +291,7 @@
 `link.displayText          `: `'link_in_yaml'`
 
 `link.originalMarkdown     `: `'[[#A link in a link_in_heading]]'`
-`link.markdown             `: `'[[#A link in a link_in_heading]]'`
+`link.markdown             `: `'[[links_everywhere#A link in a link_in_heading|A link in a link_in_heading]]'`
 `link.destinationFilename  `: `'links_everywhere'`
 `link.destination          `: `'#A link in a link_in_heading'`
 `link.displayText          `: `'A link in a link_in_heading'`

--- a/tests/Task/Link.test.visualise_links_outlinks.approved.md
+++ b/tests/Task/Link.test.visualise_links_outlinks.approved.md
@@ -1,6 +1,7 @@
 ## Test Data/comments_markdown_style.md
 
 `link.originalMarkdown     `: `'[[comments_html_style]]'`
+`link.markdown             `: `'[[comments_html_style]]'`
 `link.destinationFilename  `: `'comments_html_style'`
 `link.destination          `: `'comments_html_style'`
 `link.displayText          `: `'comments_html_style'`
@@ -8,16 +9,19 @@
 ## Test Data/docs_sample_for_task_properties_reference.md
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
+`link.markdown             `: `'[[yaml_all_property_types_populated]]'`
 `link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
+`link.markdown             `: `'[[yaml_all_property_types_populated]]'`
 `link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_empty]]'`
+`link.markdown             `: `'[[yaml_all_property_types_empty]]'`
 `link.destinationFilename  `: `'yaml_all_property_types_empty'`
 `link.destination          `: `'yaml_all_property_types_empty'`
 `link.displayText          `: `'yaml_all_property_types_empty'`
@@ -25,56 +29,67 @@
 ## Test Data/internal_heading_links.md
 
 `link.originalMarkdown     `: `'[[#Basic Internal Links]]'`
+`link.markdown             `: `'[[#Basic Internal Links]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Basic Internal Links'`
 `link.displayText          `: `'Basic Internal Links'`
 
 `link.originalMarkdown     `: `'[[#Multiple Links In One Task]]'`
+`link.markdown             `: `'[[#Multiple Links In One Task]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Multiple Links In One Task'`
 `link.displayText          `: `'Multiple Links In One Task'`
 
 `link.originalMarkdown     `: `'[[#Simple Headers]]'`
+`link.markdown             `: `'[[#Simple Headers]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Simple Headers'`
 `link.displayText          `: `'Simple Headers'`
 
 `link.originalMarkdown     `: `'[[Other File]]'`
+`link.markdown             `: `'[[Other File]]'`
 `link.destinationFilename  `: `'Other File'`
 `link.destination          `: `'Other File'`
 `link.displayText          `: `'Other File'`
 
 `link.originalMarkdown     `: `'[[Other File]]'`
+`link.markdown             `: `'[[Other File]]'`
 `link.destinationFilename  `: `'Other File'`
 `link.destination          `: `'Other File'`
 `link.displayText          `: `'Other File'`
 
 `link.originalMarkdown     `: `'[[#Mixed Link Types]]'`
+`link.markdown             `: `'[[#Mixed Link Types]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Mixed Link Types'`
 `link.displayText          `: `'Mixed Link Types'`
 
 `link.originalMarkdown     `: `'[[#Header Links With File Reference]]'`
+`link.markdown             `: `'[[#Header Links With File Reference]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Header Links With File Reference'`
 `link.displayText          `: `'Header Links With File Reference'`
 
 `link.originalMarkdown     `: `'[[Other File#Some Header]]'`
+`link.markdown             `: `'[[Other File#Some Header]]'`
 `link.destinationFilename  `: `'Other File'`
 `link.destination          `: `'Other File#Some Header'`
 `link.displayText          `: `'Other File > Some Header'`
 
 `link.originalMarkdown     `: `'[[#Another Header]]'`
+`link.markdown             `: `'[[#Another Header]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Another Header'`
 `link.displayText          `: `'Another Header'`
 
 `link.originalMarkdown     `: `'[[#Headers-With_Special Characters]]'`
+`link.markdown             `: `'[[#Headers-With_Special Characters]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Headers-With_Special Characters'`
 `link.displayText          `: `'Headers-With_Special Characters'`
 
 `link.originalMarkdown     `: `'[[#Aliased Links|I am an alias]]'`
+`link.markdown             `: `'[[#Aliased Links|I am an alias]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Aliased Links'`
 `link.displayText          `: `'I am an alias'`
@@ -82,6 +97,7 @@
 ## Test Data/link_in_file_body.md
 
 `link.originalMarkdown     `: `'[[yaml_tags_is_empty]]'`
+`link.markdown             `: `'[[yaml_tags_is_empty]]'`
 `link.destinationFilename  `: `'yaml_tags_is_empty'`
 `link.destination          `: `'yaml_tags_is_empty'`
 `link.displayText          `: `'yaml_tags_is_empty'`
@@ -89,6 +105,7 @@
 ## Test Data/link_in_file_body_with_custom_display_text.md
 
 `link.originalMarkdown     `: `'[[yaml_tags_is_empty|a file and use custom display text]]'`
+`link.markdown             `: `'[[yaml_tags_is_empty|a file and use custom display text]]'`
 `link.destinationFilename  `: `'yaml_tags_is_empty'`
 `link.destination          `: `'yaml_tags_is_empty'`
 `link.displayText          `: `'a file and use custom display text'`
@@ -96,6 +113,7 @@
 ## Test Data/link_in_heading.md
 
 `link.originalMarkdown     `: `'[[multiple_headings]]'`
+`link.markdown             `: `'[[multiple_headings]]'`
 `link.destinationFilename  `: `'multiple_headings'`
 `link.destination          `: `'multiple_headings'`
 `link.displayText          `: `'multiple_headings'`
@@ -103,61 +121,73 @@
 ## Test Data/link_in_task_markdown_link.md
 
 `link.originalMarkdown     `: `'[jason_properties](jason_properties.md)'`
+`link.markdown             `: `'[jason_properties](jason_properties.md)'`
 `link.destinationFilename  `: `'jason_properties'`
 `link.destination          `: `'jason_properties.md'`
 `link.displayText          `: `'jason_properties'`
 
 `link.originalMarkdown     `: `'[multiple_headings](multiple_headings.md)'`
+`link.markdown             `: `'[multiple_headings](multiple_headings.md)'`
 `link.destinationFilename  `: `'multiple_headings'`
 `link.destination          `: `'multiple_headings.md'`
 `link.displayText          `: `'multiple_headings'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](link_in_task_markdown_link.md)'`
+`link.markdown             `: `'[link_in_task_markdown_link](link_in_task_markdown_link.md)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'link_in_task_markdown_link.md'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](Test%20Data/link_in_task_markdown_link.md)'`
+`link.markdown             `: `'[link_in_task_markdown_link](Test%20Data/link_in_task_markdown_link.md)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'Test Data/link_in_task_markdown_link.md'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[heading_link](Test%20Data/link_in_task_markdown_link.md#heading)'`
+`link.markdown             `: `'[heading_link](Test%20Data/link_in_task_markdown_link.md#heading)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'Test Data/link_in_task_markdown_link.md#heading'`
 `link.displayText          `: `'heading_link'`
 
 `link.originalMarkdown     `: `'[alias](link_in_task_markdown_link.md)'`
+`link.markdown             `: `'[alias](link_in_task_markdown_link.md)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'link_in_task_markdown_link.md'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[alias](Test%20Data/link_in_task_markdown_link.md)'`
+`link.markdown             `: `'[alias](Test%20Data/link_in_task_markdown_link.md)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'Test Data/link_in_task_markdown_link.md'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](pa#th/path/link_in_task_markdown_link.md)'`
+`link.markdown             `: `'[link_in_task_markdown_link](pa#th/path/link_in_task_markdown_link.md)'`
 `link.destinationFilename  `: `'pa'`
 `link.destination          `: `'pa#th/path/link_in_task_markdown_link.md'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[heading](#heading)'`
+`link.markdown             `: `'[heading](#heading)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'#heading'`
 `link.displayText          `: `'heading'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](link_in_task_markdown_link)'`
+`link.markdown             `: `'[link_in_task_markdown_link](link_in_task_markdown_link)'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'link_in_task_markdown_link'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[a_pdf_file](a_pdf_file.pdf)'`
+`link.markdown             `: `'[a_pdf_file](a_pdf_file.pdf)'`
 `link.destinationFilename  `: `'a_pdf_file.pdf'`
 `link.destination          `: `'a_pdf_file.pdf'`
 `link.displayText          `: `'a_pdf_file'`
 
 `link.originalMarkdown     `: `'[spaces everywhere](Manual%20Testing/Smoke%20Testing%20the%20Tasks%20Plugin#How%20the%20tests%20work)'`
+`link.markdown             `: `'[spaces everywhere](Manual%20Testing/Smoke%20Testing%20the%20Tasks%20Plugin#How%20the%20tests%20work)'`
 `link.destinationFilename  `: `'Smoke Testing the Tasks Plugin'`
 `link.destination          `: `'Manual Testing/Smoke Testing the Tasks Plugin#How the tests work'`
 `link.displayText          `: `'spaces everywhere'`
@@ -165,61 +195,73 @@
 ## Test Data/link_in_task_wikilink.md
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink]]'`
+`link.markdown             `: `'[[link_in_task_wikilink]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink'`
 `link.displayText          `: `'link_in_task_wikilink'`
 
 `link.originalMarkdown     `: `'[[multiple_headings]]'`
+`link.markdown             `: `'[[multiple_headings]]'`
 `link.destinationFilename  `: `'multiple_headings'`
 `link.destination          `: `'multiple_headings'`
 `link.displayText          `: `'multiple_headings'`
 
 `link.originalMarkdown     `: `'[[Test Data/link_in_task_wikilink]]'`
+`link.markdown             `: `'[[Test Data/link_in_task_wikilink]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'Test Data/link_in_task_wikilink'`
 `link.displayText          `: `'Test Data/link_in_task_wikilink'`
 
 `link.originalMarkdown     `: `'[[Test Data/link_in_task_wikilink#heading_link]]'`
+`link.markdown             `: `'[[Test Data/link_in_task_wikilink#heading_link]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'Test Data/link_in_task_wikilink#heading_link'`
 `link.displayText          `: `'Test Data/link_in_task_wikilink > heading_link'`
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink|alias]]'`
+`link.markdown             `: `'[[link_in_task_wikilink|alias]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[[Test Data/link_in_task_wikilink|alias]]'`
+`link.markdown             `: `'[[Test Data/link_in_task_wikilink|alias]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'Test Data/link_in_task_wikilink'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[[pa#th/path/link_in_task_wikilink]]'`
+`link.markdown             `: `'[[pa#th/path/link_in_task_wikilink]]'`
 `link.destinationFilename  `: `'pa'`
 `link.destination          `: `'pa#th/path/link_in_task_wikilink'`
 `link.displayText          `: `'pa > th/path/link_in_task_wikilink'`
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink.md]]'`
+`link.markdown             `: `'[[link_in_task_wikilink.md]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink.md'`
 `link.displayText          `: `'link_in_task_wikilink.md'`
 
 `link.originalMarkdown     `: `'[[a_pdf_file.pdf]]'`
+`link.markdown             `: `'[[a_pdf_file.pdf]]'`
 `link.destinationFilename  `: `'a_pdf_file.pdf'`
 `link.destination          `: `'a_pdf_file.pdf'`
 `link.displayText          `: `'a_pdf_file.pdf'`
 
 `link.originalMarkdown     `: `'[[|]]'`
+`link.markdown             `: `'[[|]]'`
 `link.destinationFilename  `: `'|'`
 `link.destination          `: `'|'`
 `link.displayText          `: `'|'`
 
 `link.originalMarkdown     `: `'[[|alias]]'`
+`link.markdown             `: `'[[|alias]]'`
 `link.destinationFilename  `: `'|alias'`
 `link.destination          `: `'|alias'`
 `link.displayText          `: `'|alias'`
 
 `link.originalMarkdown     `: `'[[|#alias]]'`
+`link.markdown             `: `'[[|#alias]]'`
 `link.destinationFilename  `: `'|'`
 `link.destination          `: `'|#alias'`
 `link.displayText          `: `'| > alias'`
@@ -227,6 +269,7 @@
 ## Test Data/link_in_yaml.md
 
 `link.originalMarkdown     `: `'[[yaml_tags_is_empty]]'`
+`link.markdown             `: `'[[yaml_tags_is_empty]]'`
 `link.destinationFilename  `: `'yaml_tags_is_empty'`
 `link.destination          `: `'yaml_tags_is_empty'`
 `link.displayText          `: `'yaml_tags_is_empty'`
@@ -234,6 +277,7 @@
 ## Test Data/link_is_broken.md
 
 `link.originalMarkdown     `: `'[[broken link - do not fix me]]'`
+`link.markdown             `: `'[[broken link - do not fix me]]'`
 `link.destinationFilename  `: `'broken link - do not fix me'`
 `link.destination          `: `'broken link - do not fix me'`
 `link.displayText          `: `'broken link - do not fix me'`
@@ -241,26 +285,31 @@
 ## Test Data/links_everywhere.md
 
 `link.originalMarkdown     `: `'[[link_in_yaml]]'`
+`link.markdown             `: `'[[link_in_yaml]]'`
 `link.destinationFilename  `: `'link_in_yaml'`
 `link.destination          `: `'link_in_yaml'`
 `link.displayText          `: `'link_in_yaml'`
 
 `link.originalMarkdown     `: `'[[#A link in a link_in_heading]]'`
+`link.markdown             `: `'[[#A link in a link_in_heading]]'`
 `link.destinationFilename  `: `'links_everywhere'`
 `link.destination          `: `'#A link in a link_in_heading'`
 `link.displayText          `: `'A link in a link_in_heading'`
 
 `link.originalMarkdown     `: `'[[link_in_file_body]]'`
+`link.markdown             `: `'[[link_in_file_body]]'`
 `link.destinationFilename  `: `'link_in_file_body'`
 `link.destination          `: `'link_in_file_body'`
 `link.displayText          `: `'link_in_file_body'`
 
 `link.originalMarkdown     `: `'[[link_in_heading]]'`
+`link.markdown             `: `'[[link_in_heading]]'`
 `link.destinationFilename  `: `'link_in_heading'`
 `link.destination          `: `'link_in_heading'`
 `link.displayText          `: `'link_in_heading'`
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink]]'`
+`link.markdown             `: `'[[link_in_task_wikilink]]'`
 `link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink'`
 `link.displayText          `: `'link_in_task_wikilink'`
@@ -268,6 +317,7 @@
 ## Test Data/numbered_tasks_issue_3481.md
 
 `link.originalMarkdown     `: `'[[numbered_tasks_issue_3481_searches]]'`
+`link.markdown             `: `'[[numbered_tasks_issue_3481_searches]]'`
 `link.destinationFilename  `: `'numbered_tasks_issue_3481_searches'`
 `link.destination          `: `'numbered_tasks_issue_3481_searches'`
 `link.displayText          `: `'numbered_tasks_issue_3481_searches'`
@@ -275,16 +325,19 @@
 ## Test Data/yaml_all_property_types_populated.md
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
+`link.markdown             `: `'[[yaml_all_property_types_populated]]'`
 `link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
+`link.markdown             `: `'[[yaml_all_property_types_populated]]'`
 `link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_empty]]'`
+`link.markdown             `: `'[[yaml_all_property_types_empty]]'`
 `link.destinationFilename  `: `'yaml_all_property_types_empty'`
 `link.destination          `: `'yaml_all_property_types_empty'`
 `link.displayText          `: `'yaml_all_property_types_empty'`

--- a/tests/Task/Link.test.visualise_links_outlinks.approved.md
+++ b/tests/Task/Link.test.visualise_links_outlinks.approved.md
@@ -29,19 +29,19 @@
 ## Test Data/internal_heading_links.md
 
 `link.originalMarkdown     `: `'[[#Basic Internal Links]]'`
-`link.markdown             `: `'[[internal_heading_links#Basic Internal Links|Basic Internal Links]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Basic Internal Links|Basic Internal Links]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Basic Internal Links'`
 `link.displayText          `: `'Basic Internal Links'`
 
 `link.originalMarkdown     `: `'[[#Multiple Links In One Task]]'`
-`link.markdown             `: `'[[internal_heading_links#Multiple Links In One Task|Multiple Links In One Task]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Multiple Links In One Task|Multiple Links In One Task]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Multiple Links In One Task'`
 `link.displayText          `: `'Multiple Links In One Task'`
 
 `link.originalMarkdown     `: `'[[#Simple Headers]]'`
-`link.markdown             `: `'[[internal_heading_links#Simple Headers|Simple Headers]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Simple Headers|Simple Headers]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Simple Headers'`
 `link.displayText          `: `'Simple Headers'`
@@ -59,13 +59,13 @@
 `link.displayText          `: `'Other File'`
 
 `link.originalMarkdown     `: `'[[#Mixed Link Types]]'`
-`link.markdown             `: `'[[internal_heading_links#Mixed Link Types|Mixed Link Types]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Mixed Link Types|Mixed Link Types]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Mixed Link Types'`
 `link.displayText          `: `'Mixed Link Types'`
 
 `link.originalMarkdown     `: `'[[#Header Links With File Reference]]'`
-`link.markdown             `: `'[[internal_heading_links#Header Links With File Reference|Header Links With File Reference]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Header Links With File Reference|Header Links With File Reference]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Header Links With File Reference'`
 `link.displayText          `: `'Header Links With File Reference'`
@@ -77,19 +77,19 @@
 `link.displayText          `: `'Other File > Some Header'`
 
 `link.originalMarkdown     `: `'[[#Another Header]]'`
-`link.markdown             `: `'[[internal_heading_links#Another Header|Another Header]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Another Header|Another Header]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Another Header'`
 `link.displayText          `: `'Another Header'`
 
 `link.originalMarkdown     `: `'[[#Headers-With_Special Characters]]'`
-`link.markdown             `: `'[[internal_heading_links#Headers-With_Special Characters|Headers-With_Special Characters]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Headers-With_Special Characters|Headers-With_Special Characters]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Headers-With_Special Characters'`
 `link.displayText          `: `'Headers-With_Special Characters'`
 
 `link.originalMarkdown     `: `'[[#Aliased Links|I am an alias]]'`
-`link.markdown             `: `'[[internal_heading_links#Aliased Links|I am an alias]]'`
+`link.markdown             `: `'[[Test Data/internal_heading_links.md#Aliased Links|I am an alias]]'`
 `link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Aliased Links'`
 `link.displayText          `: `'I am an alias'`
@@ -169,7 +169,7 @@
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[heading](#heading)'`
-`link.markdown             `: `'[[link_in_task_markdown_link#heading|heading]]'`
+`link.markdown             `: `'[[Test Data/link_in_task_markdown_link.md#heading|heading]]'`
 `link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'#heading'`
 `link.displayText          `: `'heading'`
@@ -291,7 +291,7 @@
 `link.displayText          `: `'link_in_yaml'`
 
 `link.originalMarkdown     `: `'[[#A link in a link_in_heading]]'`
-`link.markdown             `: `'[[links_everywhere#A link in a link_in_heading|A link in a link_in_heading]]'`
+`link.markdown             `: `'[[Test Data/links_everywhere.md#A link in a link_in_heading|A link in a link_in_heading]]'`
 `link.destinationFilename  `: `'links_everywhere'`
 `link.destination          `: `'#A link in a link_in_heading'`
 `link.displayText          `: `'A link in a link_in_heading'`

--- a/tests/Task/Link.test.visualise_links_outlinks.approved.md
+++ b/tests/Task/Link.test.visualise_links_outlinks.approved.md
@@ -2,7 +2,6 @@
 
 `link.originalMarkdown     `: `'[[comments_html_style]]'`
 `link.markdown             `: `'[[comments_html_style]]'`
-`link.destinationFilename  `: `'comments_html_style'`
 `link.destination          `: `'comments_html_style'`
 `link.displayText          `: `'comments_html_style'`
 
@@ -10,19 +9,16 @@
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
 `link.markdown             `: `'[[yaml_all_property_types_populated]]'`
-`link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
 `link.markdown             `: `'[[yaml_all_property_types_populated]]'`
-`link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_empty]]'`
 `link.markdown             `: `'[[yaml_all_property_types_empty]]'`
-`link.destinationFilename  `: `'yaml_all_property_types_empty'`
 `link.destination          `: `'yaml_all_property_types_empty'`
 `link.displayText          `: `'yaml_all_property_types_empty'`
 
@@ -30,67 +26,56 @@
 
 `link.originalMarkdown     `: `'[[#Basic Internal Links]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Basic Internal Links|Basic Internal Links]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Basic Internal Links'`
 `link.displayText          `: `'Basic Internal Links'`
 
 `link.originalMarkdown     `: `'[[#Multiple Links In One Task]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Multiple Links In One Task|Multiple Links In One Task]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Multiple Links In One Task'`
 `link.displayText          `: `'Multiple Links In One Task'`
 
 `link.originalMarkdown     `: `'[[#Simple Headers]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Simple Headers|Simple Headers]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Simple Headers'`
 `link.displayText          `: `'Simple Headers'`
 
 `link.originalMarkdown     `: `'[[Other File]]'`
 `link.markdown             `: `'[[Other File]]'`
-`link.destinationFilename  `: `'Other File'`
 `link.destination          `: `'Other File'`
 `link.displayText          `: `'Other File'`
 
 `link.originalMarkdown     `: `'[[Other File]]'`
 `link.markdown             `: `'[[Other File]]'`
-`link.destinationFilename  `: `'Other File'`
 `link.destination          `: `'Other File'`
 `link.displayText          `: `'Other File'`
 
 `link.originalMarkdown     `: `'[[#Mixed Link Types]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Mixed Link Types|Mixed Link Types]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Mixed Link Types'`
 `link.displayText          `: `'Mixed Link Types'`
 
 `link.originalMarkdown     `: `'[[#Header Links With File Reference]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Header Links With File Reference|Header Links With File Reference]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Header Links With File Reference'`
 `link.displayText          `: `'Header Links With File Reference'`
 
 `link.originalMarkdown     `: `'[[Other File#Some Header]]'`
 `link.markdown             `: `'[[Other File#Some Header]]'`
-`link.destinationFilename  `: `'Other File'`
 `link.destination          `: `'Other File#Some Header'`
 `link.displayText          `: `'Other File > Some Header'`
 
 `link.originalMarkdown     `: `'[[#Another Header]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Another Header|Another Header]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Another Header'`
 `link.displayText          `: `'Another Header'`
 
 `link.originalMarkdown     `: `'[[#Headers-With_Special Characters]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Headers-With_Special Characters|Headers-With_Special Characters]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Headers-With_Special Characters'`
 `link.displayText          `: `'Headers-With_Special Characters'`
 
 `link.originalMarkdown     `: `'[[#Aliased Links|I am an alias]]'`
 `link.markdown             `: `'[[Test Data/internal_heading_links.md#Aliased Links|I am an alias]]'`
-`link.destinationFilename  `: `'internal_heading_links'`
 `link.destination          `: `'#Aliased Links'`
 `link.displayText          `: `'I am an alias'`
 
@@ -98,7 +83,6 @@
 
 `link.originalMarkdown     `: `'[[yaml_tags_is_empty]]'`
 `link.markdown             `: `'[[yaml_tags_is_empty]]'`
-`link.destinationFilename  `: `'yaml_tags_is_empty'`
 `link.destination          `: `'yaml_tags_is_empty'`
 `link.displayText          `: `'yaml_tags_is_empty'`
 
@@ -106,7 +90,6 @@
 
 `link.originalMarkdown     `: `'[[yaml_tags_is_empty|a file and use custom display text]]'`
 `link.markdown             `: `'[[yaml_tags_is_empty|a file and use custom display text]]'`
-`link.destinationFilename  `: `'yaml_tags_is_empty'`
 `link.destination          `: `'yaml_tags_is_empty'`
 `link.displayText          `: `'a file and use custom display text'`
 
@@ -114,7 +97,6 @@
 
 `link.originalMarkdown     `: `'[[multiple_headings]]'`
 `link.markdown             `: `'[[multiple_headings]]'`
-`link.destinationFilename  `: `'multiple_headings'`
 `link.destination          `: `'multiple_headings'`
 `link.displayText          `: `'multiple_headings'`
 
@@ -122,73 +104,61 @@
 
 `link.originalMarkdown     `: `'[jason_properties](jason_properties.md)'`
 `link.markdown             `: `'[jason_properties](jason_properties.md)'`
-`link.destinationFilename  `: `'jason_properties'`
 `link.destination          `: `'jason_properties.md'`
 `link.displayText          `: `'jason_properties'`
 
 `link.originalMarkdown     `: `'[multiple_headings](multiple_headings.md)'`
 `link.markdown             `: `'[multiple_headings](multiple_headings.md)'`
-`link.destinationFilename  `: `'multiple_headings'`
 `link.destination          `: `'multiple_headings.md'`
 `link.displayText          `: `'multiple_headings'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](link_in_task_markdown_link.md)'`
 `link.markdown             `: `'[link_in_task_markdown_link](link_in_task_markdown_link.md)'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'link_in_task_markdown_link.md'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](Test%20Data/link_in_task_markdown_link.md)'`
 `link.markdown             `: `'[link_in_task_markdown_link](Test%20Data/link_in_task_markdown_link.md)'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'Test Data/link_in_task_markdown_link.md'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[heading_link](Test%20Data/link_in_task_markdown_link.md#heading)'`
 `link.markdown             `: `'[heading_link](Test%20Data/link_in_task_markdown_link.md#heading)'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'Test Data/link_in_task_markdown_link.md#heading'`
 `link.displayText          `: `'heading_link'`
 
 `link.originalMarkdown     `: `'[alias](link_in_task_markdown_link.md)'`
 `link.markdown             `: `'[alias](link_in_task_markdown_link.md)'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'link_in_task_markdown_link.md'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[alias](Test%20Data/link_in_task_markdown_link.md)'`
 `link.markdown             `: `'[alias](Test%20Data/link_in_task_markdown_link.md)'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'Test Data/link_in_task_markdown_link.md'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](pa#th/path/link_in_task_markdown_link.md)'`
 `link.markdown             `: `'[link_in_task_markdown_link](pa#th/path/link_in_task_markdown_link.md)'`
-`link.destinationFilename  `: `'pa'`
 `link.destination          `: `'pa#th/path/link_in_task_markdown_link.md'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[heading](#heading)'`
 `link.markdown             `: `'[[Test Data/link_in_task_markdown_link.md#heading|heading]]'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'#heading'`
 `link.displayText          `: `'heading'`
 
 `link.originalMarkdown     `: `'[link_in_task_markdown_link](link_in_task_markdown_link)'`
 `link.markdown             `: `'[link_in_task_markdown_link](link_in_task_markdown_link)'`
-`link.destinationFilename  `: `'link_in_task_markdown_link'`
 `link.destination          `: `'link_in_task_markdown_link'`
 `link.displayText          `: `'link_in_task_markdown_link'`
 
 `link.originalMarkdown     `: `'[a_pdf_file](a_pdf_file.pdf)'`
 `link.markdown             `: `'[a_pdf_file](a_pdf_file.pdf)'`
-`link.destinationFilename  `: `'a_pdf_file.pdf'`
 `link.destination          `: `'a_pdf_file.pdf'`
 `link.displayText          `: `'a_pdf_file'`
 
 `link.originalMarkdown     `: `'[spaces everywhere](Manual%20Testing/Smoke%20Testing%20the%20Tasks%20Plugin#How%20the%20tests%20work)'`
 `link.markdown             `: `'[spaces everywhere](Manual%20Testing/Smoke%20Testing%20the%20Tasks%20Plugin#How%20the%20tests%20work)'`
-`link.destinationFilename  `: `'Smoke Testing the Tasks Plugin'`
 `link.destination          `: `'Manual Testing/Smoke Testing the Tasks Plugin#How the tests work'`
 `link.displayText          `: `'spaces everywhere'`
 
@@ -196,73 +166,61 @@
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink]]'`
 `link.markdown             `: `'[[link_in_task_wikilink]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink'`
 `link.displayText          `: `'link_in_task_wikilink'`
 
 `link.originalMarkdown     `: `'[[multiple_headings]]'`
 `link.markdown             `: `'[[multiple_headings]]'`
-`link.destinationFilename  `: `'multiple_headings'`
 `link.destination          `: `'multiple_headings'`
 `link.displayText          `: `'multiple_headings'`
 
 `link.originalMarkdown     `: `'[[Test Data/link_in_task_wikilink]]'`
 `link.markdown             `: `'[[Test Data/link_in_task_wikilink]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'Test Data/link_in_task_wikilink'`
 `link.displayText          `: `'Test Data/link_in_task_wikilink'`
 
 `link.originalMarkdown     `: `'[[Test Data/link_in_task_wikilink#heading_link]]'`
 `link.markdown             `: `'[[Test Data/link_in_task_wikilink#heading_link]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'Test Data/link_in_task_wikilink#heading_link'`
 `link.displayText          `: `'Test Data/link_in_task_wikilink > heading_link'`
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink|alias]]'`
 `link.markdown             `: `'[[link_in_task_wikilink|alias]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[[Test Data/link_in_task_wikilink|alias]]'`
 `link.markdown             `: `'[[Test Data/link_in_task_wikilink|alias]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'Test Data/link_in_task_wikilink'`
 `link.displayText          `: `'alias'`
 
 `link.originalMarkdown     `: `'[[pa#th/path/link_in_task_wikilink]]'`
 `link.markdown             `: `'[[pa#th/path/link_in_task_wikilink]]'`
-`link.destinationFilename  `: `'pa'`
 `link.destination          `: `'pa#th/path/link_in_task_wikilink'`
 `link.displayText          `: `'pa > th/path/link_in_task_wikilink'`
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink.md]]'`
 `link.markdown             `: `'[[link_in_task_wikilink.md]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink.md'`
 `link.displayText          `: `'link_in_task_wikilink.md'`
 
 `link.originalMarkdown     `: `'[[a_pdf_file.pdf]]'`
 `link.markdown             `: `'[[a_pdf_file.pdf]]'`
-`link.destinationFilename  `: `'a_pdf_file.pdf'`
 `link.destination          `: `'a_pdf_file.pdf'`
 `link.displayText          `: `'a_pdf_file.pdf'`
 
 `link.originalMarkdown     `: `'[[|]]'`
 `link.markdown             `: `'[[|]]'`
-`link.destinationFilename  `: `'|'`
 `link.destination          `: `'|'`
 `link.displayText          `: `'|'`
 
 `link.originalMarkdown     `: `'[[|alias]]'`
 `link.markdown             `: `'[[|alias]]'`
-`link.destinationFilename  `: `'|alias'`
 `link.destination          `: `'|alias'`
 `link.displayText          `: `'|alias'`
 
 `link.originalMarkdown     `: `'[[|#alias]]'`
 `link.markdown             `: `'[[|#alias]]'`
-`link.destinationFilename  `: `'|'`
 `link.destination          `: `'|#alias'`
 `link.displayText          `: `'| > alias'`
 
@@ -270,7 +228,6 @@
 
 `link.originalMarkdown     `: `'[[yaml_tags_is_empty]]'`
 `link.markdown             `: `'[[yaml_tags_is_empty]]'`
-`link.destinationFilename  `: `'yaml_tags_is_empty'`
 `link.destination          `: `'yaml_tags_is_empty'`
 `link.displayText          `: `'yaml_tags_is_empty'`
 
@@ -278,7 +235,6 @@
 
 `link.originalMarkdown     `: `'[[broken link - do not fix me]]'`
 `link.markdown             `: `'[[broken link - do not fix me]]'`
-`link.destinationFilename  `: `'broken link - do not fix me'`
 `link.destination          `: `'broken link - do not fix me'`
 `link.displayText          `: `'broken link - do not fix me'`
 
@@ -286,31 +242,26 @@
 
 `link.originalMarkdown     `: `'[[link_in_yaml]]'`
 `link.markdown             `: `'[[link_in_yaml]]'`
-`link.destinationFilename  `: `'link_in_yaml'`
 `link.destination          `: `'link_in_yaml'`
 `link.displayText          `: `'link_in_yaml'`
 
 `link.originalMarkdown     `: `'[[#A link in a link_in_heading]]'`
 `link.markdown             `: `'[[Test Data/links_everywhere.md#A link in a link_in_heading|A link in a link_in_heading]]'`
-`link.destinationFilename  `: `'links_everywhere'`
 `link.destination          `: `'#A link in a link_in_heading'`
 `link.displayText          `: `'A link in a link_in_heading'`
 
 `link.originalMarkdown     `: `'[[link_in_file_body]]'`
 `link.markdown             `: `'[[link_in_file_body]]'`
-`link.destinationFilename  `: `'link_in_file_body'`
 `link.destination          `: `'link_in_file_body'`
 `link.displayText          `: `'link_in_file_body'`
 
 `link.originalMarkdown     `: `'[[link_in_heading]]'`
 `link.markdown             `: `'[[link_in_heading]]'`
-`link.destinationFilename  `: `'link_in_heading'`
 `link.destination          `: `'link_in_heading'`
 `link.displayText          `: `'link_in_heading'`
 
 `link.originalMarkdown     `: `'[[link_in_task_wikilink]]'`
 `link.markdown             `: `'[[link_in_task_wikilink]]'`
-`link.destinationFilename  `: `'link_in_task_wikilink'`
 `link.destination          `: `'link_in_task_wikilink'`
 `link.displayText          `: `'link_in_task_wikilink'`
 
@@ -318,7 +269,6 @@
 
 `link.originalMarkdown     `: `'[[numbered_tasks_issue_3481_searches]]'`
 `link.markdown             `: `'[[numbered_tasks_issue_3481_searches]]'`
-`link.destinationFilename  `: `'numbered_tasks_issue_3481_searches'`
 `link.destination          `: `'numbered_tasks_issue_3481_searches'`
 `link.displayText          `: `'numbered_tasks_issue_3481_searches'`
 
@@ -326,19 +276,16 @@
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
 `link.markdown             `: `'[[yaml_all_property_types_populated]]'`
-`link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
 `link.markdown             `: `'[[yaml_all_property_types_populated]]'`
-`link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_empty]]'`
 `link.markdown             `: `'[[yaml_all_property_types_empty]]'`
-`link.destinationFilename  `: `'yaml_all_property_types_empty'`
 `link.destination          `: `'yaml_all_property_types_empty'`
 `link.displayText          `: `'yaml_all_property_types_empty'`
 

--- a/tests/Task/Link.test.visualise_links_properties.approved.md
+++ b/tests/Task/Link.test.visualise_links_properties.approved.md
@@ -35,7 +35,7 @@
 `link.displayText          `: `'link_in_yaml'`
 
 `link.originalMarkdown     `: `'[[#A link in a link_in_heading]]'`
-`link.markdown             `: `'[[links_everywhere#A link in a link_in_heading|A link in a link_in_heading]]'`
+`link.markdown             `: `'[[Test Data/links_everywhere.md#A link in a link_in_heading|A link in a link_in_heading]]'`
 `link.destinationFilename  `: `'links_everywhere'`
 `link.destination          `: `'#A link in a link_in_heading'`
 `link.displayText          `: `'A link in a link_in_heading'`

--- a/tests/Task/Link.test.visualise_links_properties.approved.md
+++ b/tests/Task/Link.test.visualise_links_properties.approved.md
@@ -2,19 +2,16 @@
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
 `link.markdown             `: `'[[yaml_all_property_types_populated]]'`
-`link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
 `link.markdown             `: `'[[yaml_all_property_types_populated]]'`
-`link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_empty]]'`
 `link.markdown             `: `'[[yaml_all_property_types_empty]]'`
-`link.destinationFilename  `: `'yaml_all_property_types_empty'`
 `link.destination          `: `'yaml_all_property_types_empty'`
 `link.displayText          `: `'yaml_all_property_types_empty'`
 
@@ -22,7 +19,6 @@
 
 `link.originalMarkdown     `: `'[[yaml_tags_is_empty]]'`
 `link.markdown             `: `'[[yaml_tags_is_empty]]'`
-`link.destinationFilename  `: `'yaml_tags_is_empty'`
 `link.destination          `: `'yaml_tags_is_empty'`
 `link.displayText          `: `'yaml_tags_is_empty'`
 
@@ -30,13 +26,11 @@
 
 `link.originalMarkdown     `: `'[[link_in_yaml]]'`
 `link.markdown             `: `'[[link_in_yaml]]'`
-`link.destinationFilename  `: `'link_in_yaml'`
 `link.destination          `: `'link_in_yaml'`
 `link.displayText          `: `'link_in_yaml'`
 
 `link.originalMarkdown     `: `'[[#A link in a link_in_heading]]'`
 `link.markdown             `: `'[[Test Data/links_everywhere.md#A link in a link_in_heading|A link in a link_in_heading]]'`
-`link.destinationFilename  `: `'links_everywhere'`
 `link.destination          `: `'#A link in a link_in_heading'`
 `link.displayText          `: `'A link in a link_in_heading'`
 
@@ -44,19 +38,16 @@
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
 `link.markdown             `: `'[[yaml_all_property_types_populated]]'`
-`link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
 `link.markdown             `: `'[[yaml_all_property_types_populated]]'`
-`link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_empty]]'`
 `link.markdown             `: `'[[yaml_all_property_types_empty]]'`
-`link.destinationFilename  `: `'yaml_all_property_types_empty'`
 `link.destination          `: `'yaml_all_property_types_empty'`
 `link.displayText          `: `'yaml_all_property_types_empty'`
 

--- a/tests/Task/Link.test.visualise_links_properties.approved.md
+++ b/tests/Task/Link.test.visualise_links_properties.approved.md
@@ -35,7 +35,7 @@
 `link.displayText          `: `'link_in_yaml'`
 
 `link.originalMarkdown     `: `'[[#A link in a link_in_heading]]'`
-`link.markdown             `: `'[[#A link in a link_in_heading]]'`
+`link.markdown             `: `'[[links_everywhere#A link in a link_in_heading|A link in a link_in_heading]]'`
 `link.destinationFilename  `: `'links_everywhere'`
 `link.destination          `: `'#A link in a link_in_heading'`
 `link.displayText          `: `'A link in a link_in_heading'`

--- a/tests/Task/Link.test.visualise_links_properties.approved.md
+++ b/tests/Task/Link.test.visualise_links_properties.approved.md
@@ -1,16 +1,19 @@
 ## Test Data/docs_sample_for_task_properties_reference.md
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
+`link.markdown             `: `'[[yaml_all_property_types_populated]]'`
 `link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
+`link.markdown             `: `'[[yaml_all_property_types_populated]]'`
 `link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_empty]]'`
+`link.markdown             `: `'[[yaml_all_property_types_empty]]'`
 `link.destinationFilename  `: `'yaml_all_property_types_empty'`
 `link.destination          `: `'yaml_all_property_types_empty'`
 `link.displayText          `: `'yaml_all_property_types_empty'`
@@ -18,6 +21,7 @@
 ## Test Data/link_in_yaml.md
 
 `link.originalMarkdown     `: `'[[yaml_tags_is_empty]]'`
+`link.markdown             `: `'[[yaml_tags_is_empty]]'`
 `link.destinationFilename  `: `'yaml_tags_is_empty'`
 `link.destination          `: `'yaml_tags_is_empty'`
 `link.displayText          `: `'yaml_tags_is_empty'`
@@ -25,11 +29,13 @@
 ## Test Data/links_everywhere.md
 
 `link.originalMarkdown     `: `'[[link_in_yaml]]'`
+`link.markdown             `: `'[[link_in_yaml]]'`
 `link.destinationFilename  `: `'link_in_yaml'`
 `link.destination          `: `'link_in_yaml'`
 `link.displayText          `: `'link_in_yaml'`
 
 `link.originalMarkdown     `: `'[[#A link in a link_in_heading]]'`
+`link.markdown             `: `'[[#A link in a link_in_heading]]'`
 `link.destinationFilename  `: `'links_everywhere'`
 `link.destination          `: `'#A link in a link_in_heading'`
 `link.displayText          `: `'A link in a link_in_heading'`
@@ -37,16 +43,19 @@
 ## Test Data/yaml_all_property_types_populated.md
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
+`link.markdown             `: `'[[yaml_all_property_types_populated]]'`
 `link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_populated]]'`
+`link.markdown             `: `'[[yaml_all_property_types_populated]]'`
 `link.destinationFilename  `: `'yaml_all_property_types_populated'`
 `link.destination          `: `'yaml_all_property_types_populated'`
 `link.displayText          `: `'yaml_all_property_types_populated'`
 
 `link.originalMarkdown     `: `'[[yaml_all_property_types_empty]]'`
+`link.markdown             `: `'[[yaml_all_property_types_empty]]'`
 `link.destinationFilename  `: `'yaml_all_property_types_empty'`
 `link.destination          `: `'yaml_all_property_types_empty'`
 `link.displayText          `: `'yaml_all_property_types_empty'`


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: Related to #3297
  - The same problem for headings - internal heading-only links like `[[#Heading]]` were broken in Tasks search results - was also occurring when grouping by outlinks.
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Implement new getter `Link.markdown` to generate a markdown link, which has been adjusted for working correctly when being rendered in Tasks query results, such as when grouping by links.

Other changes:

- In the test vault, simplify `Access links.md`, using `Link.markdown`
- `Link` now stores the original `path` instead of the original `filename`
- `Link.destinationFilename` is no longer needed, so deleted

## Motivation and Context

Trying to reduce the complexity of documentation needed before releasing the links facility.

## How has this been tested?

- New tests
- Updating existing tests
- Exploratory testing in the test vault

## Screenshots (if appropriate)


### Before

```
group by function task.outlinks.map(link => link.originalMarkdown).sort().join(' · ')
```

![image](https://github.com/user-attachments/assets/410e9124-e823-4f62-82bb-9a4451f12100)

### After

```
group by function task.outlinks.map(link => link.markdown).sort().join(' · ')
```

![image](https://github.com/user-attachments/assets/4e35fbaa-54aa-42a3-aeed-568bb47acbb2)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
