### PR TITLE
feat: add deploy:local:bash yarn script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "jest --ci",
     "test:dev": "jest --watch",
     "deploy:local": "pwsh -ExecutionPolicy Unrestricted -NoProfile -File ./scripts/Test-TasksInLocalObsidian.ps1",
+    "deploy:local:bash": "bash ./scripts/Test-TasksInLocalObsidian.sh",
     "extract-i18n": "npx i18next-parser",
     "circular-deps-text": "madge --circular --extensions ts ./src > circular-deps.txt",
     "circular-deps-image": "madge --circular --extensions ts ./src --image circular-deps.png",


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **Translation** (prefix: `i18n` - additions or improvements to the translations)
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the Tasks-Demo sample vault)
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors**)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

Adds a `deploy:local:bash` yarn script entry to `package.json` for the existing `scripts/Test-TasksInLocalObsidian.sh` bash script.

The existing `deploy:local` script requires PowerShell (`pwsh`), which not all contributors will have installed. The bash script already exists in the repo and is used in CI, but had no corresponding yarn script to run it.

## Motivation and Context

Closes #3787

Contributors on macOS/Linux who do not have PowerShell installed cannot use `yarn deploy:local`. This one-line addition makes the existing bash script easily discoverable and runnable via `yarn deploy:local:bash`, matching the convention of `deploy:local` for PowerShell.

## How has this been tested?

Verified that `yarn deploy:local:bash` correctly invokes `scripts/Test-TasksInLocalObsidian.sh`.

## Screenshots (if appropriate)

N/A

## Checklist

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)