### PR TITLE
test: Remove uses of a singleton in mocked Obsidian functions

### DIFF
--- a/tests/Obsidian/SimulatedFile.ts
+++ b/tests/Obsidian/SimulatedFile.ts
@@ -2,7 +2,6 @@ import type { CachedMetadata } from 'obsidian';
 import type { Task } from 'Task/Task';
 import { logging } from '../../src/lib/logging';
 import { FileParser } from '../../src/Obsidian/FileParser';
-import { setCurrentCacheFile } from '../__mocks__/obsidian';
 import { MockDataLoader } from '../TestingTools/MockDataLoader';
 import type { MockDataName } from './AllCacheSampleData';
 
@@ -56,7 +55,6 @@ export interface SimulatedFile {
 export function readTasksFromSimulatedFile(filename: MockDataName): Task[] {
     const testData = MockDataLoader.get(filename);
     const logger = logging.getLogger('testCache');
-    setCurrentCacheFile(testData);
     const fileParser = new FileParser(
         testData.filePath,
         testData.fileContents,

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -340,7 +340,7 @@ describe('TasksFile - reading tags', () => {
         return { link, markdownPath, firstLinkpathDest };
     }
 
-    it.failing('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
+    it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
         const destination1 = loadMockDataAndResolveFirstLink('link_in_file_body', '"[[yaml_tags_is_empty]]"');
         expect(destination1.firstLinkpathDest).toMatchInlineSnapshot('"Test Data/yaml_tags_is_empty.md"');
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -331,16 +331,16 @@ describe('TasksFile - reading tags', () => {
         expect(parseFrontMatterTags(file1.cachedMetadata.frontmatter)).toEqual(['#single-value-new-line']);
     });
 
-    function loadMockDataAndResolveFirstLink(testDataName: MockDataName, expectedLinkSource: string) {
-        const file = getTasksFileFromMockData(testDataName);
-        const link = file.cachedMetadata.links![0];
-        expect(link.original).toMatchInlineSnapshot(expectedLinkSource);
-        const markdownPath = MockDataLoader.markdownPath(testDataName);
-        const firstLinkpathDest = getFirstLinkpathDest(link, markdownPath);
-        return { link, markdownPath, firstLinkpathDest };
-    }
-
     it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
+        function loadMockDataAndResolveFirstLink(testDataName: MockDataName, expectedLinkSource: string) {
+            const file = getTasksFileFromMockData(testDataName);
+            const link = file.cachedMetadata.links![0];
+            expect(link.original).toMatchInlineSnapshot(expectedLinkSource);
+            const markdownPath = MockDataLoader.markdownPath(testDataName);
+            const firstLinkpathDest = getFirstLinkpathDest(link, markdownPath);
+            return { link, markdownPath, firstLinkpathDest };
+        }
+
         const destination1 = loadMockDataAndResolveFirstLink('link_in_file_body', '"[[yaml_tags_is_empty]]"');
         expect(destination1.firstLinkpathDest).toMatchInlineSnapshot('"Test Data/yaml_tags_is_empty.md"');
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -339,8 +339,8 @@ describe('TasksFile - reading tags', () => {
     }
 
     it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
-        const firstLinkpathDest = resolveFirstLink('link_in_file_body', '"[[yaml_tags_is_empty]]"');
-        expect(firstLinkpathDest).toMatchInlineSnapshot('"Test Data/yaml_tags_is_empty.md"');
+        const destination1 = resolveFirstLink('link_in_file_body', '"[[yaml_tags_is_empty]]"');
+        expect(destination1).toMatchInlineSnapshot('"Test Data/yaml_tags_is_empty.md"');
     });
 });
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -4,7 +4,7 @@ import { TasksFile } from '../../src/Scripting/TasksFile';
 import { getTasksFileFromMockData, listPathAndData } from '../TestingTools/MockDataHelpers';
 import { LinkResolver } from '../../src/Task/LinkResolver';
 import type { MockDataName } from '../Obsidian/AllCacheSampleData';
-import { getAllTags, parseFrontMatterTags } from '../__mocks__/obsidian';
+import { getAllTags, getFirstLinkpathDest, parseFrontMatterTags } from '../__mocks__/obsidian';
 import { MockDataLoader } from '../TestingTools/MockDataLoader';
 import { determineExpressionType, formatToRepresentType } from './ScriptingTestHelpers';
 
@@ -329,6 +329,16 @@ describe('TasksFile - reading tags', () => {
 
         // Now see if we can again find the tags in file1
         expect(parseFrontMatterTags(file1.cachedMetadata.frontmatter)).toEqual(['#single-value-new-line']);
+    });
+
+    it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
+        const testDataName = 'link_in_file_body';
+        const expectedLinkSource = '"[[yaml_tags_is_empty]]"';
+        const file = getTasksFileFromMockData(testDataName);
+        const link = file.cachedMetadata.links![0];
+        expect(link.original).toMatchInlineSnapshot(expectedLinkSource);
+        const firstLinkpathDest = getFirstLinkpathDest(link, MockDataLoader.markdownPath(testDataName));
+        expect(firstLinkpathDest).toMatchInlineSnapshot('"Test Data/yaml_tags_is_empty.md"');
     });
 });
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -331,7 +331,7 @@ describe('TasksFile - reading tags', () => {
         expect(parseFrontMatterTags(file1.cachedMetadata.frontmatter)).toEqual(['#single-value-new-line']);
     });
 
-    function resolveFirstLink(testDataName: MockDataName, expectedLinkSource: string) {
+    function loadMockDataAndResolveFirstLink(testDataName: MockDataName, expectedLinkSource: string) {
         const file = getTasksFileFromMockData(testDataName);
         const link = file.cachedMetadata.links![0];
         expect(link.original).toMatchInlineSnapshot(expectedLinkSource);
@@ -339,10 +339,10 @@ describe('TasksFile - reading tags', () => {
     }
 
     it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
-        const destination1 = resolveFirstLink('link_in_file_body', '"[[yaml_tags_is_empty]]"');
+        const destination1 = loadMockDataAndResolveFirstLink('link_in_file_body', '"[[yaml_tags_is_empty]]"');
         expect(destination1).toMatchInlineSnapshot('"Test Data/yaml_tags_is_empty.md"');
 
-        const destination2 = resolveFirstLink('link_in_heading', '"[[multiple_headings]]"');
+        const destination2 = loadMockDataAndResolveFirstLink('link_in_heading', '"[[multiple_headings]]"');
         expect(destination2).toMatchInlineSnapshot('"Test Data/multiple_headings.md"');
     });
 });

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -341,6 +341,9 @@ describe('TasksFile - reading tags', () => {
     it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
         const destination1 = resolveFirstLink('link_in_file_body', '"[[yaml_tags_is_empty]]"');
         expect(destination1).toMatchInlineSnapshot('"Test Data/yaml_tags_is_empty.md"');
+
+        const destination2 = resolveFirstLink('link_in_heading', '"[[multiple_headings]]"');
+        expect(destination2).toMatchInlineSnapshot('"Test Data/multiple_headings.md"');
     });
 });
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -308,7 +308,7 @@ describe('TasksFile - reading tags', () => {
         expect(tasksFile.frontmatter.tags).toEqual([]);
     });
 
-    it.failing('should be able to read tags for any loaded SimulatedFile', () => {
+    it('should be able to read tags for any loaded SimulatedFile', () => {
         const file1 = getTasksFileFromMockData('yaml_tags_with_one_value_on_new_line');
         expect(getAllTags(file1.cachedMetadata)).toEqual(['#single-value-new-line', '#task']);
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -4,7 +4,8 @@ import { TasksFile } from '../../src/Scripting/TasksFile';
 import { getTasksFileFromMockData, listPathAndData } from '../TestingTools/MockDataHelpers';
 import { LinkResolver } from '../../src/Task/LinkResolver';
 import type { MockDataName } from '../Obsidian/AllCacheSampleData';
-import { getAllTags } from '../__mocks__/obsidian';
+import { getAllTags, parseFrontMatterTags } from '../__mocks__/obsidian';
+import { MockDataLoader } from '../TestingTools/MockDataLoader';
 import { determineExpressionType, formatToRepresentType } from './ScriptingTestHelpers';
 
 afterEach(() => {
@@ -308,7 +309,7 @@ describe('TasksFile - reading tags', () => {
         expect(tasksFile.frontmatter.tags).toEqual([]);
     });
 
-    it('should be able to read tags for any loaded SimulatedFile', () => {
+    it('should be able to read all tags for any loaded SimulatedFile', () => {
         const file1 = getTasksFileFromMockData('yaml_tags_with_one_value_on_new_line');
         expect(getAllTags(file1.cachedMetadata)).toEqual(['#single-value-new-line', '#task']);
 
@@ -317,6 +318,17 @@ describe('TasksFile - reading tags', () => {
 
         // Now see if we can again find the tags in file1
         expect(getAllTags(file1.cachedMetadata)).toEqual(['#single-value-new-line', '#task']);
+    });
+
+    it.failing('should be able to read frontmatter tags for any loaded SimulatedFile', () => {
+        const file1 = MockDataLoader.get('yaml_tags_with_one_value_on_new_line');
+        expect(parseFrontMatterTags(file1.cachedMetadata.frontmatter)).toEqual(['#single-value-new-line']);
+
+        const file2 = MockDataLoader.get('yaml_tags_with_one_value_on_single_line');
+        expect(parseFrontMatterTags(file2.cachedMetadata.frontmatter)).toEqual(['#single-value-single-line']);
+
+        // Now see if we can again find the tags in file1
+        expect(parseFrontMatterTags(file1.cachedMetadata.frontmatter)).toEqual(['#single-value-new-line']);
     });
 });
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -320,7 +320,7 @@ describe('TasksFile - reading tags', () => {
         expect(getAllTags(file1.cachedMetadata)).toEqual(['#single-value-new-line', '#task']);
     });
 
-    it.failing('should be able to read frontmatter tags for any loaded SimulatedFile', () => {
+    it('should be able to read frontmatter tags for any loaded SimulatedFile', () => {
         const file1 = MockDataLoader.get('yaml_tags_with_one_value_on_new_line');
         expect(parseFrontMatterTags(file1.cachedMetadata.frontmatter)).toEqual(['#single-value-new-line']);
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -334,7 +334,9 @@ describe('TasksFile - reading tags', () => {
             parseFrontMatterTags(file1.frontmatter);
         };
         expect(t).toThrow(Error);
-        expect(t).toThrowError('FrontMatterCache not found in any loaded SimulatedFile');
+        expect(t).toThrowError(
+            'FrontMatterCache not found in any loaded SimulatedFile. Did you supply TasksFile.frontmatter instead of TasksFile.cachedMetadata.frontmatter?',
+        );
     });
 
     it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -339,9 +339,7 @@ describe('TasksFile - reading tags', () => {
     }
 
     it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
-        const testDataName = 'link_in_file_body';
-        const expectedLinkSource = '"[[yaml_tags_is_empty]]"';
-        const firstLinkpathDest = resolveFirstLink(testDataName, expectedLinkSource);
+        const firstLinkpathDest = resolveFirstLink('link_in_file_body', '"[[yaml_tags_is_empty]]"');
         expect(firstLinkpathDest).toMatchInlineSnapshot('"Test Data/yaml_tags_is_empty.md"');
     });
 });

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -337,15 +337,20 @@ describe('TasksFile - reading tags', () => {
         expect(link.original).toMatchInlineSnapshot(expectedLinkSource);
         const markdownPath = MockDataLoader.markdownPath(testDataName);
         const firstLinkpathDest = getFirstLinkpathDest(link, markdownPath);
-        return { file, markdownPath, firstLinkpathDest };
+        return { file, link, markdownPath, firstLinkpathDest };
     }
 
-    it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
+    it.failing('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
         const destination1 = loadMockDataAndResolveFirstLink('link_in_file_body', '"[[yaml_tags_is_empty]]"');
         expect(destination1.firstLinkpathDest).toMatchInlineSnapshot('"Test Data/yaml_tags_is_empty.md"');
 
         const destination2 = loadMockDataAndResolveFirstLink('link_in_heading', '"[[multiple_headings]]"');
         expect(destination2.firstLinkpathDest).toMatchInlineSnapshot('"Test Data/multiple_headings.md"');
+
+        // Now see if we can again resolve the link from file1
+        expect(getFirstLinkpathDest(destination1.link, destination1.markdownPath)).toMatchInlineSnapshot(
+            '"Test Data/yaml_tags_is_empty.md"',
+        );
     });
 });
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -337,7 +337,7 @@ describe('TasksFile - reading tags', () => {
         expect(link.original).toMatchInlineSnapshot(expectedLinkSource);
         const markdownPath = MockDataLoader.markdownPath(testDataName);
         const firstLinkpathDest = getFirstLinkpathDest(link, markdownPath);
-        return { file, link, markdownPath, firstLinkpathDest };
+        return { link, markdownPath, firstLinkpathDest };
     }
 
     it.failing('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -335,15 +335,17 @@ describe('TasksFile - reading tags', () => {
         const file = getTasksFileFromMockData(testDataName);
         const link = file.cachedMetadata.links![0];
         expect(link.original).toMatchInlineSnapshot(expectedLinkSource);
-        return getFirstLinkpathDest(link, MockDataLoader.markdownPath(testDataName));
+        const markdownPath = MockDataLoader.markdownPath(testDataName);
+        const firstLinkpathDest = getFirstLinkpathDest(link, markdownPath);
+        return { file, markdownPath, firstLinkpathDest };
     }
 
     it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
         const destination1 = loadMockDataAndResolveFirstLink('link_in_file_body', '"[[yaml_tags_is_empty]]"');
-        expect(destination1).toMatchInlineSnapshot('"Test Data/yaml_tags_is_empty.md"');
+        expect(destination1.firstLinkpathDest).toMatchInlineSnapshot('"Test Data/yaml_tags_is_empty.md"');
 
         const destination2 = loadMockDataAndResolveFirstLink('link_in_heading', '"[[multiple_headings]]"');
-        expect(destination2).toMatchInlineSnapshot('"Test Data/multiple_headings.md"');
+        expect(destination2.firstLinkpathDest).toMatchInlineSnapshot('"Test Data/multiple_headings.md"');
     });
 });
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -331,13 +331,17 @@ describe('TasksFile - reading tags', () => {
         expect(parseFrontMatterTags(file1.cachedMetadata.frontmatter)).toEqual(['#single-value-new-line']);
     });
 
-    it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
-        const testDataName = 'link_in_file_body';
-        const expectedLinkSource = '"[[yaml_tags_is_empty]]"';
+    function resolveFirstLink(testDataName: MockDataName, expectedLinkSource: string) {
         const file = getTasksFileFromMockData(testDataName);
         const link = file.cachedMetadata.links![0];
         expect(link.original).toMatchInlineSnapshot(expectedLinkSource);
-        const firstLinkpathDest = getFirstLinkpathDest(link, MockDataLoader.markdownPath(testDataName));
+        return getFirstLinkpathDest(link, MockDataLoader.markdownPath(testDataName));
+    }
+
+    it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {
+        const testDataName = 'link_in_file_body';
+        const expectedLinkSource = '"[[yaml_tags_is_empty]]"';
+        const firstLinkpathDest = resolveFirstLink(testDataName, expectedLinkSource);
         expect(firstLinkpathDest).toMatchInlineSnapshot('"Test Data/yaml_tags_is_empty.md"');
     });
 });

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -4,6 +4,7 @@ import { TasksFile } from '../../src/Scripting/TasksFile';
 import { getTasksFileFromMockData, listPathAndData } from '../TestingTools/MockDataHelpers';
 import { LinkResolver } from '../../src/Task/LinkResolver';
 import type { MockDataName } from '../Obsidian/AllCacheSampleData';
+import { getAllTags } from '../__mocks__/obsidian';
 import { determineExpressionType, formatToRepresentType } from './ScriptingTestHelpers';
 
 afterEach(() => {
@@ -305,6 +306,17 @@ describe('TasksFile - reading tags', () => {
     )('should provide empty list if no tags in frontmatter: "%s"', (_path: string, testDataName: MockDataName) => {
         const tasksFile = getTasksFileFromMockData(testDataName);
         expect(tasksFile.frontmatter.tags).toEqual([]);
+    });
+
+    it.failing('should be able to read tags for any loaded SimulatedFile', () => {
+        const file1 = getTasksFileFromMockData('yaml_tags_with_one_value_on_new_line');
+        expect(getAllTags(file1.cachedMetadata)).toEqual(['#single-value-new-line', '#task']);
+
+        const file2 = getTasksFileFromMockData('yaml_tags_with_one_value_on_single_line');
+        expect(getAllTags(file2.cachedMetadata)).toEqual(['#single-value-single-line', '#task']);
+
+        // Now see if we can again find the tags in file1
+        expect(getAllTags(file1.cachedMetadata)).toEqual(['#single-value-new-line', '#task']);
     });
 });
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -321,14 +321,20 @@ describe('TasksFile - reading tags', () => {
     });
 
     it('should be able to read frontmatter tags for any loaded SimulatedFile', () => {
-        const file1 = MockDataLoader.get('yaml_tags_with_one_value_on_new_line');
+        const file1 = getTasksFileFromMockData('yaml_tags_with_one_value_on_new_line');
         expect(parseFrontMatterTags(file1.cachedMetadata.frontmatter)).toEqual(['#single-value-new-line']);
 
-        const file2 = MockDataLoader.get('yaml_tags_with_one_value_on_single_line');
+        const file2 = getTasksFileFromMockData('yaml_tags_with_one_value_on_single_line');
         expect(parseFrontMatterTags(file2.cachedMetadata.frontmatter)).toEqual(['#single-value-single-line']);
 
         // Now see if we can again find the tags in file1
         expect(parseFrontMatterTags(file1.cachedMetadata.frontmatter)).toEqual(['#single-value-new-line']);
+
+        const t = () => {
+            parseFrontMatterTags(file1.frontmatter);
+        };
+        expect(t).toThrow(Error);
+        expect(t).toThrowError('FrontMatterCache not found in any loaded SimulatedFile');
     });
 
     it('should be able to call getFirstLinkpathDest() for any loaded SimulatedFile', () => {

--- a/tests/TestingTools/MockDataHelpers.ts
+++ b/tests/TestingTools/MockDataHelpers.ts
@@ -1,4 +1,3 @@
-import { setCurrentCacheFile } from '../__mocks__/obsidian';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 import type { SimulatedFile } from '../Obsidian/SimulatedFile';
 import type { MockDataName } from '../Obsidian/AllCacheSampleData';
@@ -27,7 +26,6 @@ import { MockDataLoader } from './MockDataLoader';
  */
 export function getTasksFileFromMockData(testDataName: MockDataName) {
     const data = MockDataLoader.get(testDataName);
-    setCurrentCacheFile(data);
     const cachedMetadata = data.cachedMetadata;
     return new TasksFile(data.filePath, cachedMetadata);
 }

--- a/tests/TestingTools/MockDataLoader.test.ts
+++ b/tests/TestingTools/MockDataLoader.test.ts
@@ -49,7 +49,7 @@ describe('MockDataLoader', () => {
         expect(t).toThrowError('CachedMetadata not found in any loaded SimulatedFile');
     });
 
-    it.failing('should be able to locate loaded SimulatedFile from its Frontmatter', () => {
+    it('should be able to locate loaded SimulatedFile from its Frontmatter', () => {
         const data1 = MockDataLoader.get('yaml_tags_has_multiple_values');
         const data2 = MockDataLoader.get('yaml_tags_with_two_values_on_two_lines');
 

--- a/tests/TestingTools/MockDataLoader.test.ts
+++ b/tests/TestingTools/MockDataLoader.test.ts
@@ -56,4 +56,12 @@ describe('MockDataLoader', () => {
         expect(MockDataLoader.findFrontmatter(data1.cachedMetadata.frontmatter)).toBe(data1);
         expect(MockDataLoader.findFrontmatter(data2.cachedMetadata.frontmatter)).toBe(data2);
     });
+
+    it('should be able to locate loaded SimulatedFile from its path', () => {
+        const data1 = MockDataLoader.get('callout');
+        const data2 = MockDataLoader.get('no_yaml');
+
+        expect(MockDataLoader.findDataFromMarkdownPath('Test Data/callout.md')).toBe(data1);
+        expect(MockDataLoader.findDataFromMarkdownPath('Test Data/no_yaml.md')).toBe(data2);
+    });
 });

--- a/tests/TestingTools/MockDataLoader.test.ts
+++ b/tests/TestingTools/MockDataLoader.test.ts
@@ -35,4 +35,17 @@ describe('MockDataLoader', () => {
         expect(MockDataLoader.findCachedMetaData(data1.cachedMetadata)).toBe(data1);
         expect(MockDataLoader.findCachedMetaData(data2.cachedMetadata)).toBe(data2);
     });
+
+    it('should detect CachedMetadata not previously loaded, even if it is a clone of a loaded file', () => {
+        const data1 = MockDataLoader.get('one_task');
+
+        const clonedMetadata = JSON.parse(JSON.stringify(data1.cachedMetadata));
+        expect(clonedMetadata).toStrictEqual(data1.cachedMetadata);
+        const t = () => {
+            MockDataLoader.findCachedMetaData(clonedMetadata);
+        };
+
+        expect(t).toThrow(Error);
+        expect(t).toThrowError('CachedMetadata not found in any loaded SimulatedFile');
+    });
 });

--- a/tests/TestingTools/MockDataLoader.test.ts
+++ b/tests/TestingTools/MockDataLoader.test.ts
@@ -28,7 +28,7 @@ describe('MockDataLoader', () => {
         expect(path).toEqual('Test Data/query_using_properties.md');
     });
 
-    it.failing('should be able to locate loaded SimulatedFile from its CachedMetadata', () => {
+    it('should be able to locate loaded SimulatedFile from its CachedMetadata', () => {
         const data1 = MockDataLoader.get('yaml_tags_has_multiple_values');
         const data2 = MockDataLoader.get('yaml_tags_with_two_values_on_two_lines');
 

--- a/tests/TestingTools/MockDataLoader.test.ts
+++ b/tests/TestingTools/MockDataLoader.test.ts
@@ -57,11 +57,27 @@ describe('MockDataLoader', () => {
         expect(MockDataLoader.findFrontmatter(data2.cachedMetadata.frontmatter)).toBe(data2);
     });
 
+    it('should detect call of findFrontmatter() with unknown Frontmatter', () => {
+        const t = () => {
+            MockDataLoader.findFrontmatter({});
+        };
+        expect(t).toThrow(Error);
+        expect(t).toThrowError('FrontMatterCache not found in any loaded SimulatedFile');
+    });
+
     it('should be able to locate loaded SimulatedFile from its path', () => {
         const data1 = MockDataLoader.get('callout');
         const data2 = MockDataLoader.get('no_yaml');
 
         expect(MockDataLoader.findDataFromMarkdownPath('Test Data/callout.md')).toBe(data1);
         expect(MockDataLoader.findDataFromMarkdownPath('Test Data/no_yaml.md')).toBe(data2);
+    });
+
+    it('should detect call of findDataFromMarkdownPath() with unknown path', () => {
+        const t = () => {
+            MockDataLoader.findDataFromMarkdownPath('Test Data/non-existent path.md');
+        };
+        expect(t).toThrow(Error);
+        expect(t).toThrowError('Markdown path not found in any loaded SimulatedFile');
     });
 });

--- a/tests/TestingTools/MockDataLoader.test.ts
+++ b/tests/TestingTools/MockDataLoader.test.ts
@@ -28,7 +28,7 @@ describe('MockDataLoader', () => {
         expect(path).toEqual('Test Data/query_using_properties.md');
     });
 
-    it('should be able to locate loaded SimulatedFile from its CachedMetadata', () => {
+    it('should locate loaded SimulatedFile from its CachedMetadata', () => {
         const data1 = MockDataLoader.get('yaml_tags_has_multiple_values');
         const data2 = MockDataLoader.get('yaml_tags_with_two_values_on_two_lines');
 
@@ -49,7 +49,7 @@ describe('MockDataLoader', () => {
         expect(t).toThrowError('CachedMetadata not found in any loaded SimulatedFile');
     });
 
-    it('should be able to locate loaded SimulatedFile from its Frontmatter', () => {
+    it('should locate loaded SimulatedFile from its Frontmatter', () => {
         const data1 = MockDataLoader.get('yaml_tags_has_multiple_values');
         const data2 = MockDataLoader.get('yaml_tags_with_two_values_on_two_lines');
 
@@ -65,7 +65,7 @@ describe('MockDataLoader', () => {
         expect(t).toThrowError('FrontMatterCache not found in any loaded SimulatedFile');
     });
 
-    it('should be able to locate loaded SimulatedFile from its path', () => {
+    it('should locate loaded SimulatedFile from its path', () => {
         const data1 = MockDataLoader.get('callout');
         const data2 = MockDataLoader.get('no_yaml');
 

--- a/tests/TestingTools/MockDataLoader.test.ts
+++ b/tests/TestingTools/MockDataLoader.test.ts
@@ -39,10 +39,9 @@ describe('MockDataLoader', () => {
     it('should detect CachedMetadata not previously loaded, even if it is a clone of a loaded file', () => {
         const data1 = MockDataLoader.get('one_task');
 
-        // Prefer `structuredClone(…)` over `JSON.parse(JSON.stringify(…))` to create a deep clone.
-        // But structuredClone() is not avaialble in Jest.
-        // sonar-disable-next-line typescript:S7784
-        const clonedMetadata = JSON.parse(JSON.stringify(data1.cachedMetadata));
+        // typescript:S7784 Prefer `structuredClone(…)` over `JSON.parse(JSON.stringify(…))` to create a deep clone.
+        // But structuredClone() is not available in Jest.
+        const clonedMetadata = JSON.parse(JSON.stringify(data1.cachedMetadata)); // NOSONAR
         expect(clonedMetadata).toStrictEqual(data1.cachedMetadata);
         const t = () => {
             MockDataLoader.findCachedMetaData(clonedMetadata);

--- a/tests/TestingTools/MockDataLoader.test.ts
+++ b/tests/TestingTools/MockDataLoader.test.ts
@@ -27,4 +27,12 @@ describe('MockDataLoader', () => {
         const path = MockDataLoader.markdownPath('query_using_properties');
         expect(path).toEqual('Test Data/query_using_properties.md');
     });
+
+    it.failing('should be able to locate loaded SimulatedFile from its CachedMetadata', () => {
+        const data1 = MockDataLoader.get('yaml_tags_has_multiple_values');
+        const data2 = MockDataLoader.get('yaml_tags_with_two_values_on_two_lines');
+
+        expect(MockDataLoader.findCachedMetaData(data1.cachedMetadata)).toBe(data1);
+        expect(MockDataLoader.findCachedMetaData(data2.cachedMetadata)).toBe(data2);
+    });
 });

--- a/tests/TestingTools/MockDataLoader.test.ts
+++ b/tests/TestingTools/MockDataLoader.test.ts
@@ -39,6 +39,9 @@ describe('MockDataLoader', () => {
     it('should detect CachedMetadata not previously loaded, even if it is a clone of a loaded file', () => {
         const data1 = MockDataLoader.get('one_task');
 
+        // Prefer `structuredClone(…)` over `JSON.parse(JSON.stringify(…))` to create a deep clone.
+        // But structuredClone() is not avaialble in Jest.
+        // sonar-disable-next-line typescript:S7784
         const clonedMetadata = JSON.parse(JSON.stringify(data1.cachedMetadata));
         expect(clonedMetadata).toStrictEqual(data1.cachedMetadata);
         const t = () => {

--- a/tests/TestingTools/MockDataLoader.test.ts
+++ b/tests/TestingTools/MockDataLoader.test.ts
@@ -48,4 +48,12 @@ describe('MockDataLoader', () => {
         expect(t).toThrow(Error);
         expect(t).toThrowError('CachedMetadata not found in any loaded SimulatedFile');
     });
+
+    it.failing('should be able to locate loaded SimulatedFile from its Frontmatter', () => {
+        const data1 = MockDataLoader.get('yaml_tags_has_multiple_values');
+        const data2 = MockDataLoader.get('yaml_tags_with_two_values_on_two_lines');
+
+        expect(MockDataLoader.findFrontmatter(data1.cachedMetadata.frontmatter)).toBe(data1);
+        expect(MockDataLoader.findFrontmatter(data2.cachedMetadata.frontmatter)).toBe(data2);
+    });
 });

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -98,7 +98,7 @@ export class MockDataLoader {
     public static findFrontmatter(frontmatter: FrontMatterCache | undefined) {
         return this.findByPredicate(
             (simulatedFile) => simulatedFile.cachedMetadata.frontmatter === frontmatter,
-            'FrontMatterCache not found in any loaded SimulatedFile',
+            'FrontMatterCache not found in any loaded SimulatedFile. Did you supply TasksFile.frontmatter instead of TasksFile.cachedMetadata.frontmatter?',
         );
     }
 

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -77,8 +77,9 @@ export class MockDataLoader {
      * @throws Error if no matching SimulatedFile is found in the cache
      */
     public static findCachedMetaData(cachedMetadata: CachedMetadata): SimulatedFile {
+        const predicate = (simulatedFile: SimulatedFile) => simulatedFile.cachedMetadata === cachedMetadata;
         for (const simulatedFile of this.cache.values()) {
-            if (simulatedFile.cachedMetadata === cachedMetadata) {
+            if (predicate(simulatedFile)) {
                 return simulatedFile;
             }
         }

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -96,13 +96,10 @@ export class MockDataLoader {
      * @throws Error if no matching SimulatedFile is found in the cache
      */
     public static findFrontmatter(frontmatter: FrontMatterCache | undefined) {
-        for (const simulatedFile of this.cache.values()) {
-            if (simulatedFile.cachedMetadata.frontmatter === frontmatter) {
-                return simulatedFile;
-            }
-        }
-
-        throw new Error('FrontMatterCache not found in any loaded SimulatedFile');
+        return this.findByPredicate(
+            (simulatedFile) => simulatedFile.cachedMetadata.frontmatter === frontmatter,
+            'FrontMatterCache not found in any loaded SimulatedFile',
+        );
     }
 
     /**
@@ -117,13 +114,10 @@ export class MockDataLoader {
      * @throws Error if no matching SimulatedFile is found in the cache
      */
     public static findDataFromMarkdownPath(markdownPath: string) {
-        for (const simulatedFile of this.cache.values()) {
-            if (simulatedFile.filePath === markdownPath) {
-                return simulatedFile;
-            }
-        }
-
-        throw new Error('Markdown path not found in any loaded SimulatedFile');
+        return this.findByPredicate(
+            (simulatedFile) => simulatedFile.filePath === markdownPath,
+            'Markdown path not found in any loaded SimulatedFile',
+        );
     }
 
     /**

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -79,13 +79,7 @@ export class MockDataLoader {
     public static findCachedMetaData(cachedMetadata: CachedMetadata): SimulatedFile {
         const predicate = (simulatedFile: SimulatedFile) => simulatedFile.cachedMetadata === cachedMetadata;
         const errorMessage = 'CachedMetadata not found in any loaded SimulatedFile';
-        for (const simulatedFile of this.cache.values()) {
-            if (predicate(simulatedFile)) {
-                return simulatedFile;
-            }
-        }
-
-        throw new Error(errorMessage);
+        return this.findByPredicate(predicate, errorMessage);
     }
 
     /**
@@ -129,5 +123,26 @@ export class MockDataLoader {
         }
 
         throw new Error('Markdown path not found in any loaded SimulatedFile');
+    }
+
+    /**
+     * Helper method to find a SimulatedFile using a custom predicate function.
+     *
+     * @param predicate - Function that returns true when the desired SimulatedFile is found
+     * @param errorMessage - Error message to throw if no matching SimulatedFile is found
+     * @returns The first SimulatedFile that matches the predicate
+     * @throws Error with the provided message if no match is found
+     */
+    private static findByPredicate(
+        predicate: (simulatedFile: SimulatedFile) => boolean,
+        errorMessage: string,
+    ): SimulatedFile {
+        for (const simulatedFile of this.cache.values()) {
+            if (predicate(simulatedFile)) {
+                return simulatedFile;
+            }
+        }
+
+        throw new Error(errorMessage);
     }
 }

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -86,6 +86,18 @@ export class MockDataLoader {
         throw new Error('CachedMetadata not found in any loaded SimulatedFile');
     }
 
+    /**
+     * Find the {@link SimulatedFile} that contains the specified FrontMatterCache.
+     *
+     * Searches through all cached {@link SimulatedFile} entries to find the one whose
+     * cachedMetadata.frontmatter property is identical (by reference) to the provided value.
+     * This is useful for reverse-lookup when you have a FrontMatterCache object and need
+     * to find which file it came from.
+     *
+     * @param frontmatter - The FrontMatterCache object to search for (can be undefined)
+     * @returns The SimulatedFile containing the matching frontmatter
+     * @throws Error if no matching SimulatedFile is found in the cache
+     */
     public static findFrontmatter(frontmatter: FrontMatterCache | undefined) {
         for (const simulatedFile of this.cache.values()) {
             if (simulatedFile.cachedMetadata.frontmatter === frontmatter) {
@@ -96,6 +108,17 @@ export class MockDataLoader {
         throw new Error('FrontMatterCache not found in any loaded SimulatedFile');
     }
 
+    /**
+     * Find the {@link SimulatedFile} that matches the specified Markdown file path.
+     *
+     * Searches through all cached {@link SimulatedFile} entries to find the one whose
+     * filePath property exactly matches the provided Markdown path. This enables
+     * lookup of test data by the original file path from the test vault.
+     *
+     * @param markdownPath - The Markdown file path to search for (such as "Test Data/example.md")
+     * @returns The SimulatedFile with the matching file path
+     * @throws Error if no matching SimulatedFile is found in the cache
+     */
     public static findDataFromMarkdownPath(markdownPath: string) {
         for (const simulatedFile of this.cache.values()) {
             if (simulatedFile.filePath === markdownPath) {

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -78,13 +78,14 @@ export class MockDataLoader {
      */
     public static findCachedMetaData(cachedMetadata: CachedMetadata): SimulatedFile {
         const predicate = (simulatedFile: SimulatedFile) => simulatedFile.cachedMetadata === cachedMetadata;
+        const errorMessage = 'CachedMetadata not found in any loaded SimulatedFile';
         for (const simulatedFile of this.cache.values()) {
             if (predicate(simulatedFile)) {
                 return simulatedFile;
             }
         }
 
-        throw new Error('CachedMetadata not found in any loaded SimulatedFile');
+        throw new Error(errorMessage);
     }
 
     /**

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import type { CachedMetadata } from 'obsidian';
+
 import type { SimulatedFile } from '../Obsidian/SimulatedFile';
 import type { MockDataName } from '../Obsidian/AllCacheSampleData';
 
@@ -62,5 +64,9 @@ export class MockDataLoader {
      */
     public static markdownPath(_testDataName: MockDataName) {
         return `Test Data/${_testDataName}.md`;
+    }
+
+    public static findCachedMetaData(_cachedMetadata: CachedMetadata) {
+        return MockDataLoader.get('empty_yaml'); // temporary fixed value
     }
 }

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -66,7 +66,23 @@ export class MockDataLoader {
         return `Test Data/${_testDataName}.md`;
     }
 
-    public static findCachedMetaData(_cachedMetadata: CachedMetadata) {
-        return MockDataLoader.get('empty_yaml'); // temporary fixed value
+    /**
+     * Find the {@link SimulatedFile} that contains the specified CachedMetadata.
+     *
+     * Searches through all cached {@link SimulatedFile} entries to find the one whose
+     * cachedMetadata property is identical (by reference) to the provided value.
+     *
+     * @param cachedMetadata - The CachedMetadata object to search for
+     * @returns The SimulatedFile containing the matching cachedMetadata
+     * @throws Error if no matching SimulatedFile is found in the cache
+     */
+    public static findCachedMetaData(cachedMetadata: CachedMetadata): SimulatedFile {
+        for (const simulatedFile of this.cache.values()) {
+            if (simulatedFile.cachedMetadata === cachedMetadata) {
+                return simulatedFile;
+            }
+        }
+
+        throw new Error('CachedMetadata not found in any loaded SimulatedFile');
     }
 }

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import type { CachedMetadata } from 'obsidian';
+import type { CachedMetadata, FrontMatterCache } from 'obsidian';
 
 import type { SimulatedFile } from '../Obsidian/SimulatedFile';
 import type { MockDataName } from '../Obsidian/AllCacheSampleData';
@@ -84,5 +84,9 @@ export class MockDataLoader {
         }
 
         throw new Error('CachedMetadata not found in any loaded SimulatedFile');
+    }
+
+    public static findFrontmatter(_frontmatter: FrontMatterCache | undefined) {
+        return MockDataLoader.get('empty_yaml').cachedMetadata.frontmatter; // temporary fixed value
     }
 }

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -77,9 +77,10 @@ export class MockDataLoader {
      * @throws Error if no matching SimulatedFile is found in the cache
      */
     public static findCachedMetaData(cachedMetadata: CachedMetadata): SimulatedFile {
-        const predicate = (simulatedFile: SimulatedFile) => simulatedFile.cachedMetadata === cachedMetadata;
-        const errorMessage = 'CachedMetadata not found in any loaded SimulatedFile';
-        return this.findByPredicate(predicate, errorMessage);
+        return this.findByPredicate(
+            (simulatedFile: SimulatedFile) => simulatedFile.cachedMetadata === cachedMetadata,
+            'CachedMetadata not found in any loaded SimulatedFile',
+        );
     }
 
     /**

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -78,7 +78,7 @@ export class MockDataLoader {
      */
     public static findCachedMetaData(cachedMetadata: CachedMetadata): SimulatedFile {
         return this.findByPredicate(
-            (simulatedFile: SimulatedFile) => simulatedFile.cachedMetadata === cachedMetadata,
+            (simulatedFile) => simulatedFile.cachedMetadata === cachedMetadata,
             'CachedMetadata not found in any loaded SimulatedFile',
         );
     }

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -95,4 +95,14 @@ export class MockDataLoader {
 
         throw new Error('FrontMatterCache not found in any loaded SimulatedFile');
     }
+
+    public static findDataFromMarkdownPath(markdownPath: string) {
+        for (const simulatedFile of this.cache.values()) {
+            if (simulatedFile.filePath === markdownPath) {
+                return simulatedFile;
+            }
+        }
+
+        throw new Error('Markdown path not found in any loaded SimulatedFile');
+    }
 }

--- a/tests/TestingTools/MockDataLoader.ts
+++ b/tests/TestingTools/MockDataLoader.ts
@@ -86,7 +86,13 @@ export class MockDataLoader {
         throw new Error('CachedMetadata not found in any loaded SimulatedFile');
     }
 
-    public static findFrontmatter(_frontmatter: FrontMatterCache | undefined) {
-        return MockDataLoader.get('empty_yaml').cachedMetadata.frontmatter; // temporary fixed value
+    public static findFrontmatter(frontmatter: FrontMatterCache | undefined) {
+        for (const simulatedFile of this.cache.values()) {
+            if (simulatedFile.cachedMetadata.frontmatter === frontmatter) {
+                return simulatedFile;
+            }
+        }
+
+        throw new Error('FrontMatterCache not found in any loaded SimulatedFile');
     }
 }

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -10,7 +10,6 @@ import { DateParser } from '../../src/DateTime/DateParser';
 import { StatusConfiguration, StatusType } from '../../src/Statuses/StatusConfiguration';
 import { TaskLocation } from '../../src/Task/TaskLocation';
 import { Priority } from '../../src/Task/Priority';
-import { setCurrentCacheFile } from '../__mocks__/obsidian';
 import type { ListItem } from '../../src/Task/ListItem';
 import type { SimulatedFile } from '../Obsidian/SimulatedFile';
 import type { MockDataName } from '../Obsidian/AllCacheSampleData';
@@ -78,9 +77,6 @@ export class TaskBuilder {
         let description = this._description;
         if (this._tags.length > 0) {
             description += ' ' + this._tags.join(' ');
-        }
-        if (this._mockData !== undefined) {
-            setCurrentCacheFile(this._mockData);
         }
         const cachedMetadata = this._mockData?.cachedMetadata ?? {};
         const task = new Task({

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -164,13 +164,21 @@ export function getAllTags(cachedMetadata: CachedMetadata): string[] {
  *
  * See https://docs.obsidian.md/Reference/TypeScript+API/parseFrontMatterTags
  *
- * @param frontmatter
+ * @example
+ * This works:
+ * ```typescript
+ *     const data = MockDataLoader.get('yaml_tags_with_one_value_on_new_line');
+ *     const tags = parseFrontMatterTags(data.cachedMetadata.frontmatter);
+ * ```
+ *
+ * @param frontmatter - the CachedMetadata.frontmatter instance from a SimulatedFile that has
+ *                      already been loaded via MockDataLoader.get().
+ * @throws Error if no matching frontmatter is found in the MockDataLoader cache,
+ *               or a `tasksFile.cachedMetadata.frontmatter` was supplied.
  */
 export function parseFrontMatterTags(frontmatter: any | null): string[] | null {
-    if (frontmatter !== mockedFileData.cachedMetadata.frontmatter) {
-        reportInconsistentTestData('parseFrontMatterTags');
-    }
-    return mockedFileData.parseFrontMatterTags;
+    const simulatedFile = MockDataLoader.findFrontmatter(frontmatter);
+    return simulatedFile.parseFrontMatterTags;
 }
 
 /**

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -133,8 +133,6 @@ function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): Sea
         : null;
 }
 
-export function setCurrentCacheFile(_mockData: SimulatedFile) {}
-
 /**
  * Fake implementation of Obsidian's `getAllTags()`.
  *

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -177,7 +177,8 @@ export function parseFrontMatterTags(frontmatter: any | null): string[] | null {
  * See https://docs.obsidian.md/Reference/TypeScript+API/MetadataCache/getFirstLinkpathDest
  *
  * @param rawLink
- * @param sourcePath
+ * @param sourcePath - the path to a Markdown file in the test vault whose SimulatedFile has already
+ *                     been loaded via MockDataLoader.get(). For example, 'Test Data/callout.md'
  *
  * @example
  * ```typescript

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -1,5 +1,6 @@
 import type { App, CachedMetadata, Reference } from 'obsidian';
 import type { SimulatedFile } from '../Obsidian/SimulatedFile';
+import { MockDataLoader } from '../TestingTools/MockDataLoader';
 
 export {};
 
@@ -149,13 +150,13 @@ function reportInconsistentTestData(functionName: string) {
  *
  * See https://docs.obsidian.md/Reference/TypeScript+API/getAllTags
  *
- * @param cachedMetadata
+ * @param cachedMetadata - the CachedMetadata instance from a SimulatedFile that has
+ *                         already been loaded via MockDataLoader.get().
+ * @throws Error if no matching CachedMetadata is found in the MockDataLoader cache.
  */
 export function getAllTags(cachedMetadata: CachedMetadata): string[] {
-    if (cachedMetadata !== mockedFileData.cachedMetadata) {
-        reportInconsistentTestData('getAllTags');
-    }
-    return mockedFileData.getAllTags;
+    const simulatedFile = MockDataLoader.findCachedMetaData(cachedMetadata);
+    return simulatedFile.getAllTags;
 }
 
 /**

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -155,14 +155,19 @@ export function getAllTags(cachedMetadata: CachedMetadata): string[] {
  * @example
  * This works:
  * ```typescript
- *     const data = MockDataLoader.get('yaml_tags_with_one_value_on_new_line');
- *     const tags = parseFrontMatterTags(data.cachedMetadata.frontmatter);
+ *     const tags = parseFrontMatterTags(tasksFile.cachedMetadata.frontmatter);
  * ```
  *
- * @param frontmatter - the CachedMetadata.frontmatter instance from a SimulatedFile that has
+ * @example
+ * This does not work:
+ * ```typescript
+ *     const tags = parseFrontMatterTags(tasksFile.frontmatter);
+ * ```
+ *
+ * @param frontmatter - the raw CachedMetadata.frontmatter instance from a SimulatedFile that has
  *                      already been loaded via MockDataLoader.get().
  * @throws Error if no matching frontmatter is found in the MockDataLoader cache,
- *               or a `tasksFile.cachedMetadata.frontmatter` was supplied.
+ *               or a `tasksFile.frontmatter` was supplied.
  */
 export function parseFrontMatterTags(frontmatter: any | null): string[] | null {
     const simulatedFile = MockDataLoader.findFrontmatter(frontmatter);

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -194,7 +194,7 @@ export function getFirstLinkpathDest(rawLink: Reference, sourcePath: string): st
     return getFirstLinkpathDestFromData(simulatedFile, rawLink);
 }
 
-export function getFirstLinkpathDestFromData(data: any, rawLink: Reference) {
+export function getFirstLinkpathDestFromData(data: SimulatedFile, rawLink: Reference) {
     if (!(rawLink.link in data.resolveLinkToPath)) {
         console.log(`Cannot find resolved path for ${rawLink.link} in ${data.filePath} in mock getFirstLinkpathDest()`);
     }

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -133,17 +133,7 @@ function caseInsensitiveSubstringSearch(searchTerm: string, phrase: string): Sea
         : null;
 }
 
-let mockedFileData: any = {};
-
-export function setCurrentCacheFile(mockData: SimulatedFile) {
-    mockedFileData = mockData;
-}
-
-function reportInconsistentTestData(functionName: string) {
-    throw new Error(
-        `Inconsistent test data used in mock ${functionName}(). Check setCurrentCacheFile() has been called with the correct {@link SimulatedFile} data.`,
-    );
-}
+export function setCurrentCacheFile(_mockData: SimulatedFile) {}
 
 /**
  * Fake implementation of Obsidian's `getAllTags()`.
@@ -201,10 +191,8 @@ export function parseFrontMatterTags(frontmatter: any | null): string[] | null {
  * ```
  */
 export function getFirstLinkpathDest(rawLink: Reference, sourcePath: string): string | null {
-    if (mockedFileData.filePath !== sourcePath) {
-        reportInconsistentTestData('getFirstLinkpathDest');
-    }
-    return getFirstLinkpathDestFromData(mockedFileData, rawLink);
+    const simulatedFile = MockDataLoader.findDataFromMarkdownPath(sourcePath);
+    return getFirstLinkpathDestFromData(simulatedFile, rawLink);
 }
 
 export function getFirstLinkpathDestFromData(data: any, rawLink: Reference) {


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->



Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

It is no longer necessary to call `setCurrentCacheFile()` in tests.

This makes it possible to write tests that use more than one of the MockData files at once.

This because possible now that we have `MockDataLoader`, and it caches the data that it returns.

## Motivation and Context

Preparation for implementing unit tests for:

- #3627

## How has this been tested?

Lots of work on unit tests.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
