### PR TITLE
chore: Experiment with addressing some eslint errors

### DIFF
--- a/src/Commands/AddQueryFileDefaultsProperties.ts
+++ b/src/Commands/AddQueryFileDefaultsProperties.ts
@@ -2,7 +2,7 @@ import { type App, Notice, type TFile } from 'obsidian';
 import { QueryFileDefaults } from '../Query/QueryFileDefaults';
 
 export async function ensureQueryFileDefaultsInFrontmatter(app: App, file: TFile) {
-    await app.fileManager.processFrontMatter(file, (frontmatter) => {
+    await app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
         const requiredKeys = new QueryFileDefaults().allPropertyNamesSorted();
         let updated = false;
         requiredKeys.forEach((key) => {

--- a/src/Config/Feature.ts
+++ b/src/Config/Feature.ts
@@ -82,9 +82,7 @@ export class Feature {
         }
 
         throw new RangeError(
-            `Illegal argument passed to fromString(): ${name} does not correspond to any available Feature ${
-                (this as any).prototype.constructor.name
-            }`,
+            `Illegal argument passed to fromString(): ${name} does not correspond to any available Feature ${this.name}`,
         );
     }
 }

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -268,8 +268,8 @@ export function getUserSelectedTaskFormat(): TaskFormat {
  *
  * Note: The vault's 'data.json' file is only updated when the user opens the Tasks settings UI.
  */
-function migrateSettings(loadedSettings: any): Partial<Settings> {
-    const migratedSettings = { ...loadedSettings };
+function migrateSettings(loadedSettings: Record<string, unknown>): Partial<Settings> {
+    const migratedSettings: Record<string, unknown> = { ...loadedSettings };
 
     // Migrate 'includes' to 'presets' if present
     if ('includes' in migratedSettings && !('presets' in migratedSettings)) {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -23,6 +23,26 @@ import { CustomStatusModal } from './CustomStatusModal';
 import { GlobalQuery } from './GlobalQuery';
 import { PresetsSettingsUI } from './PresetsSettingsUI';
 
+interface SettingConfiguration {
+    name: string;
+    description: string;
+    type: string;
+    initialValue: string;
+    placeholder: string;
+    settingName: string;
+    featureFlag: string;
+    notice: { class: string; text: string | null; html: string | null } | null;
+}
+
+interface HeadingConfiguration {
+    text: string;
+    level: string;
+    class: string;
+    open: boolean;
+    notice: { class: string; text: string | null; html: string | null } | null;
+    settings: SettingConfiguration[];
+}
+
 export class SettingsTab extends PluginSettingTab {
     // If the UI needs a more complex setting you can create a
     // custom function and specify it from the json file. It will
@@ -284,7 +304,7 @@ export class SettingsTab extends PluginSettingTab {
         ];
 
         // Original usage remains unchanged
-        settingsJson.forEach((heading) => {
+        settingsJson.forEach((heading: HeadingConfiguration) => {
             const initiallyOpen = headingOpened[heading.text] ?? true;
             const detailsContainer = this.addOneSettingsBlock(containerEl, heading, headingOpened);
             detailsContainer.open = initiallyOpen;
@@ -566,7 +586,7 @@ export class SettingsTab extends PluginSettingTab {
 
     private addOneSettingsBlock(
         containerEl: HTMLElement,
-        heading: any,
+        heading: HeadingConfiguration,
         headingOpened: HeadingState,
     ): HTMLDetailsElement {
         const detailsContainer = containerEl.createEl('details', {
@@ -596,7 +616,7 @@ export class SettingsTab extends PluginSettingTab {
         // This will process all the settings from settingsConfiguration.json and render
         // them out reducing the duplication of the code in this file. This will become
         // more important as features are being added over time.
-        heading.settings.forEach((setting: any) => {
+        heading.settings.forEach((setting: SettingConfiguration) => {
             if (setting.featureFlag !== '' && !isFeatureEnabled(setting.featureFlag)) {
                 // The settings configuration has a featureFlag set and the user has not
                 // enabled it. Skip adding the settings option.
@@ -666,7 +686,7 @@ export class SettingsTab extends PluginSettingTab {
             if (setting.notice !== null) {
                 const notice = detailsContainer.createEl('p', {
                     cls: setting.notice.class,
-                    text: setting.notice.text,
+                    text: setting.notice.text ?? '',
                 });
                 if (setting.notice.html !== null) {
                     notice.insertAdjacentHTML('beforeend', setting.notice.html);

--- a/src/DateTime/TasksDate.ts
+++ b/src/DateTime/TasksDate.ts
@@ -103,7 +103,7 @@ export class TasksDate {
         return Number(splitPastAndFutureDates + startDateOfThisGroup.format('YYYYMMDDHHmm'));
     }
 
-    private fromNowStartDateOfGroup(date: moment.Moment, earlier: boolean, now: any) {
+    private fromNowStartDateOfGroup(date: moment.Moment, earlier: boolean, now: Moment): Moment {
         // Calculate the earliest of all dates with the same 'fromNow()' name.
 
         // https://momentjs.com/docs/#/displaying/fromnow/

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -141,11 +141,12 @@ export class FunctionField extends Field {
         }
 
         if (valueAType === 'string') {
-            return valueA.localeCompare(valueB, undefined, { numeric: true });
+            return (valueA as string).localeCompare(valueB as string, undefined, { numeric: true });
         }
 
         if (valueAType === 'TasksDate') {
-            return compareByDate(valueA.moment, valueB.moment);
+            type WithMoment = { moment: Parameters<typeof compareByDate>[0] };
+            return compareByDate((valueA as WithMoment).moment, (valueB as WithMoment).moment);
         }
 
         if (valueAType === 'boolean') {
@@ -273,7 +274,7 @@ export function groupByFunction(task: Task, arg: GroupingArg, queryContext?: Que
         const result = parseAndEvaluateExpression(task, arg, queryContext);
 
         if (Array.isArray(result)) {
-            return result.map((h) => h.toString());
+            return result.map((h: unknown) => (h as { toString(): string }).toString());
         }
 
         // Task uses null to represent missing information.
@@ -296,7 +297,7 @@ export function groupByFunction(task: Task, arg: GroupingArg, queryContext?: Que
         // on undefined.toString() will give an exception and a useful error
         // message below. This is a feature: it gives users feedback on the problem
         // instruction line.
-        const group = result.toString();
+        const group = (result as { toString(): string }).toString();
         return [group];
     } catch (e) {
         const errorMessage = `Error: Failed calculating expression "${arg}". The error message was: `;

--- a/src/Query/Group/GroupDisplayHeadingSelector.ts
+++ b/src/Query/Group/GroupDisplayHeadingSelector.ts
@@ -89,7 +89,7 @@ export class GroupDisplayHeadingSelector {
 
     constructor(taskGroupingTreeStorage: TaskGroupingTreeStorage, groupers: Grouper[]) {
         this.groupers = groupers;
-        const firstGroup = taskGroupingTreeStorage.keys().next().value;
+        const firstGroup = taskGroupingTreeStorage.keys().next().value as string[];
         const groupCount = firstGroup.length;
         for (let i = 0; i < groupCount; i++) {
             this.lastHeadingAtLevel.push('');

--- a/src/Query/QueryFileDefaults.ts
+++ b/src/Query/QueryFileDefaults.ts
@@ -8,6 +8,15 @@ enum Handler {
     AddValue = 'addValue',
 }
 
+interface QueryProperty {
+    name: string;
+    type: string;
+    display?: string;
+    handler: Handler;
+    trueValue?: string;
+    falseValue?: string;
+}
+
 // Steps for adding a new property to Query File Defaults:
 // 1. Add the new value to queryProperties below.
 // 2. Add it to metaBindPluginWidgets() below
@@ -26,7 +35,7 @@ enum Handler {
 // Note: This file is excluded from SonarCloud duplication-checks,
 //       as the duplication here provides clarity.
 // Instructions are listed in the order that items are displayed in Tasks search results
-const queryProperties = [
+const queryProperties: QueryProperty[] = [
     {
         name: 'TQ_show_toolbar',
         type: 'checkbox',
@@ -183,7 +192,7 @@ export class QueryFileDefaults {
         return instructions.filter((i) => i !== '').join('\n');
     }
 
-    private generateInstruction(queryFile: TasksFile, prop: any) {
+    private generateInstruction(queryFile: TasksFile, prop: QueryProperty) {
         const hasProperty = queryFile.hasProperty(prop.name);
         const value = queryFile.property(prop.name);
         switch (prop.handler) {

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -10,7 +10,7 @@ export class TasksFile {
     private readonly _path: string;
     private readonly _cachedMetadata: CachedMetadata;
     // Always make TasksFile.frontmatter.tags exist and be empty, even if no frontmatter present:
-    private readonly _frontmatter = { tags: [] } as any;
+    private readonly _frontmatter = { tags: [] } as Record<string, unknown>;
     private readonly _tags: string[] = [];
 
     private readonly _outlinksInProperties: Readonly<Link[]> = [];

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -745,6 +745,16 @@ export function canSuggestForLine(line: string, cursor: EditorPosition, editor: 
     return lineHasGlobalFilter && cursorIsInTaskLineDescription(line, cursor.ch);
 }
 
+interface EditorWithTasksSuggest {
+    editorComponent?: {
+        showTasksPluginAutoSuggest?: (
+            cursor: EditorPosition,
+            editor: Editor,
+            lineHasGlobalFilter: boolean,
+        ) => boolean | undefined;
+    };
+}
+
 /**
  * This function is to specifically allow other plugins to offer Tasks auto suggest.
  *
@@ -766,7 +776,11 @@ function editorIsRequestingSuggest(
     cursor: EditorPosition,
     lineHasGlobalFilter: boolean,
 ): boolean | undefined {
-    return (editor as any)?.editorComponent?.showTasksPluginAutoSuggest?.(cursor, editor, lineHasGlobalFilter);
+    return (editor as unknown as EditorWithTasksSuggest)?.editorComponent?.showTasksPluginAutoSuggest?.(
+        cursor,
+        editor,
+        lineHasGlobalFilter,
+    );
 }
 
 /**

--- a/src/lib/TypeDetection.ts
+++ b/src/lib/TypeDetection.ts
@@ -9,7 +9,7 @@ export function getValueType(value: any): string {
 
     const type = typeof value;
     if (type === 'object') {
-        return value.constructor.name;
+        return (value as object).constructor.name;
     }
 
     return type;

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -309,7 +309,7 @@ const timingMap: TimingMap = {};
  * @return {*}
  */
 export const logCall = (target: Object, propertyKey: string, descriptor: PropertyDescriptor) => {
-    const originalMethod = descriptor.value;
+    const originalMethod = descriptor.value as (...args: unknown[]) => unknown;
     //const logger = logging.getLogger('taskssql.perf');
     descriptor.value = function (...args: any[]) {
         const startTime = new Date(Date.now());
@@ -344,7 +344,7 @@ export const logCall = (target: Object, propertyKey: string, descriptor: Propert
 
 export function logCallDetails() {
     return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
-        const originalMethod = descriptor.value;
+        const originalMethod = descriptor.value as (...args: unknown[]) => Promise<unknown>;
         const logger = logging.getLogger('tasks');
 
         descriptor.value = async function (...args: any[]) {

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -4,6 +4,10 @@ import { RemoveTaskDate, SetTaskDate } from '../EditInstructions/DateInstruction
 import type { AllTaskDateFields } from '../../DateTime/DateFieldTypes';
 import type { TaskSaver } from './TaskEditingMenu';
 
+interface LocaleWithWeekInfo extends Intl.Locale {
+    weekInfo?: { firstDay: number };
+}
+
 /**
  * A calendar date picker which edits a date value in a {@link Task} object.
  * @param parentElement
@@ -28,7 +32,7 @@ export function promptForDate(
         locale: {
             // Try to determine the first day of the week based on the locale, or use Monday
             // if unavailable
-            firstDayOfWeek: (new Intl.Locale(navigator.language) as any).weekInfo?.firstDay ?? 1,
+            firstDayOfWeek: (new Intl.Locale(navigator.language) as LocaleWithWeekInfo).weekInfo?.firstDay ?? 1,
         },
         onClose: async (selectedDates, _dateStr, instance) => {
             if (selectedDates.length > 0) {


### PR DESCRIPTION
# Types of changes


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

The Obsidian team seems to be getting a bit stricter with addressing code warnings, so I wanted to see what was involved in addressing some of the `@typescript-eslint/no-unsafe-member-access` tslint error messages in the `src/` directory.

## Motivation and Context

See above.

## How has this been tested?

- Running the tests
- Confirming that the core and custom status settings editing still works
- Check console logging still works
- Check date picker on tasks in search results still works
- Check query file defaults are still added to Obsidian vault's types.json
- Check auto-suggest in Kanban cards still works
- Check 'Tasks: Add all Query File Defaults properties' command still works

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
    - Manual testing done for all changes where there are not existing tests

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
