### PR TITLE
fix: 'Tasks: Toggle task done' converts plain text straight to checkbox

### DIFF
--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -108,8 +108,8 @@ export const toggleLine = (line: string, path: string): EditorInsertion => {
             const text = line.replace(TaskRegularExpressions.listItemRegex, '$1$2 [ ]');
             return { text, moveTo: { ch: text.length } };
         } else {
-            // Convert the line to a list item.
-            const text = line.replace(TaskRegularExpressions.indentationRegex, '$1- ');
+            // Convert the line to a checklist item.
+            const text = line.replace(TaskRegularExpressions.indentationRegex, '$1- [ ] ');
             return { text, moveTo: { ch: text.length } };
         }
     }

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -93,14 +93,14 @@ describe('ToggleDone', () => {
     // Most of the tests are run twice. The second time, they are tested with tasks that
     // do not match the global filter.
 
-    it('should add hyphen and space to empty line', () => {
-        testToggleLine('|', '- |');
-        testToggleLine('foo|bar', '- foobar|');
+    it('should add checkbox to empty line, and lines without list items', () => {
+        testToggleLine('|', '- [ ] |');
+        testToggleLine('foo|bar', '- [ ] foobar|');
 
         GlobalFilter.getInstance().set('#task');
 
-        testToggleLine('|', '- |');
-        testToggleLine('foo|bar', '- foobar|');
+        testToggleLine('|', '- [ ] |');
+        testToggleLine('foo|bar', '- [ ] foobar|');
     });
 
     it('should add checkbox to hyphen and space', () => {


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #1158

## Description

This is for consistency with the built-in 'Toggle checkbox status' command.

As noted in #1158:

> **Default Obsidian behaviour:**
> 
> 1. Execute `Toggle checkbox status`
> 2. A checkbox appears
> 
> **Obsidian Tasks behaviour:**
> 
> 1. Execute `Tasks: Toggle Tasks done`
> 2. A bullet appears
> 3. Execute `Tasks: Toggle Tasks done` again
> 4. The bullet changes to a checkbox

This change makes `Tasks: Toggle Tasks done` convert plain text lines to tasks in 1 invocation instead of 2.

## Motivation and Context

Fixes #1158.

## How has this been tested?

- With automated tests
- Manual testing, in the `Tasks-Demo` vault


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
