### PR TITLE
refactor: Rename `Link.isLinkTo()` to `Link.linksTo()`

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/How To/Access links.md
+++ b/resources/sample_vaults/Tasks-Demo/How To/Access links.md
@@ -104,12 +104,12 @@ This should match one task, in [[Link to Access links file]].
 
 ````text
 ```tasks
-filter by function task.outlinks.some(link => link.isLinkTo(query.file))
+filter by function task.outlinks.some(link => link.linksTo(query.file))
 ```
 ````
 
 ```tasks
-filter by function task.outlinks.some(link => link.isLinkTo(query.file))
+filter by function task.outlinks.some(link => link.linksTo(query.file))
 ```
 
 #### Dataview version

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -76,7 +76,7 @@ export class Link {
         return this.rawLink.displayText;
     }
 
-    public isLinkTo(destination: string | TasksFile): boolean {
+    public linksTo(destination: string | TasksFile): boolean {
         if (typeof destination === 'string') {
             const removeMd = /\.md$/;
             const thisDestinationWithoutMd = this.destination.replace(removeMd, '');

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -32,8 +32,8 @@ describe('linkClass', () => {
         expect(link.destination).toEqual('link_in_file_body');
         expect(link.displayText).toEqual('link_in_file_body');
         expect(link.markdown).toEqual(link.originalMarkdown);
-        expect(link.isLinkTo('link_in_file_body')).toEqual(true);
-        expect(link.isLinkTo('link_in_file_body.md')).toEqual(true);
+        expect(link.linksTo('link_in_file_body')).toEqual(true);
+        expect(link.linksTo('link_in_file_body.md')).toEqual(true);
     });
 
     describe('getLink() configures Link.destinationPath automatically', () => {
@@ -286,43 +286,43 @@ describe('linkClass', () => {
         });
     });
 
-    describe('isLinkTo() tests', () => {
+    describe('linksTo() tests', () => {
         it('matches filenames', () => {
             const link = getLink(links_everywhere, 0);
 
-            expect(link.isLinkTo('link_in_file_body')).toEqual(true);
-            expect(link.isLinkTo('link_in_file_body.md')).toEqual(true);
+            expect(link.linksTo('link_in_file_body')).toEqual(true);
+            expect(link.linksTo('link_in_file_body.md')).toEqual(true);
 
-            expect(link.isLinkTo('somewhere_else')).toEqual(false);
+            expect(link.linksTo('somewhere_else')).toEqual(false);
 
-            expect(link.isLinkTo('link_in_file_body_but_different')).toEqual(false);
-            expect(link.isLinkTo('link_in_file_')).toEqual(false);
+            expect(link.linksTo('link_in_file_body_but_different')).toEqual(false);
+            expect(link.linksTo('link_in_file_')).toEqual(false);
         });
 
         it('matches without folders', () => {
             const linkToAFile = getLink(link_in_task_wikilink, 0);
             expect(linkToAFile.originalMarkdown).toMatchInlineSnapshot('"[[link_in_task_wikilink]]"');
 
-            expect(linkToAFile.isLinkTo('link_in_task_wikilink')).toEqual(true);
+            expect(linkToAFile.linksTo('link_in_task_wikilink')).toEqual(true);
         });
 
         it('matches with folders', () => {
             const linkToAFolder = getLink(link_in_task_wikilink, 2);
             expect(linkToAFolder.originalMarkdown).toMatchInlineSnapshot('"[[Test Data/link_in_task_wikilink]]"');
 
-            expect(linkToAFolder.isLinkTo('link_in_task_wikilink')).toEqual(true);
-            expect(linkToAFolder.isLinkTo('Test Data/link_in_task_wikilink')).toEqual(true);
-            expect(linkToAFolder.isLinkTo('Test Data/link_in_task_wikilink.md')).toEqual(true);
+            expect(linkToAFolder.linksTo('link_in_task_wikilink')).toEqual(true);
+            expect(linkToAFolder.linksTo('Test Data/link_in_task_wikilink')).toEqual(true);
+            expect(linkToAFolder.linksTo('Test Data/link_in_task_wikilink.md')).toEqual(true);
         });
 
         it('matches TasksFile - only exact paths match', () => {
             const linkToAFolder = getLink(link_in_task_wikilink, 2);
             expect(linkToAFolder.originalMarkdown).toMatchInlineSnapshot('"[[Test Data/link_in_task_wikilink]]"');
 
-            expect(linkToAFolder.isLinkTo(new TasksFile('Test Data/link_in_task_wikilink.md'))).toEqual(true);
-            expect(linkToAFolder.isLinkTo(new TasksFile('link_in_task_wikilink.md'))).toEqual(false);
-            expect(linkToAFolder.isLinkTo(new TasksFile('Wrong Test Data/link_in_task_wikilink.md'))).toEqual(false);
-            expect(linkToAFolder.isLinkTo(new TasksFile('something_obviously_different.md'))).toEqual(false);
+            expect(linkToAFolder.linksTo(new TasksFile('Test Data/link_in_task_wikilink.md'))).toEqual(true);
+            expect(linkToAFolder.linksTo(new TasksFile('link_in_task_wikilink.md'))).toEqual(false);
+            expect(linkToAFolder.linksTo(new TasksFile('Wrong Test Data/link_in_task_wikilink.md'))).toEqual(false);
+            expect(linkToAFolder.linksTo(new TasksFile('something_obviously_different.md'))).toEqual(false);
         });
     });
 });


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

I am labelling this as a refactor, because it changes un-released code.

I kept finding this to be rather unreadable - and not intuitive to type:

````text
```tasks
filter by function task.outlinks.some(link => link.isLinkTo(query.file))
```
````

So I have changed it to:

````text
```tasks
filter by function task.outlinks.some(link => link.linksTo(query.file))
```
````

In other words, `isLinkTo()` becomes `linksTo()`


## Motivation and Context

One step closing to releasing searching of links.

## How has this been tested?

- Automated tests
- Exploratory testing


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
