### PR TITLE
fix: Enable themes to modify indentation in Live Preview (#3603)

### DIFF
--- a/src/Renderer/Renderer.scss
+++ b/src/Renderer/Renderer.scss
@@ -3,11 +3,6 @@
 
 }
 
-/* Fix indentation of wrapped task lines in Tasks search results, when in Live Preview. */
-ul.contains-task-list .task-list-item-checkbox {
-    margin-inline-start: calc(var(--checkbox-size) * -1.5) !important;
-}
-
 .plugin-tasks-query-explanation{
     /* Prevent long explanation lines wrapping, so they are more readable,
        especially on small screens.


### PR DESCRIPTION


# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3603

## Description

Remove a !important CSS block that is no longer needed.

This was added to fix this issue:

- #2361

Investigation has shown that the underlying issue has been fixed in Obsidian, so the workaround is no longer needed.

## Motivation and Context

Fixes #3603

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

See all my discussion in #3603 for the testing I did before making this change.

## Screenshots (if appropriate)

See my screenshots posted in #3603

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
