### PR TITLE
refactor: extract PriorityEditor component

### DIFF
--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -154,7 +154,7 @@ Availability of access keys:
     <!--  Priority  -->
     <!-- --------------------------------------------------------------------------- -->
     <section class="tasks-modal-priority-section">
-        <PriorityEditor bind:priority={editableTask.priority} {editableTask} {withAccessKeys} />
+        <PriorityEditor bind:priority={editableTask.priority} {withAccessKeys} />
     </section>
 
     <!-- --------------------------------------------------------------------------- -->

--- a/src/ui/PriorityEditor.svelte
+++ b/src/ui/PriorityEditor.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
     import { TASK_FORMATS } from '../Config/Settings';
-    import type { EditableTask } from './EditableTask';
 
     export let priority: string;
-    export let editableTask: EditableTask;
     export let withAccessKeys: boolean;
 
     $: accesskey = (key: string) => (withAccessKeys ? key : null);


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

- Extract PriorityEditor component from EditTask modal

## Motivation and Context

- Prepare for conditional field rendering of the EditTask modal
- Make a reusable component for priority editing

## How has this been tested?

- Unit tests
- Manual test in demo vault - set priority in modal, verify it has been set

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - one of the change was not covered by Jest, so I went for a manual test 

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
