### PR TITLE
refactor: rename interface to `HtmlQueryRendererParameters`

### DIFF
--- a/src/Renderer/HtmlQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlQueryResultsRenderer.ts
@@ -19,7 +19,7 @@ import { TaskLineRenderer, type TextRenderer, createAndAppendElement } from './T
  * and display query results such as tasks, markdown files, and certain event handlers
  * for user interactions, like handling backlinks and editing tasks.
  */
-export interface QueryRendererParameters {
+export interface HTMLQueryRendererParameters {
     allTasks: () => Task[];
     allMarkdownFiles: () => TFile[];
     backlinksClickHandler: BacklinksEventHandler;
@@ -51,7 +51,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
     private readonly ulElementStack: HTMLUListElement[] = [];
     private lastLIElement: HTMLLIElement = document.createElement('li');
 
-    private readonly queryRendererParameters: QueryRendererParameters;
+    private readonly htmlQueryRendererParameters: HTMLQueryRendererParameters;
 
     constructor(
         renderMarkdown: (
@@ -64,7 +64,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
         obsidianComponent: Component | null,
         obsidianApp: App,
         textRenderer: TextRenderer,
-        queryRendererParameters: QueryRendererParameters,
+        queryRendererParameters: HTMLQueryRendererParameters,
         getters: QueryResultsRendererGetters,
     ) {
         super(getters);
@@ -73,7 +73,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
         this.obsidianComponent = obsidianComponent;
         this.obsidianApp = obsidianApp;
         this.textRenderer = textRenderer;
-        this.queryRendererParameters = queryRendererParameters;
+        this.htmlQueryRendererParameters = queryRendererParameters;
 
         this.taskLineRenderer = this.createTaskLineRenderer();
     }
@@ -149,7 +149,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
     }
 
     protected async addTask(task: Task, taskIndex: number): Promise<void> {
-        const isFilenameUnique = this.isFilenameUnique({ task }, this.queryRendererParameters.allMarkdownFiles());
+        const isFilenameUnique = this.isFilenameUnique({ task }, this.htmlQueryRendererParameters.allMarkdownFiles());
         const listItem = this.lastLIElement;
 
         await this.taskLineRenderer.renderTaskLine({
@@ -195,10 +195,10 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
         editTaskPencil.href = '#';
 
         editTaskPencil.addEventListener('click', (event: MouseEvent) =>
-            this.queryRendererParameters.editTaskPencilClickHandler(
+            this.htmlQueryRendererParameters.editTaskPencilClickHandler(
                 event,
                 task,
-                this.queryRendererParameters.allTasks(),
+                this.htmlQueryRendererParameters.allTasks(),
             ),
         );
     }
@@ -263,11 +263,11 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
 
         // Go to the line the task is defined at
         link.addEventListener('click', async (ev: MouseEvent) => {
-            await this.queryRendererParameters.backlinksClickHandler(ev, task);
+            await this.htmlQueryRendererParameters.backlinksClickHandler(ev, task);
         });
 
         link.addEventListener('mousedown', async (ev: MouseEvent) => {
-            await this.queryRendererParameters.backlinksMousedownHandler(ev, task);
+            await this.htmlQueryRendererParameters.backlinksMousedownHandler(ev, task);
         });
 
         if (!shortMode) {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -9,7 +9,7 @@ import { getQueryForQueryRenderer } from '../Query/QueryRendererHelper';
 import type { QueryResult } from '../Query/QueryResult';
 import type { TasksFile } from '../Scripting/TasksFile';
 import type { Task } from '../Task/Task';
-import { HtmlQueryResultsRenderer, type QueryRendererParameters } from './HtmlQueryResultsRenderer';
+import { type HTMLQueryRendererParameters, HtmlQueryResultsRenderer } from './HtmlQueryResultsRenderer';
 import { MarkdownQueryResultsRenderer } from './MarkdownQueryResultsRenderer';
 import { type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
 
@@ -63,7 +63,7 @@ export class QueryResultsRenderer {
         obsidianComponent: Component | null,
         obsidianApp: App,
         textRenderer: TextRenderer,
-        queryRendererParameters: QueryRendererParameters,
+        htmlQueryRendererParameters: HTMLQueryRendererParameters,
     ) {
         this.source = source;
         this._tasksFile = tasksFile;
@@ -98,7 +98,7 @@ export class QueryResultsRenderer {
             obsidianComponent,
             obsidianApp,
             textRenderer,
-            queryRendererParameters,
+            htmlQueryRendererParameters,
             getters,
         );
 

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.ts
@@ -10,7 +10,7 @@ import type { Task } from '../../src/Task/Task';
 import { mockApp } from '../__mocks__/obsidian';
 import { readTasksFromSimulatedFile } from '../Obsidian/SimulatedFile';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
-import { makeQueryRendererParameters, mockHTMLRenderer, verifyRenderedTasks } from './RenderingTestHelpers';
+import { makeHtmlQueryRendererParameters, mockHTMLRenderer, verifyRenderedTasks } from './RenderingTestHelpers';
 
 window.moment = moment;
 
@@ -22,7 +22,7 @@ function makeHtmlRenderer(source: string, tasksFile: TasksFile, allTasks: Task[]
         null,
         mockApp,
         mockHTMLRenderer,
-        makeQueryRendererParameters(allTasks),
+        makeHtmlQueryRendererParameters(allTasks),
         {
             source: () => source,
             tasksFile: () => tasksFile,

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -12,7 +12,7 @@ import { mockApp } from '../__mocks__/obsidian';
 import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import {
-    makeQueryRendererParameters,
+    makeHtmlQueryRendererParameters,
     mockHTMLRenderer,
     tasksMarkdownAndPrettifiedHtml,
     verifyRenderedTasks,
@@ -32,7 +32,7 @@ afterEach(() => {
 });
 
 function makeQueryResultsRenderer(source: string, tasksFile: TasksFile, allTasks: Task[]) {
-    const queryRendererParameters = makeQueryRendererParameters(allTasks);
+    const htmlQueryRendererParameters = makeHtmlQueryRendererParameters(allTasks);
 
     const queryResultsRenderer = new QueryResultsRenderer(
         'block-language-tasks',
@@ -42,7 +42,7 @@ function makeQueryResultsRenderer(source: string, tasksFile: TasksFile, allTasks
         null,
         mockApp,
         mockHTMLRenderer,
-        queryRendererParameters,
+        htmlQueryRendererParameters,
     );
 
     expect(queryResultsRenderer.query.error).toBeUndefined();

--- a/tests/Renderer/RenderingTestHelpers.ts
+++ b/tests/Renderer/RenderingTestHelpers.ts
@@ -2,7 +2,7 @@ import type { App } from 'obsidian';
 import { State } from '../../src/Obsidian/Cache';
 import type { FilterOrErrorMessage } from '../../src/Query/Filter/FilterOrErrorMessage';
 import { Query } from '../../src/Query/Query';
-import type { QueryRendererParameters } from '../../src/Renderer/HtmlQueryResultsRenderer';
+import type { HTMLQueryRendererParameters } from '../../src/Renderer/HtmlQueryResultsRenderer';
 import { MarkdownQueryResultsRenderer } from '../../src/Renderer/MarkdownQueryResultsRenderer';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 import type { Task } from '../../src/Task/Task';
@@ -22,7 +22,7 @@ export const mockTextRenderer = async (_obsidianApp: App, text: string, element:
     element.innerText = text;
 };
 
-export function makeQueryRendererParameters(allTasks: Task[]): QueryRendererParameters {
+export function makeHtmlQueryRendererParameters(allTasks: Task[]): HTMLQueryRendererParameters {
     return {
         allTasks: () => allTasks,
         allMarkdownFiles: () => [],


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

- Rename interface and move it closer to usage

## Motivation and Context

- Prepare removal of `getters`
- Cleaner code

## How has this been tested?

- Unit tests

## Checklist

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
