### PR TITLE
Add Claude Code skill for Tasks plugin

### DIFF
--- a/.claude/skills/tasks/SKILL.md
+++ b/.claude/skills/tasks/SKILL.md
@@ -85,7 +85,7 @@ Dates must be in `YYYY-MM-DD` format.
 ### Date Types
 
 | Date | Purpose |
-|------|--------|
+|------|---------|
 | **Due** (📅) | When task must be completed |
 | **Scheduled** (⏳) | When you plan to work on it |
 | **Start** (🛫) | When task becomes available |
@@ -139,7 +139,7 @@ Dates must be in `YYYY-MM-DD` format.
 ### Recurrence Periods
 
 | Period | Aliases |
-|--------|--------|
+|--------|---------|
 | `day` | `daily` |
 | `week` | `weekly` |
 | `month` | `monthly` |
@@ -149,6 +149,7 @@ Dates must be in `YYYY-MM-DD` format.
 
 ```markdown
 - [ ] Daily standup 🔁 every day 📅 2024-02-15
+- [ ] Weekday task 🔁 every weekday 📅 2024-02-15
 - [ ] Weekly review 🔁 every week 📅 2024-02-16
 - [ ] Monthly report 🔁 every month 📅 2024-02-28
 - [ ] Annual review 🔁 every year 📅 2024-12-31
@@ -160,6 +161,7 @@ Dates must be in `YYYY-MM-DD` format.
 - [ ] Every Monday 🔁 every week on Monday 📅 2024-02-19
 - [ ] Every Mon/Wed/Fri 🔁 every week on Monday, Wednesday, Friday 📅 2024-02-16
 - [ ] First of month 🔁 every month on the 1st 📅 2024-03-01
+- [ ] Last day of month 🔁 every month on the last 📅 2024-02-29
 - [ ] Last Friday 🔁 every month on the last Friday 📅 2024-02-23
 ```
 
@@ -227,7 +229,7 @@ Default behavior keeps the completed task. Use `🏁 delete` to remove it.
 Custom statuses must be configured in Tasks settings before use. Common examples:
 
 | Status | Character | Type | Meaning |
-|--------|-----------|------|--------|
+|--------|-----------|------|---------|
 | In Progress | `[/]` | `IN_PROGRESS` | Working on it |
 | Cancelled | `[-]` | `CANCELLED` | Won't do |
 | Forwarded | `[>]` | `TODO` | Moved to later |
@@ -286,6 +288,20 @@ has depends on
 no depends on
 is blocked
 is not blocked
+exclude sub-items
+```
+
+#### Date Validation Filters
+
+Check for invalid dates (e.g., 2024-02-30):
+
+```
+due date is invalid
+scheduled date is invalid
+start date is invalid
+created date is invalid
+done date is invalid
+cancelled date is invalid
 ```
 
 #### Date Filters
@@ -297,6 +313,8 @@ due after today
 due on 2024-02-15
 due before 2024-02-15
 due after 2024-02-15
+due on or before 2024-02-15
+due on or after 2024-02-15
 due in 2024-02
 due in 2024
 
@@ -304,21 +322,29 @@ scheduled today
 scheduled before today
 scheduled after today
 scheduled on 2024-02-15
+scheduled on or before 2024-02-15
+scheduled on or after 2024-02-15
 
 starts today
 starts before today
 starts after today
 starts on 2024-02-15
+starts on or before 2024-02-15
+starts on or after 2024-02-15
 
 created today
 created before today
 created after today
 created on 2024-02-15
+created on or before 2024-02-15
+created on or after 2024-02-15
 
 done today
 done before today
 done after today
 done on 2024-02-15
+done on or before 2024-02-15
+done on or after 2024-02-15
 ```
 
 #### Relative Date Filters
@@ -337,7 +363,23 @@ due this year
 due in 7 days
 due in 2 weeks
 due in 3 months
+
+due in or before 7 days
+due in or after 2 weeks
 ```
+
+#### Numbered Date Ranges
+
+Filter by ISO week, month, quarter, or year:
+
+```
+due in 2024-W05
+due in 2024-02
+due in 2024-Q1
+due in 2024
+```
+
+Works with all date types (due, scheduled, starts, created, done, cancelled, happens).
 
 #### Happens Filter
 
@@ -405,6 +447,7 @@ status.name includes in progress
 status.type is TODO
 status.type is DONE
 status.type is IN_PROGRESS
+status.type is ON_HOLD
 status.type is CANCELLED
 status.type is NON_TASK
 ```
@@ -840,6 +883,77 @@ Urgency scoring can be customized in Tasks settings.
 View with: `show urgency`
 
 Sort with: `sort by urgency reverse`
+
+## Presets
+
+Presets allow you to save commonly used query instructions and reuse them across multiple queries.
+
+### Defining Presets
+
+Define presets in Tasks settings with a name and instructions.
+
+### Using Presets
+
+Basic syntax:
+```
+preset preset_name
+```
+
+Placeholder syntax (for Boolean combinations):
+```
+{{preset.preset_name}}
+```
+
+### Default Presets
+
+| Name | Instructions |
+|------|--------------|
+| `this_file` | `path includes {{query.file.path}}` |
+| `this_folder` | `folder includes {{query.file.folder}}` |
+| `this_folder_only` | `filter by function task.file.folder === query.file.folder` |
+| `this_root` | `root includes {{query.file.root}}` |
+| `hide_date_fields` | Hides all date fields |
+| `hide_non_date_fields` | Hides id, depends on, recurrence, on completion, priority |
+| `hide_query_elements` | Hides postpone button, edit button, backlinks |
+| `hide_everything` | Combines hide_date_fields, hide_non_date_fields, hide_query_elements |
+
+### Preset Examples
+
+````markdown
+```tasks
+preset this_folder
+not done
+sort by due
+```
+````
+
+Using in Boolean combinations:
+```
+({{preset.work_tasks}}) AND ({{preset.high_priority}})
+```
+
+### Listing Available Presets
+
+Use a non-existent preset name to see all available presets:
+```
+preset xxxx
+```
+
+## Line Continuations
+
+Use backslash (`\`) at the end of a line to continue on the next line:
+
+```
+(priority is highest) OR       \
+    (priority is lowest)
+```
+
+This is useful for long Boolean combinations or complex function expressions.
+
+To search for a literal trailing backslash, use `\\`:
+```
+description includes \\
+```
 
 ## Custom Filters and Groups
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
  - **WARNING: If the link is absent, the PR may be closed without review**, due to the workload that such reviews usually require.
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
- [ ] **Translation** (prefix: `i18n` - additions or improvements to the translations - see [Support a new language](https://publish.obsidian.md/tasks-contributing/Translation/Support+a+new+language))
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

This PR adds a Claude Code skill that enables AI assistants to generate accurate Tasks plugin syntax.

### Background

I originally submitted this skill to [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills/pull/26), where both kepano and @claremacrae suggested that plugin-specific skills belong in their respective plugin repositories. Clare mentioned she'd be happy to maintain it here to keep it accurate as Tasks evolves.

### What is a Claude Code Skill?

[Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) are markdown reference documents that Claude automatically loads when relevant keywords appear in user requests. When a user mentions "Tasks plugin", "recurring tasks", or "task queries", Claude will reference this skill to generate accurate syntax.

### Skill Coverage

The skill covers the complete Tasks plugin syntax:

- **Task syntax**: Emojis and text alternatives for all fields
- **Date types**: Due, scheduled, start, created, done, cancelled
- **Priorities**: All six levels (highest to lowest)
- **Recurrence**: All patterns including ordinal days, weekdays, "when done"
- **Dependencies**: ID and depends-on syntax
- **Custom statuses**: Default and configurable statuses (all 6 status types including ON_HOLD)
- **Queries**: All filters, sorts, groups, and display options
- **Presets**: Default presets and placeholder syntax (new in 7.20.0)
- **Line continuations**: Backslash syntax for multi-line queries
- **Date filters**: Including `on or before`, `in or after`, numbered date ranges (YYYY-Www, YYYY-Qq)
- **Date validation**: `date is invalid` filters
- **Patterns**: GTD weekly review, daily notes, project dashboards

### File Location

```
.claude/skills/tasks/SKILL.md
```

This follows the [Claude Code skill conventions](https://docs.anthropic.com/en/docs/claude-code/skills).

## Motivation and Context

Plugin authors maintaining their own Claude Code skills ensures accuracy as the plugin evolves. This was the consensus from the discussion on kepano/obsidian-skills#26.

## How has this been tested?

- The skill was written referencing the [Tasks Documentation](https://publish.obsidian.md/tasks/)
- Tested against Tasks plugin version: **7.22.0**
- Syntax examples were validated against the official documentation
- The skill was previously reviewed by @claremacrae on the kepano PR, and I incorporated her feedback (corrected priority emoji order, etc.)

## Screenshots (if appropriate)

N/A - This is a markdown reference file for AI assistants.

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)