### PR TITLE
refactor: improved HTML sanitization

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,7 +49,6 @@ const typescriptCommonRules = {
 
     // Bulk-disable new rules that fail, in order to be able to enable them
     // incrementally later on.
-    '@microsoft/sdl/no-inner-html': on_or_off,
     '@typescript-eslint/no-base-to-string': on_or_off,
     '@typescript-eslint/no-deprecated': on_or_off, // in tests: `toThrowError` is deprecated. in favor of `toThrow`
     '@typescript-eslint/no-explicit-any': on_or_off,
@@ -111,7 +110,6 @@ export default defineConfig([
         },
         rules:  {
             ...typescriptCommonRules,
-            '@microsoft/sdl/no-inner-html': 0,
             '@typescript-eslint/no-base-to-string': 0,
             '@typescript-eslint/no-deprecated': 0, // in tests: `toThrowError` is deprecated. in favor of `toThrow`
             '@typescript-eslint/no-explicit-any': 0,

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -1,4 +1,4 @@
-import { Notice, PluginSettingTab, Setting, debounce } from 'obsidian';
+import { Notice, PluginSettingTab, Setting, debounce, sanitizeHTMLToDom } from 'obsidian';
 import { StatusConfiguration, StatusType } from '../Statuses/StatusConfiguration';
 import type TasksPlugin from '../main';
 import { StatusRegistry } from '../Statuses/StatusRegistry';
@@ -64,8 +64,7 @@ export class SettingsTab extends PluginSettingTab {
         this.events = events;
     }
 
-    private static createFragmentWithHTML = (html: string) =>
-        createFragment((documentFragment) => (documentFragment.createDiv().innerHTML = html));
+    private static createFragmentWithHTML = (html: string) => sanitizeHTMLToDom(html);
 
     public async saveSettings(update?: boolean): Promise<void> {
         await this.plugin.saveSettings();
@@ -689,7 +688,7 @@ export class SettingsTab extends PluginSettingTab {
                     text: setting.notice.text ?? '',
                 });
                 if (setting.notice.html !== null) {
-                    notice.insertAdjacentHTML('beforeend', setting.notice.html);
+                    notice.append(sanitizeHTMLToDom(setting.notice.html));
                 }
             }
         });

--- a/src/Renderer/HtmlQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlQueryResultsRenderer.ts
@@ -103,7 +103,8 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
 
     protected renderErrorMessage(errorMessage: string): void {
         const container = createAndAppendElement('div', this.content);
-        container.innerHTML = '<pre>' + `Tasks query: ${errorMessage.replace(/\n/g, '<br>')}` + '</pre>';
+        const pre = createAndAppendElement('pre', container);
+        pre.textContent = `Tasks query: ${errorMessage}`;
     }
 
     protected renderLoadingMessage(): void {

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -285,7 +285,7 @@ export class TaskLineRenderer {
         if (component === TaskLayoutComponent.Description) {
             return await this.renderDescription(task, span, isTaskInQueryFile);
         }
-        span.innerHTML = componentString;
+        span.textContent = componentString;
     }
 
     private async renderDescription(task: Task, span: HTMLSpanElement, isTaskInQueryFile: boolean) {

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_error_message.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_error_message.approved.html
@@ -4,6 +4,9 @@
 
 <div>
   <div>
-    <pre>Tasks query: do not understand query<br>Problem line: "apple sauce"</pre>
+    <pre>
+Tasks query: do not understand query
+Problem line: "apple sauce"</pre
+    >
   </div>
 </div>

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_error_message_with_ampersand_and_quotes.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_error_message_with_ampersand_and_quotes.approved.html
@@ -1,0 +1,16 @@
+<!--
+  - [ ] Do exercises #todo #health 🆔 abcdef ⛔ 123456,abc123 🔼 🔁 every day when done 🏁 delete ➕ 2023-07-01 🛫 2023-07-02 ⏳ 2023-07-03 📅 2023-07-04 ❌ 2023-07-06 ✅ 2023-07-05 ^dcf64c
+-->
+
+<div>
+  <div>
+    <pre>
+Tasks query: Could not interpret the following instruction as a Boolean combination:
+    this &amp; that "test"
+
+The error message is:
+    All filters in a Boolean instruction must be inside one of these pairs of delimiter characters: (...) or [...] or {...} or "...". Combinations of those delimiters are no longer supported.
+Problem line: "this &amp; that "test""</pre
+    >
+  </div>
+</div>

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_error_message_with_angle_brackets.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_error_message_with_angle_brackets.approved.html
@@ -1,0 +1,12 @@
+<!--
+  - [ ] Do exercises #todo #health 🆔 abcdef ⛔ 123456,abc123 🔼 🔁 every day when done 🏁 delete ➕ 2023-07-01 🛫 2023-07-02 ⏳ 2023-07-03 📅 2023-07-04 ❌ 2023-07-06 ✅ 2023-07-05 ^dcf64c
+-->
+
+<div>
+  <div>
+    <pre>
+Tasks query: do not understand query
+Problem line: "price&lt;10 &amp; value&gt;5"</pre
+    >
+  </div>
+</div>

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.ts
@@ -78,6 +78,16 @@ describe('HtmlQueryResultsRenderer tests', () => {
         await verifyRenderedHtml(allTasks, 'apple sauce');
     });
 
+    it('error message with angle brackets', async () => {
+        const allTasks = [TaskBuilder.createFullyPopulatedTask()];
+        await verifyRenderedHtml(allTasks, 'price<10 & value>5');
+    });
+
+    it('error message with ampersand and quotes', async () => {
+        const allTasks = [TaskBuilder.createFullyPopulatedTask()];
+        await verifyRenderedHtml(allTasks, 'this & that "test"');
+    });
+
     it('explain', async () => {
         GlobalQuery.getInstance().set('hide toolbar');
         const allTasks = [TaskBuilder.createFullyPopulatedTask()];

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_-_rendering_queries_should_render_search-time_error.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_-_rendering_queries_should_render_search-time_error.approved.html
@@ -11,6 +11,10 @@
     <button test-icon="lucide-copy" test-tooltip="Copy results"></button>
   </div>
   <div>
-    <pre>Tasks query: Error: Search failed.<br>The error message was:<br>    "Error: "undefined" is not a valid sort key: while evaluating instruction 'sort by function task.linenumer'"</pre>
+    <pre>
+Tasks query: Error: Search failed.
+The error message was:
+    "Error: "undefined" is not a valid sort key: while evaluating instruction 'sort by function task.linenumer'"</pre
+    >
   </div>
 </div>

--- a/tests/Renderer/RenderingTestHelpers.ts
+++ b/tests/Renderer/RenderingTestHelpers.ts
@@ -15,7 +15,11 @@ export const mockHTMLRenderer = async (_obsidianApp: App, text: string, element:
     // instead of the rendered HTMLSpanElement.innerText,
     // we need the plain HTML here like in TaskLineRenderer.renderComponentText(),
     // to ensure that description and tags are retained.
-    element.innerHTML = text;
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(text, 'text/html');
+    while (doc.body.firstChild) {
+        element.appendChild(doc.body.firstChild);
+    }
 };
 
 export const mockTextRenderer = async (_obsidianApp: App, text: string, element: HTMLSpanElement, _path: string) => {


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The changeset addresses the existing linting issues related to the `@microsoft/sdl/no-inner-html` ESLint rule. This rule is enabled by default in the recommended ruleset of the Obsidian ESLint plugin. As a result of the changes, this rule is no longer disabled. All usages of `innerHTML` have been replaced.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The changeset has been tested against all existing test cases. In addition, two regression tests have been added to test for proper sanitization of HTML-like characters (e.g. `<`, `>`, `&`) which would previously been handled as HTML. Two approval test results have been updated due to backtick strings in `<pre>` elements already keeping newlines, thus rendering the previous `\n` to `<br>` replacement redundant. The resulting approval test results are visually identical when rendered.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
