### PR TITLE
fix: 'Tasks: Toggle task done' keeps list markers if no Global Filter (#3708)

### DIFF
--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -102,7 +102,7 @@ export const toggleLine = (line: string, path: string): EditorInsertion => {
             const statusString = regexMatch[3];
             const status = StatusRegistry.getInstance().bySymbol(statusString);
             const newStatusString = status.nextStatusSymbol;
-            return { text: line.replace(TaskRegularExpressions.taskRegex, `$1- [${newStatusString}] $4`) };
+            return { text: line.replace(TaskRegularExpressions.taskRegex, `$1$2 [${newStatusString}] $4`) };
         } else if (TaskRegularExpressions.listItemRegex.test(line)) {
             // Convert the list item to a checklist item.
             const text = line.replace(TaskRegularExpressions.listItemRegex, '$1$2 [ ]');

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -115,7 +115,7 @@ describe('ToggleDone', () => {
         testToggleLine('1. |foobar', '1. [ ] foobar|');
     });
 
-    it.failing('should complete a task', () => {
+    it('should complete a task', () => {
         testToggleLine('|- [ ] ', '|- [x]  ✅ 2022-09-04');
         testToggleLine('- [ ] |', '- [x] | ✅ 2022-09-04');
         testToggleLine('- [ ] description|', '- [x] description| ✅ 2022-09-04');
@@ -137,7 +137,7 @@ describe('ToggleDone', () => {
         testToggleLine('- [ ] I have a |proper description', '- [x] I have a |proper description');
     });
 
-    it.failing('should un-complete a completed task', () => {
+    it('should un-complete a completed task', () => {
         testToggleLine('|- [x]  ✅ 2022-09-04', '|- [ ] ');
         testToggleLine('1. [x]  ✅ 2022-09-04|', '1. [ ] |');
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3708

## Description


I have found that the `Tasks: Toggle task done` could previously break list markers `*`, `+` and `1.` on task lines without the global filter.

This fixes that issue.

## Motivation and Context

Fix this issue:

- #3708

## How has this been tested?

- Adding tests
- Manual testing to confirm the example I quoted in #3708 now works.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
