### PR TITLE
feat: redraw search results after global filter is edited

### DIFF
--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -110,14 +110,20 @@ export class SettingsTab extends PluginSettingTab {
                 // wide enough for the whole string to be visible.
                 text.setPlaceholder(i18n.t('settings.globalFilter.filter.placeholder'))
                     .setValue(GlobalFilter.getInstance().get())
-                    .onChange(async (value) => {
-                        updateSettings({ globalFilter: value });
-                        GlobalFilter.getInstance().set(value);
-                        await this.plugin.saveSettings();
-                        setSettingVisibility(globalFilterHidden, value.length > 0);
+                    .onChange(
+                        debounce(
+                            async (value) => {
+                                updateSettings({ globalFilter: value });
+                                GlobalFilter.getInstance().set(value);
+                                await this.plugin.saveSettings();
+                                setSettingVisibility(globalFilterHidden, value.length > 0);
 
-                        await this.plugin.cache?.loadVault();
-                    });
+                                await this.plugin.cache?.loadVault();
+                            },
+                            500,
+                            true,
+                        ),
+                    );
             });
 
         globalFilterHidden = new Setting(containerEl)

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -118,6 +118,8 @@ export class SettingsTab extends PluginSettingTab {
                                 await this.plugin.saveSettings();
                                 setSettingVisibility(globalFilterHidden, value.length > 0);
 
+                                this.events.triggerReloadVault();
+
                                 await this.plugin.cache?.loadVault();
                             },
                             500,

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -115,6 +115,8 @@ export class SettingsTab extends PluginSettingTab {
                         GlobalFilter.getInstance().set(value);
                         await this.plugin.saveSettings();
                         setSettingVisibility(globalFilterHidden, value.length > 0);
+
+                        await this.plugin.cache?.loadVault();
                     });
             });
 

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -119,8 +119,6 @@ export class SettingsTab extends PluginSettingTab {
                                 setSettingVisibility(globalFilterHidden, value.length > 0);
 
                                 this.events.triggerReloadVault();
-
-                                await this.plugin.cache?.loadVault();
                             },
                             500,
                             true,

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -231,6 +231,9 @@ export class Cache {
             handler({ tasks: this.tasks, state: this.state });
         });
         this.eventsEventReferences.push(requestReference);
+
+        const reloadVaultReference = this.events.onReloadVault(() => console.warn('Reload vault please'));
+        this.eventsEventReferences.push(reloadVaultReference);
     }
 
     public loadVault(): Promise<void> {

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -31,9 +31,11 @@ export class Cache {
 
     private readonly metadataCache: MetadataCache;
     private readonly metadataCacheEventReferences: EventRef[];
+
     private readonly vault: Vault;
     private readonly workspace: Workspace;
     private readonly vaultEventReferences: EventRef[];
+
     private readonly events: TasksEvents;
     private readonly eventsEventReferences: EventRef[];
 
@@ -72,9 +74,11 @@ export class Cache {
 
         this.metadataCache = metadataCache;
         this.metadataCacheEventReferences = [];
+
         this.vault = vault;
         this.workspace = workspace;
         this.vaultEventReferences = [];
+
         this.events = events;
         this.eventsEventReferences = [];
 

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -232,7 +232,10 @@ export class Cache {
         });
         this.eventsEventReferences.push(requestReference);
 
-        const reloadVaultReference = this.events.onReloadVault(() => console.warn('Reload vault please'));
+        const reloadVaultReference = this.events.onReloadVault(async () => {
+            // The caller is responsible for debouncing this.
+            await this.loadVault();
+        });
         this.eventsEventReferences.push(reloadVaultReference);
     }
 

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -239,7 +239,7 @@ export class Cache {
         this.eventsEventReferences.push(reloadVaultReference);
     }
 
-    public loadVault(): Promise<void> {
+    private loadVault(): Promise<void> {
         this.logger.debug('Cache.loadVault()');
         return this.tasksMutex.runExclusive(async () => {
             this.state = State.Initializing;

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -229,7 +229,7 @@ export class Cache {
         this.eventsEventReferences.push(requestReference);
     }
 
-    private loadVault(): Promise<void> {
+    public loadVault(): Promise<void> {
         this.logger.debug('Cache.loadVault()');
         return this.tasksMutex.runExclusive(async () => {
             this.state = State.Initializing;

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -234,10 +234,8 @@ export class Cache {
         });
         this.eventsEventReferences.push(requestReference);
 
-        const reloadVaultReference = this.events.onReloadVault(async () => {
-            // The caller is responsible for debouncing this.
-            await this.loadVault();
-        });
+        // The caller is responsible for debouncing this:
+        const reloadVaultReference = this.events.onReloadVault(async () => await this.loadVault());
         this.eventsEventReferences.push(reloadVaultReference);
     }
 

--- a/src/Obsidian/TasksEvents.ts
+++ b/src/Obsidian/TasksEvents.ts
@@ -8,6 +8,7 @@ enum Event {
     CacheUpdate = 'obsidian-tasks-plugin:cache-update',
     RequestCacheUpdate = 'obsidian-tasks-plugin:request-cache-update',
     ReloadOpenSearchResults = 'obsidian-tasks-plugin:reload-open-search-results',
+    ReloadVault = 'obsidian-tasks-plugin:reload-vault',
 }
 
 interface CacheUpdateData {
@@ -67,6 +68,20 @@ export class TasksEvents {
     public triggerReloadOpenSearchResults(): void {
         this.logger.debug('TasksEvents.triggerReloadOpenSearchResults()');
         this.obsidianEvents.trigger(Event.ReloadOpenSearchResults);
+    }
+
+    // ------------------------------------------------------------------------
+    // ReloadVault event
+
+    public onReloadVault(handler: () => void): EventRef {
+        this.logger.debug('TasksEvents.onReloadVault()');
+        const name = Event.ReloadVault;
+        return this.obsidianEvents.on(name, handler);
+    }
+
+    public triggerReloadVault(): void {
+        this.logger.debug('TasksEvents.triggerReloadVault()');
+        this.obsidianEvents.trigger(Event.ReloadVault);
     }
 
     public off(eventRef: EventRef): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ import { QueryFileDefaults } from './Query/QueryFileDefaults';
 import { LinkResolver } from './Task/LinkResolver';
 
 export default class TasksPlugin extends Plugin {
-    private cache: Cache | undefined;
+    public cache: Cache | undefined;
     public inlineRenderer: InlineRenderer | undefined;
     public queryRenderer: QueryRenderer | undefined;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ import { QueryFileDefaults } from './Query/QueryFileDefaults';
 import { LinkResolver } from './Task/LinkResolver';
 
 export default class TasksPlugin extends Plugin {
-    public cache: Cache | undefined;
+    private cache: Cache | undefined;
     public inlineRenderer: InlineRenderer | undefined;
     public queryRenderer: QueryRenderer | undefined;
 


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2684

## Description

- redraw automatically debounced search results after global filter is edited

## Motivation and Context

- Related to #2684

## How has this been tested?

- manual test in demo vault

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
