### PR TITLE
fix: prevent mouse cursor becoming stuck in "scroll" mode when middle clicking a task backlink

### DIFF
--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -381,11 +381,11 @@ function createBacklinksMousedownHandler(app: App): BacklinksEventHandler {
         // (for regular left-click we prefer the 'click' event, and not to just do everything here, because
         // the 'click' event is more generic for touch devices etc.)
         if (ev.button === 1) {
+            ev.preventDefault();
             const result = await getTaskLineAndFile(task, app.vault);
             if (result) {
                 const [line, file] = result;
                 const leaf = app.workspace.getLeaf('tab');
-                ev.preventDefault();
                 await leaf.openFile(file, { eState: { line: line } });
             }
         }


### PR DESCRIPTION
## Summary
Move `ev.preventDefault()` earlier in the handler created in `createBacklinksMousedownHandler()` to prevent the mouse cursor becoming locked in scroll mode.

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3458

## Description

It appears that `ev.preventDefault()` doesn't work if it appears after an `await`, as event propagation is handled synchronously (see [here](https://stackoverflow.com/questions/37146302/event-preventdefault-in-async-functions)).
Moving it earlier properly prevents default behaviour of enabling scroll mode.

## Motivation and Context

For some users, middle clicking on a backlink in a `tasks` block causes the mouse cursor to become stuck in "scroll" mode.
Fixes #3458.

## How has this been tested?

I've tested the changes in a minimal, blank vault (the same vault I uploaded [here](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3458#issuecomment-3253009471)).

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
