### PR TITLE
docs: Refine 'Priority of Dates' section for recurring tasks

### DIFF
--- a/docs/Getting Started/Recurring Tasks.md
+++ b/docs/Getting Started/Recurring Tasks.md
@@ -192,13 +192,25 @@ This is intentional. As well as matching what the user requested, it matches the
 ## Priority of Dates
 
 A task can have [[Dates|various dates]].
+
 When a task has multiple dates, one of them is selected as reference date based on the following priorities:
 
-1. Due date
-2. Scheduled date
-3. Start date
+> [!Info] Priority of date fields, with default settings
+>
+> 1. **Due** date
+> 2. **Scheduled** date
+> 3. **Start** date
 
-> If the "Remove scheduled date on recurrence" setting is true, the Start Date will be chosen before the Scheduled date.
+> [!Info] Priority of date fields if 'Remove scheduled date on recurrence' is enabled
+> When the [[#Remove scheduled date on recurrence]] setting is enabled, the Start date is prioritized over the Scheduled date because the Scheduled date will be removed from the next occurrence.
+>
+> 1. **Due** date
+> 2. **Start** date
+> 3. **Scheduled** date
+>
+> It makes more sense to calculate the next occurrence based on a date that will actually exist in the new task.
+>
+> The Start date provides a more stable reference for calculating future recurrences, especially since you'll typically add a new Scheduled date later when you're ready to work on the task.
 
 If more dates than the reference date exist on the original recurring task, the next occurrence will have the same dates.
 All dates of the next occurring task will have the relative distance to the reference date that they had on the original task.

--- a/docs/Getting Started/Recurring Tasks.md
+++ b/docs/Getting Started/Recurring Tasks.md
@@ -201,8 +201,8 @@ When a task has multiple dates, one of them is selected as reference date based 
 > 2. **Scheduled** date
 > 3. **Start** date
 
-> [!Info] Priority of date fields if 'Remove scheduled date on recurrence' is enabled
-> When the [[#Remove scheduled date on recurrence]] setting is enabled, the Start date is prioritized over the Scheduled date because the Scheduled date will be removed from the next occurrence.
+> [!Info] Priority of date fields if Scheduled date might be removed
+> When the [[#Remove scheduled date on recurrence]] setting is enabled, the Start date is prioritized over the Scheduled date because the Scheduled date will be removed from the next occurrence:
 >
 > 1. **Due** date
 > 2. **Start** date
@@ -210,7 +210,7 @@ When a task has multiple dates, one of them is selected as reference date based 
 >
 > It makes more sense to calculate the next occurrence based on a date that will actually exist in the new task.
 >
-> The Start date provides a more stable reference for calculating future recurrences, especially since you'll typically add a new Scheduled date later when you're ready to work on the task.
+> The Start date also provides a more stable reference for calculating future recurrences, especially since you'll typically add a new Scheduled date later when you're ready to work on the task.
 
 If more dates than the reference date exist on the original recurring task, the next occurrence will have the same dates.
 All dates of the next occurring task will have the relative distance to the reference date that they had on the original task.

--- a/docs/Getting Started/Recurring Tasks.md
+++ b/docs/Getting Started/Recurring Tasks.md
@@ -211,6 +211,9 @@ When a task has multiple dates, one of them is selected as reference date based 
 > It makes more sense to calculate the next occurrence based on a date that will actually exist in the new task.
 >
 > The Start date also provides a more stable reference for calculating future recurrences, especially since you'll typically add a new Scheduled date later when you're ready to work on the task.
+>
+> > [!released]
+> > This different order was introduced in Tasks X.Y.Z.
 
 If more dates than the reference date exist on the original recurring task, the next occurrence will have the same dates.
 All dates of the next occurring task will have the relative distance to the reference date that they had on the original task.


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

## Description

This slightly refines the documentation changes made in #3592.

## Motivation and Context

Getting ready for release...

## How has this been tested?

Edited and reviewed in Obsidian.

## Screenshots (if appropriate)

_Click to expand image..._

<img width="1890" height="1008" alt="image" src="https://github.com/user-attachments/assets/50d9c2cb-b8c4-408b-becb-9eb525c02bdc" />



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
