### PR TITLE
fix: Correct order of groups like  `task.happens.fromNow` for non-English setups

### DIFF
--- a/src/DateTime/TasksDate.ts
+++ b/src/DateTime/TasksDate.ts
@@ -108,7 +108,8 @@ export class TasksDate {
 
         // https://momentjs.com/docs/#/displaying/fromnow/
         // 'If you pass true, you can get the value without the suffix.'
-        const words = date.fromNow(true).split(' ');
+        // We change the locale to english, to get values like 'hours', 'days', 'years' that we can pass to Moment.
+        const words = date.clone().locale('en').fromNow(true).split(' ');
 
         let multiplier: number;
         const word0AsNumber = Number(words[0]);

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -140,12 +140,16 @@ describe('TasksDate', () => {
         expect(expectedTaskTimeSortOrder).toEqual(3202306132000);
 
         describe('should calculate correct sort order for fromNow value in given language, for a date in two days', () => {
-            const locales = ['en', 'es'];
-            it.each(locales)('%s locale', (loc: string) => {
+            const locales = [
+                ['en', 'in 2 days'],
+                ['es', 'en 2 días'],
+            ];
+            it.each(locales)('%s locale', (loc: string, expectedFromNow: string) => {
                 jest.setSystemTime(new Date(thisTime));
 
                 const now = moment(taskTime);
                 const tasksDate = new TasksDate(now.clone().locale(loc));
+                expect(tasksDate.fromNow.name).toEqual(expectedFromNow);
                 expect(tasksDate.fromNow.sortOrder).toEqual(expectedTaskTimeSortOrder);
             });
 

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -134,7 +134,7 @@ describe('TasksDate', () => {
             // we get the same sort order:
             const tasksDate = new TasksDate(moment(date).locale('es'));
             const spanishGroupText = tasksDate.fromNow.groupText;
-            const actualSortOrder = spanishGroupText.split(' ')[0];
+            const actualSortOrder = extractSortOrder(spanishGroupText);
 
             expect(actualSortOrder).toEqual(expectedSortOrder);
         },

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -119,23 +119,23 @@ describe('TasksDate', () => {
         'should categorise dates in correct order, in Spanish: on "%s" - expected "%s"',
         (date: string, expectedResult: string) => {
             const extractSortOrder = (result: string): string => {
-                const expectedSortOrder = result.split(' ')[0];
+                const sortOrder = result.split(' ')[0];
 
                 // Example value: %%3202307112000%%
-                expect(expectedSortOrder.slice(0, 2)).toEqual('%%');
-                expect(expectedSortOrder.slice(-2)).toEqual('%%');
+                expect(sortOrder.slice(0, 2)).toEqual('%%');
+                expect(sortOrder.slice(-2)).toEqual('%%');
 
-                return expectedSortOrder;
+                return sortOrder;
             };
 
-            const expectedSortOrder = extractSortOrder(expectedResult);
+            const englishSortOrder = extractSortOrder(expectedResult);
 
             // Check that if we ask for the group name on a Spanish language machine,
             // we get the same sort order:
             const tasksDate = new TasksDate(moment(date).locale('es'));
-            const actualSortOrder = extractSortOrder(tasksDate.fromNow.groupText);
+            const spanishSortOrder = extractSortOrder(tasksDate.fromNow.groupText);
 
-            expect(actualSortOrder).toEqual(expectedSortOrder);
+            expect(spanishSortOrder).toEqual(englishSortOrder);
         },
     );
 

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -115,6 +115,25 @@ describe('TasksDate', () => {
         },
     );
 
+    it.each(sampleDatesSortedByDate)(
+        'should categorise dates in correct order, in Spanish: on "%s" - expected "%s"',
+        (date: string, expectedResult: string) => {
+            const expectedSortOrder = expectedResult.split(' ')[0];
+
+            // Example value: %%3202307112000%%
+            expect(expectedSortOrder.slice(0, 2)).toEqual('%%');
+            expect(expectedSortOrder.slice(-2)).toEqual('%%');
+
+            // Check that if we ask for the group name on a Spanish language machine,
+            // we get the same sort order:
+            const tasksDate = new TasksDate(moment(date).locale('es'));
+            const spanishGroupText = tasksDate.fromNow.groupText;
+            const actualSortOrder = spanishGroupText.split(' ')[0];
+
+            expect(actualSortOrder).toEqual(expectedSortOrder);
+        },
+    );
+
     it('should sort group categories in ascending order by date', () => {
         // See:
         //      https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2789

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -136,6 +136,7 @@ describe('TasksDate', () => {
         const thisTime = '2023-06-11 20:00';
         const taskTime = '2023-06-13 20:00';
 
+        // The initial '3' indicates that the date is in future of the current time.
         const expectedTaskTimeSortOrder = 3 * 1e12 + 2023 * 1e8 + 6 * 1e6 + 13 * 1e4 + 20 * 1e2;
         expect(expectedTaskTimeSortOrder).toEqual(3202306132000);
 

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -152,24 +152,6 @@ describe('TasksDate', () => {
                 expect(tasksDate.fromNow.name).toEqual(expectedFromNow);
                 expect(tasksDate.fromNow.sortOrder).toEqual(expectedTaskTimeSortOrder);
             });
-
-            it('English locale', () => {
-                jest.setSystemTime(new Date(thisTime));
-
-                const now = moment(taskTime);
-                const tasksDate = new TasksDate(now.clone().locale('en'));
-                expect(tasksDate.fromNow.name).toEqual('in 2 days');
-                expect(tasksDate.fromNow.sortOrder).toEqual(expectedTaskTimeSortOrder);
-            });
-
-            it('Spanish locale', () => {
-                jest.setSystemTime(new Date(thisTime));
-
-                const now = moment(taskTime);
-                const tasksDate = new TasksDate(now.clone().locale('es'));
-                expect(tasksDate.fromNow.name).toEqual('en 2 días');
-                expect(tasksDate.fromNow.sortOrder).toEqual(expectedTaskTimeSortOrder); // actual value is 3202306112000, not 3202306132000
-            });
         });
     });
 });

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -119,13 +119,7 @@ describe('TasksDate', () => {
         'should categorise dates in correct order, in Spanish: on "%s" - expected "%s"',
         (date: string, expectedResult: string) => {
             const extractSortOrder = (result: string): string => {
-                const sortOrder = result.split(' ')[0];
-
-                // Example value: %%3202307112000%%
-                expect(sortOrder.slice(0, 2)).toEqual('%%');
-                expect(sortOrder.slice(-2)).toEqual('%%');
-
-                return sortOrder;
+                return result.split(' ')[0];
             };
 
             const englishSortOrder = extractSortOrder(expectedResult);

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -118,11 +118,17 @@ describe('TasksDate', () => {
     it.each(sampleDatesSortedByDate)(
         'should categorise dates in correct order, in Spanish: on "%s" - expected "%s"',
         (date: string, expectedResult: string) => {
-            const expectedSortOrder = expectedResult.split(' ')[0];
+            const extractSortOrder = (result: string): string => {
+                const expectedSortOrder = result.split(' ')[0];
 
-            // Example value: %%3202307112000%%
-            expect(expectedSortOrder.slice(0, 2)).toEqual('%%');
-            expect(expectedSortOrder.slice(-2)).toEqual('%%');
+                // Example value: %%3202307112000%%
+                expect(expectedSortOrder.slice(0, 2)).toEqual('%%');
+                expect(expectedSortOrder.slice(-2)).toEqual('%%');
+
+                return expectedSortOrder;
+            };
+
+            const expectedSortOrder = extractSortOrder(expectedResult);
 
             // Check that if we ask for the group name on a Spanish language machine,
             // we get the same sort order:

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -149,7 +149,7 @@ describe('TasksDate', () => {
                 expect(tasksDate.fromNow.sortOrder).toEqual(expectedTaskTimeSortOrder);
             });
 
-            it.failing('Spanish locale', () => {
+            it('Spanish locale', () => {
                 jest.setSystemTime(new Date(thisTime));
 
                 const now = moment(taskTime);

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -133,8 +133,7 @@ describe('TasksDate', () => {
             // Check that if we ask for the group name on a Spanish language machine,
             // we get the same sort order:
             const tasksDate = new TasksDate(moment(date).locale('es'));
-            const spanishGroupText = tasksDate.fromNow.groupText;
-            const actualSortOrder = extractSortOrder(spanishGroupText);
+            const actualSortOrder = extractSortOrder(tasksDate.fromNow.groupText);
 
             expect(actualSortOrder).toEqual(expectedSortOrder);
         },

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -142,6 +142,8 @@ describe('TasksDate', () => {
         describe('should calculate correct sort order for fromNow value in given language, for a date in two days', () => {
             const locales = ['en', 'es'];
             it.each(locales)('%s locale', (loc: string) => {
+                jest.setSystemTime(new Date(thisTime));
+
                 const now = moment(taskTime);
                 const tasksDate = new TasksDate(now.clone().locale(loc));
                 expect(tasksDate.fromNow.sortOrder).toEqual(expectedTaskTimeSortOrder);

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -131,6 +131,34 @@ describe('TasksDate', () => {
         expect(new TasksDate(moment('1999-02-31')).fromNow.groupText).toEqual('%%0%% Invalid date');
         expect(new TasksDate(moment('2023-02-31')).fromNow.groupText).toEqual('%%0%% Invalid date');
     });
+
+    describe('language-aware fromNow() calculations', () => {
+        const thisTime = '2023-06-11 20:00';
+        const taskTime = '2023-06-13 20:00';
+
+        const expectedTaskTimeSortOrder = 3 * 1e12 + 2023 * 1e8 + 6 * 1e6 + 13 * 1e4 + 20 * 1e2;
+        expect(expectedTaskTimeSortOrder).toEqual(3202306132000);
+
+        describe('should calculate correct sort order for fromNow value in given language, for a date in two days', () => {
+            it('English locale', () => {
+                jest.setSystemTime(new Date(thisTime));
+
+                const now = moment(taskTime);
+                const tasksDate = new TasksDate(now.clone().locale('en'));
+                expect(tasksDate.fromNow.name).toEqual('in 2 days');
+                expect(tasksDate.fromNow.sortOrder).toEqual(expectedTaskTimeSortOrder);
+            });
+
+            it.failing('Spanish locale', () => {
+                jest.setSystemTime(new Date(thisTime));
+
+                const now = moment(taskTime);
+                const tasksDate = new TasksDate(now.clone().locale('es'));
+                expect(tasksDate.fromNow.name).toEqual('en 2 días');
+                expect(tasksDate.fromNow.sortOrder).toEqual(expectedTaskTimeSortOrder); // actual value is 3202306112000, not 3202306132000
+            });
+        });
+    });
 });
 
 describe('TasksDate - postpone', () => {

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -140,6 +140,12 @@ describe('TasksDate', () => {
         expect(expectedTaskTimeSortOrder).toEqual(3202306132000);
 
         describe('should calculate correct sort order for fromNow value in given language, for a date in two days', () => {
+            const locales = ['en', 'es'];
+            it.each(locales)('%s locale', (loc: string) => {
+                const now = moment(taskTime);
+                expect(new TasksDate(now.clone().locale(loc)).fromNow.sortOrder).toEqual(expectedTaskTimeSortOrder);
+            });
+
             it('English locale', () => {
                 jest.setSystemTime(new Date(thisTime));
 

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -116,7 +116,7 @@ describe('TasksDate', () => {
     );
 
     it.each(sampleDatesSortedByDate)(
-        'should categorise dates in correct order, in Spanish: on "%s" - expected "%s"',
+        'should categorise dates for grouping, in correct order, in Spanish: on "%s"',
         (date: string, expectedResult: string) => {
             const extractSortOrder = (result: string): string => {
                 return result.split(' ')[0];

--- a/tests/DateTime/TasksDate.test.ts
+++ b/tests/DateTime/TasksDate.test.ts
@@ -143,7 +143,8 @@ describe('TasksDate', () => {
             const locales = ['en', 'es'];
             it.each(locales)('%s locale', (loc: string) => {
                 const now = moment(taskTime);
-                expect(new TasksDate(now.clone().locale(loc)).fromNow.sortOrder).toEqual(expectedTaskTimeSortOrder);
+                const tasksDate = new TasksDate(now.clone().locale(loc));
+                expect(tasksDate.fromNow.sortOrder).toEqual(expectedTaskTimeSortOrder);
             });
 
             it('English locale', () => {


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3834

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Fix the order of groups created by this instruction, for non-English language environments:

```
group by function task.happens.fromNow.groupText
```

## Motivation and Context

Fixes #3834

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Manual testing, with languages English, Spanish and Chinese
- Adding new Jest tests

## Screenshots (if appropriate)


Markdown note used for creating the following screenshots:

~~~
# sample dates

- [ ] [#task](https://github.com/obsidian-tasks-group/obsidian-tasks/compare/fix-fromNow-group-order?expand=1#task) -3 days 📅 2026-04-08
- [ ] [#task](https://github.com/obsidian-tasks-group/obsidian-tasks/compare/fix-fromNow-group-order?expand=1#task) -2 days 📅 2026-04-09
- [ ] [#task](https://github.com/obsidian-tasks-group/obsidian-tasks/compare/fix-fromNow-group-order?expand=1#task) -1 days 📅 2026-04-10
- [ ] [#task](https://github.com/obsidian-tasks-group/obsidian-tasks/compare/fix-fromNow-group-order?expand=1#task) 0 days 📅 2026-04-11
- [ ] [#task](https://github.com/obsidian-tasks-group/obsidian-tasks/compare/fix-fromNow-group-order?expand=1#task) 1 days 📅 2026-04-12
- [ ] [#task](https://github.com/obsidian-tasks-group/obsidian-tasks/compare/fix-fromNow-group-order?expand=1#task) 2 days 📅 2026-04-13
- [ ] [#task](https://github.com/obsidian-tasks-group/obsidian-tasks/compare/fix-fromNow-group-order?expand=1#task) 3 days 📅 2026-04-14

```tasks
preset this_file
group by function task.happens.fromNow.groupText
hide task count
hide toolbar
```
~~~

All tasks in the screenshots should be in ascending numerical order.

The screenshots show that this was not previously the case for Spanish and English. It affected all non-English languages - languages that do not use the words `second`, `minute`, `hour`, `day`, `month`, `year`.

| Language | Before                                                                                                                             | After                                                                                                                              |
| -------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
| English  | <img width="476" height="611" alt="image" src="https://github.com/user-attachments/assets/a1a77db8-2dd2-4ee4-aca0-6546d608cb29" /> | <img width="471" height="612" alt="image" src="https://github.com/user-attachments/assets/9cfec415-0e9e-4ed0-ae20-61abdc0f5527" /> |
| Spanish  | <img width="470" height="606" alt="image" src="https://github.com/user-attachments/assets/8980d3b4-6e7c-4882-9313-36055b7ec0e5" /> | <img width="469" height="604" alt="image" src="https://github.com/user-attachments/assets/8b75ca73-15bf-43bf-a4d2-7b2ba938916c" /> |
| Chinese  | <img width="474" height="614" alt="image" src="https://github.com/user-attachments/assets/b4dbb487-ce27-48e6-8b37-b98faa47f32d" /> | <img width="471" height="605" alt="image" src="https://github.com/user-attachments/assets/d83082d2-3704-4b3b-a5e6-2ada512e073c" /> |



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
