### PR TITLE
refactor: reduce memory usage with dynamic destination path

### DIFF
--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -1,6 +1,5 @@
 import { type CachedMetadata, type FrontMatterCache, type Reference, getAllTags, parseFrontMatterTags } from 'obsidian';
-import type { Link } from '../Task/Link';
-import { LinkResolver } from '../Task/LinkResolver';
+import { Link } from '../Task/Link';
 
 export type OptionalTasksFile = TasksFile | undefined;
 
@@ -36,7 +35,7 @@ export class TasksFile {
     }
 
     private createLinks(obsidianRawLinks: Reference[] | undefined) {
-        return obsidianRawLinks?.map((link) => LinkResolver.getInstance().resolve(link, this.path)) ?? [];
+        return obsidianRawLinks?.map((link) => new Link(link, this.path)) ?? [];
     }
 
     /**

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -5,18 +5,14 @@ import { LinkResolver } from './LinkResolver';
 export class Link {
     private readonly rawLink: Reference;
     private readonly pathContainingLink: string;
-    // @ts-expect-error
-    private readonly _destinationPath: string | null;
 
     /**
      * @param {Reference} rawLink - The raw link from Obsidian cache.
      * @param {string} pathContainingLink - The path of the file where this link is located.
-     * @param {string | undefined} destinationPath - The path of the note being linked tio.
      */
-    constructor(rawLink: Reference, pathContainingLink: string, destinationPath?: string) {
+    constructor(rawLink: Reference, pathContainingLink: string) {
         this.rawLink = rawLink;
         this.pathContainingLink = pathContainingLink;
-        this._destinationPath = destinationPath ?? null;
     }
 
     /**

--- a/src/Task/Link.ts
+++ b/src/Task/Link.ts
@@ -1,9 +1,11 @@
 import type { Reference } from 'obsidian';
 import type { TasksFile } from '../Scripting/TasksFile';
+import { LinkResolver } from './LinkResolver';
 
 export class Link {
     private readonly rawLink: Reference;
     private readonly pathContainingLink: string;
+    // @ts-expect-error
     private readonly _destinationPath: string | null;
 
     /**
@@ -80,7 +82,7 @@ export class Link {
      * See {@link LinkResolver} docs for more info.
      */
     public get destinationPath(): string | null {
-        return this._destinationPath;
+        return LinkResolver.getInstance().getDestinationPath(this.rawLink, this.pathContainingLink) ?? null;
     }
 
     /**

--- a/src/Task/LinkResolver.ts
+++ b/src/Task/LinkResolver.ts
@@ -30,7 +30,7 @@ export class LinkResolver {
         return new Link(rawLink, pathContainingLink, this.getDestinationPath(rawLink, pathContainingLink));
     }
 
-    private getDestinationPath(rawLink: Reference, pathContainingLink: string) {
+    public getDestinationPath(rawLink: Reference, pathContainingLink: string) {
         return this.getFirstLinkpathDestFn(rawLink, pathContainingLink) ?? undefined;
     }
 

--- a/src/Task/LinkResolver.ts
+++ b/src/Task/LinkResolver.ts
@@ -27,11 +27,11 @@ export class LinkResolver {
     }
 
     public resolve(rawLink: Reference, pathContainingLink: string) {
-        return new Link(
-            rawLink,
-            pathContainingLink,
-            this.getFirstLinkpathDestFn(rawLink, pathContainingLink) ?? undefined,
-        );
+        return new Link(rawLink, pathContainingLink, this.getDestinationPath(rawLink, pathContainingLink));
+    }
+
+    private getDestinationPath(rawLink: Reference, pathContainingLink: string) {
+        return this.getFirstLinkpathDestFn(rawLink, pathContainingLink) ?? undefined;
     }
 
     /**

--- a/src/Task/LinkResolver.ts
+++ b/src/Task/LinkResolver.ts
@@ -5,7 +5,7 @@ export type GetFirstLinkpathDestFn = (rawLink: Reference, sourcePath: string) =>
 const defaultGetFirstLinkpathDestFn = (_rawLink: Reference, _sourcePath: string) => null;
 
 /**
- * An abstraction to populate {@link Link.destinationPath}.
+ * An abstraction to implement {@link Link.destinationPath}.
  *
  * See also:
  * - `src/main.ts` - search for `LinkResolver.getInstance()`

--- a/src/Task/LinkResolver.ts
+++ b/src/Task/LinkResolver.ts
@@ -1,5 +1,4 @@
 import type { Reference } from 'obsidian';
-import { Link } from './Link';
 
 export type GetFirstLinkpathDestFn = (rawLink: Reference, sourcePath: string) => string | null;
 
@@ -25,11 +24,6 @@ export class LinkResolver {
     public resetGetFirstLinkpathDestFn() {
         this.getFirstLinkpathDestFn = defaultGetFirstLinkpathDestFn;
     }
-
-    public resolve(rawLink: Reference, pathContainingLink: string) {
-        return new Link(rawLink, pathContainingLink);
-    }
-
     public getDestinationPath(rawLink: Reference, pathContainingLink: string) {
         return this.getFirstLinkpathDestFn(rawLink, pathContainingLink) ?? undefined;
     }

--- a/src/Task/LinkResolver.ts
+++ b/src/Task/LinkResolver.ts
@@ -27,7 +27,7 @@ export class LinkResolver {
     }
 
     public resolve(rawLink: Reference, pathContainingLink: string) {
-        return new Link(rawLink, pathContainingLink, this.getDestinationPath(rawLink, pathContainingLink));
+        return new Link(rawLink, pathContainingLink);
     }
 
     public getDestinationPath(rawLink: Reference, pathContainingLink: string) {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -3,8 +3,7 @@ import type { TasksFile } from '../Scripting/TasksFile';
 import type { Task } from './Task';
 import type { TaskLocation } from './TaskLocation';
 import { TaskRegularExpressions } from './TaskRegularExpressions';
-import type { Link } from './Link';
-import { LinkResolver } from './LinkResolver';
+import { Link } from './Link';
 
 export class ListItem {
     // The original line read from file.
@@ -211,7 +210,7 @@ export class ListItem {
     public get outlinks(): Readonly<Link[]> {
         return this.rawLinksInFileBody
             .filter((link) => link.position.start.line === this.lineNumber)
-            .map((link) => LinkResolver.getInstance().resolve(link, this.file.path));
+            .map((link) => new Link(link, this.file.path));
     }
 
     /**

--- a/tests/Scripting/TaskProperties.test.ts
+++ b/tests/Scripting/TaskProperties.test.ts
@@ -3,7 +3,6 @@
  */
 
 import moment from 'moment';
-import type { Reference } from 'obsidian';
 import { Status } from '../../src/Statuses/Status';
 
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
@@ -159,9 +158,7 @@ describe('task', () => {
 
     it('links', () => {
         // This is getting annoying, having to do this repeatedly.
-        LinkResolver.getInstance().setGetFirstLinkpathDestFn((rawLink: Reference, sourcePath: string) =>
-            getFirstLinkpathDest(rawLink, sourcePath),
-        );
+        LinkResolver.getInstance().setGetFirstLinkpathDestFn(getFirstLinkpathDest);
 
         const tasks = readTasksFromSimulatedFile(links_everywhere);
         verifyFieldDataFromTasksForReferenceDocs(tasks, [

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -19,6 +19,10 @@ import { getFirstLinkpathDest, getFirstLinkpathDestFromData } from '../__mocks__
 function getLink(data: any, index: number) {
     const rawLink = data.cachedMetadata.links[index];
     const destinationPath = getFirstLinkpathDestFromData(data, rawLink);
+
+    const resolver = LinkResolver.getInstance();
+    resolver.setGetFirstLinkpathDestFn(() => destinationPath);
+
     return new Link(rawLink, data.filePath, destinationPath);
 }
 

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -6,7 +6,6 @@ import link_in_task_markdown_link from '../Obsidian/__test_data__/link_in_task_m
 import link_in_task_wikilink from '../Obsidian/__test_data__/link_in_task_wikilink.json';
 import link_is_broken from '../Obsidian/__test_data__/link_is_broken.json';
 
-import link_in_file_body from '../Obsidian/__test_data__/link_in_file_body.json';
 import links_everywhere from '../Obsidian/__test_data__/links_everywhere.json';
 import { allCacheSampleData } from '../Obsidian/AllCacheSampleData';
 import type { SimulatedFile } from '../Obsidian/SimulatedFile';
@@ -262,31 +261,6 @@ describe('linkClass', () => {
 
         // Empty Markdown Link Tests
         // []() and [alias]() are not detected by the obsidian parser as a link
-    });
-
-    describe('destinationPath tests', () => {
-        it.failing('should accept and return destinationPath', () => {
-            const data = link_in_file_body;
-            const rawLink = data.cachedMetadata.links[0];
-            expect(rawLink.original).toEqual('[[yaml_tags_is_empty]]');
-            expect(rawLink.link).toEqual('yaml_tags_is_empty');
-
-            const destinationPath = 'Test Data/yaml_tags_is_empty.md';
-            const link = new Link(rawLink, data.filePath);
-
-            expect(link.destinationPath).toEqual(destinationPath);
-        });
-
-        it.failing('should return null path if destinationPath not supplied', () => {
-            const data = link_in_file_body;
-            const rawLink = data.cachedMetadata.links[0];
-            expect(rawLink.original).toEqual('[[yaml_tags_is_empty]]');
-            expect(rawLink.link).toEqual('yaml_tags_is_empty');
-
-            const link = new Link(rawLink, data.filePath);
-
-            expect(link.destinationPath).toBeNull();
-        });
     });
 
     describe('linksTo() tests', () => {

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -23,7 +23,7 @@ function getLink(data: any, index: number) {
     const resolver = LinkResolver.getInstance();
     resolver.setGetFirstLinkpathDestFn(() => destinationPath);
 
-    return new Link(rawLink, data.filePath, destinationPath);
+    return new Link(rawLink, data.filePath);
 }
 
 describe('linkClass', () => {
@@ -272,7 +272,7 @@ describe('linkClass', () => {
             expect(rawLink.link).toEqual('yaml_tags_is_empty');
 
             const destinationPath = 'Test Data/yaml_tags_is_empty.md';
-            const link = new Link(rawLink, data.filePath, destinationPath);
+            const link = new Link(rawLink, data.filePath);
 
             expect(link.destinationPath).toEqual(destinationPath);
         });

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -1,4 +1,3 @@
-import type { Reference } from 'obsidian';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Link } from '../../src/Task/Link';
 import internal_heading_links from '../Obsidian/__test_data__/internal_heading_links.json';
@@ -329,9 +328,7 @@ describe('linkClass', () => {
 
 describe('visualise links', () => {
     beforeAll(() => {
-        LinkResolver.getInstance().setGetFirstLinkpathDestFn((rawLink: Reference, sourcePath: string) => {
-            return getFirstLinkpathDest(rawLink, sourcePath);
-        });
+        LinkResolver.getInstance().setGetFirstLinkpathDestFn(getFirstLinkpathDest);
     });
 
     afterAll(() => {

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -265,7 +265,7 @@ describe('linkClass', () => {
     });
 
     describe('destinationPath tests', () => {
-        it('should accept and return destinationPath', () => {
+        it.failing('should accept and return destinationPath', () => {
             const data = link_in_file_body;
             const rawLink = data.cachedMetadata.links[0];
             expect(rawLink.original).toEqual('[[yaml_tags_is_empty]]');
@@ -277,7 +277,7 @@ describe('linkClass', () => {
             expect(link.destinationPath).toEqual(destinationPath);
         });
 
-        it('should return null path if destinationPath not supplied', () => {
+        it.failing('should return null path if destinationPath not supplied', () => {
             const data = link_in_file_body;
             const rawLink = data.cachedMetadata.links[0];
             expect(rawLink.original).toEqual('[[yaml_tags_is_empty]]');

--- a/tests/Task/LinkResolver.test.ts
+++ b/tests/Task/LinkResolver.test.ts
@@ -25,7 +25,7 @@ describe('LinkResolver', () => {
     });
 
     it('should allow a function to be supplied, to find the destination of a link', () => {
-        const resolver = new LinkResolver();
+        const resolver = LinkResolver.getInstance();
         resolver.setGetFirstLinkpathDestFn((_rawLink: Reference, _sourcePath: string) => 'Hello World.md');
 
         const link = resolver.resolve(rawLink, link_in_file_body.filePath);

--- a/tests/Task/LinkResolver.test.ts
+++ b/tests/Task/LinkResolver.test.ts
@@ -26,7 +26,7 @@ describe('LinkResolver', () => {
 
     it('should allow a function to be supplied, to find the destination of a link', () => {
         const resolver = LinkResolver.getInstance();
-        resolver.setGetFirstLinkpathDestFn((_rawLink: Reference, _sourcePath: string) => 'Hello World.md');
+        resolver.setGetFirstLinkpathDestFn(() => 'Hello World.md');
 
         const link = resolver.resolve(rawLink, link_in_file_body.filePath);
         expect(link.destinationPath).toEqual('Hello World.md');
@@ -34,9 +34,7 @@ describe('LinkResolver', () => {
 
     it('should allow the global instance to be reset', () => {
         const globalInstance = LinkResolver.getInstance();
-        globalInstance.setGetFirstLinkpathDestFn(
-            (_rawLink: Reference, _sourcePath: string) => 'From Global Instance.md',
-        );
+        globalInstance.setGetFirstLinkpathDestFn(() => 'From Global Instance.md');
 
         const link1 = globalInstance.resolve(rawLink, link_in_file_body.filePath);
         expect(link1.destinationPath).toEqual('From Global Instance.md');

--- a/tests/Task/LinkResolver.test.ts
+++ b/tests/Task/LinkResolver.test.ts
@@ -44,4 +44,16 @@ describe('LinkResolver', () => {
         const link2 = new Link(rawLink, link_in_file_body.filePath);
         expect(link2.destinationPath).toBeNull();
     });
+
+    it('resetting global instance affects pre-existing links', () => {
+        const globalInstance = LinkResolver.getInstance();
+        globalInstance.setGetFirstLinkpathDestFn(() => 'From Global Instance.md');
+
+        const link1 = new Link(rawLink, link_in_file_body.filePath);
+        expect(link1.destinationPath).toEqual('From Global Instance.md');
+
+        globalInstance.resetGetFirstLinkpathDestFn();
+
+        expect(link1.destinationPath).toBeNull();
+    });
 });

--- a/tests/Task/LinkResolver.test.ts
+++ b/tests/Task/LinkResolver.test.ts
@@ -1,6 +1,7 @@
 import type { Reference } from 'obsidian';
 import link_in_file_body from '../Obsidian/__test_data__/link_in_file_body.json';
 import { LinkResolver } from '../../src/Task/LinkResolver';
+import { Link } from '../../src/Task/Link';
 
 describe('LinkResolver', () => {
     let rawLink: Reference;
@@ -10,15 +11,14 @@ describe('LinkResolver', () => {
     });
 
     it('should resolve a link via local instance', () => {
-        const resolver = new LinkResolver();
-        const link = resolver.resolve(rawLink, link_in_file_body.filePath);
+        const link = new Link(rawLink, link_in_file_body.filePath);
 
         expect(link.originalMarkdown).toEqual('[[yaml_tags_is_empty]]');
         expect(link.destinationPath).toBeNull();
     });
 
     it('should resolve a link via global instance', () => {
-        const link = LinkResolver.getInstance().resolve(rawLink, link_in_file_body.filePath);
+        const link = new Link(rawLink, link_in_file_body.filePath);
 
         expect(link.originalMarkdown).toEqual('[[yaml_tags_is_empty]]');
         expect(link.destinationPath).toBeNull();
@@ -28,7 +28,7 @@ describe('LinkResolver', () => {
         const resolver = LinkResolver.getInstance();
         resolver.setGetFirstLinkpathDestFn(() => 'Hello World.md');
 
-        const link = resolver.resolve(rawLink, link_in_file_body.filePath);
+        const link = new Link(rawLink, link_in_file_body.filePath);
         expect(link.destinationPath).toEqual('Hello World.md');
     });
 
@@ -36,12 +36,12 @@ describe('LinkResolver', () => {
         const globalInstance = LinkResolver.getInstance();
         globalInstance.setGetFirstLinkpathDestFn(() => 'From Global Instance.md');
 
-        const link1 = globalInstance.resolve(rawLink, link_in_file_body.filePath);
+        const link1 = new Link(rawLink, link_in_file_body.filePath);
         expect(link1.destinationPath).toEqual('From Global Instance.md');
 
         globalInstance.resetGetFirstLinkpathDestFn();
 
-        const link2 = globalInstance.resolve(rawLink, link_in_file_body.filePath);
+        const link2 = new Link(rawLink, link_in_file_body.filePath);
         expect(link2.destinationPath).toBeNull();
     });
 });


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae.

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- `Link` objects now take less memory

## Motivation and Context

- May reduce Obsidian restarts in large vaults on mobile devices

## How has this been tested?

- Unit tests
- Exploratory test in demo vault

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
