### PR TITLE
fix: Correct query.file.hasProperty() and query.file.property()

### DIFF
--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -372,7 +372,7 @@ ${statement.explainStatement('    ')}
                 taskGroups.applyTaskLimit(this._taskGroupLimit);
             }
 
-            return new QueryResult(taskGroups, tasksSorted.length, undefined);
+            return new QueryResult(taskGroups, tasksSorted.length, this.tasksFile);
         } catch (e) {
             const description = 'Search failed';
             let message = errorMessageForException(description, e);

--- a/src/Query/QueryResult.ts
+++ b/src/Query/QueryResult.ts
@@ -1,4 +1,4 @@
-import { type OptionalTasksFile, TasksFile } from '../Scripting/TasksFile';
+import type { OptionalTasksFile } from '../Scripting/TasksFile';
 import type { Task } from '../Task/Task';
 import type { Filter } from './Filter/Filter';
 import { TaskGroups } from './Group/TaskGroups';
@@ -14,8 +14,7 @@ export class QueryResult {
     public readonly totalTasksCountBeforeLimit: number = 0;
 
     private _searchErrorMessage: string | undefined = undefined;
-    // @ts-expect-error: _tasksFile is unused
-    private _tasksFile: OptionalTasksFile;
+    private readonly _tasksFile: OptionalTasksFile;
 
     constructor(groups: TaskGroups, totalTasksCountBeforeLimit: number, tasksFile: OptionalTasksFile) {
         this.taskGroups = groups;
@@ -113,14 +112,14 @@ export class QueryResult {
         }
 
         const queryResultTasks = this.taskGroups.groups.flatMap((group) => group.tasks);
-        const searchInfo = new SearchInfo(new TasksFile('fix_me.md'), queryResultTasks);
+        const searchInfo = new SearchInfo(this._tasksFile, queryResultTasks);
         const filterFunction = (task: Task) => filter.filterFunction(task, searchInfo);
         const filteredTasks = [...new Set(queryResultTasks.filter(filterFunction))];
 
         return new QueryResult(
             new TaskGroups(this.taskGroups.groupers, filteredTasks, searchInfo),
             this.totalTasksCountBeforeLimit,
-            undefined,
+            this._tasksFile,
         );
     }
 }

--- a/tests/Query/QueryResult.test.ts
+++ b/tests/Query/QueryResult.test.ts
@@ -66,7 +66,7 @@ describe('QueryResult', () => {
         );
     });
 
-    it.failing('should preserve query file properties when filtering results', () => {
+    it('should preserve query file properties when filtering results', () => {
         const queryFile = getTasksFileFromMockData('docs_sample_for_task_properties_reference');
         expect(queryFile.property('sample_date_and_time_property')).toEqual('2024-07-21T12:37:00');
 
@@ -88,8 +88,6 @@ describe('QueryResult', () => {
 
         // Confirm that the properties in the query file are retained in the filtered results:
         const filteredResult = queryResult.applyFilter(filter!);
-        // This line fails: the actual result is "no date"
-        // expect(filteredResult.taskGroups.groups[0].groups[0]).toEqual('2024-07-21T12:37:00');
         expect(getFirstGroupName(filteredResult)).toEqual('2024-07-21T12:37:00');
     });
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3774

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

This fixes use of the following, which was broken in Tasks 7.23.0:

- `query.file.hasProperty()`
- `query.file.property()`

## Motivation and Context

Fix #3774

## How has this been tested?

- Added a failing test that showed the problem
- And built the plugin and confirmed that the fix does work.

## Screenshots (if appropriate)

Screenshot of the corrected group heading, in a test build with the fix included:

<img width="1294" height="491" alt="image" src="https://github.com/user-attachments/assets/4612ad32-db97-4e42-aff4-cd5f0deb394e" />


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
