### PR TITLE
feat: Speed up the search in results toolbar, by debouncing

### DIFF
--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -1,4 +1,4 @@
-import { type App, type Component, Notice, type TFile, setIcon, setTooltip } from 'obsidian';
+import { type App, type Component, Notice, type TFile, debounce, setIcon, setTooltip } from 'obsidian';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import type { IQuery } from '../IQuery';
 import { PerformanceTracker } from '../lib/PerformanceTracker';
@@ -203,7 +203,7 @@ export class QueryResultsRenderer {
             const filterString = searchBox.value;
             await this.applySearchBoxFilterAndRerender(filterString, content);
         };
-        searchBox.addEventListener('input', doSearch);
+        searchBox.addEventListener('input', debounce(doSearch, 500, true));
     }
 
     public async applySearchBoxFilterAndRerender(filterString: string, content: HTMLDivElement) {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -1,4 +1,4 @@
-import type { App, CachedMetadata, Reference } from 'obsidian';
+import type { App, CachedMetadata, Debouncer, Reference } from 'obsidian';
 import type { SimulatedFile } from '../Obsidian/SimulatedFile';
 import { MockDataLoader } from '../TestingTools/MockDataLoader';
 
@@ -228,6 +228,19 @@ export function setIcon(element: HTMLElement, iconId: IconName): void {
 
 export function setTooltip(element: HTMLElement, text: string): void {
     element.setAttribute('test-tooltip', text);
+}
+
+export function debounce<T extends unknown[], V>(
+    cb: (...args: [...T]) => V,
+    _timeout?: number,
+    _resetTimer?: boolean,
+): Debouncer<T, V> {
+    const debouncer = ((..._args: T) => debouncer) as Debouncer<T, V>;
+    debouncer.cancel = () => debouncer;
+    debouncer.run = () => {
+        return cb(...([] as any));
+    };
+    return debouncer;
 }
 
 /**


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: #3693

## Description

Speed up the post-search filter in the Tasks query results, by only performing the search when the user pauses typing.

When filtering a search with several thousand found tasks, this makes a lot of difference.

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->


## Motivation and Context

Better performance - see above.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Manually, in the test vault and in my main vault.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
