### PR TITLE
fix!!: For security, JS search features now disabled by default, with setting to enable

### DIFF
--- a/contributing/.obsidian/plugins/obsidian-plugin-update-tracker/data.json
+++ b/contributing/.obsidian/plugins/obsidian-plugin-update-tracker/data.json
@@ -2,6 +2,7 @@
   "daysToSuppressNewUpdates": 0,
   "dismissedVersionsByPluginId": {},
   "showIconOnMobile": true,
+  "showNotificationOnNewUpdate": false,
   "excludeBetaVersions": true,
   "excludeDisabledPlugins": true,
   "minUpdateCountToShowIcon": 1,

--- a/contributing/Architecture Decisions/ADR-002 - Security Response to JavaScript Execution in Queries.md
+++ b/contributing/Architecture Decisions/ADR-002 - Security Response to JavaScript Execution in Queries.md
@@ -6,7 +6,9 @@ publish: true
 
 ## Status
 
-**ACCEPTED** - Decision made on 2026-05-04
+**ACCEPTED** - Decision made on 2026-04-20
+
+Implementation completed on 2026-05-07 after discussion with the Obsidian team.
 
 ## Context
 
@@ -53,8 +55,8 @@ filter by function task.tags.find( (tag) => tag.includes('/') ) && true || false
 
 The `new Function()` call in `Expression.ts` executing this JavaScript is therefore working
 as designed. A user typing `filter by function require('child_process').execSync('calc')`
-into their own vault is running their own code, which is no different in principle from using
-the browser console.
+into their own vault is intentionally running privileged JavaScript inside Obsidian, similar
+in effect to running code in the developer console.
 
 ### The Placeholder Expansion Path
 
@@ -69,6 +71,11 @@ This means the attack path and the legitimate usage path are structurally identi
 the expander's perspective. Both involve content containing `{{...}}` that resolves through
 multiple passes. Blocking re-expansion, or escaping `{{`/`}}` in resolved values, would
 break legitimate user workflows.
+
+Some placeholder expressions also use JavaScript-like syntax, for example, function calls
+such as `{{query.file.property('task_instruction')}}`. These are safe when they resolve to
+known placeholder behaviour, but the syntax means the implementation must distinguish
+between documented placeholder forms and arbitrary JavaScript expressions.
 
 ### The Obsidian Trust Model
 
@@ -141,16 +148,20 @@ API access. Would imply the issue is resolved when it is not, creating false con
 
 ### 5. Opt-in plugin setting to enable JavaScript execution
 
-Add a plugin setting, disabled by default, that gates the `filter|sort|group by function`
-functionality. Users who wish to use this feature must explicitly enable it and acknowledge
+Add a plugin setting, disabled by default, that gates JavaScript execution in Tasks queries.
+This includes the `filter|sort|group by function` functionality and arbitrary JavaScript
+expressions in placeholders.
+
+Users who wish to use these features must explicitly enable the setting and acknowledge
 the associated risk. This is consistent with how some other Obsidian plugins handle the same
 situation, for example:
 
 > "Enable JavaScript — Enable features that run user written JavaScript. This is
 > potentially DANGEROUS, thus it's disabled by default."
 
-When the feature is disabled and a query contains a `by function` instruction, the query
-would fail with a clear, actionable error message directing the user to the setting.
+When the feature is disabled and a query contains a `by function` instruction, or an
+unsupported placeholder requiring JavaScript evaluation, the query would fail with a clear,
+actionable error message directing the user to the setting.
 
 **Assessment:** Selected. See rationale below.
 
@@ -165,12 +176,25 @@ regardless. Does not address the placeholder expansion path at all.
 
 ## Decision
 
-Add a plugin setting — **disabled by default** — that gates the `filter by function`,
-`sort by function`, and `group by function` functionality.
+Add a plugin setting — **disabled by default** — that gates JavaScript execution in Tasks
+queries.
+
+This setting applies to:
+
+- `filter by function`
+- `sort by function`
+- `group by function`
+- arbitrary JavaScript expressions in placeholders
 
 When the setting is disabled (the default for new installs and existing installs after
-the upgrade), any query containing a `by function` instruction will fail with a clear
-error message that names the setting and explains why it exists.
+the upgrade), any query containing JavaScript execution will fail with a clear error message
+that names the setting and explains why it exists.
+
+Documented placeholder forms that can be resolved without arbitrary JavaScript execution
+may continue to work while the setting is disabled.
+
+This is a consent and communication response, not a sandbox. Enabling the setting restores
+arbitrary JavaScript execution with the privileges available to the Tasks plugin.
 
 Additionally, raise the issue with the Obsidian team, as the underlying vault trust model
 is a platform-level concern.
@@ -195,15 +219,15 @@ function` are engaged enough to find a settings toggle.
 
 ### Positive
 
-- Existing `by function` users are unaffected once they enable the setting.
+- Existing users of JavaScript in Tasks queries are unaffected once they enable the setting.
 - New users and users upgrading are prompted to make an explicit, informed choice.
 - The plugin's position on JavaScript execution is clearly communicated.
 - Consistent with the broader Obsidian plugin ecosystem norms.
 
 ### Negative
 
-- Breaking change: all existing `by function` queries stop working until the user enables
-  the setting.
+- Breaking change: all existing queries that rely on JavaScript execution stop working until
+  the user enables the setting.
 - Users will inevitably file bug reports, though a clear error message should reduce these
   significantly compared to a silent failure.
 - Users may enable the setting without reading the warning, limiting the practical security
@@ -212,21 +236,22 @@ function` are engaged enough to find a settings toggle.
 ### Neutral
 
 - The underlying technical capability (`new Function()`) is unchanged.
-- The placeholder expansion path is unchanged.
+- The iterative placeholder expansion mechanism is unchanged, but JavaScript evaluation
+  during expansion is gated by the setting.
 - The Obsidian-level trust model is unchanged; this decision acknowledges that and routes
   the systemic concern appropriately.
 
-## Open Questions
+## Other Questions
 
 1. Should the setting warning text mention specific risks (filesystem access, data
    exfiltration) or remain general?
+    - Yes, it should say enough to convey to users the severity of the concern if they could run untrusted code.
 2. Should the error message shown to users when the setting is disabled link to
    documentation?
-3. Should there be a separate setting for placeholder-based JavaScript execution
-   (`{{query.file.property(...)}}` expressions) vs. `by function` instructions, or is one
-   combined setting clearer?
-4. What should the migration story be for users upgrading from an older version — silent
+    - Yes. Implemented.
+3. What should the migration story be for users upgrading from an older version — silent
    disable, or a one-time modal prompt?
+    - Silent. Because of time limitations and the importance of getting the release out.
 
 ## Further Work
 

--- a/contributing/Architecture Decisions/ADR-002 - Security Response to JavaScript Execution in Queries.md
+++ b/contributing/Architecture Decisions/ADR-002 - Security Response to JavaScript Execution in Queries.md
@@ -1,0 +1,243 @@
+---
+publish: true
+---
+
+# ADR-002 - Security Response to JavaScript Execution in Queries
+
+## Status
+
+**DRAFT** - Pending feedback before implementation
+
+## Context
+
+### The Reported Vulnerability
+
+A security report (recorded 2026-04-20) described a Remote Code Execution (RCE) vulnerability
+in the Tasks plugin, rated high severity (8.6). The report identified a path by which untrusted content could reach code execution:
+
+1. `Expression.ts` uses `new Function()` to compile and execute arbitrary JavaScript strings.
+2. `ExpandPlaceholders.ts` feeds the contents of `{{...}}` placeholders directly into that evaluator.
+3. `TasksFile.property()` returns raw frontmatter values with no sanitisation.
+4. Query parsing calls `expandPlaceholders()` iteratively.
+
+The claimed exploit path was: attacker-controlled note frontmatter → `property()` → inserted into
+query string → re-expanded as a placeholder → compiled and executed by `new Function()`.
+
+The reporter also noted a simpler direct exploit requiring no placeholder expansion at all:
+
+```js
+filter by function require('child_process').execSync('calc') || true
+```
+
+The full report cited four source locations:
+
+- [`src/Scripting/Expression.ts:23`](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/4ac2e5a4a0109cca46a12439def3ecece24211b4/src/Scripting/Expression.ts#L23)
+- [`src/Scripting/ExpandPlaceholders.ts:68-70`](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/4ac2e5a4a0109cca46a12439def3ecece24211b4/src/Scripting/ExpandPlaceholders.ts#L68-L70)
+- [`src/Query/Query.ts:200`](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/4ac2e5a4a0109cca46a12439def3ecece24211b4/src/Query/Query.ts#L200)
+- [`src/Scripting/TasksFile.ts:230`](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/4ac2e5a4a0109cca46a12439def3ecece24211b4/src/Scripting/TasksFile.ts#:L230)
+
+### The `filter|sort|group by function` Feature
+
+The `filter by function`, `sort by function`, and `group by function` instructions are
+intentional, documented features that allow users to write arbitrary JavaScript expressions
+to filter, sort, and group their tasks. This is a deliberately powerful facility, with
+hundreds of documented examples, and is in active use across a large user base.
+
+Example legitimate uses include:
+
+```js
+filter by function task.due.moment?.isSameOrBefore(moment(), 'day') || false
+filter by function task.file.property("sample_list_property")?.length > 0
+filter by function task.tags.find( (tag) => tag.includes('/') ) && true || false
+```
+
+The `new Function()` call in `Expression.ts` executing this JavaScript is therefore working
+as designed. A user typing `filter by function require('child_process').execSync('calc')`
+into their own vault is running their own code, which is no different in principle from using
+the browser console.
+
+### The Placeholder Expansion Path
+
+The iterative placeholder expansion is also legitimate and necessary. The plugin supports:
+
+- `{{query.file.property('task_instruction')}}` — expanding a frontmatter property value into a query
+- `{{preset.standard_options}}` — expanding a named preset from plugin settings
+- Preset values that themselves contain placeholders (e.g. `{{query.file.folder}}`)
+- Frontmatter values (e.g. `TQ_extra_instructions`) that contain multiple query lines, some of which contain `{{preset...}}` or similar placeholders
+
+This means the attack path and the legitimate usage path are structurally identical from
+the expander's perspective. Both involve content containing `{{...}}` that resolves through
+multiple passes. Blocking re-expansion, or escaping `{{`/`}}` in resolved values, would
+break legitimate user workflows.
+
+### The Obsidian Trust Model
+
+Obsidian plugins run with full access to the user's filesystem and the Node.js/Electron
+environment. Obsidian itself is not sandboxed. This means:
+
+- Even if `require('child_process')` were blocked, an attacker could use `app.vault.adapter.fs`
+  to access the filesystem directly.
+- Any plugin that evaluates user-supplied JavaScript has this same property.
+- The vault trust model — where the vault owner is implicitly trusted — is an Obsidian-wide
+  concern, not specific to the Tasks plugin.
+
+The reporter cited a Git plugin as a potential vector for introducing malicious vault content.
+This is a real concern, but it is a general Obsidian platform issue rather than a Tasks
+plugin issue specifically.
+
+An experienced Obsidian plugin developer consulted during this analysis noted:
+
+> The risk is real and it stems from you allowing arbitrary code execution. However,
+> Obsidian itself is not really sandboxed, so even with a banned `require()`, you can
+> still access the entire file system via `app.vault.adapter.fs`.
+
+## Options Considered
+
+### 1. Do nothing / documentation only
+
+Document clearly that `filter by function` executes JavaScript with full plugin privileges,
+and that vault content from untrusted sources carries the same risks as running untrusted
+code generally.
+
+**Assessment:** Honest framing of the situation, but "doing nothing is not an option" given
+a formal security report has been filed. Insufficient as a sole response.
+
+### 2. Break the re-expansion loop
+
+Only call `expandPlaceholders()` once per query, so injected `{{...}}` content from frontmatter
+can never be re-evaluated.
+
+**Assessment:** Rejected. Legitimate use cases (presets containing placeholders,
+`TQ_extra_instructions` with `{{preset...}}` references) require iterative expansion.
+
+### 3. Escape `{{`/`}}` in resolved placeholder values
+
+After resolving any `{{query.file.property(...)}}` placeholder, escape the result before
+reinserting it into the template.
+
+**Assessment:** Rejected for the same reason as option 2. Legitimate frontmatter values
+intentionally contain `{{...}}` that must be further expanded.
+
+### 4. Override `require()` with a safe version
+
+Pass a `safeRequire` function as a parameter to `new Function()`, blocking known dangerous
+modules such as `child_process`.
+
+```js
+const fn = new Function('require', fnText);
+fn(safeRequire);
+
+function safeRequire(id) {
+  if (id === 'child_process' || id === 'node:child_process') {
+    throw new Error('child_process is banned');
+  }
+  return window.require(id);
+}
+```
+
+**Assessment:** Rejected as security theatre. Closes only the specific reported Proof of Concept.
+Does not block `app.vault.adapter.fs`, `fetch()`, DOM manipulation, or other Obsidian
+API access. Would imply the issue is resolved when it is not, creating false confidence.
+
+### 5. Opt-in plugin setting to enable JavaScript execution
+
+Add a plugin setting, disabled by default, that gates the `filter|sort|group by function`
+functionality. Users who wish to use this feature must explicitly enable it and acknowledge
+the associated risk. This is consistent with how some other Obsidian plugins handle the same
+situation, for example:
+
+> "Enable JavaScript — Enable features that run user written JavaScript. This is
+> potentially DANGEROUS, thus it's disabled by default."
+
+When the feature is disabled and a query contains a `by function` instruction, the query
+would fail with a clear, actionable error message directing the user to the setting.
+
+**Assessment:** Selected. See rationale below.
+
+### 6. Improve the core query language to reduce reliance on `by function`
+
+Over time, add built-in query instructions that cover the most common `filter by function`
+use cases, reducing the need for users to write JavaScript.
+
+**Assessment:** Worthwhile as an independent product quality improvement, but not a security
+mitigation. The `by function` escape hatch would remain in place and in use for years
+regardless. Does not address the placeholder expansion path at all.
+
+## Decision
+
+Add a plugin setting — **disabled by default** — that gates the `filter by function`,
+`sort by function`, and `group by function` functionality.
+
+When the setting is disabled (the default for new installs and existing installs after
+the upgrade), any query containing a `by function` instruction will fail with a clear
+error message that names the setting and explains why it exists.
+
+Additionally, raise the issue with the Obsidian team, as the underlying vault trust model
+is a platform-level concern.
+
+## Rationale
+
+This is the only option that is both technically honest and communicates genuine intent to
+users:
+
+- It does not pretend to close a hole that remains open.
+- It is consistent with community norms among Obsidian plugins.
+- It places informed consent where it belongs — with the user who chooses to enable a
+  powerful feature.
+- It does not break any existing functionality silently; users receive a clear prompt to act.
+- A clear, actionable error message will absorb the majority of support burden from the
+  migration.
+
+The breaking-change cost is real but one-time. Users who care enough to use `filter by
+function` are engaged enough to find a settings toggle.
+
+## Consequences
+
+### Positive
+
+- Existing `by function` users are unaffected once they enable the setting.
+- New users and users upgrading are prompted to make an explicit, informed choice.
+- The plugin's position on JavaScript execution is clearly communicated.
+- Consistent with the broader Obsidian plugin ecosystem norms.
+
+### Negative
+
+- Breaking change: all existing `by function` queries stop working until the user enables
+  the setting.
+- Users will inevitably file bug reports, though a clear error message should reduce these
+  significantly compared to a silent failure.
+- Users may enable the setting without reading the warning, limiting the practical security
+  gain for that population — though this is inherent to any opt-in model.
+
+### Neutral
+
+- The underlying technical capability (`new Function()`) is unchanged.
+- The placeholder expansion path is unchanged.
+- The Obsidian-level trust model is unchanged; this decision acknowledges that and routes
+  the systemic concern appropriately.
+
+## Open Questions
+
+1. Should the setting warning text mention specific risks (filesystem access, data
+   exfiltration) or remain general?
+2. Should the error message shown to users when the setting is disabled link to
+   documentation?
+3. Should there be a separate setting for placeholder-based JavaScript execution
+   (`{{query.file.property(...)}}` expressions) vs. `by function` instructions, or is one
+   combined setting clearer?
+4. What should the migration story be for users upgrading from an older version — silent
+   disable, or a one-time modal prompt?
+
+## Further Work
+
+- Implementation of the opt-in setting and associated error messaging.
+- User-facing documentation update explaining the setting and the reasoning behind it.
+- Raise the vault trust model concern with the Obsidian team.
+- Longer-term: continue improving the core query language to reduce the need for
+  `by function` in common cases.
+
+---
+
+**Decision made by:** Clare Macrae
+**Date:** 2026-04-20
+**ADR Number:** 002

--- a/contributing/Architecture Decisions/ADR-002 - Security Response to JavaScript Execution in Queries.md
+++ b/contributing/Architecture Decisions/ADR-002 - Security Response to JavaScript Execution in Queries.md
@@ -6,7 +6,7 @@ publish: true
 
 ## Status
 
-**DRAFT** - Pending feedback before implementation
+**ACCEPTED** - Decision made on 2026-05-04
 
 ## Context
 
@@ -230,9 +230,7 @@ function` are engaged enough to find a settings toggle.
 
 ## Further Work
 
-- Implementation of the opt-in setting and associated error messaging.
 - User-facing documentation update explaining the setting and the reasoning behind it.
-- Raise the vault trust model concern with the Obsidian team.
 - Longer-term: continue improving the core query language to reduce the need for
   `by function` in common cases.
 

--- a/contributing/Architecture Decisions/About Architecture Decisions.md
+++ b/contributing/Architecture Decisions/About Architecture Decisions.md
@@ -11,3 +11,4 @@ This a collection of [Architecture decision records (ADRs)](https://github.com/j
 If a design decision was non-obvious, we will record the thought process here.
 
 - [[ADR-001 - Nomenclature for Reusable Instruction Blocks Feature]]
+- [[ADR-002 - Security Response to JavaScript Execution in Queries]]

--- a/docs/Scripting/About Scripting.md
+++ b/docs/Scripting/About Scripting.md
@@ -15,6 +15,11 @@ We are using the word 'scripting' in a very loose sense here:
 - For now, it refers only to writing JavaScript expressions in Tasks query blocks.
 - It is intended to evolve in to something broader over time.
 
+> [!warning] JavaScript must be enabled
+> Most of these instructions in this section execute JavaScript and require [[JavaScript in Tasks Queries|JavaScript in Tasks queries]] to be enabled.
+> Only enable it if you trust the current and future contents of the vault.
+> This requirement was added in Tasks X.Y.Z.
+
 ## Placeholder capabilities
 
 - [[Placeholders]] - use placeholder text in native Tasks queries, such as  `{{query.file.path}}` to refer to some properties of the file containing the query.

--- a/docs/Scripting/Custom Filters.md
+++ b/docs/Scripting/Custom Filters.md
@@ -9,6 +9,11 @@ publish: true
 > [!released]
 > Custom filters were introduced in Tasks 4.2.0.
 
+> [!warning] JavaScript must be enabled
+> This feature executes JavaScript and requires [[JavaScript in Tasks Queries|JavaScript in Tasks queries]] to be enabled.  
+> Only enable it if you trust the current and future contents of the vault.  
+> This requirement was added in Tasks X.Y.Z.
+
 ## Summary
 
 - Define your own custom task filters, using JavaScript expressions such as:

--- a/docs/Scripting/Custom Grouping.md
+++ b/docs/Scripting/Custom Grouping.md
@@ -9,6 +9,11 @@ publish: true
 > [!released]
 > Custom grouping was introduced in Tasks 4.0.0.
 
+> [!warning] JavaScript must be enabled
+> This feature executes JavaScript and requires [[JavaScript in Tasks Queries|JavaScript in Tasks queries]] to be enabled.
+> Only enable it if you trust the current and future contents of the vault.
+> This requirement was added in Tasks X.Y.Z.
+
 ## Summary
 
 - Define your own custom task groups, using JavaScript expressions such as:

--- a/docs/Scripting/Custom Sorting.md
+++ b/docs/Scripting/Custom Sorting.md
@@ -9,6 +9,11 @@ publish: true
 > [!released]
 > Custom sorting was introduced in Tasks 6.0.0.
 
+> [!warning] JavaScript must be enabled
+> This feature executes JavaScript and requires [[JavaScript in Tasks Queries|JavaScript in Tasks queries]] to be enabled.
+> Only enable it if you trust the current and future contents of the vault.
+> This requirement was added in Tasks X.Y.Z.
+
 ## Summary
 
 - Define your own custom task sort order, using JavaScript expressions such as:

--- a/docs/Scripting/Expressions.md
+++ b/docs/Scripting/Expressions.md
@@ -9,6 +9,11 @@ publish: true
 > [!released]
 > Expressions were introduced in Tasks 4.0.0.
 
+> [!warning] JavaScript must be enabled
+> This facility executes JavaScript and requires [[JavaScript in Tasks Queries|JavaScript in Tasks queries]] to be enabled.
+> Only enable it if you trust the current and future contents of the vault.
+> This requirement was added in Tasks X.Y.Z.
+
 ## Introduction
 
 > [!Note]

--- a/docs/Scripting/JavaScript in Tasks Queries.md
+++ b/docs/Scripting/JavaScript in Tasks Queries.md
@@ -1,5 +1,9 @@
 # JavaScript in Tasks Queries
 
+> [!released]
+> Since Tasks X.Y.Z, JavaScript in Tasks queries is disabled by default.
+> This was a breaking change for users of `filter by function`, `sort by function`, and `group by function`.
+
 Some advanced Tasks query instructions can execute JavaScript:
 
 - `filter by function`

--- a/docs/Scripting/JavaScript in Tasks Queries.md
+++ b/docs/Scripting/JavaScript in Tasks Queries.md
@@ -30,6 +30,8 @@ You are affected if you use any of these instructions in Tasks query blocks:
 - `sort by function`
 - `group by function`
 
+Some users may also be affected if they rely on undocumented JavaScript expressions inside `{{...}}` placeholders. Documented placeholders continue to work without enabling JavaScript.
+
 Most Tasks users are not affected. Regular filters, sorting, grouping, presets, and documented non-JavaScript placeholders continue to work without this setting.
 
 ## How to enable JavaScript in Tasks queries

--- a/docs/Scripting/JavaScript in Tasks Queries.md
+++ b/docs/Scripting/JavaScript in Tasks Queries.md
@@ -63,7 +63,7 @@ For example, these do not require JavaScript:
 
 - regular filters such as `not done`, `due before tomorrow`, and `path includes ...`
 - regular sorting and grouping instructions
-- presets
+- presets that only use instructions that do not require JavaScript
 - documented non-JavaScript placeholders such as `{{query.file.path}}`
 - documented file-property placeholders such as `{{query.file.property("name")}}`
 
@@ -89,7 +89,7 @@ If you sync your vault between devices, enable **Enable custom searches** on eac
 
 ### Do I need to rewrite my existing queries?
 
-No. Existing `filter by function`, `sort by function`, and `group by function` queries can continue to work unchanged once you enable **Enable custom searches**.
+No. Existing `filter by function`, `sort by function`, and `group by function` queries can continue to work unchanged once you enable **Enable custom searches**, if you feel it is safe to do so.
 
 ## See also
 

--- a/docs/Scripting/JavaScript in Tasks Queries.md
+++ b/docs/Scripting/JavaScript in Tasks Queries.md
@@ -1,0 +1,91 @@
+# JavaScript in Tasks Queries
+
+Some advanced Tasks query instructions can execute JavaScript:
+
+- `filter by function`
+- `sort by function`
+- `group by function`
+
+These instructions are powerful, but JavaScript in Tasks queries runs inside Obsidian. Malicious JavaScript in a Tasks query or Markdown file could access or modify your vault contents, local files, or other system resources.
+
+For this reason, JavaScript in Tasks queries is disabled by default.
+
+## What changed?
+
+Tasks no longer runs JavaScript in queries by default.
+
+If a query uses `filter by function`, `sort by function`, or `group by function`, it will not run until JavaScript in Tasks queries is enabled.
+
+Existing queries do not need to be rewritten. To restore the previous behaviour, enable the setting described below.
+
+## Who is affected?
+
+You are affected if you use any of these instructions in Tasks query blocks:
+
+- `filter by function`
+- `sort by function`
+- `group by function`
+
+Most Tasks users are not affected. Regular filters, sorting, grouping, presets, and documented non-JavaScript placeholders continue to work without this setting.
+
+## How to enable JavaScript in Tasks queries
+
+To enable JavaScript in Tasks queries:
+
+1. Open Obsidian **Settings**.
+2. Go to **Tasks**.
+3. Find **Searches**.
+4. Enable **Enable custom searches**.
+
+Only enable this if you trust the current and future contents of this vault, including files you may later download, copy, or sync from other people.
+
+This setting is stored on this device only. If you sync this vault to other devices, you must enable the setting separately on each device.
+
+## Why this setting exists
+
+JavaScript in Tasks queries is intentionally powerful. It allows custom searches, sorts, and groups that are not possible with the built-in query language alone.
+
+However, that power also carries risk. JavaScript in a Tasks query can run inside Obsidian. If malicious query text is present in your vault, including inside downloaded or synced Markdown files, it could access or modify vault contents, local files, or other system resources.
+
+Disabling JavaScript by default means users must make an explicit choice before allowing this behaviour.
+
+## What still works when JavaScript is disabled?
+
+Most Tasks query features continue to work when JavaScript is disabled.
+
+For example, these do not require JavaScript:
+
+- regular filters such as `not done`, `due before tomorrow`, and `path includes ...`
+- regular sorting and grouping instructions
+- presets
+- documented non-JavaScript placeholders such as `{{query.file.path}}`
+- documented file-property placeholders such as `{{query.file.property("name")}}`
+
+## Troubleshooting
+
+### I see an error saying JavaScript is disabled
+
+This means the query uses JavaScript, usually through one of these instructions:
+
+- `filter by function`
+- `sort by function`
+- `group by function`
+
+To allow the query to run, enable **Settings** → **Tasks** → **Searches** → **Enable custom searches**.
+
+Only do this if you trust the contents of the vault.
+
+### It works on one device but not another
+
+The setting is stored separately on each device.
+
+If you sync your vault between devices, enable **Enable custom searches** on each device where you want JavaScript in Tasks queries to run.
+
+### Do I need to rewrite my existing queries?
+
+No. Existing `filter by function`, `sort by function`, and `group by function` queries can continue to work unchanged once you enable **Enable custom searches**.
+
+## See also
+
+- [[Breaking Changes]]
+- [Obsidian plugin security](https://obsidian.md/help/plugin-security)

--- a/docs/What is New/Breaking Changes.md
+++ b/docs/What is New/Breaking Changes.md
@@ -28,6 +28,8 @@ To help users updating across multiple Tasks releases, we collect here links to 
 Tasks queries no longer execute JavaScript by default. This affects `filter by function`,
 `sort by function`, and `group by function` instructions.
 
+Some users may also be affected if they rely on undocumented JavaScript expressions inside `{{...}}` placeholders.
+
 If you use these instructions, your queries will now show an error until you enable the
 setting **Tasks → Searches → Enable custom searches**.
 

--- a/docs/What is New/Breaking Changes.md
+++ b/docs/What is New/Breaking Changes.md
@@ -19,6 +19,28 @@ In this case, as we use [semantic versioning](https://semver.org), we will alway
 
 To help users updating across multiple Tasks releases, we collect here links to the few Tasks breaking changes - most recent first.
 
+## Tasks 8.0.0 (May 2026)
+
+*Release notes: [Tasks 8.0.0](https://github.com/obsidian-tasks-group/obsidian-tasks/releases/tag/780.0).*
+
+### JavaScript in Tasks queries is now disabled by default
+
+Tasks queries no longer execute JavaScript by default. This affects `filter by function`,
+`sort by function`, and `group by function` instructions.
+
+If you use these instructions, your queries will now show an error until you enable the
+setting **Tasks → Searches → Enable custom searches**.
+
+This change was made because JavaScript in Tasks queries can run inside Obsidian and could
+access or modify vault contents, local files, or other system resources. Only enable this
+setting if you trust the current and future contents of the vault, including Markdown files
+downloaded, copied, or synced from other people.
+
+The setting is stored separately on each device, so if you sync your vault between devices,
+you must enable it separately on each device where you want to use custom searches.
+
+See [[JavaScript in Tasks Queries]] for details.
+
 ## Tasks 7.0.0 (14 April 2024)
 
 *Release notes: [Tasks 7.0.0](https://github.com/obsidian-tasks-group/obsidian-tasks/releases/tag/7.0.0).*

--- a/docs/What is New/Changelog.md
+++ b/docs/What is New/Changelog.md
@@ -10,6 +10,14 @@ See also [[Breaking Changes]]: Tasks releases with version numbers ending `.0.0`
 
 _In recent [Tasks releases](https://github.com/obsidian-tasks-group/obsidian-tasks/releases)..._
 
+## 8.x releases
+
+- X.Y.Z:
+  - **Breaking change**:
+    - JavaScript in Tasks queries is now disabled by default.
+    - This affects `filter by function`, `sort by function`, and `group by function`.
+    - See [[JavaScript in Tasks Queries]] before deciding whether to enable it.
+
 ## 7.x releases
 
 - 7.24.0:

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,9 @@ module.exports = {
 
     // A list of paths to modules that run some code to configure or
     // set up the testing framework before each test.
-    setupFilesAfterEnv: ['<rootDir>/tests/CustomMatchers/jest.custom_matchers.setup.ts'],
+    setupFilesAfterEnv: [
+        '<rootDir>/tests/jest.setup.ts',
+        '<rootDir>/tests/CustomMatchers/jest.custom_matchers.setup.ts',
+    ],
     globalSetup: './tests/global-setup.js',
 };

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "madge": "^8.0.0",
     "markdownlint-cli2": "^0.21.0",
     "moment": "^2.29.4",
-    "obsidian": "^1.4.0",
+    "obsidian": "1.8.7",
     "obsidian-typings": "^2.11.1",
     "prettier": "^2.8.8",
     "prettier-plugin-svelte": "^2.10.1",

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/data.json
@@ -14,7 +14,8 @@
     "daily_note_done_this_day": "# Tasks that have been done this day - requires YYYY-MM-DD file name\ndone\ndone {{query.file.filenameWithoutExtension}}",
     "filter_by_context": "filter by function let fn = (ctx) => task.tags.includes(`#context/${ctx}`); return fn",
     "extract_contexts_1": "ctx => task.tags.includes(`#context/${ctx}`)",
-    "extract_contexts_2": "(ctx => task.tags.includes(`#context/${ctx}`))"
+    "extract_contexts_2": "(ctx => task.tags.includes(`#context/${ctx}`))",
+    "path_includes_test_data": "path includes Test Data"
   },
   "globalQuery": "# Exclude templates files:\nroot does not include _meta\n\n# Ignore the sample tasks that demonstrate Theme and Snippet support:\npath does not include Manual Testing/SlrVb's Alternative Checkboxes\npath does not include Styling/Snippet -\npath does not include Styling/Theme -\n",
   "globalFilter": "#task",

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/manifest.json
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-tasks-plugin",
   "name": "Tasks",
-  "version": "7.22.0",
+  "version": "7.24.0",
   "minAppVersion": "1.4.0",
   "description": "Track tasks across your vault. Supports due dates, recurring tasks, done dates, sub-set of checklist items, and filtering.",
   "helpUrl": "https://publish.obsidian.md/tasks/",

--- a/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/styles.css
+++ b/resources/sample_vaults/Tasks-Demo/.obsidian/plugins/obsidian-tasks-plugin/styles.css
@@ -1,1 +1,1329 @@
-@charset "UTF-8";.flatpickr-calendar{background:transparent;opacity:0;display:none;text-align:center;visibility:hidden;padding:0;-webkit-animation:none;animation:none;direction:ltr;border:0;font-size:14px;line-height:24px;border-radius:5px;position:absolute;width:307.875px;-webkit-box-sizing:border-box;box-sizing:border-box;-ms-touch-action:manipulation;touch-action:manipulation;background:#fff;-webkit-box-shadow:1px 0 0 #e6e6e6,-1px 0 0 #e6e6e6,0 1px 0 #e6e6e6,0 -1px 0 #e6e6e6,0 3px 13px rgba(0,0,0,.08);box-shadow:1px 0 #e6e6e6,-1px 0 #e6e6e6,0 1px #e6e6e6,0 -1px #e6e6e6,0 3px 13px #00000014}.flatpickr-calendar.open,.flatpickr-calendar.inline{opacity:1;max-height:640px;visibility:visible}.flatpickr-calendar.open{display:inline-block;z-index:99999}.flatpickr-calendar.animate.open{-webkit-animation:fpFadeInDown .3s cubic-bezier(.23,1,.32,1);animation:fpFadeInDown .3s cubic-bezier(.23,1,.32,1)}.flatpickr-calendar.inline{display:block;position:relative;top:2px}.flatpickr-calendar.static{position:absolute;top:calc(100% + 2px)}.flatpickr-calendar.static.open{z-index:999;display:block}.flatpickr-calendar.multiMonth .flatpickr-days .dayContainer:nth-child(n+1) .flatpickr-day.inRange:nth-child(7n+7){-webkit-box-shadow:none!important;box-shadow:none!important}.flatpickr-calendar.multiMonth .flatpickr-days .dayContainer:nth-child(n+2) .flatpickr-day.inRange:nth-child(7n+1){-webkit-box-shadow:-2px 0 0 #e6e6e6,5px 0 0 #e6e6e6;box-shadow:-2px 0 #e6e6e6,5px 0 #e6e6e6}.flatpickr-calendar .hasWeeks .dayContainer,.flatpickr-calendar .hasTime .dayContainer{border-bottom:0;border-bottom-right-radius:0;border-bottom-left-radius:0}.flatpickr-calendar .hasWeeks .dayContainer{border-left:0}.flatpickr-calendar.hasTime .flatpickr-time{height:40px;border-top:1px solid #e6e6e6}.flatpickr-calendar.noCalendar.hasTime .flatpickr-time{height:auto}.flatpickr-calendar:before,.flatpickr-calendar:after{position:absolute;display:block;pointer-events:none;border:solid transparent;content:"";height:0;width:0;left:22px}.flatpickr-calendar.rightMost:before,.flatpickr-calendar.arrowRight:before,.flatpickr-calendar.rightMost:after,.flatpickr-calendar.arrowRight:after{left:auto;right:22px}.flatpickr-calendar.arrowCenter:before,.flatpickr-calendar.arrowCenter:after{left:50%;right:50%}.flatpickr-calendar:before{border-width:5px;margin:0 -5px}.flatpickr-calendar:after{border-width:4px;margin:0 -4px}.flatpickr-calendar.arrowTop:before,.flatpickr-calendar.arrowTop:after{bottom:100%}.flatpickr-calendar.arrowTop:before{border-bottom-color:#e6e6e6}.flatpickr-calendar.arrowTop:after{border-bottom-color:#fff}.flatpickr-calendar.arrowBottom:before,.flatpickr-calendar.arrowBottom:after{top:100%}.flatpickr-calendar.arrowBottom:before{border-top-color:#e6e6e6}.flatpickr-calendar.arrowBottom:after{border-top-color:#fff}.flatpickr-calendar:focus{outline:0}.flatpickr-wrapper{position:relative;display:inline-block}.flatpickr-months{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex}.flatpickr-months .flatpickr-month{background:transparent;color:#000000e6;fill:#000000e6;height:34px;line-height:1;text-align:center;position:relative;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;overflow:hidden;-webkit-box-flex:1;-webkit-flex:1;-ms-flex:1;flex:1}.flatpickr-months .flatpickr-prev-month,.flatpickr-months .flatpickr-next-month{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;text-decoration:none;cursor:pointer;position:absolute;top:0;height:34px;padding:10px;z-index:3;color:#000000e6;fill:#000000e6}.flatpickr-months .flatpickr-prev-month.flatpickr-disabled,.flatpickr-months .flatpickr-next-month.flatpickr-disabled{display:none}.flatpickr-months .flatpickr-prev-month i,.flatpickr-months .flatpickr-next-month i{position:relative}.flatpickr-months .flatpickr-prev-month.flatpickr-prev-month,.flatpickr-months .flatpickr-next-month.flatpickr-prev-month{left:0}.flatpickr-months .flatpickr-prev-month.flatpickr-next-month,.flatpickr-months .flatpickr-next-month.flatpickr-next-month{right:0}.flatpickr-months .flatpickr-prev-month:hover,.flatpickr-months .flatpickr-next-month:hover{color:#959ea9}.flatpickr-months .flatpickr-prev-month:hover svg,.flatpickr-months .flatpickr-next-month:hover svg{fill:#f64747}.flatpickr-months .flatpickr-prev-month svg,.flatpickr-months .flatpickr-next-month svg{width:14px;height:14px}.flatpickr-months .flatpickr-prev-month svg path,.flatpickr-months .flatpickr-next-month svg path{-webkit-transition:fill .1s;transition:fill .1s;fill:inherit}.numInputWrapper{position:relative;height:auto}.numInputWrapper input,.numInputWrapper span{display:inline-block}.numInputWrapper input{width:100%}.numInputWrapper input::-ms-clear{display:none}.numInputWrapper input::-webkit-outer-spin-button,.numInputWrapper input::-webkit-inner-spin-button{margin:0;-webkit-appearance:none}.numInputWrapper span{position:absolute;right:0;width:14px;padding:0 4px 0 2px;height:50%;line-height:50%;opacity:0;cursor:pointer;border:1px solid rgba(57,57,57,.15);-webkit-box-sizing:border-box;box-sizing:border-box}.numInputWrapper span:hover{background:rgba(0,0,0,.1)}.numInputWrapper span:active{background:rgba(0,0,0,.2)}.numInputWrapper span:after{display:block;content:"";position:absolute}.numInputWrapper span.arrowUp{top:0;border-bottom:0}.numInputWrapper span.arrowUp:after{border-left:4px solid transparent;border-right:4px solid transparent;border-bottom:4px solid rgba(57,57,57,.6);top:26%}.numInputWrapper span.arrowDown{top:50%}.numInputWrapper span.arrowDown:after{border-left:4px solid transparent;border-right:4px solid transparent;border-top:4px solid rgba(57,57,57,.6);top:40%}.numInputWrapper span svg{width:inherit;height:auto}.numInputWrapper span svg path{fill:#00000080}.numInputWrapper:hover{background:rgba(0,0,0,.05)}.numInputWrapper:hover span{opacity:1}.flatpickr-current-month{font-size:135%;line-height:inherit;font-weight:300;color:inherit;position:absolute;width:75%;left:12.5%;padding:7.48px 0 0;line-height:1;height:34px;display:inline-block;text-align:center;-webkit-transform:translate3d(0px,0px,0px);transform:translateZ(0)}.flatpickr-current-month span.cur-month{font-family:inherit;font-weight:700;color:inherit;display:inline-block;margin-left:.5ch;padding:0}.flatpickr-current-month span.cur-month:hover{background:rgba(0,0,0,.05)}.flatpickr-current-month .numInputWrapper{width:6ch;width:7ch\fffd;display:inline-block}.flatpickr-current-month .numInputWrapper span.arrowUp:after{border-bottom-color:#000000e6}.flatpickr-current-month .numInputWrapper span.arrowDown:after{border-top-color:#000000e6}.flatpickr-current-month input.cur-year{background:transparent;-webkit-box-sizing:border-box;box-sizing:border-box;color:inherit;cursor:text;padding:0 0 0 .5ch;margin:0;display:inline-block;font-size:inherit;font-family:inherit;font-weight:300;line-height:inherit;height:auto;border:0;border-radius:0;vertical-align:initial;-webkit-appearance:textfield;-moz-appearance:textfield;appearance:textfield}.flatpickr-current-month input.cur-year:focus{outline:0}.flatpickr-current-month input.cur-year[disabled],.flatpickr-current-month input.cur-year[disabled]:hover{font-size:100%;color:#00000080;background:transparent;pointer-events:none}.flatpickr-current-month .flatpickr-monthDropdown-months{appearance:menulist;background:transparent;border:none;border-radius:0;box-sizing:border-box;color:inherit;cursor:pointer;font-size:inherit;font-family:inherit;font-weight:300;height:auto;line-height:inherit;margin:-1px 0 0;outline:none;padding:0 0 0 .5ch;position:relative;vertical-align:initial;-webkit-box-sizing:border-box;-webkit-appearance:menulist;-moz-appearance:menulist;width:auto}.flatpickr-current-month .flatpickr-monthDropdown-months:focus,.flatpickr-current-month .flatpickr-monthDropdown-months:active{outline:none}.flatpickr-current-month .flatpickr-monthDropdown-months:hover{background:rgba(0,0,0,.05)}.flatpickr-current-month .flatpickr-monthDropdown-months .flatpickr-monthDropdown-month{background-color:transparent;outline:none;padding:0}.flatpickr-weekdays{background:transparent;text-align:center;overflow:hidden;width:100%;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-align:center;-webkit-align-items:center;-ms-flex-align:center;align-items:center;height:28px}.flatpickr-weekdays .flatpickr-weekdaycontainer{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-flex:1;-webkit-flex:1;-ms-flex:1;flex:1}span.flatpickr-weekday{cursor:default;font-size:90%;background:transparent;color:#0000008a;line-height:1;margin:0;text-align:center;display:block;-webkit-box-flex:1;-webkit-flex:1;-ms-flex:1;flex:1;font-weight:bolder}.dayContainer,.flatpickr-weeks{padding:1px 0 0}.flatpickr-days{position:relative;overflow:hidden;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-align:start;-webkit-align-items:flex-start;-ms-flex-align:start;align-items:flex-start;width:307.875px}.flatpickr-days:focus{outline:0}.dayContainer{padding:0;outline:0;text-align:left;width:307.875px;min-width:307.875px;max-width:307.875px;-webkit-box-sizing:border-box;box-sizing:border-box;display:inline-block;display:-ms-flexbox;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-flex-wrap:wrap;flex-wrap:wrap;-ms-flex-wrap:wrap;-ms-flex-pack:justify;-webkit-justify-content:space-around;justify-content:space-around;-webkit-transform:translate3d(0px,0px,0px);transform:translateZ(0);opacity:1}.dayContainer+.dayContainer{-webkit-box-shadow:-1px 0 0 #e6e6e6;box-shadow:-1px 0 #e6e6e6}.flatpickr-day{background:none;border:1px solid transparent;border-radius:150px;-webkit-box-sizing:border-box;box-sizing:border-box;color:#393939;cursor:pointer;font-weight:400;width:14.2857143%;-webkit-flex-basis:14.2857143%;-ms-flex-preferred-size:14.2857143%;flex-basis:14.2857143%;max-width:39px;height:39px;line-height:39px;margin:0;display:inline-block;position:relative;-webkit-box-pack:center;-webkit-justify-content:center;-ms-flex-pack:center;justify-content:center;text-align:center}.flatpickr-day.inRange,.flatpickr-day.prevMonthDay.inRange,.flatpickr-day.nextMonthDay.inRange,.flatpickr-day.today.inRange,.flatpickr-day.prevMonthDay.today.inRange,.flatpickr-day.nextMonthDay.today.inRange,.flatpickr-day:hover,.flatpickr-day.prevMonthDay:hover,.flatpickr-day.nextMonthDay:hover,.flatpickr-day:focus,.flatpickr-day.prevMonthDay:focus,.flatpickr-day.nextMonthDay:focus{cursor:pointer;outline:0;background:#e6e6e6;border-color:#e6e6e6}.flatpickr-day.today{border-color:#959ea9}.flatpickr-day.today:hover,.flatpickr-day.today:focus{border-color:#959ea9;background:#959ea9;color:#fff}.flatpickr-day.selected,.flatpickr-day.startRange,.flatpickr-day.endRange,.flatpickr-day.selected.inRange,.flatpickr-day.startRange.inRange,.flatpickr-day.endRange.inRange,.flatpickr-day.selected:focus,.flatpickr-day.startRange:focus,.flatpickr-day.endRange:focus,.flatpickr-day.selected:hover,.flatpickr-day.startRange:hover,.flatpickr-day.endRange:hover,.flatpickr-day.selected.prevMonthDay,.flatpickr-day.startRange.prevMonthDay,.flatpickr-day.endRange.prevMonthDay,.flatpickr-day.selected.nextMonthDay,.flatpickr-day.startRange.nextMonthDay,.flatpickr-day.endRange.nextMonthDay{background:#569ff7;-webkit-box-shadow:none;box-shadow:none;color:#fff;border-color:#569ff7}.flatpickr-day.selected.startRange,.flatpickr-day.startRange.startRange,.flatpickr-day.endRange.startRange{border-radius:50px 0 0 50px}.flatpickr-day.selected.endRange,.flatpickr-day.startRange.endRange,.flatpickr-day.endRange.endRange{border-radius:0 50px 50px 0}.flatpickr-day.selected.startRange+.endRange:not(:nth-child(7n+1)),.flatpickr-day.startRange.startRange+.endRange:not(:nth-child(7n+1)),.flatpickr-day.endRange.startRange+.endRange:not(:nth-child(7n+1)){-webkit-box-shadow:-10px 0 0 #569ff7;box-shadow:-10px 0 #569ff7}.flatpickr-day.selected.startRange.endRange,.flatpickr-day.startRange.startRange.endRange,.flatpickr-day.endRange.startRange.endRange{border-radius:50px}.flatpickr-day.inRange{border-radius:0;-webkit-box-shadow:-5px 0 0 #e6e6e6,5px 0 0 #e6e6e6;box-shadow:-5px 0 #e6e6e6,5px 0 #e6e6e6}.flatpickr-day.flatpickr-disabled,.flatpickr-day.flatpickr-disabled:hover,.flatpickr-day.prevMonthDay,.flatpickr-day.nextMonthDay,.flatpickr-day.notAllowed,.flatpickr-day.notAllowed.prevMonthDay,.flatpickr-day.notAllowed.nextMonthDay{color:#3939394d;background:transparent;border-color:transparent;cursor:default}.flatpickr-day.flatpickr-disabled,.flatpickr-day.flatpickr-disabled:hover{cursor:not-allowed;color:#3939391a}.flatpickr-day.week.selected{border-radius:0;-webkit-box-shadow:-5px 0 0 #569ff7,5px 0 0 #569ff7;box-shadow:-5px 0 #569ff7,5px 0 #569ff7}.flatpickr-day.hidden{visibility:hidden}.rangeMode .flatpickr-day{margin-top:1px}.flatpickr-weekwrapper{float:left}.flatpickr-weekwrapper .flatpickr-weeks{padding:0 12px;-webkit-box-shadow:1px 0 0 #e6e6e6;box-shadow:1px 0 #e6e6e6}.flatpickr-weekwrapper .flatpickr-weekday{float:none;width:100%;line-height:28px}.flatpickr-weekwrapper span.flatpickr-day,.flatpickr-weekwrapper span.flatpickr-day:hover{display:block;width:100%;max-width:none;color:#3939394d;background:transparent;cursor:default;border:none}.flatpickr-innerContainer{display:block;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-sizing:border-box;box-sizing:border-box;overflow:hidden}.flatpickr-rContainer{display:inline-block;padding:0;-webkit-box-sizing:border-box;box-sizing:border-box}.flatpickr-time{text-align:center;outline:0;display:block;height:0;line-height:40px;max-height:40px;-webkit-box-sizing:border-box;box-sizing:border-box;overflow:hidden;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex}.flatpickr-time:after{content:"";display:table;clear:both}.flatpickr-time .numInputWrapper{-webkit-box-flex:1;-webkit-flex:1;-ms-flex:1;flex:1;width:40%;height:40px;float:left}.flatpickr-time .numInputWrapper span.arrowUp:after{border-bottom-color:#393939}.flatpickr-time .numInputWrapper span.arrowDown:after{border-top-color:#393939}.flatpickr-time.hasSeconds .numInputWrapper{width:26%}.flatpickr-time.time24hr .numInputWrapper{width:49%}.flatpickr-time input{background:transparent;-webkit-box-shadow:none;box-shadow:none;border:0;border-radius:0;text-align:center;margin:0;padding:0;height:inherit;line-height:inherit;color:#393939;font-size:14px;position:relative;-webkit-box-sizing:border-box;box-sizing:border-box;-webkit-appearance:textfield;-moz-appearance:textfield;appearance:textfield}.flatpickr-time input.flatpickr-hour{font-weight:700}.flatpickr-time input.flatpickr-minute,.flatpickr-time input.flatpickr-second{font-weight:400}.flatpickr-time input:focus{outline:0;border:0}.flatpickr-time .flatpickr-time-separator,.flatpickr-time .flatpickr-am-pm{height:inherit;float:left;line-height:inherit;color:#393939;font-weight:700;width:2%;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;-webkit-align-self:center;-ms-flex-item-align:center;align-self:center}.flatpickr-time .flatpickr-am-pm{outline:0;width:18%;cursor:pointer;text-align:center;font-weight:400}.flatpickr-time input:hover,.flatpickr-time .flatpickr-am-pm:hover,.flatpickr-time input:focus,.flatpickr-time .flatpickr-am-pm:focus{background:#eee}.flatpickr-input[readonly]{cursor:pointer}@-webkit-keyframes fpFadeInDown{0%{opacity:0;-webkit-transform:translate3d(0,-20px,0);transform:translate3d(0,-20px,0)}to{opacity:1;-webkit-transform:translate3d(0,0,0);transform:translateZ(0)}}@keyframes fpFadeInDown{0%{opacity:0;-webkit-transform:translate3d(0,-20px,0);transform:translate3d(0,-20px,0)}to{opacity:1;-webkit-transform:translate3d(0,0,0);transform:translateZ(0)}}:root{--tasks-details-icon: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42z'/></svg>")}.plugin-tasks-query-explanation{--code-white-space: pre}.tasks-count{color:var(--text-faint);padding-left:20px}.tooltip.pop-up{animation:pop-up-animation .2s forwards ease-in-out}@keyframes pop-up-animation{0%{opacity:0;transform:translateY(-100%) scale(1)}20%{opacity:.7;transform:translateY(-100%) scale(1.02)}40%{opacity:1;transform:translateY(-100%) scale(1.05)}to{opacity:1;transform:translateY(-100%) scale(1)}}.task-cancelled,.task-created,.task-done,.task-due,.task-scheduled,.task-start{cursor:pointer;user-select:none;-webkit-user-select:none;-webkit-touch-callout:none}.tasks-edit,.tasks-postpone{width:1em;height:1em;vertical-align:middle;margin-left:.33em;cursor:pointer;font-family:var(--font-interface);color:var(--text-accent);user-select:none;-webkit-user-select:none;-webkit-touch-callout:none}a.tasks-edit,a.tasks-postpone{text-decoration:none}.tasks-edit:after{content:"\1f4dd"}.tasks-postpone:after{content:"\23e9"}.tasks-urgency{font-size:var(--font-ui-smaller);font-family:var(--font-interface);padding:2px 6px;border-radius:var(--radius-s);color:var(--text-normal);background-color:var(--background-secondary);margin-left:.5em;line-height:1}.internal-link.internal-link-short-mode{text-decoration:none}.tasks-list-text{position:relative}.tasks-list-text .tooltip{position:absolute;top:0;left:0;white-space:nowrap}.task-list-item-checkbox{cursor:pointer}.tasks-layout-hide-tags .task-description a.tag,.task-list-item .task-block-link{display:none}.tasks-modal section+section{margin-top:6px}.tasks-modal hr{margin:6px 0}.tasks-modal .tasks-modal-error{border:1px solid red!important}.tasks-modal .accesskey{text-decoration:underline;text-underline-offset:1pt}.tasks-modal-description-section textarea{width:100%;min-height:calc(var(--input-height) * 2);resize:vertical;margin-top:8px}.tasks-modal-priority-section{display:grid;grid-template-columns:6em auto auto auto;grid-row-gap:.15em}.tasks-modal-priority-section>label{grid-row-start:1;grid-row-end:3}.tasks-modal-priority-section .task-modal-priority-option-container{white-space:nowrap}.tasks-modal-priority-section .task-modal-priority-option-container input+label{font-size:var(--font-ui-small);border-radius:var(--input-radius);padding:2px 3px}.tasks-modal-priority-section .task-modal-priority-option-container input{accent-color:var(--interactive-accent)}.tasks-modal-priority-section .task-modal-priority-option-container input:focus+label{box-shadow:0 0 0 2px var(--background-modifier-border-focus);border-color:var(--background-modifier-border-focus)}.tasks-modal-priority-section .task-modal-priority-option-container input:checked+label{font-weight:700}.tasks-modal-priority-section .task-modal-priority-option-container input:not(:checked)+label>span:nth-child(4){filter:grayscale(100%) opacity(60%)}.tasks-modal-dates-section{display:grid;grid-template-columns:6em 13em auto;column-gap:.5em;row-gap:5px;align-items:center}.tasks-modal-dates-section label{grid-column:1}.tasks-modal-dates-section .tasks-modal-date-input{min-width:15em}.tasks-modal-dates-section .tasks-modal-date-editor-picker{margin-left:.5em}.tasks-modal-dates-section .tasks-modal-parsed-date{grid-column:3;font-size:var(--font-ui-small)}.tasks-modal-dates-section .future-dates-only{grid-column-start:1;grid-column-end:3}.tasks-modal-dates-section .future-dates-only input{margin-left:.67em;top:2px}.tasks-modal-dates-section .status-editor-status-selector{grid-column:2}.tasks-modal-dependencies-section{display:grid;grid-template-columns:6em auto;column-gap:.5em;row-gap:5px;align-items:center}.tasks-modal-dependencies-section .tasks-modal-dependency-input{grid-column:2;width:100%}.tasks-modal-dependencies-section .results-dependency{grid-column:2}.tasks-modal-button-section{position:sticky;bottom:0;background-color:var(--modal-background);padding-bottom:16px;padding-top:16px;display:grid;grid-template-columns:3fr 1fr;column-gap:.5em}.tasks-modal-button-section button:disabled{pointer-events:none!important;opacity:.3!important}@media (max-width: 649px){.tasks-modal-priority-section{grid-template-columns:6em auto auto}.tasks-modal-priority-section>label{grid-row:1/span 3}}@media (max-width: 499px){.tasks-modal-priority-section{grid-template-columns:4em auto auto}.tasks-modal-dates-section{grid-template-columns:1fr;grid-auto-columns:auto}.tasks-modal-dates-section .tasks-modal-date-input{grid-column:1}.tasks-modal-dates-section .tasks-modal-parsed-date{grid-column:2}.tasks-modal-dates-section .status-editor-status-selector,.tasks-modal-dependencies-section label,.tasks-modal-dependencies-section .results-dependency{grid-column:1}}@media (max-width: 399px){.tasks-modal-dates-section .status-editor-status-selector{grid-column:1}.tasks-modal-dates-section>.tasks-modal-parsed-date{grid-column:1}.tasks-modal-priority-section{grid-template-columns:4em auto}.tasks-modal-priority-section>label{grid-row:1/span 6}.tasks-modal-dependencies-section{grid-template-columns:1fr;grid-auto-columns:auto}}@media (max-width: 259px){.tasks-modal-priority-section{grid-template-columns:1fr}.tasks-modal-priority-section>label{grid-row:1}}.task-dependencies-container{grid-column:2;display:flex;flex-wrap:wrap;gap:8px}.task-dependency{display:inline-flex;background-color:var(--interactive-normal);box-shadow:var(--input-shadow);border-radius:28px;padding:4px 4px 4px 8px}.task-dependency-name{font-size:var(--font-ui-small);max-width:160px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}.task-dependency-delete{padding:3px;cursor:pointer;height:inherit;box-shadow:none!important;border-radius:50%}.task-dependency-dropdown{list-style:none;position:absolute;top:0;left:0;padding:4px;margin:0;background-color:var(--background-primary);border:1px;border-radius:6px;border-color:var(--background-modifier-border);border-style:solid;z-index:99;max-height:170px;overflow-y:auto}.task-dependency-dropdown li{padding:5px;margin:2px;border-radius:6px;cursor:pointer;display:flex;justify-content:space-between}.task-dependency-dropdown li .dependency-name{overflow:hidden;white-space:nowrap;text-overflow:ellipsis}.task-dependency-dropdown li .dependency-name-shared{width:60%;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}.task-dependency-dropdown li .dependency-path{width:40%;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;font-style:italic;text-align:right;color:var(--italic-color)}.task-dependency-dropdown li.selected{background-color:var(--text-selection)}.tasks-setting-important{color:red;font-weight:700}.tasks-settings-is-invalid{color:var(--text-error)!important;background-color:rgba(var(--background-modifier-error-rgb),.2)!important}.tasks-settings .additional{margin:6px 12px}.tasks-settings .additional>.setting-item{border-top:0;padding-top:9px}.tasks-settings details>summary{outline:none;display:block!important;list-style:none!important;list-style-type:none!important;min-height:1rem;border-top-left-radius:.1rem;border-top-right-radius:.1rem;cursor:pointer;position:relative}.tasks-settings details>summary::-webkit-details-marker,.tasks-settings details>summary::marker{display:none!important}.tasks-settings details>summary>.collapser{position:absolute;top:50%;right:8px;transform:translateY(-50%);content:""}.tasks-settings details>summary>.collapser>.handle{transform:rotate(0);transition:transform .25s;background-color:currentColor;-webkit-mask-repeat:no-repeat;mask-repeat:no-repeat;-webkit-mask-size:contain;mask-size:contain;-webkit-mask-image:var(--tasks-details-icon);mask-image:var(--tasks-details-icon);width:20px;height:20px}.tasks-settings details[open]>summary>.collapser>.handle{transform:rotate(90deg)}.tasks-nested-settings .setting-item{border:0px;padding-bottom:0}.tasks-nested-settings{padding-bottom:18px}.tasks-nested-settings[open] .setting-item-heading,.tasks-nested-settings:not(details) .setting-item-heading{border-top:0px;border-bottom:1px solid var(--background-modifier-border)}.tasks-settings .row-for-status{margin-top:0;margin-bottom:0}.tasks-settings .tasks-presets-wrapper{width:100%;position:relative;transition:all .2s ease}.tasks-settings .tasks-presets-wrapper.tasks-presets-dragging{opacity:.5;transform:rotate(2deg)}.tasks-settings .tasks-presets-wrapper.tasks-presets-drop-above:before{content:"";position:absolute;top:-2px;left:0;right:0;height:4px;background-color:var(--interactive-accent);border-radius:2px;z-index:10}.tasks-settings .tasks-presets-wrapper.tasks-presets-drop-below:after{content:"";position:absolute;bottom:-2px;left:0;right:0;height:4px;background-color:var(--interactive-accent);border-radius:2px;z-index:10}.tasks-settings .tasks-presets-setting .tasks-presets-key{grid-area:key}.tasks-settings .tasks-presets-setting .tasks-presets-key.has-error{border-color:var(--text-error);border-width:2px}.tasks-settings .tasks-presets-setting .tasks-presets-value{grid-area:value;min-width:300px;min-height:3em;font-family:var(--font-monospace);resize:horizontal;overflow-x:auto;overflow-y:hidden;white-space:pre}.tasks-settings .tasks-presets-setting .tasks-presets-drag-handle{grid-area:drag;color:var(--text-muted)}.tasks-settings .tasks-presets-setting .tasks-presets-drag-handle:hover{color:var(--text-normal)}.tasks-settings .tasks-presets-setting .tasks-presets-delete-button{grid-area:delete}.tasks-settings .tasks-presets-setting .setting-item-control{justify-content:start;display:grid;grid-template-columns:200px 1fr auto auto;grid-template-areas:"key value drag delete";gap:4px;align-items:unset;border:1px solid var(--background-modifier-border)!important;padding:.5em!important;background-color:var(--background-secondary)!important;border-radius:4px!important}@container (max-width: 600px){.tasks-settings .tasks-presets-setting .setting-item-control{grid-template-columns:5fr 1fr 1fr;grid-template-areas:"key drag delete" "value value value"}.tasks-settings .tasks-presets-setting .setting-item-control .tasks-presets-key{width:100%}}
+@charset "UTF-8";
+
+/* node_modules/flatpickr/dist/flatpickr.css */
+.flatpickr-calendar {
+  background: transparent;
+  opacity: 0;
+  display: none;
+  text-align: center;
+  visibility: hidden;
+  padding: 0;
+  -webkit-animation: none;
+  animation: none;
+  direction: ltr;
+  border: 0;
+  font-size: 14px;
+  line-height: 24px;
+  border-radius: 5px;
+  position: absolute;
+  width: 307.875px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  -ms-touch-action: manipulation;
+  touch-action: manipulation;
+  background: #fff;
+  -webkit-box-shadow:
+    1px 0 0 #e6e6e6,
+    -1px 0 0 #e6e6e6,
+    0 1px 0 #e6e6e6,
+    0 -1px 0 #e6e6e6,
+    0 3px 13px rgba(0, 0, 0, 0.08);
+  box-shadow:
+    1px 0 0 #e6e6e6,
+    -1px 0 0 #e6e6e6,
+    0 1px 0 #e6e6e6,
+    0 -1px 0 #e6e6e6,
+    0 3px 13px rgba(0, 0, 0, 0.08);
+}
+.flatpickr-calendar.open,
+.flatpickr-calendar.inline {
+  opacity: 1;
+  max-height: 640px;
+  visibility: visible;
+}
+.flatpickr-calendar.open {
+  display: inline-block;
+  z-index: 99999;
+}
+.flatpickr-calendar.animate.open {
+  -webkit-animation: fpFadeInDown 300ms cubic-bezier(0.23, 1, 0.32, 1);
+  animation: fpFadeInDown 300ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.flatpickr-calendar.inline {
+  display: block;
+  position: relative;
+  top: 2px;
+}
+.flatpickr-calendar.static {
+  position: absolute;
+  top: calc(100% + 2px);
+}
+.flatpickr-calendar.static.open {
+  z-index: 999;
+  display: block;
+}
+.flatpickr-calendar.multiMonth .flatpickr-days .dayContainer:nth-child(n+1) .flatpickr-day.inRange:nth-child(7n+7) {
+  -webkit-box-shadow: none !important;
+  box-shadow: none !important;
+}
+.flatpickr-calendar.multiMonth .flatpickr-days .dayContainer:nth-child(n+2) .flatpickr-day.inRange:nth-child(7n+1) {
+  -webkit-box-shadow: -2px 0 0 #e6e6e6, 5px 0 0 #e6e6e6;
+  box-shadow: -2px 0 0 #e6e6e6, 5px 0 0 #e6e6e6;
+}
+.flatpickr-calendar .hasWeeks .dayContainer,
+.flatpickr-calendar .hasTime .dayContainer {
+  border-bottom: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.flatpickr-calendar .hasWeeks .dayContainer {
+  border-left: 0;
+}
+.flatpickr-calendar.hasTime .flatpickr-time {
+  height: 40px;
+  border-top: 1px solid #e6e6e6;
+}
+.flatpickr-calendar.noCalendar.hasTime .flatpickr-time {
+  height: auto;
+}
+.flatpickr-calendar:before,
+.flatpickr-calendar:after {
+  position: absolute;
+  display: block;
+  pointer-events: none;
+  border: solid transparent;
+  content: "";
+  height: 0;
+  width: 0;
+  left: 22px;
+}
+.flatpickr-calendar.rightMost:before,
+.flatpickr-calendar.arrowRight:before,
+.flatpickr-calendar.rightMost:after,
+.flatpickr-calendar.arrowRight:after {
+  left: auto;
+  right: 22px;
+}
+.flatpickr-calendar.arrowCenter:before,
+.flatpickr-calendar.arrowCenter:after {
+  left: 50%;
+  right: 50%;
+}
+.flatpickr-calendar:before {
+  border-width: 5px;
+  margin: 0 -5px;
+}
+.flatpickr-calendar:after {
+  border-width: 4px;
+  margin: 0 -4px;
+}
+.flatpickr-calendar.arrowTop:before,
+.flatpickr-calendar.arrowTop:after {
+  bottom: 100%;
+}
+.flatpickr-calendar.arrowTop:before {
+  border-bottom-color: #e6e6e6;
+}
+.flatpickr-calendar.arrowTop:after {
+  border-bottom-color: #fff;
+}
+.flatpickr-calendar.arrowBottom:before,
+.flatpickr-calendar.arrowBottom:after {
+  top: 100%;
+}
+.flatpickr-calendar.arrowBottom:before {
+  border-top-color: #e6e6e6;
+}
+.flatpickr-calendar.arrowBottom:after {
+  border-top-color: #fff;
+}
+.flatpickr-calendar:focus {
+  outline: 0;
+}
+.flatpickr-wrapper {
+  position: relative;
+  display: inline-block;
+}
+.flatpickr-months {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+.flatpickr-months .flatpickr-month {
+  background: transparent;
+  color: rgba(0, 0, 0, 0.9);
+  fill: rgba(0, 0, 0, 0.9);
+  height: 34px;
+  line-height: 1;
+  text-align: center;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  overflow: hidden;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+.flatpickr-months .flatpickr-prev-month,
+.flatpickr-months .flatpickr-next-month {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  text-decoration: none;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  height: 34px;
+  padding: 10px;
+  z-index: 3;
+  color: rgba(0, 0, 0, 0.9);
+  fill: rgba(0, 0, 0, 0.9);
+}
+.flatpickr-months .flatpickr-prev-month.flatpickr-disabled,
+.flatpickr-months .flatpickr-next-month.flatpickr-disabled {
+  display: none;
+}
+.flatpickr-months .flatpickr-prev-month i,
+.flatpickr-months .flatpickr-next-month i {
+  position: relative;
+}
+.flatpickr-months .flatpickr-prev-month.flatpickr-prev-month,
+.flatpickr-months .flatpickr-next-month.flatpickr-prev-month {
+  left: 0;
+}
+.flatpickr-months .flatpickr-prev-month.flatpickr-next-month,
+.flatpickr-months .flatpickr-next-month.flatpickr-next-month {
+  right: 0;
+}
+.flatpickr-months .flatpickr-prev-month:hover,
+.flatpickr-months .flatpickr-next-month:hover {
+  color: #959ea9;
+}
+.flatpickr-months .flatpickr-prev-month:hover svg,
+.flatpickr-months .flatpickr-next-month:hover svg {
+  fill: #f64747;
+}
+.flatpickr-months .flatpickr-prev-month svg,
+.flatpickr-months .flatpickr-next-month svg {
+  width: 14px;
+  height: 14px;
+}
+.flatpickr-months .flatpickr-prev-month svg path,
+.flatpickr-months .flatpickr-next-month svg path {
+  -webkit-transition: fill 0.1s;
+  transition: fill 0.1s;
+  fill: inherit;
+}
+.numInputWrapper {
+  position: relative;
+  height: auto;
+}
+.numInputWrapper input,
+.numInputWrapper span {
+  display: inline-block;
+}
+.numInputWrapper input {
+  width: 100%;
+}
+.numInputWrapper input::-ms-clear {
+  display: none;
+}
+.numInputWrapper input::-webkit-outer-spin-button,
+.numInputWrapper input::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+}
+.numInputWrapper span {
+  position: absolute;
+  right: 0;
+  width: 14px;
+  padding: 0 4px 0 2px;
+  height: 50%;
+  line-height: 50%;
+  opacity: 0;
+  cursor: pointer;
+  border: 1px solid rgba(57, 57, 57, 0.15);
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.numInputWrapper span:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+.numInputWrapper span:active {
+  background: rgba(0, 0, 0, 0.2);
+}
+.numInputWrapper span:after {
+  display: block;
+  content: "";
+  position: absolute;
+}
+.numInputWrapper span.arrowUp {
+  top: 0;
+  border-bottom: 0;
+}
+.numInputWrapper span.arrowUp:after {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-bottom: 4px solid rgba(57, 57, 57, 0.6);
+  top: 26%;
+}
+.numInputWrapper span.arrowDown {
+  top: 50%;
+}
+.numInputWrapper span.arrowDown:after {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 4px solid rgba(57, 57, 57, 0.6);
+  top: 40%;
+}
+.numInputWrapper span svg {
+  width: inherit;
+  height: auto;
+}
+.numInputWrapper span svg path {
+  fill: rgba(0, 0, 0, 0.5);
+}
+.numInputWrapper:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+.numInputWrapper:hover span {
+  opacity: 1;
+}
+.flatpickr-current-month {
+  font-size: 135%;
+  line-height: inherit;
+  font-weight: 300;
+  color: inherit;
+  position: absolute;
+  width: 75%;
+  left: 12.5%;
+  padding: 7.48px 0 0 0;
+  line-height: 1;
+  height: 34px;
+  display: inline-block;
+  text-align: center;
+  -webkit-transform: translate3d(0px, 0px, 0px);
+  transform: translate3d(0px, 0px, 0px);
+}
+.flatpickr-current-month span.cur-month {
+  font-family: inherit;
+  font-weight: 700;
+  color: inherit;
+  display: inline-block;
+  margin-left: 0.5ch;
+  padding: 0;
+}
+.flatpickr-current-month span.cur-month:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+.flatpickr-current-month .numInputWrapper {
+  width: 6ch;
+  width: 7ch\fffd;
+  display: inline-block;
+}
+.flatpickr-current-month .numInputWrapper span.arrowUp:after {
+  border-bottom-color: rgba(0, 0, 0, 0.9);
+}
+.flatpickr-current-month .numInputWrapper span.arrowDown:after {
+  border-top-color: rgba(0, 0, 0, 0.9);
+}
+.flatpickr-current-month input.cur-year {
+  background: transparent;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  color: inherit;
+  cursor: text;
+  padding: 0 0 0 0.5ch;
+  margin: 0;
+  display: inline-block;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: 300;
+  line-height: inherit;
+  height: auto;
+  border: 0;
+  border-radius: 0;
+  vertical-align: initial;
+  -webkit-appearance: textfield;
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+.flatpickr-current-month input.cur-year:focus {
+  outline: 0;
+}
+.flatpickr-current-month input.cur-year[disabled],
+.flatpickr-current-month input.cur-year[disabled]:hover {
+  font-size: 100%;
+  color: rgba(0, 0, 0, 0.5);
+  background: transparent;
+  pointer-events: none;
+}
+.flatpickr-current-month .flatpickr-monthDropdown-months {
+  appearance: menulist;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-sizing: border-box;
+  color: inherit;
+  cursor: pointer;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: 300;
+  height: auto;
+  line-height: inherit;
+  margin: -1px 0 0 0;
+  outline: none;
+  padding: 0 0 0 0.5ch;
+  position: relative;
+  vertical-align: initial;
+  -webkit-box-sizing: border-box;
+  -webkit-appearance: menulist;
+  -moz-appearance: menulist;
+  width: auto;
+}
+.flatpickr-current-month .flatpickr-monthDropdown-months:focus,
+.flatpickr-current-month .flatpickr-monthDropdown-months:active {
+  outline: none;
+}
+.flatpickr-current-month .flatpickr-monthDropdown-months:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+.flatpickr-current-month .flatpickr-monthDropdown-months .flatpickr-monthDropdown-month {
+  background-color: transparent;
+  outline: none;
+  padding: 0;
+}
+.flatpickr-weekdays {
+  background: transparent;
+  text-align: center;
+  overflow: hidden;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 28px;
+}
+.flatpickr-weekdays .flatpickr-weekdaycontainer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+span.flatpickr-weekday {
+  cursor: default;
+  font-size: 90%;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.54);
+  line-height: 1;
+  margin: 0;
+  text-align: center;
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  font-weight: bolder;
+}
+.dayContainer,
+.flatpickr-weeks {
+  padding: 1px 0 0 0;
+}
+.flatpickr-days {
+  position: relative;
+  overflow: hidden;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: start;
+  -webkit-align-items: flex-start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  width: 307.875px;
+}
+.flatpickr-days:focus {
+  outline: 0;
+}
+.dayContainer {
+  padding: 0;
+  outline: 0;
+  text-align: left;
+  width: 307.875px;
+  min-width: 307.875px;
+  max-width: 307.875px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  display: inline-block;
+  display: -ms-flexbox;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  -ms-flex-pack: justify;
+  -webkit-justify-content: space-around;
+  justify-content: space-around;
+  -webkit-transform: translate3d(0px, 0px, 0px);
+  transform: translate3d(0px, 0px, 0px);
+  opacity: 1;
+}
+.dayContainer + .dayContainer {
+  -webkit-box-shadow: -1px 0 0 #e6e6e6;
+  box-shadow: -1px 0 0 #e6e6e6;
+}
+.flatpickr-day {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 150px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  color: #393939;
+  cursor: pointer;
+  font-weight: 400;
+  width: 14.2857143%;
+  -webkit-flex-basis: 14.2857143%;
+  -ms-flex-preferred-size: 14.2857143%;
+  flex-basis: 14.2857143%;
+  max-width: 39px;
+  height: 39px;
+  line-height: 39px;
+  margin: 0;
+  display: inline-block;
+  position: relative;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  text-align: center;
+}
+.flatpickr-day.inRange,
+.flatpickr-day.prevMonthDay.inRange,
+.flatpickr-day.nextMonthDay.inRange,
+.flatpickr-day.today.inRange,
+.flatpickr-day.prevMonthDay.today.inRange,
+.flatpickr-day.nextMonthDay.today.inRange,
+.flatpickr-day:hover,
+.flatpickr-day.prevMonthDay:hover,
+.flatpickr-day.nextMonthDay:hover,
+.flatpickr-day:focus,
+.flatpickr-day.prevMonthDay:focus,
+.flatpickr-day.nextMonthDay:focus {
+  cursor: pointer;
+  outline: 0;
+  background: #e6e6e6;
+  border-color: #e6e6e6;
+}
+.flatpickr-day.today {
+  border-color: #959ea9;
+}
+.flatpickr-day.today:hover,
+.flatpickr-day.today:focus {
+  border-color: #959ea9;
+  background: #959ea9;
+  color: #fff;
+}
+.flatpickr-day.selected,
+.flatpickr-day.startRange,
+.flatpickr-day.endRange,
+.flatpickr-day.selected.inRange,
+.flatpickr-day.startRange.inRange,
+.flatpickr-day.endRange.inRange,
+.flatpickr-day.selected:focus,
+.flatpickr-day.startRange:focus,
+.flatpickr-day.endRange:focus,
+.flatpickr-day.selected:hover,
+.flatpickr-day.startRange:hover,
+.flatpickr-day.endRange:hover,
+.flatpickr-day.selected.prevMonthDay,
+.flatpickr-day.startRange.prevMonthDay,
+.flatpickr-day.endRange.prevMonthDay,
+.flatpickr-day.selected.nextMonthDay,
+.flatpickr-day.startRange.nextMonthDay,
+.flatpickr-day.endRange.nextMonthDay {
+  background: #569ff7;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  color: #fff;
+  border-color: #569ff7;
+}
+.flatpickr-day.selected.startRange,
+.flatpickr-day.startRange.startRange,
+.flatpickr-day.endRange.startRange {
+  border-radius: 50px 0 0 50px;
+}
+.flatpickr-day.selected.endRange,
+.flatpickr-day.startRange.endRange,
+.flatpickr-day.endRange.endRange {
+  border-radius: 0 50px 50px 0;
+}
+.flatpickr-day.selected.startRange + .endRange:not(:nth-child(7n+1)),
+.flatpickr-day.startRange.startRange + .endRange:not(:nth-child(7n+1)),
+.flatpickr-day.endRange.startRange + .endRange:not(:nth-child(7n+1)) {
+  -webkit-box-shadow: -10px 0 0 #569ff7;
+  box-shadow: -10px 0 0 #569ff7;
+}
+.flatpickr-day.selected.startRange.endRange,
+.flatpickr-day.startRange.startRange.endRange,
+.flatpickr-day.endRange.startRange.endRange {
+  border-radius: 50px;
+}
+.flatpickr-day.inRange {
+  border-radius: 0;
+  -webkit-box-shadow: -5px 0 0 #e6e6e6, 5px 0 0 #e6e6e6;
+  box-shadow: -5px 0 0 #e6e6e6, 5px 0 0 #e6e6e6;
+}
+.flatpickr-day.flatpickr-disabled,
+.flatpickr-day.flatpickr-disabled:hover,
+.flatpickr-day.prevMonthDay,
+.flatpickr-day.nextMonthDay,
+.flatpickr-day.notAllowed,
+.flatpickr-day.notAllowed.prevMonthDay,
+.flatpickr-day.notAllowed.nextMonthDay {
+  color: rgba(57, 57, 57, 0.3);
+  background: transparent;
+  border-color: transparent;
+  cursor: default;
+}
+.flatpickr-day.flatpickr-disabled,
+.flatpickr-day.flatpickr-disabled:hover {
+  cursor: not-allowed;
+  color: rgba(57, 57, 57, 0.1);
+}
+.flatpickr-day.week.selected {
+  border-radius: 0;
+  -webkit-box-shadow: -5px 0 0 #569ff7, 5px 0 0 #569ff7;
+  box-shadow: -5px 0 0 #569ff7, 5px 0 0 #569ff7;
+}
+.flatpickr-day.hidden {
+  visibility: hidden;
+}
+.rangeMode .flatpickr-day {
+  margin-top: 1px;
+}
+.flatpickr-weekwrapper {
+  float: left;
+}
+.flatpickr-weekwrapper .flatpickr-weeks {
+  padding: 0 12px;
+  -webkit-box-shadow: 1px 0 0 #e6e6e6;
+  box-shadow: 1px 0 0 #e6e6e6;
+}
+.flatpickr-weekwrapper .flatpickr-weekday {
+  float: none;
+  width: 100%;
+  line-height: 28px;
+}
+.flatpickr-weekwrapper span.flatpickr-day,
+.flatpickr-weekwrapper span.flatpickr-day:hover {
+  display: block;
+  width: 100%;
+  max-width: none;
+  color: rgba(57, 57, 57, 0.3);
+  background: transparent;
+  cursor: default;
+  border: none;
+}
+.flatpickr-innerContainer {
+  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+.flatpickr-rContainer {
+  display: inline-block;
+  padding: 0;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.flatpickr-time {
+  text-align: center;
+  outline: 0;
+  display: block;
+  height: 0;
+  line-height: 40px;
+  max-height: 40px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  overflow: hidden;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+.flatpickr-time:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+.flatpickr-time .numInputWrapper {
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  width: 40%;
+  height: 40px;
+  float: left;
+}
+.flatpickr-time .numInputWrapper span.arrowUp:after {
+  border-bottom-color: #393939;
+}
+.flatpickr-time .numInputWrapper span.arrowDown:after {
+  border-top-color: #393939;
+}
+.flatpickr-time.hasSeconds .numInputWrapper {
+  width: 26%;
+}
+.flatpickr-time.time24hr .numInputWrapper {
+  width: 49%;
+}
+.flatpickr-time input {
+  background: transparent;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  border: 0;
+  border-radius: 0;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+  height: inherit;
+  line-height: inherit;
+  color: #393939;
+  font-size: 14px;
+  position: relative;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  -webkit-appearance: textfield;
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+.flatpickr-time input.flatpickr-hour {
+  font-weight: bold;
+}
+.flatpickr-time input.flatpickr-minute,
+.flatpickr-time input.flatpickr-second {
+  font-weight: 400;
+}
+.flatpickr-time input:focus {
+  outline: 0;
+  border: 0;
+}
+.flatpickr-time .flatpickr-time-separator,
+.flatpickr-time .flatpickr-am-pm {
+  height: inherit;
+  float: left;
+  line-height: inherit;
+  color: #393939;
+  font-weight: bold;
+  width: 2%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+.flatpickr-time .flatpickr-am-pm {
+  outline: 0;
+  width: 18%;
+  cursor: pointer;
+  text-align: center;
+  font-weight: 400;
+}
+.flatpickr-time input:hover,
+.flatpickr-time .flatpickr-am-pm:hover,
+.flatpickr-time input:focus,
+.flatpickr-time .flatpickr-am-pm:focus {
+  background: #eee;
+}
+.flatpickr-input[readonly] {
+  cursor: pointer;
+}
+@-webkit-keyframes fpFadeInDown {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(0, -20px, 0);
+    transform: translate3d(0, -20px, 0);
+  }
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+  }
+}
+@keyframes fpFadeInDown {
+  from {
+    opacity: 0;
+    -webkit-transform: translate3d(0, -20px, 0);
+    transform: translate3d(0, -20px, 0);
+  }
+  to {
+    opacity: 1;
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+/* src/styles.scss */
+:root {
+  --tasks-details-icon: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42z'/></svg>");
+}
+.plugin-tasks-query-explanation {
+  --code-white-space: pre;
+}
+.plugin-tasks-toolbar {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: var(--size-4-1);
+}
+.plugin-tasks-toolbar label {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+.plugin-tasks-toolbar label input {
+  height: 100%;
+  padding-left: 24px;
+}
+.plugin-tasks-toolbar label svg {
+  position: absolute;
+  transform: translateX(25%);
+}
+.tasks-count {
+  color: var(--text-faint);
+  padding-left: 20px;
+}
+.tooltip.pop-up {
+  animation: pop-up-animation 200ms forwards ease-in-out;
+}
+@keyframes pop-up-animation {
+  0% {
+    opacity: 0;
+    transform: translateY(-100%) scale(1);
+  }
+  20% {
+    opacity: 0.7;
+    transform: translateY(-100%) scale(1.02);
+  }
+  40% {
+    opacity: 1;
+    transform: translateY(-100%) scale(1.05);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(-100%) scale(1);
+  }
+}
+.task-cancelled,
+.task-created,
+.task-done,
+.task-due,
+.task-scheduled,
+.task-start {
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+.tasks-edit,
+.tasks-postpone {
+  width: 1em;
+  height: 1em;
+  vertical-align: middle;
+  margin-left: 0.33em;
+  cursor: pointer;
+  font-family: var(--font-interface);
+  color: var(--text-accent);
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+a.tasks-edit,
+a.tasks-postpone {
+  text-decoration: none;
+}
+.tasks-edit::after {
+  content: "\1f4dd";
+}
+.tasks-postpone::after {
+  content: "\23e9";
+}
+.tasks-urgency {
+  font-size: var(--font-ui-smaller);
+  font-family: var(--font-interface);
+  padding: 2px 6px;
+  border-radius: var(--radius-s);
+  color: var(--text-normal);
+  background-color: var(--background-secondary);
+  margin-left: 0.5em;
+  line-height: 1;
+}
+.internal-link.internal-link-short-mode {
+  text-decoration: none;
+}
+.tasks-list-text {
+  position: relative;
+}
+.tasks-list-text .tooltip {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  white-space: nowrap;
+}
+.task-list-item-checkbox {
+  cursor: pointer;
+}
+.tasks-layout-hide-tags .task-description a.tag {
+  display: none;
+}
+.task-list-item .task-block-link {
+  display: none;
+}
+.modal-option-button {
+  inset-inline-end: var(--size-4-8);
+}
+.is-mobile .modal-option-button {
+  inset-inline-end: var(--size-4-16);
+}
+.tasks-modal section + section {
+  margin-top: 6px;
+}
+.tasks-modal hr {
+  margin: 6px 0;
+}
+.tasks-modal .tasks-modal-error {
+  border: 1px solid red !important;
+}
+.tasks-modal .accesskey {
+  text-decoration: underline;
+  text-underline-offset: 1pt;
+}
+.tasks-modal-description-section textarea {
+  width: 100%;
+  min-height: calc(var(--input-height) * 2);
+  resize: vertical;
+  margin-top: 8px;
+}
+.tasks-modal-priority-section {
+  display: grid;
+  grid-template-columns: 6em auto auto auto;
+  grid-row-gap: 0.15em;
+}
+.tasks-modal-priority-section > label {
+  grid-row-start: 1;
+  grid-row-end: 3;
+}
+.tasks-modal-priority-section .task-modal-priority-option-container {
+  white-space: nowrap;
+}
+.tasks-modal-priority-section .task-modal-priority-option-container input + label {
+  font-size: var(--font-ui-small);
+  border-radius: var(--input-radius);
+  padding: 2px 3px;
+}
+.tasks-modal-priority-section .task-modal-priority-option-container input {
+  accent-color: var(--interactive-accent);
+}
+.tasks-modal-priority-section .task-modal-priority-option-container input:focus + label {
+  box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
+  border-color: var(--background-modifier-border-focus);
+}
+.tasks-modal-priority-section .task-modal-priority-option-container input:checked + label {
+  font-weight: bold;
+}
+.tasks-modal-priority-section .task-modal-priority-option-container input:not(:checked) + label > span:nth-child(4) {
+  filter: grayscale(100%) opacity(60%);
+}
+.tasks-modal-dates-section {
+  display: grid;
+  grid-template-columns: 6em 13em auto;
+  column-gap: 0.5em;
+  row-gap: 5px;
+  align-items: center;
+}
+.tasks-modal-dates-section label {
+  grid-column: 1;
+}
+.tasks-modal-dates-section .tasks-modal-date-input {
+  min-width: 15em;
+}
+.tasks-modal-dates-section .tasks-modal-date-editor-picker {
+  margin-left: 0.5em;
+}
+.tasks-modal-dates-section .tasks-modal-parsed-date {
+  grid-column: 3;
+  font-size: var(--font-ui-small);
+}
+.tasks-modal-dates-section .future-dates-only {
+  grid-column-start: 1;
+  grid-column-end: 3;
+}
+.tasks-modal-dates-section .future-dates-only input {
+  margin-left: 0.67em;
+  top: 2px;
+}
+.tasks-modal-dates-section .status-editor-status-selector {
+  grid-column: 2;
+}
+.tasks-modal-dependencies-section {
+  display: grid;
+  grid-template-columns: 6em auto;
+  column-gap: 0.5em;
+  row-gap: 5px;
+  align-items: center;
+}
+.tasks-modal-dependencies-section .tasks-modal-dependency-input {
+  grid-column: 2;
+  width: 100%;
+}
+.tasks-modal-dependencies-section .results-dependency {
+  grid-column: 2;
+}
+.tasks-modal-button-section {
+  position: sticky;
+  bottom: 0;
+  background-color: var(--modal-background);
+  padding-bottom: 16px;
+  padding-top: 16px;
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  column-gap: 0.5em;
+}
+.tasks-modal-button-section button:disabled {
+  pointer-events: none !important;
+  opacity: 0.3 !important;
+}
+@media (max-width: 649px) {
+  .tasks-modal-priority-section {
+    grid-template-columns: 6em auto auto;
+  }
+  .tasks-modal-priority-section > label {
+    grid-row: 1/span 3;
+  }
+}
+@media (max-width: 499px) {
+  .tasks-modal-priority-section {
+    grid-template-columns: 4em auto auto;
+  }
+  .tasks-modal-dates-section {
+    grid-template-columns: 1fr;
+    grid-auto-columns: auto;
+  }
+  .tasks-modal-dates-section .tasks-modal-date-input {
+    grid-column: 1;
+  }
+  .tasks-modal-dates-section .tasks-modal-parsed-date {
+    grid-column: 2;
+  }
+  .tasks-modal-dates-section .status-editor-status-selector {
+    grid-column: 1;
+  }
+  .tasks-modal-dependencies-section label {
+    grid-column: 1;
+  }
+  .tasks-modal-dependencies-section .results-dependency {
+    grid-column: 1;
+  }
+}
+@media (max-width: 399px) {
+  .tasks-modal-dates-section .status-editor-status-selector {
+    grid-column: 1;
+  }
+  .tasks-modal-dates-section > .tasks-modal-parsed-date {
+    grid-column: 1;
+  }
+  .tasks-modal-priority-section {
+    grid-template-columns: 4em auto;
+  }
+  .tasks-modal-priority-section > label {
+    grid-row: 1/span 6;
+  }
+  .tasks-modal-dependencies-section {
+    grid-template-columns: 1fr;
+    grid-auto-columns: auto;
+  }
+}
+@media (max-width: 259px) {
+  .tasks-modal-priority-section {
+    grid-template-columns: 1fr;
+  }
+  .tasks-modal-priority-section > label {
+    grid-row: 1;
+  }
+}
+.task-dependencies-container {
+  grid-column: 2;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.task-dependency {
+  display: inline-flex;
+  background-color: var(--interactive-normal);
+  box-shadow: var(--input-shadow);
+  border-radius: 28px;
+  padding: 4px 4px 4px 8px;
+}
+.task-dependency-name {
+  font-size: var(--font-ui-small);
+  max-width: 160px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.task-dependency-delete {
+  padding: 3px;
+  cursor: pointer;
+  height: inherit;
+  box-shadow: none !important;
+  border-radius: 50%;
+}
+.task-dependency-dropdown {
+  list-style: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 4px;
+  margin: 0;
+  background-color: var(--background-primary);
+  border: 1px;
+  border-radius: 6px;
+  border-color: var(--background-modifier-border);
+  border-style: solid;
+  z-index: 99;
+  max-height: 170px;
+  overflow-y: auto;
+}
+.task-dependency-dropdown li {
+  padding: 5px;
+  margin: 2px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+}
+.task-dependency-dropdown li .dependency-name {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.task-dependency-dropdown li .dependency-name-shared {
+  width: 60%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.task-dependency-dropdown li .dependency-path {
+  width: 40%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-style: italic;
+  text-align: right;
+  color: var(--italic-color);
+}
+.task-dependency-dropdown li.selected {
+  background-color: var(--text-selection);
+}
+.tasks-options-modal-container {
+  padding-bottom: 0;
+  width: fit-content;
+}
+.tasks-options-modal-container .modal-title {
+  margin-right: var(--size-4-6);
+}
+.is-mobile .tasks-options-modal-container .modal-title {
+  margin-right: var(--size-4-12);
+}
+.tasks-options-modal {
+  padding: 0;
+}
+.tasks-options-modal .tasks-options-modal-checkboxes {
+  display: flex;
+  flex-direction: column;
+}
+.tasks-options-modal .tasks-options-modal-checkboxes label {
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  gap: 8px;
+}
+.tasks-options-modal .tasks-options-modal-checkboxes label input[type=checkbox] {
+  margin: 0;
+}
+.tasks-options-modal .tasks-options-modal-checkboxes hr {
+  margin: 2px 0;
+}
+.tasks-options-modal .tasks-options-modal-footer {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5em;
+  padding: 16px 0;
+}
+.tasks-settings-is-invalid {
+  color: var(--text-error) !important;
+  background-color: rgba(var(--background-modifier-error-rgb), 0.2) !important;
+}
+.tasks-settings .additional {
+  margin: 6px 12px;
+}
+.tasks-settings .additional > .setting-item {
+  border-top: 0;
+  padding-top: 9px;
+}
+.tasks-settings details > summary {
+  outline: none;
+  display: block !important;
+  list-style: none !important;
+  list-style-type: none !important;
+  min-height: 1rem;
+  border-top-left-radius: 0.1rem;
+  border-top-right-radius: 0.1rem;
+  cursor: pointer;
+  position: relative;
+}
+.tasks-settings details > summary::-webkit-details-marker,
+.tasks-settings details > summary::marker {
+  display: none !important;
+}
+.tasks-settings details > summary > .collapser {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  content: "";
+}
+.tasks-settings details > summary > .collapser > .handle {
+  transform: rotate(0deg);
+  transition: transform 0.25s;
+  background-color: currentColor;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  -webkit-mask-image: var(--tasks-details-icon);
+  mask-image: var(--tasks-details-icon);
+  width: 20px;
+  height: 20px;
+}
+.tasks-settings details[open] > summary > .collapser > .handle {
+  transform: rotate(90deg);
+}
+.tasks-nested-settings .setting-item {
+  border: 0px;
+  padding-bottom: 0;
+}
+.tasks-nested-settings {
+  padding-bottom: 18px;
+}
+.tasks-nested-settings[open] .setting-item-heading,
+.tasks-nested-settings:not(details) .setting-item-heading {
+  border-top: 0px;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+.tasks-settings .row-for-status {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+.tasks-settings .tasks-presets-wrapper {
+  width: 100%;
+  position: relative;
+  transition: all 0.2s ease;
+}
+.tasks-settings .tasks-presets-wrapper.tasks-presets-dragging {
+  opacity: 0.5;
+  transform: rotate(2deg);
+}
+.tasks-settings .tasks-presets-wrapper.tasks-presets-drop-above::before {
+  content: "";
+  position: absolute;
+  top: -2px;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background-color: var(--interactive-accent);
+  border-radius: 2px;
+  z-index: 10;
+}
+.tasks-settings .tasks-presets-wrapper.tasks-presets-drop-below::after {
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background-color: var(--interactive-accent);
+  border-radius: 2px;
+  z-index: 10;
+}
+.tasks-settings .tasks-presets-setting .tasks-presets-key {
+  grid-area: key;
+}
+.tasks-settings .tasks-presets-setting .tasks-presets-key.has-error {
+  border-color: var(--text-error);
+  border-width: 2px;
+}
+.tasks-settings .tasks-presets-setting .tasks-presets-value {
+  grid-area: value;
+  min-width: 300px;
+  min-height: 3em;
+  font-family: var(--font-monospace);
+  resize: horizontal;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: pre;
+}
+.tasks-settings .tasks-presets-setting .tasks-presets-drag-handle {
+  grid-area: drag;
+  color: var(--text-muted);
+}
+.tasks-settings .tasks-presets-setting .tasks-presets-drag-handle:hover {
+  color: var(--text-normal);
+}
+.tasks-settings .tasks-presets-setting .tasks-presets-delete-button {
+  grid-area: delete;
+}
+.tasks-settings .tasks-presets-setting .setting-item-control {
+  justify-content: start;
+  display: grid;
+  grid-template-columns: 200px 1fr auto auto;
+  grid-template-areas: "key value drag delete";
+  gap: 4px;
+  align-items: unset;
+  border: 1px solid var(--background-modifier-border) !important;
+  padding: 0.5em !important;
+  background-color: var(--background-secondary) !important;
+  border-radius: 4px !important;
+}
+@container (max-width: 600px) {
+  .tasks-settings .tasks-presets-setting .setting-item-control {
+    grid-template-columns: 5fr 1fr 1fr;
+    grid-template-areas: "key drag delete" "value value value";
+  }
+  .tasks-settings .tasks-presets-setting .setting-item-control .tasks-presets-key {
+    width: 100%;
+  }
+}
+/*# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsibm9kZV9tb2R1bGVzL2ZsYXRwaWNrci9kaXN0L2ZsYXRwaWNrci5jc3MiLCAic3R5bGVzLnNjc3MiLCAiUmVuZGVyZXIvUmVuZGVyZXIuc2NzcyIsICJ1aS9FZGl0VGFzay5zY3NzIiwgInVpL0RlcGVuZGVuY3kuc2NzcyIsICJ1aS9Nb2RhbE9wdGlvbnNFZGl0b3Iuc2NzcyIsICJDb25maWcvU2V0dGluZ3NUYWIuc2NzcyIsICJDb25maWcvUHJlc2V0c1NldHRpbmdzVUkuc2NzcyJdLAogICJzb3VyY2VzQ29udGVudCI6IFsiLmZsYXRwaWNrci1jYWxlbmRhciB7XG4gIGJhY2tncm91bmQ6IHRyYW5zcGFyZW50O1xuICBvcGFjaXR5OiAwO1xuICBkaXNwbGF5OiBub25lO1xuICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gIHZpc2liaWxpdHk6IGhpZGRlbjtcbiAgcGFkZGluZzogMDtcbiAgLXdlYmtpdC1hbmltYXRpb246IG5vbmU7XG4gICAgICAgICAgYW5pbWF0aW9uOiBub25lO1xuICBkaXJlY3Rpb246IGx0cjtcbiAgYm9yZGVyOiAwO1xuICBmb250LXNpemU6IDE0cHg7XG4gIGxpbmUtaGVpZ2h0OiAyNHB4O1xuICBib3JkZXItcmFkaXVzOiA1cHg7XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgd2lkdGg6IDMwNy44NzVweDtcbiAgLXdlYmtpdC1ib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICAgICAgICAgIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gIC1tcy10b3VjaC1hY3Rpb246IG1hbmlwdWxhdGlvbjtcbiAgICAgIHRvdWNoLWFjdGlvbjogbWFuaXB1bGF0aW9uO1xuICBiYWNrZ3JvdW5kOiAjZmZmO1xuICAtd2Via2l0LWJveC1zaGFkb3c6IDFweCAwIDAgI2U2ZTZlNiwgLTFweCAwIDAgI2U2ZTZlNiwgMCAxcHggMCAjZTZlNmU2LCAwIC0xcHggMCAjZTZlNmU2LCAwIDNweCAxM3B4IHJnYmEoMCwwLDAsMC4wOCk7XG4gICAgICAgICAgYm94LXNoYWRvdzogMXB4IDAgMCAjZTZlNmU2LCAtMXB4IDAgMCAjZTZlNmU2LCAwIDFweCAwICNlNmU2ZTYsIDAgLTFweCAwICNlNmU2ZTYsIDAgM3B4IDEzcHggcmdiYSgwLDAsMCwwLjA4KTtcbn1cbi5mbGF0cGlja3ItY2FsZW5kYXIub3Blbixcbi5mbGF0cGlja3ItY2FsZW5kYXIuaW5saW5lIHtcbiAgb3BhY2l0eTogMTtcbiAgbWF4LWhlaWdodDogNjQwcHg7XG4gIHZpc2liaWxpdHk6IHZpc2libGU7XG59XG4uZmxhdHBpY2tyLWNhbGVuZGFyLm9wZW4ge1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIHotaW5kZXg6IDk5OTk5O1xufVxuLmZsYXRwaWNrci1jYWxlbmRhci5hbmltYXRlLm9wZW4ge1xuICAtd2Via2l0LWFuaW1hdGlvbjogZnBGYWRlSW5Eb3duIDMwMG1zIGN1YmljLWJlemllcigwLjIzLCAxLCAwLjMyLCAxKTtcbiAgICAgICAgICBhbmltYXRpb246IGZwRmFkZUluRG93biAzMDBtcyBjdWJpYy1iZXppZXIoMC4yMywgMSwgMC4zMiwgMSk7XG59XG4uZmxhdHBpY2tyLWNhbGVuZGFyLmlubGluZSB7XG4gIGRpc3BsYXk6IGJsb2NrO1xuICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gIHRvcDogMnB4O1xufVxuLmZsYXRwaWNrci1jYWxlbmRhci5zdGF0aWMge1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIHRvcDogY2FsYygxMDAlICsgMnB4KTtcbn1cbi5mbGF0cGlja3ItY2FsZW5kYXIuc3RhdGljLm9wZW4ge1xuICB6LWluZGV4OiA5OTk7XG4gIGRpc3BsYXk6IGJsb2NrO1xufVxuLmZsYXRwaWNrci1jYWxlbmRhci5tdWx0aU1vbnRoIC5mbGF0cGlja3ItZGF5cyAuZGF5Q29udGFpbmVyOm50aC1jaGlsZChuKzEpIC5mbGF0cGlja3ItZGF5LmluUmFuZ2U6bnRoLWNoaWxkKDduKzcpIHtcbiAgLXdlYmtpdC1ib3gtc2hhZG93OiBub25lICFpbXBvcnRhbnQ7XG4gICAgICAgICAgYm94LXNoYWRvdzogbm9uZSAhaW1wb3J0YW50O1xufVxuLmZsYXRwaWNrci1jYWxlbmRhci5tdWx0aU1vbnRoIC5mbGF0cGlja3ItZGF5cyAuZGF5Q29udGFpbmVyOm50aC1jaGlsZChuKzIpIC5mbGF0cGlja3ItZGF5LmluUmFuZ2U6bnRoLWNoaWxkKDduKzEpIHtcbiAgLXdlYmtpdC1ib3gtc2hhZG93OiAtMnB4IDAgMCAjZTZlNmU2LCA1cHggMCAwICNlNmU2ZTY7XG4gICAgICAgICAgYm94LXNoYWRvdzogLTJweCAwIDAgI2U2ZTZlNiwgNXB4IDAgMCAjZTZlNmU2O1xufVxuLmZsYXRwaWNrci1jYWxlbmRhciAuaGFzV2Vla3MgLmRheUNvbnRhaW5lcixcbi5mbGF0cGlja3ItY2FsZW5kYXIgLmhhc1RpbWUgLmRheUNvbnRhaW5lciB7XG4gIGJvcmRlci1ib3R0b206IDA7XG4gIGJvcmRlci1ib3R0b20tcmlnaHQtcmFkaXVzOiAwO1xuICBib3JkZXItYm90dG9tLWxlZnQtcmFkaXVzOiAwO1xufVxuLmZsYXRwaWNrci1jYWxlbmRhciAuaGFzV2Vla3MgLmRheUNvbnRhaW5lciB7XG4gIGJvcmRlci1sZWZ0OiAwO1xufVxuLmZsYXRwaWNrci1jYWxlbmRhci5oYXNUaW1lIC5mbGF0cGlja3ItdGltZSB7XG4gIGhlaWdodDogNDBweDtcbiAgYm9yZGVyLXRvcDogMXB4IHNvbGlkICNlNmU2ZTY7XG59XG4uZmxhdHBpY2tyLWNhbGVuZGFyLm5vQ2FsZW5kYXIuaGFzVGltZSAuZmxhdHBpY2tyLXRpbWUge1xuICBoZWlnaHQ6IGF1dG87XG59XG4uZmxhdHBpY2tyLWNhbGVuZGFyOmJlZm9yZSxcbi5mbGF0cGlja3ItY2FsZW5kYXI6YWZ0ZXIge1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIGRpc3BsYXk6IGJsb2NrO1xuICBwb2ludGVyLWV2ZW50czogbm9uZTtcbiAgYm9yZGVyOiBzb2xpZCB0cmFuc3BhcmVudDtcbiAgY29udGVudDogJyc7XG4gIGhlaWdodDogMDtcbiAgd2lkdGg6IDA7XG4gIGxlZnQ6IDIycHg7XG59XG4uZmxhdHBpY2tyLWNhbGVuZGFyLnJpZ2h0TW9zdDpiZWZvcmUsXG4uZmxhdHBpY2tyLWNhbGVuZGFyLmFycm93UmlnaHQ6YmVmb3JlLFxuLmZsYXRwaWNrci1jYWxlbmRhci5yaWdodE1vc3Q6YWZ0ZXIsXG4uZmxhdHBpY2tyLWNhbGVuZGFyLmFycm93UmlnaHQ6YWZ0ZXIge1xuICBsZWZ0OiBhdXRvO1xuICByaWdodDogMjJweDtcbn1cbi5mbGF0cGlja3ItY2FsZW5kYXIuYXJyb3dDZW50ZXI6YmVmb3JlLFxuLmZsYXRwaWNrci1jYWxlbmRhci5hcnJvd0NlbnRlcjphZnRlciB7XG4gIGxlZnQ6IDUwJTtcbiAgcmlnaHQ6IDUwJTtcbn1cbi5mbGF0cGlja3ItY2FsZW5kYXI6YmVmb3JlIHtcbiAgYm9yZGVyLXdpZHRoOiA1cHg7XG4gIG1hcmdpbjogMCAtNXB4O1xufVxuLmZsYXRwaWNrci1jYWxlbmRhcjphZnRlciB7XG4gIGJvcmRlci13aWR0aDogNHB4O1xuICBtYXJnaW46IDAgLTRweDtcbn1cbi5mbGF0cGlja3ItY2FsZW5kYXIuYXJyb3dUb3A6YmVmb3JlLFxuLmZsYXRwaWNrci1jYWxlbmRhci5hcnJvd1RvcDphZnRlciB7XG4gIGJvdHRvbTogMTAwJTtcbn1cbi5mbGF0cGlja3ItY2FsZW5kYXIuYXJyb3dUb3A6YmVmb3JlIHtcbiAgYm9yZGVyLWJvdHRvbS1jb2xvcjogI2U2ZTZlNjtcbn1cbi5mbGF0cGlja3ItY2FsZW5kYXIuYXJyb3dUb3A6YWZ0ZXIge1xuICBib3JkZXItYm90dG9tLWNvbG9yOiAjZmZmO1xufVxuLmZsYXRwaWNrci1jYWxlbmRhci5hcnJvd0JvdHRvbTpiZWZvcmUsXG4uZmxhdHBpY2tyLWNhbGVuZGFyLmFycm93Qm90dG9tOmFmdGVyIHtcbiAgdG9wOiAxMDAlO1xufVxuLmZsYXRwaWNrci1jYWxlbmRhci5hcnJvd0JvdHRvbTpiZWZvcmUge1xuICBib3JkZXItdG9wLWNvbG9yOiAjZTZlNmU2O1xufVxuLmZsYXRwaWNrci1jYWxlbmRhci5hcnJvd0JvdHRvbTphZnRlciB7XG4gIGJvcmRlci10b3AtY29sb3I6ICNmZmY7XG59XG4uZmxhdHBpY2tyLWNhbGVuZGFyOmZvY3VzIHtcbiAgb3V0bGluZTogMDtcbn1cbi5mbGF0cGlja3Itd3JhcHBlciB7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xufVxuLmZsYXRwaWNrci1tb250aHMge1xuICBkaXNwbGF5OiAtd2Via2l0LWJveDtcbiAgZGlzcGxheTogLXdlYmtpdC1mbGV4O1xuICBkaXNwbGF5OiAtbXMtZmxleGJveDtcbiAgZGlzcGxheTogZmxleDtcbn1cbi5mbGF0cGlja3ItbW9udGhzIC5mbGF0cGlja3ItbW9udGgge1xuICBiYWNrZ3JvdW5kOiB0cmFuc3BhcmVudDtcbiAgY29sb3I6IHJnYmEoMCwwLDAsMC45KTtcbiAgZmlsbDogcmdiYSgwLDAsMCwwLjkpO1xuICBoZWlnaHQ6IDM0cHg7XG4gIGxpbmUtaGVpZ2h0OiAxO1xuICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgLXdlYmtpdC11c2VyLXNlbGVjdDogbm9uZTtcbiAgICAgLW1vei11c2VyLXNlbGVjdDogbm9uZTtcbiAgICAgIC1tcy11c2VyLXNlbGVjdDogbm9uZTtcbiAgICAgICAgICB1c2VyLXNlbGVjdDogbm9uZTtcbiAgb3ZlcmZsb3c6IGhpZGRlbjtcbiAgLXdlYmtpdC1ib3gtZmxleDogMTtcbiAgLXdlYmtpdC1mbGV4OiAxO1xuICAgICAgLW1zLWZsZXg6IDE7XG4gICAgICAgICAgZmxleDogMTtcbn1cbi5mbGF0cGlja3ItbW9udGhzIC5mbGF0cGlja3ItcHJldi1tb250aCxcbi5mbGF0cGlja3ItbW9udGhzIC5mbGF0cGlja3ItbmV4dC1tb250aCB7XG4gIC13ZWJraXQtdXNlci1zZWxlY3Q6IG5vbmU7XG4gICAgIC1tb3otdXNlci1zZWxlY3Q6IG5vbmU7XG4gICAgICAtbXMtdXNlci1zZWxlY3Q6IG5vbmU7XG4gICAgICAgICAgdXNlci1zZWxlY3Q6IG5vbmU7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgY3Vyc29yOiBwb2ludGVyO1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIHRvcDogMDtcbiAgaGVpZ2h0OiAzNHB4O1xuICBwYWRkaW5nOiAxMHB4O1xuICB6LWluZGV4OiAzO1xuICBjb2xvcjogcmdiYSgwLDAsMCwwLjkpO1xuICBmaWxsOiByZ2JhKDAsMCwwLDAuOSk7XG59XG4uZmxhdHBpY2tyLW1vbnRocyAuZmxhdHBpY2tyLXByZXYtbW9udGguZmxhdHBpY2tyLWRpc2FibGVkLFxuLmZsYXRwaWNrci1tb250aHMgLmZsYXRwaWNrci1uZXh0LW1vbnRoLmZsYXRwaWNrci1kaXNhYmxlZCB7XG4gIGRpc3BsYXk6IG5vbmU7XG59XG4uZmxhdHBpY2tyLW1vbnRocyAuZmxhdHBpY2tyLXByZXYtbW9udGggaSxcbi5mbGF0cGlja3ItbW9udGhzIC5mbGF0cGlja3ItbmV4dC1tb250aCBpIHtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xufVxuLmZsYXRwaWNrci1tb250aHMgLmZsYXRwaWNrci1wcmV2LW1vbnRoLmZsYXRwaWNrci1wcmV2LW1vbnRoLFxuLmZsYXRwaWNrci1tb250aHMgLmZsYXRwaWNrci1uZXh0LW1vbnRoLmZsYXRwaWNrci1wcmV2LW1vbnRoIHtcbi8qXG4gICAgICAvKnJ0bDpiZWdpbjppZ25vcmUqL1xuLypcbiAgICAgICovXG4gIGxlZnQ6IDA7XG4vKlxuICAgICAgLypydGw6ZW5kOmlnbm9yZSovXG4vKlxuICAgICAgKi9cbn1cbi8qXG4gICAgICAvKnJ0bDpiZWdpbjppZ25vcmUqL1xuLypcbiAgICAgIC8qcnRsOmVuZDppZ25vcmUqL1xuLmZsYXRwaWNrci1tb250aHMgLmZsYXRwaWNrci1wcmV2LW1vbnRoLmZsYXRwaWNrci1uZXh0LW1vbnRoLFxuLmZsYXRwaWNrci1tb250aHMgLmZsYXRwaWNrci1uZXh0LW1vbnRoLmZsYXRwaWNrci1uZXh0LW1vbnRoIHtcbi8qXG4gICAgICAvKnJ0bDpiZWdpbjppZ25vcmUqL1xuLypcbiAgICAgICovXG4gIHJpZ2h0OiAwO1xuLypcbiAgICAgIC8qcnRsOmVuZDppZ25vcmUqL1xuLypcbiAgICAgICovXG59XG4vKlxuICAgICAgLypydGw6YmVnaW46aWdub3JlKi9cbi8qXG4gICAgICAvKnJ0bDplbmQ6aWdub3JlKi9cbi5mbGF0cGlja3ItbW9udGhzIC5mbGF0cGlja3ItcHJldi1tb250aDpob3Zlcixcbi5mbGF0cGlja3ItbW9udGhzIC5mbGF0cGlja3ItbmV4dC1tb250aDpob3ZlciB7XG4gIGNvbG9yOiAjOTU5ZWE5O1xufVxuLmZsYXRwaWNrci1tb250aHMgLmZsYXRwaWNrci1wcmV2LW1vbnRoOmhvdmVyIHN2Zyxcbi5mbGF0cGlja3ItbW9udGhzIC5mbGF0cGlja3ItbmV4dC1tb250aDpob3ZlciBzdmcge1xuICBmaWxsOiAjZjY0NzQ3O1xufVxuLmZsYXRwaWNrci1tb250aHMgLmZsYXRwaWNrci1wcmV2LW1vbnRoIHN2Zyxcbi5mbGF0cGlja3ItbW9udGhzIC5mbGF0cGlja3ItbmV4dC1tb250aCBzdmcge1xuICB3aWR0aDogMTRweDtcbiAgaGVpZ2h0OiAxNHB4O1xufVxuLmZsYXRwaWNrci1tb250aHMgLmZsYXRwaWNrci1wcmV2LW1vbnRoIHN2ZyBwYXRoLFxuLmZsYXRwaWNrci1tb250aHMgLmZsYXRwaWNrci1uZXh0LW1vbnRoIHN2ZyBwYXRoIHtcbiAgLXdlYmtpdC10cmFuc2l0aW9uOiBmaWxsIDAuMXM7XG4gIHRyYW5zaXRpb246IGZpbGwgMC4xcztcbiAgZmlsbDogaW5oZXJpdDtcbn1cbi5udW1JbnB1dFdyYXBwZXIge1xuICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gIGhlaWdodDogYXV0bztcbn1cbi5udW1JbnB1dFdyYXBwZXIgaW5wdXQsXG4ubnVtSW5wdXRXcmFwcGVyIHNwYW4ge1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG59XG4ubnVtSW5wdXRXcmFwcGVyIGlucHV0IHtcbiAgd2lkdGg6IDEwMCU7XG59XG4ubnVtSW5wdXRXcmFwcGVyIGlucHV0OjotbXMtY2xlYXIge1xuICBkaXNwbGF5OiBub25lO1xufVxuLm51bUlucHV0V3JhcHBlciBpbnB1dDo6LXdlYmtpdC1vdXRlci1zcGluLWJ1dHRvbixcbi5udW1JbnB1dFdyYXBwZXIgaW5wdXQ6Oi13ZWJraXQtaW5uZXItc3Bpbi1idXR0b24ge1xuICBtYXJnaW46IDA7XG4gIC13ZWJraXQtYXBwZWFyYW5jZTogbm9uZTtcbn1cbi5udW1JbnB1dFdyYXBwZXIgc3BhbiB7XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgcmlnaHQ6IDA7XG4gIHdpZHRoOiAxNHB4O1xuICBwYWRkaW5nOiAwIDRweCAwIDJweDtcbiAgaGVpZ2h0OiA1MCU7XG4gIGxpbmUtaGVpZ2h0OiA1MCU7XG4gIG9wYWNpdHk6IDA7XG4gIGN1cnNvcjogcG9pbnRlcjtcbiAgYm9yZGVyOiAxcHggc29saWQgcmdiYSg1Nyw1Nyw1NywwLjE1KTtcbiAgLXdlYmtpdC1ib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICAgICAgICAgIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG59XG4ubnVtSW5wdXRXcmFwcGVyIHNwYW46aG92ZXIge1xuICBiYWNrZ3JvdW5kOiByZ2JhKDAsMCwwLDAuMSk7XG59XG4ubnVtSW5wdXRXcmFwcGVyIHNwYW46YWN0aXZlIHtcbiAgYmFja2dyb3VuZDogcmdiYSgwLDAsMCwwLjIpO1xufVxuLm51bUlucHV0V3JhcHBlciBzcGFuOmFmdGVyIHtcbiAgZGlzcGxheTogYmxvY2s7XG4gIGNvbnRlbnQ6IFwiXCI7XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbn1cbi5udW1JbnB1dFdyYXBwZXIgc3Bhbi5hcnJvd1VwIHtcbiAgdG9wOiAwO1xuICBib3JkZXItYm90dG9tOiAwO1xufVxuLm51bUlucHV0V3JhcHBlciBzcGFuLmFycm93VXA6YWZ0ZXIge1xuICBib3JkZXItbGVmdDogNHB4IHNvbGlkIHRyYW5zcGFyZW50O1xuICBib3JkZXItcmlnaHQ6IDRweCBzb2xpZCB0cmFuc3BhcmVudDtcbiAgYm9yZGVyLWJvdHRvbTogNHB4IHNvbGlkIHJnYmEoNTcsNTcsNTcsMC42KTtcbiAgdG9wOiAyNiU7XG59XG4ubnVtSW5wdXRXcmFwcGVyIHNwYW4uYXJyb3dEb3duIHtcbiAgdG9wOiA1MCU7XG59XG4ubnVtSW5wdXRXcmFwcGVyIHNwYW4uYXJyb3dEb3duOmFmdGVyIHtcbiAgYm9yZGVyLWxlZnQ6IDRweCBzb2xpZCB0cmFuc3BhcmVudDtcbiAgYm9yZGVyLXJpZ2h0OiA0cHggc29saWQgdHJhbnNwYXJlbnQ7XG4gIGJvcmRlci10b3A6IDRweCBzb2xpZCByZ2JhKDU3LDU3LDU3LDAuNik7XG4gIHRvcDogNDAlO1xufVxuLm51bUlucHV0V3JhcHBlciBzcGFuIHN2ZyB7XG4gIHdpZHRoOiBpbmhlcml0O1xuICBoZWlnaHQ6IGF1dG87XG59XG4ubnVtSW5wdXRXcmFwcGVyIHNwYW4gc3ZnIHBhdGgge1xuICBmaWxsOiByZ2JhKDAsMCwwLDAuNSk7XG59XG4ubnVtSW5wdXRXcmFwcGVyOmhvdmVyIHtcbiAgYmFja2dyb3VuZDogcmdiYSgwLDAsMCwwLjA1KTtcbn1cbi5udW1JbnB1dFdyYXBwZXI6aG92ZXIgc3BhbiB7XG4gIG9wYWNpdHk6IDE7XG59XG4uZmxhdHBpY2tyLWN1cnJlbnQtbW9udGgge1xuICBmb250LXNpemU6IDEzNSU7XG4gIGxpbmUtaGVpZ2h0OiBpbmhlcml0O1xuICBmb250LXdlaWdodDogMzAwO1xuICBjb2xvcjogaW5oZXJpdDtcbiAgcG9zaXRpb246IGFic29sdXRlO1xuICB3aWR0aDogNzUlO1xuICBsZWZ0OiAxMi41JTtcbiAgcGFkZGluZzogNy40OHB4IDAgMCAwO1xuICBsaW5lLWhlaWdodDogMTtcbiAgaGVpZ2h0OiAzNHB4O1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgLXdlYmtpdC10cmFuc2Zvcm06IHRyYW5zbGF0ZTNkKDBweCwgMHB4LCAwcHgpO1xuICAgICAgICAgIHRyYW5zZm9ybTogdHJhbnNsYXRlM2QoMHB4LCAwcHgsIDBweCk7XG59XG4uZmxhdHBpY2tyLWN1cnJlbnQtbW9udGggc3Bhbi5jdXItbW9udGgge1xuICBmb250LWZhbWlseTogaW5oZXJpdDtcbiAgZm9udC13ZWlnaHQ6IDcwMDtcbiAgY29sb3I6IGluaGVyaXQ7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgbWFyZ2luLWxlZnQ6IDAuNWNoO1xuICBwYWRkaW5nOiAwO1xufVxuLmZsYXRwaWNrci1jdXJyZW50LW1vbnRoIHNwYW4uY3VyLW1vbnRoOmhvdmVyIHtcbiAgYmFja2dyb3VuZDogcmdiYSgwLDAsMCwwLjA1KTtcbn1cbi5mbGF0cGlja3ItY3VycmVudC1tb250aCAubnVtSW5wdXRXcmFwcGVyIHtcbiAgd2lkdGg6IDZjaDtcbiAgd2lkdGg6IDdjaFxcMDtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xufVxuLmZsYXRwaWNrci1jdXJyZW50LW1vbnRoIC5udW1JbnB1dFdyYXBwZXIgc3Bhbi5hcnJvd1VwOmFmdGVyIHtcbiAgYm9yZGVyLWJvdHRvbS1jb2xvcjogcmdiYSgwLDAsMCwwLjkpO1xufVxuLmZsYXRwaWNrci1jdXJyZW50LW1vbnRoIC5udW1JbnB1dFdyYXBwZXIgc3Bhbi5hcnJvd0Rvd246YWZ0ZXIge1xuICBib3JkZXItdG9wLWNvbG9yOiByZ2JhKDAsMCwwLDAuOSk7XG59XG4uZmxhdHBpY2tyLWN1cnJlbnQtbW9udGggaW5wdXQuY3VyLXllYXIge1xuICBiYWNrZ3JvdW5kOiB0cmFuc3BhcmVudDtcbiAgLXdlYmtpdC1ib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICAgICAgICAgIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gIGNvbG9yOiBpbmhlcml0O1xuICBjdXJzb3I6IHRleHQ7XG4gIHBhZGRpbmc6IDAgMCAwIDAuNWNoO1xuICBtYXJnaW46IDA7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgZm9udC1zaXplOiBpbmhlcml0O1xuICBmb250LWZhbWlseTogaW5oZXJpdDtcbiAgZm9udC13ZWlnaHQ6IDMwMDtcbiAgbGluZS1oZWlnaHQ6IGluaGVyaXQ7XG4gIGhlaWdodDogYXV0bztcbiAgYm9yZGVyOiAwO1xuICBib3JkZXItcmFkaXVzOiAwO1xuICB2ZXJ0aWNhbC1hbGlnbjogaW5pdGlhbDtcbiAgLXdlYmtpdC1hcHBlYXJhbmNlOiB0ZXh0ZmllbGQ7XG4gIC1tb3otYXBwZWFyYW5jZTogdGV4dGZpZWxkO1xuICBhcHBlYXJhbmNlOiB0ZXh0ZmllbGQ7XG59XG4uZmxhdHBpY2tyLWN1cnJlbnQtbW9udGggaW5wdXQuY3VyLXllYXI6Zm9jdXMge1xuICBvdXRsaW5lOiAwO1xufVxuLmZsYXRwaWNrci1jdXJyZW50LW1vbnRoIGlucHV0LmN1ci15ZWFyW2Rpc2FibGVkXSxcbi5mbGF0cGlja3ItY3VycmVudC1tb250aCBpbnB1dC5jdXIteWVhcltkaXNhYmxlZF06aG92ZXIge1xuICBmb250LXNpemU6IDEwMCU7XG4gIGNvbG9yOiByZ2JhKDAsMCwwLDAuNSk7XG4gIGJhY2tncm91bmQ6IHRyYW5zcGFyZW50O1xuICBwb2ludGVyLWV2ZW50czogbm9uZTtcbn1cbi5mbGF0cGlja3ItY3VycmVudC1tb250aCAuZmxhdHBpY2tyLW1vbnRoRHJvcGRvd24tbW9udGhzIHtcbiAgYXBwZWFyYW5jZTogbWVudWxpc3Q7XG4gIGJhY2tncm91bmQ6IHRyYW5zcGFyZW50O1xuICBib3JkZXI6IG5vbmU7XG4gIGJvcmRlci1yYWRpdXM6IDA7XG4gIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gIGNvbG9yOiBpbmhlcml0O1xuICBjdXJzb3I6IHBvaW50ZXI7XG4gIGZvbnQtc2l6ZTogaW5oZXJpdDtcbiAgZm9udC1mYW1pbHk6IGluaGVyaXQ7XG4gIGZvbnQtd2VpZ2h0OiAzMDA7XG4gIGhlaWdodDogYXV0bztcbiAgbGluZS1oZWlnaHQ6IGluaGVyaXQ7XG4gIG1hcmdpbjogLTFweCAwIDAgMDtcbiAgb3V0bGluZTogbm9uZTtcbiAgcGFkZGluZzogMCAwIDAgMC41Y2g7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgdmVydGljYWwtYWxpZ246IGluaXRpYWw7XG4gIC13ZWJraXQtYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgLXdlYmtpdC1hcHBlYXJhbmNlOiBtZW51bGlzdDtcbiAgLW1vei1hcHBlYXJhbmNlOiBtZW51bGlzdDtcbiAgd2lkdGg6IGF1dG87XG59XG4uZmxhdHBpY2tyLWN1cnJlbnQtbW9udGggLmZsYXRwaWNrci1tb250aERyb3Bkb3duLW1vbnRoczpmb2N1cyxcbi5mbGF0cGlja3ItY3VycmVudC1tb250aCAuZmxhdHBpY2tyLW1vbnRoRHJvcGRvd24tbW9udGhzOmFjdGl2ZSB7XG4gIG91dGxpbmU6IG5vbmU7XG59XG4uZmxhdHBpY2tyLWN1cnJlbnQtbW9udGggLmZsYXRwaWNrci1tb250aERyb3Bkb3duLW1vbnRoczpob3ZlciB7XG4gIGJhY2tncm91bmQ6IHJnYmEoMCwwLDAsMC4wNSk7XG59XG4uZmxhdHBpY2tyLWN1cnJlbnQtbW9udGggLmZsYXRwaWNrci1tb250aERyb3Bkb3duLW1vbnRocyAuZmxhdHBpY2tyLW1vbnRoRHJvcGRvd24tbW9udGgge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgb3V0bGluZTogbm9uZTtcbiAgcGFkZGluZzogMDtcbn1cbi5mbGF0cGlja3Itd2Vla2RheXMge1xuICBiYWNrZ3JvdW5kOiB0cmFuc3BhcmVudDtcbiAgdGV4dC1hbGlnbjogY2VudGVyO1xuICBvdmVyZmxvdzogaGlkZGVuO1xuICB3aWR0aDogMTAwJTtcbiAgZGlzcGxheTogLXdlYmtpdC1ib3g7XG4gIGRpc3BsYXk6IC13ZWJraXQtZmxleDtcbiAgZGlzcGxheTogLW1zLWZsZXhib3g7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIC13ZWJraXQtYm94LWFsaWduOiBjZW50ZXI7XG4gIC13ZWJraXQtYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICAgIC1tcy1mbGV4LWFsaWduOiBjZW50ZXI7XG4gICAgICAgICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgaGVpZ2h0OiAyOHB4O1xufVxuLmZsYXRwaWNrci13ZWVrZGF5cyAuZmxhdHBpY2tyLXdlZWtkYXljb250YWluZXIge1xuICBkaXNwbGF5OiAtd2Via2l0LWJveDtcbiAgZGlzcGxheTogLXdlYmtpdC1mbGV4O1xuICBkaXNwbGF5OiAtbXMtZmxleGJveDtcbiAgZGlzcGxheTogZmxleDtcbiAgLXdlYmtpdC1ib3gtZmxleDogMTtcbiAgLXdlYmtpdC1mbGV4OiAxO1xuICAgICAgLW1zLWZsZXg6IDE7XG4gICAgICAgICAgZmxleDogMTtcbn1cbnNwYW4uZmxhdHBpY2tyLXdlZWtkYXkge1xuICBjdXJzb3I6IGRlZmF1bHQ7XG4gIGZvbnQtc2l6ZTogOTAlO1xuICBiYWNrZ3JvdW5kOiB0cmFuc3BhcmVudDtcbiAgY29sb3I6IHJnYmEoMCwwLDAsMC41NCk7XG4gIGxpbmUtaGVpZ2h0OiAxO1xuICBtYXJnaW46IDA7XG4gIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgZGlzcGxheTogYmxvY2s7XG4gIC13ZWJraXQtYm94LWZsZXg6IDE7XG4gIC13ZWJraXQtZmxleDogMTtcbiAgICAgIC1tcy1mbGV4OiAxO1xuICAgICAgICAgIGZsZXg6IDE7XG4gIGZvbnQtd2VpZ2h0OiBib2xkZXI7XG59XG4uZGF5Q29udGFpbmVyLFxuLmZsYXRwaWNrci13ZWVrcyB7XG4gIHBhZGRpbmc6IDFweCAwIDAgMDtcbn1cbi5mbGF0cGlja3ItZGF5cyB7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgb3ZlcmZsb3c6IGhpZGRlbjtcbiAgZGlzcGxheTogLXdlYmtpdC1ib3g7XG4gIGRpc3BsYXk6IC13ZWJraXQtZmxleDtcbiAgZGlzcGxheTogLW1zLWZsZXhib3g7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIC13ZWJraXQtYm94LWFsaWduOiBzdGFydDtcbiAgLXdlYmtpdC1hbGlnbi1pdGVtczogZmxleC1zdGFydDtcbiAgICAgIC1tcy1mbGV4LWFsaWduOiBzdGFydDtcbiAgICAgICAgICBhbGlnbi1pdGVtczogZmxleC1zdGFydDtcbiAgd2lkdGg6IDMwNy44NzVweDtcbn1cbi5mbGF0cGlja3ItZGF5czpmb2N1cyB7XG4gIG91dGxpbmU6IDA7XG59XG4uZGF5Q29udGFpbmVyIHtcbiAgcGFkZGluZzogMDtcbiAgb3V0bGluZTogMDtcbiAgdGV4dC1hbGlnbjogbGVmdDtcbiAgd2lkdGg6IDMwNy44NzVweDtcbiAgbWluLXdpZHRoOiAzMDcuODc1cHg7XG4gIG1heC13aWR0aDogMzA3Ljg3NXB4O1xuICAtd2Via2l0LWJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gICAgICAgICAgYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICBkaXNwbGF5OiAtbXMtZmxleGJveDtcbiAgZGlzcGxheTogLXdlYmtpdC1ib3g7XG4gIGRpc3BsYXk6IC13ZWJraXQtZmxleDtcbiAgZGlzcGxheTogZmxleDtcbiAgLXdlYmtpdC1mbGV4LXdyYXA6IHdyYXA7XG4gICAgICAgICAgZmxleC13cmFwOiB3cmFwO1xuICAtbXMtZmxleC13cmFwOiB3cmFwO1xuICAtbXMtZmxleC1wYWNrOiBqdXN0aWZ5O1xuICAtd2Via2l0LWp1c3RpZnktY29udGVudDogc3BhY2UtYXJvdW5kO1xuICAgICAgICAgIGp1c3RpZnktY29udGVudDogc3BhY2UtYXJvdW5kO1xuICAtd2Via2l0LXRyYW5zZm9ybTogdHJhbnNsYXRlM2QoMHB4LCAwcHgsIDBweCk7XG4gICAgICAgICAgdHJhbnNmb3JtOiB0cmFuc2xhdGUzZCgwcHgsIDBweCwgMHB4KTtcbiAgb3BhY2l0eTogMTtcbn1cbi5kYXlDb250YWluZXIgKyAuZGF5Q29udGFpbmVyIHtcbiAgLXdlYmtpdC1ib3gtc2hhZG93OiAtMXB4IDAgMCAjZTZlNmU2O1xuICAgICAgICAgIGJveC1zaGFkb3c6IC0xcHggMCAwICNlNmU2ZTY7XG59XG4uZmxhdHBpY2tyLWRheSB7XG4gIGJhY2tncm91bmQ6IG5vbmU7XG4gIGJvcmRlcjogMXB4IHNvbGlkIHRyYW5zcGFyZW50O1xuICBib3JkZXItcmFkaXVzOiAxNTBweDtcbiAgLXdlYmtpdC1ib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICAgICAgICAgIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gIGNvbG9yOiAjMzkzOTM5O1xuICBjdXJzb3I6IHBvaW50ZXI7XG4gIGZvbnQtd2VpZ2h0OiA0MDA7XG4gIHdpZHRoOiAxNC4yODU3MTQzJTtcbiAgLXdlYmtpdC1mbGV4LWJhc2lzOiAxNC4yODU3MTQzJTtcbiAgICAgIC1tcy1mbGV4LXByZWZlcnJlZC1zaXplOiAxNC4yODU3MTQzJTtcbiAgICAgICAgICBmbGV4LWJhc2lzOiAxNC4yODU3MTQzJTtcbiAgbWF4LXdpZHRoOiAzOXB4O1xuICBoZWlnaHQ6IDM5cHg7XG4gIGxpbmUtaGVpZ2h0OiAzOXB4O1xuICBtYXJnaW46IDA7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAtd2Via2l0LWJveC1wYWNrOiBjZW50ZXI7XG4gIC13ZWJraXQtanVzdGlmeS1jb250ZW50OiBjZW50ZXI7XG4gICAgICAtbXMtZmxleC1wYWNrOiBjZW50ZXI7XG4gICAgICAgICAganVzdGlmeS1jb250ZW50OiBjZW50ZXI7XG4gIHRleHQtYWxpZ246IGNlbnRlcjtcbn1cbi5mbGF0cGlja3ItZGF5LmluUmFuZ2UsXG4uZmxhdHBpY2tyLWRheS5wcmV2TW9udGhEYXkuaW5SYW5nZSxcbi5mbGF0cGlja3ItZGF5Lm5leHRNb250aERheS5pblJhbmdlLFxuLmZsYXRwaWNrci1kYXkudG9kYXkuaW5SYW5nZSxcbi5mbGF0cGlja3ItZGF5LnByZXZNb250aERheS50b2RheS5pblJhbmdlLFxuLmZsYXRwaWNrci1kYXkubmV4dE1vbnRoRGF5LnRvZGF5LmluUmFuZ2UsXG4uZmxhdHBpY2tyLWRheTpob3Zlcixcbi5mbGF0cGlja3ItZGF5LnByZXZNb250aERheTpob3Zlcixcbi5mbGF0cGlja3ItZGF5Lm5leHRNb250aERheTpob3Zlcixcbi5mbGF0cGlja3ItZGF5OmZvY3VzLFxuLmZsYXRwaWNrci1kYXkucHJldk1vbnRoRGF5OmZvY3VzLFxuLmZsYXRwaWNrci1kYXkubmV4dE1vbnRoRGF5OmZvY3VzIHtcbiAgY3Vyc29yOiBwb2ludGVyO1xuICBvdXRsaW5lOiAwO1xuICBiYWNrZ3JvdW5kOiAjZTZlNmU2O1xuICBib3JkZXItY29sb3I6ICNlNmU2ZTY7XG59XG4uZmxhdHBpY2tyLWRheS50b2RheSB7XG4gIGJvcmRlci1jb2xvcjogIzk1OWVhOTtcbn1cbi5mbGF0cGlja3ItZGF5LnRvZGF5OmhvdmVyLFxuLmZsYXRwaWNrci1kYXkudG9kYXk6Zm9jdXMge1xuICBib3JkZXItY29sb3I6ICM5NTllYTk7XG4gIGJhY2tncm91bmQ6ICM5NTllYTk7XG4gIGNvbG9yOiAjZmZmO1xufVxuLmZsYXRwaWNrci1kYXkuc2VsZWN0ZWQsXG4uZmxhdHBpY2tyLWRheS5zdGFydFJhbmdlLFxuLmZsYXRwaWNrci1kYXkuZW5kUmFuZ2UsXG4uZmxhdHBpY2tyLWRheS5zZWxlY3RlZC5pblJhbmdlLFxuLmZsYXRwaWNrci1kYXkuc3RhcnRSYW5nZS5pblJhbmdlLFxuLmZsYXRwaWNrci1kYXkuZW5kUmFuZ2UuaW5SYW5nZSxcbi5mbGF0cGlja3ItZGF5LnNlbGVjdGVkOmZvY3VzLFxuLmZsYXRwaWNrci1kYXkuc3RhcnRSYW5nZTpmb2N1cyxcbi5mbGF0cGlja3ItZGF5LmVuZFJhbmdlOmZvY3VzLFxuLmZsYXRwaWNrci1kYXkuc2VsZWN0ZWQ6aG92ZXIsXG4uZmxhdHBpY2tyLWRheS5zdGFydFJhbmdlOmhvdmVyLFxuLmZsYXRwaWNrci1kYXkuZW5kUmFuZ2U6aG92ZXIsXG4uZmxhdHBpY2tyLWRheS5zZWxlY3RlZC5wcmV2TW9udGhEYXksXG4uZmxhdHBpY2tyLWRheS5zdGFydFJhbmdlLnByZXZNb250aERheSxcbi5mbGF0cGlja3ItZGF5LmVuZFJhbmdlLnByZXZNb250aERheSxcbi5mbGF0cGlja3ItZGF5LnNlbGVjdGVkLm5leHRNb250aERheSxcbi5mbGF0cGlja3ItZGF5LnN0YXJ0UmFuZ2UubmV4dE1vbnRoRGF5LFxuLmZsYXRwaWNrci1kYXkuZW5kUmFuZ2UubmV4dE1vbnRoRGF5IHtcbiAgYmFja2dyb3VuZDogIzU2OWZmNztcbiAgLXdlYmtpdC1ib3gtc2hhZG93OiBub25lO1xuICAgICAgICAgIGJveC1zaGFkb3c6IG5vbmU7XG4gIGNvbG9yOiAjZmZmO1xuICBib3JkZXItY29sb3I6ICM1NjlmZjc7XG59XG4uZmxhdHBpY2tyLWRheS5zZWxlY3RlZC5zdGFydFJhbmdlLFxuLmZsYXRwaWNrci1kYXkuc3RhcnRSYW5nZS5zdGFydFJhbmdlLFxuLmZsYXRwaWNrci1kYXkuZW5kUmFuZ2Uuc3RhcnRSYW5nZSB7XG4gIGJvcmRlci1yYWRpdXM6IDUwcHggMCAwIDUwcHg7XG59XG4uZmxhdHBpY2tyLWRheS5zZWxlY3RlZC5lbmRSYW5nZSxcbi5mbGF0cGlja3ItZGF5LnN0YXJ0UmFuZ2UuZW5kUmFuZ2UsXG4uZmxhdHBpY2tyLWRheS5lbmRSYW5nZS5lbmRSYW5nZSB7XG4gIGJvcmRlci1yYWRpdXM6IDAgNTBweCA1MHB4IDA7XG59XG4uZmxhdHBpY2tyLWRheS5zZWxlY3RlZC5zdGFydFJhbmdlICsgLmVuZFJhbmdlOm5vdCg6bnRoLWNoaWxkKDduKzEpKSxcbi5mbGF0cGlja3ItZGF5LnN0YXJ0UmFuZ2Uuc3RhcnRSYW5nZSArIC5lbmRSYW5nZTpub3QoOm50aC1jaGlsZCg3bisxKSksXG4uZmxhdHBpY2tyLWRheS5lbmRSYW5nZS5zdGFydFJhbmdlICsgLmVuZFJhbmdlOm5vdCg6bnRoLWNoaWxkKDduKzEpKSB7XG4gIC13ZWJraXQtYm94LXNoYWRvdzogLTEwcHggMCAwICM1NjlmZjc7XG4gICAgICAgICAgYm94LXNoYWRvdzogLTEwcHggMCAwICM1NjlmZjc7XG59XG4uZmxhdHBpY2tyLWRheS5zZWxlY3RlZC5zdGFydFJhbmdlLmVuZFJhbmdlLFxuLmZsYXRwaWNrci1kYXkuc3RhcnRSYW5nZS5zdGFydFJhbmdlLmVuZFJhbmdlLFxuLmZsYXRwaWNrci1kYXkuZW5kUmFuZ2Uuc3RhcnRSYW5nZS5lbmRSYW5nZSB7XG4gIGJvcmRlci1yYWRpdXM6IDUwcHg7XG59XG4uZmxhdHBpY2tyLWRheS5pblJhbmdlIHtcbiAgYm9yZGVyLXJhZGl1czogMDtcbiAgLXdlYmtpdC1ib3gtc2hhZG93OiAtNXB4IDAgMCAjZTZlNmU2LCA1cHggMCAwICNlNmU2ZTY7XG4gICAgICAgICAgYm94LXNoYWRvdzogLTVweCAwIDAgI2U2ZTZlNiwgNXB4IDAgMCAjZTZlNmU2O1xufVxuLmZsYXRwaWNrci1kYXkuZmxhdHBpY2tyLWRpc2FibGVkLFxuLmZsYXRwaWNrci1kYXkuZmxhdHBpY2tyLWRpc2FibGVkOmhvdmVyLFxuLmZsYXRwaWNrci1kYXkucHJldk1vbnRoRGF5LFxuLmZsYXRwaWNrci1kYXkubmV4dE1vbnRoRGF5LFxuLmZsYXRwaWNrci1kYXkubm90QWxsb3dlZCxcbi5mbGF0cGlja3ItZGF5Lm5vdEFsbG93ZWQucHJldk1vbnRoRGF5LFxuLmZsYXRwaWNrci1kYXkubm90QWxsb3dlZC5uZXh0TW9udGhEYXkge1xuICBjb2xvcjogcmdiYSg1Nyw1Nyw1NywwLjMpO1xuICBiYWNrZ3JvdW5kOiB0cmFuc3BhcmVudDtcbiAgYm9yZGVyLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgY3Vyc29yOiBkZWZhdWx0O1xufVxuLmZsYXRwaWNrci1kYXkuZmxhdHBpY2tyLWRpc2FibGVkLFxuLmZsYXRwaWNrci1kYXkuZmxhdHBpY2tyLWRpc2FibGVkOmhvdmVyIHtcbiAgY3Vyc29yOiBub3QtYWxsb3dlZDtcbiAgY29sb3I6IHJnYmEoNTcsNTcsNTcsMC4xKTtcbn1cbi5mbGF0cGlja3ItZGF5LndlZWsuc2VsZWN0ZWQge1xuICBib3JkZXItcmFkaXVzOiAwO1xuICAtd2Via2l0LWJveC1zaGFkb3c6IC01cHggMCAwICM1NjlmZjcsIDVweCAwIDAgIzU2OWZmNztcbiAgICAgICAgICBib3gtc2hhZG93OiAtNXB4IDAgMCAjNTY5ZmY3LCA1cHggMCAwICM1NjlmZjc7XG59XG4uZmxhdHBpY2tyLWRheS5oaWRkZW4ge1xuICB2aXNpYmlsaXR5OiBoaWRkZW47XG59XG4ucmFuZ2VNb2RlIC5mbGF0cGlja3ItZGF5IHtcbiAgbWFyZ2luLXRvcDogMXB4O1xufVxuLmZsYXRwaWNrci13ZWVrd3JhcHBlciB7XG4gIGZsb2F0OiBsZWZ0O1xufVxuLmZsYXRwaWNrci13ZWVrd3JhcHBlciAuZmxhdHBpY2tyLXdlZWtzIHtcbiAgcGFkZGluZzogMCAxMnB4O1xuICAtd2Via2l0LWJveC1zaGFkb3c6IDFweCAwIDAgI2U2ZTZlNjtcbiAgICAgICAgICBib3gtc2hhZG93OiAxcHggMCAwICNlNmU2ZTY7XG59XG4uZmxhdHBpY2tyLXdlZWt3cmFwcGVyIC5mbGF0cGlja3Itd2Vla2RheSB7XG4gIGZsb2F0OiBub25lO1xuICB3aWR0aDogMTAwJTtcbiAgbGluZS1oZWlnaHQ6IDI4cHg7XG59XG4uZmxhdHBpY2tyLXdlZWt3cmFwcGVyIHNwYW4uZmxhdHBpY2tyLWRheSxcbi5mbGF0cGlja3Itd2Vla3dyYXBwZXIgc3Bhbi5mbGF0cGlja3ItZGF5OmhvdmVyIHtcbiAgZGlzcGxheTogYmxvY2s7XG4gIHdpZHRoOiAxMDAlO1xuICBtYXgtd2lkdGg6IG5vbmU7XG4gIGNvbG9yOiByZ2JhKDU3LDU3LDU3LDAuMyk7XG4gIGJhY2tncm91bmQ6IHRyYW5zcGFyZW50O1xuICBjdXJzb3I6IGRlZmF1bHQ7XG4gIGJvcmRlcjogbm9uZTtcbn1cbi5mbGF0cGlja3ItaW5uZXJDb250YWluZXIge1xuICBkaXNwbGF5OiBibG9jaztcbiAgZGlzcGxheTogLXdlYmtpdC1ib3g7XG4gIGRpc3BsYXk6IC13ZWJraXQtZmxleDtcbiAgZGlzcGxheTogLW1zLWZsZXhib3g7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIC13ZWJraXQtYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgICAgICAgICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICBvdmVyZmxvdzogaGlkZGVuO1xufVxuLmZsYXRwaWNrci1yQ29udGFpbmVyIHtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICBwYWRkaW5nOiAwO1xuICAtd2Via2l0LWJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gICAgICAgICAgYm94LXNpemluZzogYm9yZGVyLWJveDtcbn1cbi5mbGF0cGlja3ItdGltZSB7XG4gIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgb3V0bGluZTogMDtcbiAgZGlzcGxheTogYmxvY2s7XG4gIGhlaWdodDogMDtcbiAgbGluZS1oZWlnaHQ6IDQwcHg7XG4gIG1heC1oZWlnaHQ6IDQwcHg7XG4gIC13ZWJraXQtYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgICAgICAgICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICBvdmVyZmxvdzogaGlkZGVuO1xuICBkaXNwbGF5OiAtd2Via2l0LWJveDtcbiAgZGlzcGxheTogLXdlYmtpdC1mbGV4O1xuICBkaXNwbGF5OiAtbXMtZmxleGJveDtcbiAgZGlzcGxheTogZmxleDtcbn1cbi5mbGF0cGlja3ItdGltZTphZnRlciB7XG4gIGNvbnRlbnQ6IFwiXCI7XG4gIGRpc3BsYXk6IHRhYmxlO1xuICBjbGVhcjogYm90aDtcbn1cbi5mbGF0cGlja3ItdGltZSAubnVtSW5wdXRXcmFwcGVyIHtcbiAgLXdlYmtpdC1ib3gtZmxleDogMTtcbiAgLXdlYmtpdC1mbGV4OiAxO1xuICAgICAgLW1zLWZsZXg6IDE7XG4gICAgICAgICAgZmxleDogMTtcbiAgd2lkdGg6IDQwJTtcbiAgaGVpZ2h0OiA0MHB4O1xuICBmbG9hdDogbGVmdDtcbn1cbi5mbGF0cGlja3ItdGltZSAubnVtSW5wdXRXcmFwcGVyIHNwYW4uYXJyb3dVcDphZnRlciB7XG4gIGJvcmRlci1ib3R0b20tY29sb3I6ICMzOTM5Mzk7XG59XG4uZmxhdHBpY2tyLXRpbWUgLm51bUlucHV0V3JhcHBlciBzcGFuLmFycm93RG93bjphZnRlciB7XG4gIGJvcmRlci10b3AtY29sb3I6ICMzOTM5Mzk7XG59XG4uZmxhdHBpY2tyLXRpbWUuaGFzU2Vjb25kcyAubnVtSW5wdXRXcmFwcGVyIHtcbiAgd2lkdGg6IDI2JTtcbn1cbi5mbGF0cGlja3ItdGltZS50aW1lMjRociAubnVtSW5wdXRXcmFwcGVyIHtcbiAgd2lkdGg6IDQ5JTtcbn1cbi5mbGF0cGlja3ItdGltZSBpbnB1dCB7XG4gIGJhY2tncm91bmQ6IHRyYW5zcGFyZW50O1xuICAtd2Via2l0LWJveC1zaGFkb3c6IG5vbmU7XG4gICAgICAgICAgYm94LXNoYWRvdzogbm9uZTtcbiAgYm9yZGVyOiAwO1xuICBib3JkZXItcmFkaXVzOiAwO1xuICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gIG1hcmdpbjogMDtcbiAgcGFkZGluZzogMDtcbiAgaGVpZ2h0OiBpbmhlcml0O1xuICBsaW5lLWhlaWdodDogaW5oZXJpdDtcbiAgY29sb3I6ICMzOTM5Mzk7XG4gIGZvbnQtc2l6ZTogMTRweDtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAtd2Via2l0LWJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gICAgICAgICAgYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgLXdlYmtpdC1hcHBlYXJhbmNlOiB0ZXh0ZmllbGQ7XG4gIC1tb3otYXBwZWFyYW5jZTogdGV4dGZpZWxkO1xuICBhcHBlYXJhbmNlOiB0ZXh0ZmllbGQ7XG59XG4uZmxhdHBpY2tyLXRpbWUgaW5wdXQuZmxhdHBpY2tyLWhvdXIge1xuICBmb250LXdlaWdodDogYm9sZDtcbn1cbi5mbGF0cGlja3ItdGltZSBpbnB1dC5mbGF0cGlja3ItbWludXRlLFxuLmZsYXRwaWNrci10aW1lIGlucHV0LmZsYXRwaWNrci1zZWNvbmQge1xuICBmb250LXdlaWdodDogNDAwO1xufVxuLmZsYXRwaWNrci10aW1lIGlucHV0OmZvY3VzIHtcbiAgb3V0bGluZTogMDtcbiAgYm9yZGVyOiAwO1xufVxuLmZsYXRwaWNrci10aW1lIC5mbGF0cGlja3ItdGltZS1zZXBhcmF0b3IsXG4uZmxhdHBpY2tyLXRpbWUgLmZsYXRwaWNrci1hbS1wbSB7XG4gIGhlaWdodDogaW5oZXJpdDtcbiAgZmxvYXQ6IGxlZnQ7XG4gIGxpbmUtaGVpZ2h0OiBpbmhlcml0O1xuICBjb2xvcjogIzM5MzkzOTtcbiAgZm9udC13ZWlnaHQ6IGJvbGQ7XG4gIHdpZHRoOiAyJTtcbiAgLXdlYmtpdC11c2VyLXNlbGVjdDogbm9uZTtcbiAgICAgLW1vei11c2VyLXNlbGVjdDogbm9uZTtcbiAgICAgIC1tcy11c2VyLXNlbGVjdDogbm9uZTtcbiAgICAgICAgICB1c2VyLXNlbGVjdDogbm9uZTtcbiAgLXdlYmtpdC1hbGlnbi1zZWxmOiBjZW50ZXI7XG4gICAgICAtbXMtZmxleC1pdGVtLWFsaWduOiBjZW50ZXI7XG4gICAgICAgICAgYWxpZ24tc2VsZjogY2VudGVyO1xufVxuLmZsYXRwaWNrci10aW1lIC5mbGF0cGlja3ItYW0tcG0ge1xuICBvdXRsaW5lOiAwO1xuICB3aWR0aDogMTglO1xuICBjdXJzb3I6IHBvaW50ZXI7XG4gIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgZm9udC13ZWlnaHQ6IDQwMDtcbn1cbi5mbGF0cGlja3ItdGltZSBpbnB1dDpob3Zlcixcbi5mbGF0cGlja3ItdGltZSAuZmxhdHBpY2tyLWFtLXBtOmhvdmVyLFxuLmZsYXRwaWNrci10aW1lIGlucHV0OmZvY3VzLFxuLmZsYXRwaWNrci10aW1lIC5mbGF0cGlja3ItYW0tcG06Zm9jdXMge1xuICBiYWNrZ3JvdW5kOiAjZWVlO1xufVxuLmZsYXRwaWNrci1pbnB1dFtyZWFkb25seV0ge1xuICBjdXJzb3I6IHBvaW50ZXI7XG59XG5ALXdlYmtpdC1rZXlmcmFtZXMgZnBGYWRlSW5Eb3duIHtcbiAgZnJvbSB7XG4gICAgb3BhY2l0eTogMDtcbiAgICAtd2Via2l0LXRyYW5zZm9ybTogdHJhbnNsYXRlM2QoMCwgLTIwcHgsIDApO1xuICAgICAgICAgICAgdHJhbnNmb3JtOiB0cmFuc2xhdGUzZCgwLCAtMjBweCwgMCk7XG4gIH1cbiAgdG8ge1xuICAgIG9wYWNpdHk6IDE7XG4gICAgLXdlYmtpdC10cmFuc2Zvcm06IHRyYW5zbGF0ZTNkKDAsIDAsIDApO1xuICAgICAgICAgICAgdHJhbnNmb3JtOiB0cmFuc2xhdGUzZCgwLCAwLCAwKTtcbiAgfVxufVxuQGtleWZyYW1lcyBmcEZhZGVJbkRvd24ge1xuICBmcm9tIHtcbiAgICBvcGFjaXR5OiAwO1xuICAgIC13ZWJraXQtdHJhbnNmb3JtOiB0cmFuc2xhdGUzZCgwLCAtMjBweCwgMCk7XG4gICAgICAgICAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZTNkKDAsIC0yMHB4LCAwKTtcbiAgfVxuICB0byB7XG4gICAgb3BhY2l0eTogMTtcbiAgICAtd2Via2l0LXRyYW5zZm9ybTogdHJhbnNsYXRlM2QoMCwgMCwgMCk7XG4gICAgICAgICAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZTNkKDAsIDAsIDApO1xuICB9XG59XG4iLCAiQGltcG9ydCAnZmxhdHBpY2tyL2Rpc3QvZmxhdHBpY2tyLmNzcyc7XG5AaW1wb3J0ICcuL1JlbmRlcmVyL1JlbmRlcmVyJztcbkBpbXBvcnQgJy4vdWkvRWRpdFRhc2snO1xuQGltcG9ydCAnLi91aS9EZXBlbmRlbmN5JztcbkBpbXBvcnQgJy4vdWkvTW9kYWxPcHRpb25zRWRpdG9yJztcbkBpbXBvcnQgJy4vQ29uZmlnL1NldHRpbmdzVGFiJztcbkBpbXBvcnQgJy4vQ29uZmlnL1ByZXNldHNTZXR0aW5nc1VJJztcbiIsICI6cm9vdCB7XG4gICAgLS10YXNrcy1kZXRhaWxzLWljb246IHVybChcImRhdGE6aW1hZ2Uvc3ZnK3htbDtjaGFyc2V0PXV0Zi04LDxzdmcgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJyB2aWV3Qm94PScwIDAgMjQgMjQnPjxwYXRoIGQ9J004LjU5IDE2LjU4TDEzLjE3IDEyIDguNTkgNy40MSAxMCA2bDYgNi02IDYtMS40MS0xLjQyeicvPjwvc3ZnPlwiKTtcblxufVxuXG4ucGx1Z2luLXRhc2tzLXF1ZXJ5LWV4cGxhbmF0aW9ue1xuICAgIC8qIFByZXZlbnQgbG9uZyBleHBsYW5hdGlvbiBsaW5lcyB3cmFwcGluZywgc28gdGhleSBhcmUgbW9yZSByZWFkYWJsZSxcbiAgICAgICBlc3BlY2lhbGx5IG9uIHNtYWxsIHNjcmVlbnMuXG5cbiAgICAgICBBIGhvcml6b250YWwgc2Nyb2xsIGJhciB3aWxsIGJlIGRpc3BsYXllZCwgaWYgdGhlIGV4cGxhbmF0aW9uXG4gICAgICAgaXMgdG9vIHdpZGUgdG8gZml0LlxuICAgICAqL1xuICAgIC0tY29kZS13aGl0ZS1zcGFjZTogcHJlO1xufVxuXG4ucGx1Z2luLXRhc2tzLXRvb2xiYXIge1xuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgZmxleC1kaXJlY3Rpb246IHJvdztcbiAgICBqdXN0aWZ5LWNvbnRlbnQ6IHNwYWNlLWJldHdlZW47XG4gICAgZ2FwOiB2YXIoLS1zaXplLTQtMSk7XG5cbiAgICBsYWJlbCB7XG4gICAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgICAgIGZsZXgtZGlyZWN0aW9uOiByb3c7XG4gICAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG5cbiAgICAgICAgaW5wdXQge1xuICAgICAgICAgICAgaGVpZ2h0OiAxMDAlO1xuICAgICAgICAgICAgcGFkZGluZy1sZWZ0OiAyNHB4O1xuICAgICAgICB9XG5cbiAgICAgICAgc3ZnIHtcbiAgICAgICAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgICAgICAgIHRyYW5zZm9ybTogdHJhbnNsYXRlWCgyNSUpO1xuICAgICAgICB9XG4gICAgfVxufVxuXG4udGFza3MtY291bnQge1xuICAgIGNvbG9yOiB2YXIoLS10ZXh0LWZhaW50KTtcbiAgICBwYWRkaW5nLWxlZnQ6IDIwcHg7XG59XG5cbi8qIFRvb2x0aXAgcG9wIHVwIGFib3ZlIHRoZSBkZXNjcmlwdGlvbiBpbiBzaG9ydCBtb2RlICovXG4udG9vbHRpcC5wb3AtdXAge1xuICAgIGFuaW1hdGlvbjogcG9wLXVwLWFuaW1hdGlvbiAyMDBtcyBmb3J3YXJkcyBlYXNlLWluLW91dDtcbn1cbkBrZXlmcmFtZXMgcG9wLXVwLWFuaW1hdGlvbiB7XG4gICAgMCUge1xuICAgICAgICBvcGFjaXR5OiAwO1xuICAgICAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoLTEwMCUpIHNjYWxlKDEpO1xuICAgIH1cbiAgICAyMCUge1xuICAgICAgICBvcGFjaXR5OiAwLjc7XG4gICAgICAgIHRyYW5zZm9ybTogdHJhbnNsYXRlWSgtMTAwJSkgc2NhbGUoMS4wMik7XG4gICAgfVxuICAgIDQwJSB7XG4gICAgICAgIG9wYWNpdHk6IDE7XG4gICAgICAgIHRyYW5zZm9ybTogdHJhbnNsYXRlWSgtMTAwJSkgc2NhbGUoMS4wNSk7XG4gICAgfVxuICAgIDEwMCUge1xuICAgICAgICBvcGFjaXR5OiAxO1xuICAgICAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoLTEwMCUpIHNjYWxlKDEpO1xuICAgIH1cbn1cblxuLyogRGF0ZSBmaWVsZHM6IG1ha2UgaXQgb2J2aW91cyB0aGV5IGNhbiBiZSBjbGlja2VkICovXG4vKiBUT0RPIEludHJvZHVjZSBhIENTUyBjbGFzcyBmb3IgY2xpY2thYmxlIHRoaW5ncywgdG8gcmVtb3ZlIHRoZSBuZWVkIHRvIGxpc3QgYWxsIHRoZSBkYXRlIGZpZWxkcyBoZXJlICovXG4udGFzay1jYW5jZWxsZWQsXG4udGFzay1jcmVhdGVkLFxuLnRhc2stZG9uZSxcbi50YXNrLWR1ZSxcbi50YXNrLXNjaGVkdWxlZCxcbi50YXNrLXN0YXJ0IHtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgdXNlci1zZWxlY3Q6IG5vbmU7XG4gICAgLXdlYmtpdC11c2VyLXNlbGVjdDogbm9uZTtcbiAgICAtd2Via2l0LXRvdWNoLWNhbGxvdXQ6IG5vbmU7XG59XG5cbi8qIEVkaXQgYW5kIHBvc3Rwb25lICovXG4udGFza3MtZWRpdCwgLnRhc2tzLXBvc3Rwb25lIHtcbiAgICB3aWR0aDogMWVtO1xuICAgIGhlaWdodDogMWVtO1xuICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gICAgbWFyZ2luLWxlZnQ6IC4zM2VtO1xuICAgIGN1cnNvcjogcG9pbnRlcjtcbiAgICBmb250LWZhbWlseTogdmFyKC0tZm9udC1pbnRlcmZhY2UpO1xuICAgIGNvbG9yOiB2YXIoLS10ZXh0LWFjY2VudCk7XG4gICAgdXNlci1zZWxlY3Q6IG5vbmU7XG4gICAgLXdlYmtpdC11c2VyLXNlbGVjdDogbm9uZTtcbiAgICAtd2Via2l0LXRvdWNoLWNhbGxvdXQ6IG5vbmU7XG59XG5cbmEudGFza3MtZWRpdCwgYS50YXNrcy1wb3N0cG9uZSB7XG4gICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xufVxuXG4udGFza3MtZWRpdDo6YWZ0ZXIge1xuICAgIGNvbnRlbnQ6ICfwn5OdJztcbn1cblxuLnRhc2tzLXBvc3Rwb25lOjphZnRlciB7XG4gICAgY29udGVudDogJ+KPqSc7XG59XG5cbi8qIFVyZ2VuY3kgc2NvcmUgKi9cbi50YXNrcy11cmdlbmN5IHtcbiAgICBmb250LXNpemU6IHZhcigtLWZvbnQtdWktc21hbGxlcik7XG4gICAgZm9udC1mYW1pbHk6IHZhcigtLWZvbnQtaW50ZXJmYWNlKTtcbiAgICBwYWRkaW5nOiAycHggNnB4O1xuICAgIGJvcmRlci1yYWRpdXM6IHZhcigtLXJhZGl1cy1zKTtcbiAgICBjb2xvcjogdmFyKC0tdGV4dC1ub3JtYWwpO1xuICAgIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWJhY2tncm91bmQtc2Vjb25kYXJ5KTtcbiAgICBtYXJnaW4tbGVmdDogMC41ZW07XG4gICAgbGluZS1oZWlnaHQ6IDE7XG59XG5cbi5pbnRlcm5hbC1saW5rLmludGVybmFsLWxpbmstc2hvcnQtbW9kZSB7XG4gICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xufVxuXG4udGFza3MtbGlzdC10ZXh0IHtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG59XG5cbi50YXNrcy1saXN0LXRleHQgLnRvb2x0aXAge1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICB0b3A6IDBweDtcbiAgICBsZWZ0OiAwcHg7XG4gICAgd2hpdGUtc3BhY2U6IG5vd3JhcDtcbn1cblxuLnRhc2stbGlzdC1pdGVtLWNoZWNrYm94IHtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG59XG5cbi8qIEhpZGUgdGFncyB0aGF0IE9ic2lkaWFuIHJlY29nbmlzZXMsIGlmIGBoaWRlIHRhZ3NgIGluc3RydWN0aW9uIHdhcyB1c2VkLiAqL1xuLnRhc2tzLWxheW91dC1oaWRlLXRhZ3MgLnRhc2stZGVzY3JpcHRpb24gYS50YWcge1xuICAgIGRpc3BsYXk6IG5vbmU7XG59XG5cbi8qIFdvcmthcm91bmQgZm9yIGlzc3VlICMyMDczOiBFbmFibGluZyB0aGUgcGx1Z2luIGNhdXNlcyBibG9ja0lkcyB0byBiZSBub3QgaGlkZGVuIGluIHJlYWRpbmcgdmlld1xuICAgaHR0cHM6Ly9naXRodWIuY29tL29ic2lkaWFuLXRhc2tzLWdyb3VwL29ic2lkaWFuLXRhc2tzL2lzc3Vlcy8yMDczICovXG4udGFzay1saXN0LWl0ZW0gLnRhc2stYmxvY2stbGlua3tcbiAgICBkaXNwbGF5OiBub25lO1xufVxuIiwgIi5tb2RhbC1vcHRpb24tYnV0dG9uIHtcbiAgICBpbnNldC1pbmxpbmUtZW5kOiB2YXIoLS1zaXplLTQtOCk7XG59XG5cbi5pcy1tb2JpbGUge1xuICAgIC5tb2RhbC1vcHRpb24tYnV0dG9uIHtcbiAgICAgICAgaW5zZXQtaW5saW5lLWVuZDogdmFyKC0tc2l6ZS00LTE2KTtcbiAgICB9XG59XG5cbi50YXNrcy1tb2RhbCB7XG4gICAgc2VjdGlvbiArIHNlY3Rpb24ge1xuICAgICAgICAgICAgLy8gUHV0IHNvbWUgc3BhY2Ugd2hlbiBzZWN0aW9ucyBhcmUgb25lIG5leHQgdG8gYW5vdGhlclxuICAgICAgICAgICAgbWFyZ2luLXRvcDogNnB4O1xuICAgIH1cblxuICAgIGhyIHtcbiAgICAgICAgbWFyZ2luOiA2cHggMDtcbiAgICB9XG5cbiAgICAudGFza3MtbW9kYWwtZXJyb3Ige1xuICAgICAgICBib3JkZXI6IDFweCBzb2xpZCByZWQgIWltcG9ydGFudDtcbiAgICB9XG5cbiAgICAuYWNjZXNza2V5IHtcbiAgICAgICAgdGV4dC1kZWNvcmF0aW9uOiB1bmRlcmxpbmU7XG4gICAgICAgIHRleHQtdW5kZXJsaW5lLW9mZnNldDogMXB0O1xuICAgIH1cbn1cblxuLnRhc2tzLW1vZGFsLWRlc2NyaXB0aW9uLXNlY3Rpb24ge1xuICAgIHRleHRhcmVhIHtcbiAgICAgICAgd2lkdGg6IDEwMCU7XG4gICAgICAgIG1pbi1oZWlnaHQ6IGNhbGModmFyKC0taW5wdXQtaGVpZ2h0KSAqIDIpO1xuICAgICAgICByZXNpemU6IHZlcnRpY2FsO1xuICAgICAgICBtYXJnaW4tdG9wOiA4cHg7XG4gICAgfVxufVxuXG4udGFza3MtbW9kYWwtcHJpb3JpdHktc2VjdGlvbiB7XG4gICAgZGlzcGxheTogZ3JpZDtcbiAgICBncmlkLXRlbXBsYXRlLWNvbHVtbnM6IDZlbSBhdXRvIGF1dG8gYXV0bztcbiAgICBncmlkLXJvdy1nYXA6IDAuMTVlbTtcblxuICAgID4gbGFiZWwge1xuICAgICAgICBncmlkLXJvdy1zdGFydDogMTtcbiAgICAgICAgZ3JpZC1yb3ctZW5kOiAzO1xuICAgIH1cblxuICAgIC50YXNrLW1vZGFsLXByaW9yaXR5LW9wdGlvbi1jb250YWluZXIge1xuICAgICAgICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuXG4gICAgICAgIGlucHV0ICsgbGFiZWwge1xuICAgICAgICAgICAgZm9udC1zaXplOiB2YXIoLS1mb250LXVpLXNtYWxsKTtcbiAgICAgICAgICAgIGJvcmRlci1yYWRpdXM6IHZhcigtLWlucHV0LXJhZGl1cyk7XG4gICAgICAgICAgICBwYWRkaW5nOiAycHggM3B4O1xuICAgICAgICB9XG5cbiAgICAgICAgaW5wdXQge1xuICAgICAgICAgICAgYWNjZW50LWNvbG9yOiB2YXIoLS1pbnRlcmFjdGl2ZS1hY2NlbnQpO1xuICAgICAgICB9XG5cbiAgICAgICAgaW5wdXQ6Zm9jdXMgKyBsYWJlbCB7XG4gICAgICAgICAgICBib3gtc2hhZG93OiAwIDAgMCAycHggdmFyKC0tYmFja2dyb3VuZC1tb2RpZmllci1ib3JkZXItZm9jdXMpO1xuICAgICAgICAgICAgYm9yZGVyLWNvbG9yOiB2YXIoLS1iYWNrZ3JvdW5kLW1vZGlmaWVyLWJvcmRlci1mb2N1cyk7XG4gICAgICAgIH1cblxuICAgICAgICBpbnB1dDpjaGVja2VkICsgbGFiZWwge1xuICAgICAgICAgICAgZm9udC13ZWlnaHQ6IGJvbGQ7XG4gICAgICAgIH1cblxuICAgICAgICBpbnB1dDpub3QoOmNoZWNrZWQpICsgbGFiZWwgPiBzcGFuOm50aC1jaGlsZCg0KSB7XG4gICAgICAgICAgICBmaWx0ZXI6IGdyYXlzY2FsZSgxMDAlKSBvcGFjaXR5KDYwJSk7XG4gICAgICAgIH1cbiAgICB9XG59XG5cbi50YXNrcy1tb2RhbC1kYXRlcy1zZWN0aW9uIHtcbiAgICBkaXNwbGF5OiBncmlkO1xuICAgIGdyaWQtdGVtcGxhdGUtY29sdW1uczogNi4wZW0gMTNlbSBhdXRvO1xuICAgIGNvbHVtbi1nYXA6IC41ZW07XG4gICAgcm93LWdhcDogNXB4O1xuICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG5cbiAgICBsYWJlbCB7XG4gICAgICAgIGdyaWQtY29sdW1uOiAxO1xuICAgIH1cblxuICAgIC50YXNrcy1tb2RhbC1kYXRlLWlucHV0IHtcbiAgICAgICAgbWluLXdpZHRoOiAxNWVtO1xuICAgIH1cblxuICAgIC50YXNrcy1tb2RhbC1kYXRlLWVkaXRvci1waWNrZXIge1xuICAgICAgICBtYXJnaW4tbGVmdDogLjVlbTtcbiAgICB9XG5cbiAgICAudGFza3MtbW9kYWwtcGFyc2VkLWRhdGUge1xuICAgICAgICBncmlkLWNvbHVtbjogMztcbiAgICAgICAgZm9udC1zaXplOiB2YXIoLS1mb250LXVpLXNtYWxsKTtcbiAgICB9XG5cbiAgICAuZnV0dXJlLWRhdGVzLW9ubHkge1xuICAgICAgICBncmlkLWNvbHVtbi1zdGFydDogMTtcbiAgICAgICAgZ3JpZC1jb2x1bW4tZW5kOiAzO1xuXG4gICAgICAgIGlucHV0IHtcbiAgICAgICAgICAgIG1hcmdpbi1sZWZ0OiAwLjY3ZW07XG4gICAgICAgICAgICB0b3A6IDJweDtcbiAgICAgICAgfVxuICAgIH1cblxuICAgIC5zdGF0dXMtZWRpdG9yLXN0YXR1cy1zZWxlY3RvciB7XG4gICAgICAgIGdyaWQtY29sdW1uOiAyO1xuICAgIH1cbn1cblxuLnRhc2tzLW1vZGFsLWRlcGVuZGVuY2llcy1zZWN0aW9uIHtcbiAgICBkaXNwbGF5OiBncmlkO1xuICAgIGdyaWQtdGVtcGxhdGUtY29sdW1uczogNi4wZW0gYXV0bztcbiAgICBjb2x1bW4tZ2FwOiAwLjVlbTtcbiAgICByb3ctZ2FwOiA1cHg7XG4gICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcblxuICAgIC50YXNrcy1tb2RhbC1kZXBlbmRlbmN5LWlucHV0IHtcbiAgICAgICAgZ3JpZC1jb2x1bW46IDI7XG4gICAgICAgIHdpZHRoOiAxMDAlO1xuICAgIH1cblxuICAgIC5yZXN1bHRzLWRlcGVuZGVuY3kge1xuICAgICAgICBncmlkLWNvbHVtbjogMjtcbiAgICB9XG59XG5cbi50YXNrcy1tb2RhbC1idXR0b24tc2VjdGlvbiB7XG4gICAgcG9zaXRpb246IHN0aWNreTtcbiAgICBib3R0b206IDA7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tbW9kYWwtYmFja2dyb3VuZCk7XG4gICAgcGFkZGluZy1ib3R0b206IDE2cHg7XG4gICAgcGFkZGluZy10b3A6IDE2cHg7XG4gICAgZGlzcGxheTogZ3JpZDtcbiAgICBncmlkLXRlbXBsYXRlLWNvbHVtbnM6IDNmciAxZnI7XG4gICAgY29sdW1uLWdhcDogLjVlbTtcblxuICAgIGJ1dHRvbjpkaXNhYmxlZCB7XG4gICAgICAgIHBvaW50ZXItZXZlbnRzOiBub25lICFpbXBvcnRhbnQ7XG4gICAgICAgIG9wYWNpdHk6IDAuMyAhaW1wb3J0YW50O1xuICAgIH1cbn1cblxuQG1lZGlhIChtYXgtd2lkdGg6IDY0OXB4KSB7XG4gICAgLnRhc2tzLW1vZGFsLXByaW9yaXR5LXNlY3Rpb24ge1xuICAgICAgICBncmlkLXRlbXBsYXRlLWNvbHVtbnM6IDZlbSBhdXRvIGF1dG87XG5cbiAgICAgICAgPiBsYWJlbCB7XG4gICAgICAgICAgICBncmlkLXJvdzogMSAvIHNwYW4gMztcbiAgICAgICAgfVxuICAgIH1cbn1cblxuQG1lZGlhIChtYXgtd2lkdGg6IDQ5OXB4KSB7XG4gICAgLnRhc2tzLW1vZGFsLXByaW9yaXR5LXNlY3Rpb24ge1xuICAgICAgICBncmlkLXRlbXBsYXRlLWNvbHVtbnM6IDRlbSBhdXRvIGF1dG87XG4gICAgfVxuXG4gICAgLnRhc2tzLW1vZGFsLWRhdGVzLXNlY3Rpb24ge1xuICAgICAgICBncmlkLXRlbXBsYXRlLWNvbHVtbnM6IDFmcjtcbiAgICAgICAgZ3JpZC1hdXRvLWNvbHVtbnM6IGF1dG87XG5cbiAgICAgICAgLnRhc2tzLW1vZGFsLWRhdGUtaW5wdXQge1xuICAgICAgICAgICAgZ3JpZC1jb2x1bW46IDE7XG4gICAgICAgIH1cblxuICAgICAgICAudGFza3MtbW9kYWwtcGFyc2VkLWRhdGUge1xuICAgICAgICAgICAgZ3JpZC1jb2x1bW46IDI7XG4gICAgICAgIH1cblxuICAgICAgICAuc3RhdHVzLWVkaXRvci1zdGF0dXMtc2VsZWN0b3Ige1xuICAgICAgICAgICAgZ3JpZC1jb2x1bW46IDE7XG4gICAgICAgIH1cbiAgICB9XG5cbiAgICAudGFza3MtbW9kYWwtZGVwZW5kZW5jaWVzLXNlY3Rpb24ge1xuICAgICAgICBsYWJlbCB7XG4gICAgICAgICAgICBncmlkLWNvbHVtbjogMTtcbiAgICAgICAgfVxuXG4gICAgICAgIC5yZXN1bHRzLWRlcGVuZGVuY3kge1xuICAgICAgICAgICAgZ3JpZC1jb2x1bW46IDE7XG4gICAgICAgIH1cbiAgICB9XG59XG5cbkBtZWRpYSAobWF4LXdpZHRoOiAzOTlweCkge1xuICAgIC50YXNrcy1tb2RhbC1kYXRlcy1zZWN0aW9uIHtcbiAgICAgICAgLnN0YXR1cy1lZGl0b3Itc3RhdHVzLXNlbGVjdG9yIHtcbiAgICAgICAgICAgIGdyaWQtY29sdW1uOiAxO1xuICAgICAgICB9XG5cbiAgICAgICAgPiAudGFza3MtbW9kYWwtcGFyc2VkLWRhdGUge1xuICAgICAgICAgICAgZ3JpZC1jb2x1bW46IDE7XG4gICAgICAgIH1cbiAgICB9XG5cbiAgICAudGFza3MtbW9kYWwtcHJpb3JpdHktc2VjdGlvbiB7XG4gICAgICAgIGdyaWQtdGVtcGxhdGUtY29sdW1uczogNGVtIGF1dG87XG5cbiAgICAgICAgPiBsYWJlbCB7XG4gICAgICAgICAgICBncmlkLXJvdzogMSAvIHNwYW4gNjtcbiAgICAgICAgfVxuICAgIH1cblxuICAgIC50YXNrcy1tb2RhbC1kZXBlbmRlbmNpZXMtc2VjdGlvbiB7XG4gICAgICAgIGdyaWQtdGVtcGxhdGUtY29sdW1uczogMWZyO1xuICAgICAgICBncmlkLWF1dG8tY29sdW1uczogYXV0bztcbiAgICB9XG59XG5cbkBtZWRpYSAobWF4LXdpZHRoOiAyNTlweCkge1xuICAgIC50YXNrcy1tb2RhbC1wcmlvcml0eS1zZWN0aW9uIHtcbiAgICAgICAgZ3JpZC10ZW1wbGF0ZS1jb2x1bW5zOiAxZnI7XG5cbiAgICAgICAgPiBsYWJlbCB7XG4gICAgICAgICAgICBncmlkLXJvdzogMTtcbiAgICAgICAgfVxuICAgIH1cbn1cbiIsICIudGFzay1kZXBlbmRlbmNpZXMtY29udGFpbmVyIHtcbiAgICBncmlkLWNvbHVtbjogMjtcblxuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgZmxleC13cmFwOiB3cmFwO1xuICAgIGdhcDogOHB4O1xufVxuLnRhc2stZGVwZW5kZW5jeSB7XG4gICAgZGlzcGxheTogaW5saW5lLWZsZXg7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0taW50ZXJhY3RpdmUtbm9ybWFsKTtcbiAgICBib3gtc2hhZG93OiB2YXIoLS1pbnB1dC1zaGFkb3cpO1xuICAgIGJvcmRlci1yYWRpdXM6IDI4cHg7XG4gICAgcGFkZGluZzogNHB4IDRweCA0cHggOHB4O1xufVxuXG4udGFzay1kZXBlbmRlbmN5LW5hbWUge1xuICAgIGZvbnQtc2l6ZTogdmFyKC0tZm9udC11aS1zbWFsbCk7XG4gICAgbWF4LXdpZHRoOiAxNjBweDtcbiAgICBvdmVyZmxvdzogaGlkZGVuO1xuICAgIHdoaXRlLXNwYWNlOiBub3dyYXA7XG4gICAgdGV4dC1vdmVyZmxvdzogZWxsaXBzaXM7XG59XG5cbi50YXNrLWRlcGVuZGVuY3ktZGVsZXRlIHtcbiAgICBwYWRkaW5nOiAzcHg7XG4gICAgY3Vyc29yOiBwb2ludGVyO1xuICAgIGhlaWdodDogaW5oZXJpdDtcbiAgICBib3gtc2hhZG93OiBub25lICFpbXBvcnRhbnQ7XG4gICAgYm9yZGVyLXJhZGl1czogNTAlO1xufVxuXG4udGFzay1kZXBlbmRlbmN5LWRyb3Bkb3duIHtcbiAgICBsaXN0LXN0eWxlOiBub25lO1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICB0b3A6IDA7XG4gICAgbGVmdDogMDtcbiAgICBwYWRkaW5nOiA0cHg7XG4gICAgbWFyZ2luOiAwO1xuICAgIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWJhY2tncm91bmQtcHJpbWFyeSk7XG4gICAgYm9yZGVyOiAxcHg7XG4gICAgYm9yZGVyLXJhZGl1czogNnB4O1xuICAgIGJvcmRlci1jb2xvcjogdmFyKC0tYmFja2dyb3VuZC1tb2RpZmllci1ib3JkZXIpO1xuICAgIGJvcmRlci1zdHlsZTogc29saWQ7XG4gICAgei1pbmRleDogOTk7XG4gICAgbWF4LWhlaWdodDogMTcwcHg7XG4gICAgb3ZlcmZsb3cteTogYXV0bztcbn1cblxuLnRhc2stZGVwZW5kZW5jeS1kcm9wZG93biBsaSB7XG4gICAgcGFkZGluZzogNXB4O1xuICAgIG1hcmdpbjogMnB4O1xuICAgIGJvcmRlci1yYWRpdXM6IDZweDtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgZGlzcGxheTogZmxleDtcbiAgICBqdXN0aWZ5LWNvbnRlbnQ6IHNwYWNlLWJldHdlZW5cbn1cbi50YXNrLWRlcGVuZGVuY3ktZHJvcGRvd24gbGkgLmRlcGVuZGVuY3ktbmFtZSB7XG4gICAgb3ZlcmZsb3c6IGhpZGRlbjtcbiAgICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuICAgIHRleHQtb3ZlcmZsb3c6IGVsbGlwc2lzO1xufVxuXG4udGFzay1kZXBlbmRlbmN5LWRyb3Bkb3duIGxpIC5kZXBlbmRlbmN5LW5hbWUtc2hhcmVkIHtcbiAgICB3aWR0aDogY2FsYyg2MCUpO1xuICAgIG92ZXJmbG93OiBoaWRkZW47XG4gICAgd2hpdGUtc3BhY2U6IG5vd3JhcDtcbiAgICB0ZXh0LW92ZXJmbG93OiBlbGxpcHNpcztcbn1cblxuLnRhc2stZGVwZW5kZW5jeS1kcm9wZG93biBsaSAuZGVwZW5kZW5jeS1wYXRoIHtcbiAgICB3aWR0aDogY2FsYyg0MCUpO1xuICAgIG92ZXJmbG93OiBoaWRkZW47XG4gICAgd2hpdGUtc3BhY2U6IG5vd3JhcDtcbiAgICB0ZXh0LW92ZXJmbG93OiBlbGxpcHNpcztcbiAgICBmb250LXN0eWxlOiBpdGFsaWM7XG4gICAgdGV4dC1hbGlnbjogcmlnaHQ7XG4gICAgY29sb3I6IHZhcigtLWl0YWxpYy1jb2xvcilcbn1cblxuLnRhc2stZGVwZW5kZW5jeS1kcm9wZG93biBsaS5zZWxlY3RlZCB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdmFyKC0tdGV4dC1zZWxlY3Rpb24pO1xufVxuIiwgIi50YXNrcy1vcHRpb25zLW1vZGFsLWNvbnRhaW5lciB7XG4gICAgcGFkZGluZy1ib3R0b206IDA7XG4gICAgd2lkdGg6IGZpdC1jb250ZW50O1xuXG4gICAgLm1vZGFsLXRpdGxlIHtcbiAgICAgICAgbWFyZ2luLXJpZ2h0OiB2YXIoLS1zaXplLTQtNik7XG4gICAgfVxufVxuXG4uaXMtbW9iaWxlIHtcbiAgICAudGFza3Mtb3B0aW9ucy1tb2RhbC1jb250YWluZXIge1xuICAgICAgICAubW9kYWwtdGl0bGUge1xuICAgICAgICAgICAgbWFyZ2luLXJpZ2h0OiB2YXIoLS1zaXplLTQtMTIpO1xuICAgICAgICB9XG4gICAgfVxufVxuXG4udGFza3Mtb3B0aW9ucy1tb2RhbCB7XG4gICAgcGFkZGluZzogMDtcblxuICAgIC50YXNrcy1vcHRpb25zLW1vZGFsLWNoZWNrYm94ZXMge1xuICAgICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgICBmbGV4LWRpcmVjdGlvbjogY29sdW1uO1xuXG4gICAgICAgIGxhYmVsIHtcbiAgICAgICAgICAgIHBhZGRpbmc6IDRweDtcbiAgICAgICAgICAgIGJvcmRlci1yYWRpdXM6IDRweDtcblxuICAgICAgICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgICAgICAgIGdhcDogOHB4O1xuXG4gICAgICAgICAgICBpbnB1dFt0eXBlPVwiY2hlY2tib3hcIl0ge1xuICAgICAgICAgICAgICAgIG1hcmdpbjogMDtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuXG4gICAgICAgIGhyIHtcbiAgICAgICAgICAgIG1hcmdpbjogMnB4IDA7XG4gICAgICAgIH1cbiAgICB9XG5cbiAgICAudGFza3Mtb3B0aW9ucy1tb2RhbC1mb290ZXIge1xuICAgICAgICBwb3NpdGlvbjogc3RpY2t5O1xuICAgICAgICBib3R0b206IDA7XG5cbiAgICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgICAganVzdGlmeS1jb250ZW50OiBmbGV4LWVuZDtcbiAgICAgICAgZ2FwOiAwLjVlbTtcbiAgICAgICAgcGFkZGluZzogMTZweCAwO1xuICAgIH1cbn1cbiIsICIudGFza3Mtc2V0dGluZ3MtaXMtaW52YWxpZCB7XG4gICAgLyogRGFyayByZWQgdGV4dCBvbiBwYWxlIGJhY2tncm91bmQqL1xuICAgIGNvbG9yOiB2YXIoLS10ZXh0LWVycm9yKSAhaW1wb3J0YW50O1xuICAgIGJhY2tncm91bmQtY29sb3I6IHJnYmEodmFyKC0tYmFja2dyb3VuZC1tb2RpZmllci1lcnJvci1yZ2IpLCAwLjIpICFpbXBvcnRhbnQ7XG59XG5cblxuLnRhc2tzLXNldHRpbmdzIC5hZGRpdGlvbmFsIHtcbiAgICBtYXJnaW46IDZweCAxMnB4O1xufVxuLnRhc2tzLXNldHRpbmdzIC5hZGRpdGlvbmFsID4gLnNldHRpbmctaXRlbSB7XG4gICAgYm9yZGVyLXRvcDogMDtcbiAgICBwYWRkaW5nLXRvcDogOXB4O1xufVxuXG5cbi50YXNrcy1zZXR0aW5ncyBkZXRhaWxzID4gc3VtbWFyeSB7XG4gICAgb3V0bGluZTogbm9uZTtcbiAgICBkaXNwbGF5OiBibG9jayAhaW1wb3J0YW50O1xuICAgIGxpc3Qtc3R5bGU6IG5vbmUgIWltcG9ydGFudDtcbiAgICBsaXN0LXN0eWxlLXR5cGU6IG5vbmUgIWltcG9ydGFudDtcbiAgICBtaW4taGVpZ2h0OiAxcmVtO1xuICAgIGJvcmRlci10b3AtbGVmdC1yYWRpdXM6IDAuMXJlbTtcbiAgICBib3JkZXItdG9wLXJpZ2h0LXJhZGl1czogMC4xcmVtO1xuICAgIGN1cnNvcjogcG9pbnRlcjtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG59XG5cbi50YXNrcy1zZXR0aW5ncyBkZXRhaWxzID4gc3VtbWFyeTo6LXdlYmtpdC1kZXRhaWxzLW1hcmtlcixcbi50YXNrcy1zZXR0aW5ncyBkZXRhaWxzID4gc3VtbWFyeTo6bWFya2VyIHtcbiAgICBkaXNwbGF5OiBub25lICFpbXBvcnRhbnQ7XG59XG5cbi50YXNrcy1zZXR0aW5ncyBkZXRhaWxzID4gc3VtbWFyeSA+IC5jb2xsYXBzZXIge1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICB0b3A6IDUwJTtcbiAgICByaWdodDogOHB4O1xuICAgIHRyYW5zZm9ybTogdHJhbnNsYXRlWSgtNTAlKTtcbiAgICBjb250ZW50OiBcIlwiO1xufVxuXG4udGFza3Mtc2V0dGluZ3MgZGV0YWlscyA+IHN1bW1hcnkgPiAuY29sbGFwc2VyID4gLmhhbmRsZSB7XG4gICAgdHJhbnNmb3JtOiByb3RhdGUoMGRlZyk7XG4gICAgdHJhbnNpdGlvbjogdHJhbnNmb3JtIDAuMjVzO1xuICAgIGJhY2tncm91bmQtY29sb3I6IGN1cnJlbnRDb2xvcjtcbiAgICAtd2Via2l0LW1hc2stcmVwZWF0OiBuby1yZXBlYXQ7XG4gICAgbWFzay1yZXBlYXQ6IG5vLXJlcGVhdDtcbiAgICAtd2Via2l0LW1hc2stc2l6ZTogY29udGFpbjtcbiAgICBtYXNrLXNpemU6IGNvbnRhaW47XG4gICAgLXdlYmtpdC1tYXNrLWltYWdlOiB2YXIoLS10YXNrcy1kZXRhaWxzLWljb24pO1xuICAgIG1hc2staW1hZ2U6IHZhcigtLXRhc2tzLWRldGFpbHMtaWNvbik7XG4gICAgd2lkdGg6IDIwcHg7XG4gICAgaGVpZ2h0OiAyMHB4O1xufVxuXG4udGFza3Mtc2V0dGluZ3MgZGV0YWlsc1tvcGVuXSA+IHN1bW1hcnkgPiAuY29sbGFwc2VyID4gLmhhbmRsZSB7XG4gICAgdHJhbnNmb3JtOiByb3RhdGUoOTBkZWcpO1xufVxuXG4udGFza3MtbmVzdGVkLXNldHRpbmdzIC5zZXR0aW5nLWl0ZW0ge1xuICAgIGJvcmRlcjogMHB4O1xuICAgIHBhZGRpbmctYm90dG9tOiAwO1xufVxuLnRhc2tzLW5lc3RlZC1zZXR0aW5ncyB7XG4gICAgcGFkZGluZy1ib3R0b206IDE4cHg7XG59XG4udGFza3MtbmVzdGVkLXNldHRpbmdzW29wZW5dIC5zZXR0aW5nLWl0ZW0taGVhZGluZyxcbi50YXNrcy1uZXN0ZWQtc2V0dGluZ3M6bm90KGRldGFpbHMpIC5zZXR0aW5nLWl0ZW0taGVhZGluZyB7XG4gICAgYm9yZGVyLXRvcDogMHB4O1xuICAgIGJvcmRlci1ib3R0b206IDFweCBzb2xpZCB2YXIoLS1iYWNrZ3JvdW5kLW1vZGlmaWVyLWJvcmRlcik7XG59XG5cbi50YXNrcy1zZXR0aW5ncyAucm93LWZvci1zdGF0dXMge1xuICAgIG1hcmdpbi10b3A6IDBweDtcbiAgICBtYXJnaW4tYm90dG9tOiAwcHg7XG59XG4iLCAiLyogLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLSAqL1xuLyogUHJlc2V0cyBzZWN0aW9uICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICovXG4vKiAtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tICovXG5cbi50YXNrcy1zZXR0aW5ncyB7XG4gICAgLy8gTWFpbiB3cmFwcGVyIGZvciBwcmVzZXRzIHNlY3Rpb25cbiAgICAudGFza3MtcHJlc2V0cy13cmFwcGVyIHtcbiAgICAgICAgd2lkdGg6IDEwMCU7XG4gICAgICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICAgICAgdHJhbnNpdGlvbjogYWxsIDAuMnMgZWFzZTtcblxuICAgICAgICAvLyBEcmFnIHZpc3VhbCBzdGF0ZVxuICAgICAgICAmLnRhc2tzLXByZXNldHMtZHJhZ2dpbmcge1xuICAgICAgICAgICAgb3BhY2l0eTogMC41O1xuICAgICAgICAgICAgdHJhbnNmb3JtOiByb3RhdGUoMmRlZyk7XG4gICAgICAgIH1cblxuICAgICAgICAmLnRhc2tzLXByZXNldHMtZHJvcC1hYm92ZTo6YmVmb3JlIHtcbiAgICAgICAgICAgIGNvbnRlbnQ6ICcnO1xuICAgICAgICAgICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgICAgICAgICAgdG9wOiAtMnB4O1xuICAgICAgICAgICAgbGVmdDogMDtcbiAgICAgICAgICAgIHJpZ2h0OiAwO1xuICAgICAgICAgICAgaGVpZ2h0OiA0cHg7XG4gICAgICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1pbnRlcmFjdGl2ZS1hY2NlbnQpO1xuICAgICAgICAgICAgYm9yZGVyLXJhZGl1czogMnB4O1xuICAgICAgICAgICAgei1pbmRleDogMTA7XG4gICAgICAgIH1cblxuICAgICAgICAmLnRhc2tzLXByZXNldHMtZHJvcC1iZWxvdzo6YWZ0ZXIge1xuICAgICAgICAgICAgY29udGVudDogJyc7XG4gICAgICAgICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICAgICAgICBib3R0b206IC0ycHg7XG4gICAgICAgICAgICBsZWZ0OiAwO1xuICAgICAgICAgICAgcmlnaHQ6IDA7XG4gICAgICAgICAgICBoZWlnaHQ6IDRweDtcbiAgICAgICAgICAgIGJhY2tncm91bmQtY29sb3I6IHZhcigtLWludGVyYWN0aXZlLWFjY2VudCk7XG4gICAgICAgICAgICBib3JkZXItcmFkaXVzOiAycHg7XG4gICAgICAgICAgICB6LWluZGV4OiAxMDtcbiAgICAgICAgfVxuICAgIH1cblxuICAgIC8vIEluZGl2aWR1YWwgc2V0dGluZyByb3dcbiAgICAudGFza3MtcHJlc2V0cy1zZXR0aW5nIHtcbiAgICAgICAgLy8gTmFtZSBpbnB1dCBmaWVsZCAobGVmdCBjb2x1bW4pXG4gICAgICAgIC50YXNrcy1wcmVzZXRzLWtleSB7XG4gICAgICAgICAgICBncmlkLWFyZWE6IGtleTtcblxuICAgICAgICAgICAgLy8gRXJyb3Igc3RhdGUgc3R5bGluZ1xuICAgICAgICAgICAgJi5oYXMtZXJyb3Ige1xuICAgICAgICAgICAgICAgIGJvcmRlci1jb2xvcjogdmFyKC0tdGV4dC1lcnJvcik7XG4gICAgICAgICAgICAgICAgYm9yZGVyLXdpZHRoOiAycHg7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cblxuICAgICAgICAvLyBWYWx1ZSB0ZXh0YXJlYSAocmlnaHQgY29sdW1uKVxuICAgICAgICAudGFza3MtcHJlc2V0cy12YWx1ZSB7XG4gICAgICAgICAgICBncmlkLWFyZWE6IHZhbHVlO1xuXG4gICAgICAgICAgICBtaW4td2lkdGg6IDMwMHB4O1xuICAgICAgICAgICAgbWluLWhlaWdodDogM2VtO1xuICAgICAgICAgICAgZm9udC1mYW1pbHk6IHZhcigtLWZvbnQtbW9ub3NwYWNlKTtcblxuICAgICAgICAgICAgLy8gSG9yaXpvbnRhbC1vbmx5IHJlc2l6aW5nIGFuZCBzY3JvbGxpbmdcbiAgICAgICAgICAgIHJlc2l6ZTogaG9yaXpvbnRhbDtcbiAgICAgICAgICAgIG92ZXJmbG93LXg6IGF1dG87XG4gICAgICAgICAgICBvdmVyZmxvdy15OiBoaWRkZW47XG4gICAgICAgICAgICB3aGl0ZS1zcGFjZTogcHJlOyAgICAgICAgLy8gUHJlc2VydmUgZm9ybWF0dGluZ1xuICAgICAgICB9XG5cbiAgICAgICAgLnRhc2tzLXByZXNldHMtZHJhZy1oYW5kbGUge1xuICAgICAgICAgICAgZ3JpZC1hcmVhOiBkcmFnO1xuICAgICAgICAgICAgY29sb3I6IHZhcigtLXRleHQtbXV0ZWQpO1xuXG4gICAgICAgICAgICAmOmhvdmVyIHtcbiAgICAgICAgICAgICAgICBjb2xvcjogdmFyKC0tdGV4dC1ub3JtYWwpO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG5cbiAgICAgICAgLnRhc2tzLXByZXNldHMtZGVsZXRlLWJ1dHRvbiB7XG4gICAgICAgICAgICBncmlkLWFyZWE6IGRlbGV0ZTtcbiAgICAgICAgfVxuXG4gICAgICAgIC8vIENvbnRyb2wgYWxpZ25tZW50IGFkanVzdG1lbnRcbiAgICAgICAgLnNldHRpbmctaXRlbS1jb250cm9sIHtcbiAgICAgICAgICAgIGp1c3RpZnktY29udGVudDogc3RhcnQ7XG4gICAgICAgICAgICBkaXNwbGF5OiBncmlkO1xuICAgICAgICAgICAgZ3JpZC10ZW1wbGF0ZS1jb2x1bW5zOiAyMDBweCAxZnIgYXV0byBhdXRvO1xuICAgICAgICAgICAgZ3JpZC10ZW1wbGF0ZS1hcmVhczogXCJrZXkgdmFsdWUgZHJhZyBkZWxldGVcIjtcbiAgICAgICAgICAgIGdhcDogNHB4O1xuXG4gICAgICAgICAgICBhbGlnbi1pdGVtczogdW5zZXQ7XG5cbiAgICAgICAgICAgIC8vIFB1dCBhIGJvcmRlciBhcm91bmQgdGhlIGVsZW1lbnRzIGZvciBlYWNoIFByZXNldCwgdG8gbWFrZSBzdHJ1Y3R1cmUgZWFzaWVyXG4gICAgICAgICAgICAvLyB0byBzZWUuXG4gICAgICAgICAgICBib3JkZXI6IDFweCBzb2xpZCB2YXIoLS1iYWNrZ3JvdW5kLW1vZGlmaWVyLWJvcmRlcikgIWltcG9ydGFudDtcbiAgICAgICAgICAgIHBhZGRpbmc6IDAuNWVtICFpbXBvcnRhbnQ7XG4gICAgICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiB2YXIoLS1iYWNrZ3JvdW5kLXNlY29uZGFyeSkgIWltcG9ydGFudDtcbiAgICAgICAgICAgIGJvcmRlci1yYWRpdXM6IDRweCAhaW1wb3J0YW50O1xuXG4gICAgICAgICAgICAvLyBGb3JjZSB3cmFwcGluZyBiZWhhdmlvciBvbiBuYXJyb3cgc2NyZWVuc1xuICAgICAgICAgICAgQGNvbnRhaW5lciAobWF4LXdpZHRoOiA2MDBweCkge1xuICAgICAgICAgICAgICAgIGdyaWQtdGVtcGxhdGUtY29sdW1uczogNWZyIDFmciAxZnI7XG4gICAgICAgICAgICAgICAgZ3JpZC10ZW1wbGF0ZS1hcmVhczpcbiAgICAgICAgICAgICAgICAgIFwia2V5IGRyYWcgZGVsZXRlXCJcbiAgICAgICAgICAgICAgICAgIFwidmFsdWUgdmFsdWUgdmFsdWVcIjtcblxuICAgICAgICAgICAgICAgIC50YXNrcy1wcmVzZXRzLWtleSB7XG4gICAgICAgICAgICAgICAgICAgIC8vIE1ha2UgdGhlIE5hbWUgaW5wdXQgZmllbGQgZnVsbC13aWR0aC5cbiAgICAgICAgICAgICAgICAgICAgLy8gVGhlIHZhbHVlIHRleHRhcmVhIHdpbGwgdGFrZSB1cCBtb3N0IG9mIHRoZSB3aWR0aCwgd2l0aCB0aGUgRGVsZXRlIGJ1dHRvbiB0byBpdHMgcmlnaHQuXG4gICAgICAgICAgICAgICAgICAgIHdpZHRoOiAxMDAlO1xuICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgIH1cbn1cbiJdLAogICJtYXBwaW5ncyI6ICI7OztBQUFBLENBQUM7QUFDQyxjQUFZO0FBQ1osV0FBUztBQUNULFdBQVM7QUFDVCxjQUFZO0FBQ1osY0FBWTtBQUNaLFdBQVM7QUFDVCxxQkFBbUI7QUFDWCxhQUFXO0FBQ25CLGFBQVc7QUFDWCxVQUFRO0FBQ1IsYUFBVztBQUNYLGVBQWE7QUFDYixpQkFBZTtBQUNmLFlBQVU7QUFDVixTQUFPO0FBQ1Asc0JBQW9CO0FBQ1osY0FBWTtBQUNwQixvQkFBa0I7QUFDZCxnQkFBYztBQUNsQixjQUFZO0FBQ1o7QUFBQSxJQUFvQixJQUFJLEVBQUUsRUFBRSxPQUFPO0FBQUEsSUFBRSxLQUFLLEVBQUUsRUFBRSxPQUFPO0FBQUEsSUFBRSxFQUFFLElBQUksRUFBRSxPQUFPO0FBQUEsSUFBRSxFQUFFLEtBQUssRUFBRSxPQUFPO0FBQUEsSUFBRSxFQUFFLElBQUksS0FBSyxLQUFLLENBQUMsRUFBQyxDQUFDLEVBQUMsQ0FBQyxFQUFDO0FBQ3hHO0FBQUEsSUFBWSxJQUFJLEVBQUUsRUFBRSxPQUFPO0FBQUEsSUFBRSxLQUFLLEVBQUUsRUFBRSxPQUFPO0FBQUEsSUFBRSxFQUFFLElBQUksRUFBRSxPQUFPO0FBQUEsSUFBRSxFQUFFLEtBQUssRUFBRSxPQUFPO0FBQUEsSUFBRSxFQUFFLElBQUksS0FBSyxLQUFLLENBQUMsRUFBQyxDQUFDLEVBQUMsQ0FBQyxFQUFDO0FBQ2xIO0FBQ0EsQ0F4QkMsa0JBd0JrQixDQUFDO0FBQ3BCLENBekJDLGtCQXlCa0IsQ0FBQztBQUNsQixXQUFTO0FBQ1QsY0FBWTtBQUNaLGNBQVk7QUFDZDtBQUNBLENBOUJDLGtCQThCa0IsQ0FOQztBQU9sQixXQUFTO0FBQ1QsV0FBUztBQUNYO0FBQ0EsQ0FsQ0Msa0JBa0NrQixDQUFDLE9BQU8sQ0FWUDtBQVdsQixxQkFBbUIsYUFBYSxNQUFNLGFBQWEsSUFBSSxFQUFFLENBQUMsRUFBRSxJQUFJLEVBQUU7QUFDMUQsYUFBVyxhQUFhLE1BQU0sYUFBYSxJQUFJLEVBQUUsQ0FBQyxFQUFFLElBQUksRUFBRTtBQUNwRTtBQUNBLENBdENDLGtCQXNDa0IsQ0FiQztBQWNsQixXQUFTO0FBQ1QsWUFBVTtBQUNWLE9BQUs7QUFDUDtBQUNBLENBM0NDLGtCQTJDa0IsQ0FBQztBQUNsQixZQUFVO0FBQ1YsT0FBSyxLQUFLLEtBQUssRUFBRTtBQUNuQjtBQUNBLENBL0NDLGtCQStDa0IsQ0FKQyxNQUlNLENBdkJOO0FBd0JsQixXQUFTO0FBQ1QsV0FBUztBQUNYO0FBQ0EsQ0FuREMsa0JBbURrQixDQUFDLFdBQVcsQ0FBQyxlQUFlLENBQUMsWUFBWSxnQkFBZ0IsQ0FBQyxhQUFhLENBQUMsT0FBTztBQUNoRyxzQkFBb0I7QUFDWixjQUFZO0FBQ3RCO0FBQ0EsQ0F2REMsa0JBdURrQixDQUpDLFdBSVcsQ0FKQyxlQUllLENBSkMsWUFJWSxnQkFBZ0IsQ0FKQyxhQUlhLENBSkMsT0FJTztBQUNoRyxzQkFBb0IsS0FBSyxFQUFFLEVBQUUsT0FBTyxFQUFFLElBQUksRUFBRSxFQUFFO0FBQ3RDLGNBQVksS0FBSyxFQUFFLEVBQUUsT0FBTyxFQUFFLElBQUksRUFBRSxFQUFFO0FBQ2hEO0FBQ0EsQ0EzREMsbUJBMkRtQixDQUFDLFNBQVMsQ0FSa0I7QUFTaEQsQ0E1REMsbUJBNERtQixDQUFDLFFBQVEsQ0FUbUI7QUFVOUMsaUJBQWU7QUFDZiw4QkFBNEI7QUFDNUIsNkJBQTJCO0FBQzdCO0FBQ0EsQ0FqRUMsbUJBaUVtQixDQU5DLFNBTVMsQ0Fka0I7QUFlOUMsZUFBYTtBQUNmO0FBQ0EsQ0FwRUMsa0JBb0VrQixDQVJFLFFBUU8sQ0FBQztBQUMzQixVQUFRO0FBQ1IsY0FBWSxJQUFJLE1BQU07QUFDeEI7QUFDQSxDQXhFQyxrQkF3RWtCLENBQUMsVUFBVSxDQVpULFFBWWtCLENBSlY7QUFLM0IsVUFBUTtBQUNWO0FBQ0EsQ0EzRUMsa0JBMkVrQjtBQUNuQixDQTVFQyxrQkE0RWtCO0FBQ2pCLFlBQVU7QUFDVixXQUFTO0FBQ1Qsa0JBQWdCO0FBQ2hCLFVBQVEsTUFBTTtBQUNkLFdBQVM7QUFDVCxVQUFRO0FBQ1IsU0FBTztBQUNQLFFBQU07QUFDUjtBQUNBLENBdEZDLGtCQXNGa0IsQ0FBQyxTQUFTO0FBQzdCLENBdkZDLGtCQXVGa0IsQ0FBQyxVQUFVO0FBQzlCLENBeEZDLGtCQXdGa0IsQ0FGQyxTQUVTO0FBQzdCLENBekZDLGtCQXlGa0IsQ0FGQyxVQUVVO0FBQzVCLFFBQU07QUFDTixTQUFPO0FBQ1Q7QUFDQSxDQTdGQyxrQkE2RmtCLENBQUMsV0FBVztBQUMvQixDQTlGQyxrQkE4RmtCLENBREMsV0FDVztBQUM3QixRQUFNO0FBQ04sU0FBTztBQUNUO0FBQ0EsQ0FsR0Msa0JBa0drQjtBQUNqQixnQkFBYztBQUNkLFVBQVEsRUFBRTtBQUNaO0FBQ0EsQ0F0R0Msa0JBc0drQjtBQUNqQixnQkFBYztBQUNkLFVBQVEsRUFBRTtBQUNaO0FBQ0EsQ0ExR0Msa0JBMEdrQixDQUFDLFFBQVE7QUFDNUIsQ0EzR0Msa0JBMkdrQixDQURDLFFBQ1E7QUFDMUIsVUFBUTtBQUNWO0FBQ0EsQ0E5R0Msa0JBOEdrQixDQUpDLFFBSVE7QUFDMUIsdUJBQXFCO0FBQ3ZCO0FBQ0EsQ0FqSEMsa0JBaUhrQixDQVBDLFFBT1E7QUFDMUIsdUJBQXFCO0FBQ3ZCO0FBQ0EsQ0FwSEMsa0JBb0hrQixDQUFDLFdBQVc7QUFDL0IsQ0FySEMsa0JBcUhrQixDQURDLFdBQ1c7QUFDN0IsT0FBSztBQUNQO0FBQ0EsQ0F4SEMsa0JBd0hrQixDQUpDLFdBSVc7QUFDN0Isb0JBQWtCO0FBQ3BCO0FBQ0EsQ0EzSEMsa0JBMkhrQixDQVBDLFdBT1c7QUFDN0Isb0JBQWtCO0FBQ3BCO0FBQ0EsQ0E5SEMsa0JBOEhrQjtBQUNqQixXQUFTO0FBQ1g7QUFDQSxDQUFDO0FBQ0MsWUFBVTtBQUNWLFdBQVM7QUFDWDtBQUNBLENBQUM7QUFDQyxXQUFTO0FBQ1QsV0FBUztBQUNULFdBQVM7QUFDVCxXQUFTO0FBQ1g7QUFDQSxDQU5DLGlCQU1pQixDQUFDO0FBQ2pCLGNBQVk7QUFDWixTQUFPLEtBQUssQ0FBQyxFQUFDLENBQUMsRUFBQyxDQUFDLEVBQUM7QUFDbEIsUUFBTSxLQUFLLENBQUMsRUFBQyxDQUFDLEVBQUMsQ0FBQyxFQUFDO0FBQ2pCLFVBQVE7QUFDUixlQUFhO0FBQ2IsY0FBWTtBQUNaLFlBQVU7QUFDVix1QkFBcUI7QUFDbEIsb0JBQWtCO0FBQ2pCLG1CQUFpQjtBQUNiLGVBQWE7QUFDckIsWUFBVTtBQUNWLG9CQUFrQjtBQUNsQixnQkFBYztBQUNWLFlBQVU7QUFDTixRQUFNO0FBQ2hCO0FBQ0EsQ0F4QkMsaUJBd0JpQixDQUFDO0FBQ25CLENBekJDLGlCQXlCaUIsQ0FBQztBQUNqQix1QkFBcUI7QUFDbEIsb0JBQWtCO0FBQ2pCLG1CQUFpQjtBQUNiLGVBQWE7QUFDckIsbUJBQWlCO0FBQ2pCLFVBQVE7QUFDUixZQUFVO0FBQ1YsT0FBSztBQUNMLFVBQVE7QUFDUixXQUFTO0FBQ1QsV0FBUztBQUNULFNBQU8sS0FBSyxDQUFDLEVBQUMsQ0FBQyxFQUFDLENBQUMsRUFBQztBQUNsQixRQUFNLEtBQUssQ0FBQyxFQUFDLENBQUMsRUFBQyxDQUFDLEVBQUM7QUFDbkI7QUFDQSxDQXhDQyxpQkF3Q2lCLENBaEJDLG9CQWdCb0IsQ0FBQztBQUN4QyxDQXpDQyxpQkF5Q2lCLENBaEJDLG9CQWdCb0IsQ0FEQztBQUV0QyxXQUFTO0FBQ1g7QUFDQSxDQTVDQyxpQkE0Q2lCLENBcEJDLHFCQW9CcUI7QUFDeEMsQ0E3Q0MsaUJBNkNpQixDQXBCQyxxQkFvQnFCO0FBQ3RDLFlBQVU7QUFDWjtBQUNBLENBaERDLGlCQWdEaUIsQ0F4QkMsb0JBd0JvQixDQXhCcEI7QUF5Qm5CLENBakRDLGlCQWlEaUIsQ0F4QkMsb0JBd0JvQixDQXpCcEI7QUE4QmpCLFFBQU07QUFLUjtBQUtBLENBaEVDLGlCQWdFaUIsQ0F4Q0Msb0JBd0NvQixDQXZDcEI7QUF3Q25CLENBakVDLGlCQWlFaUIsQ0F4Q0Msb0JBd0NvQixDQXhDcEI7QUE2Q2pCLFNBQU87QUFLVDtBQUtBLENBaEZDLGlCQWdGaUIsQ0F4REMsb0JBd0RvQjtBQUN2QyxDQWpGQyxpQkFpRmlCLENBeERDLG9CQXdEb0I7QUFDckMsU0FBTztBQUNUO0FBQ0EsQ0FwRkMsaUJBb0ZpQixDQTVEQyxvQkE0RG9CLE9BQU87QUFDOUMsQ0FyRkMsaUJBcUZpQixDQTVEQyxvQkE0RG9CLE9BQU87QUFDNUMsUUFBTTtBQUNSO0FBQ0EsQ0F4RkMsaUJBd0ZpQixDQWhFQyxxQkFnRXFCO0FBQ3hDLENBekZDLGlCQXlGaUIsQ0FoRUMscUJBZ0VxQjtBQUN0QyxTQUFPO0FBQ1AsVUFBUTtBQUNWO0FBQ0EsQ0E3RkMsaUJBNkZpQixDQXJFQyxxQkFxRXFCLElBQUk7QUFDNUMsQ0E5RkMsaUJBOEZpQixDQXJFQyxxQkFxRXFCLElBQUk7QUFDMUMsc0JBQW9CLEtBQUs7QUFDekIsY0FBWSxLQUFLO0FBQ2pCLFFBQU07QUFDUjtBQUNBLENBQUM7QUFDQyxZQUFVO0FBQ1YsVUFBUTtBQUNWO0FBQ0EsQ0FKQyxnQkFJZ0I7QUFDakIsQ0FMQyxnQkFLZ0I7QUFDZixXQUFTO0FBQ1g7QUFDQSxDQVJDLGdCQVFnQjtBQUNmLFNBQU87QUFDVDtBQUNBLENBWEMsZ0JBV2dCLEtBQUs7QUFDcEIsV0FBUztBQUNYO0FBQ0EsQ0FkQyxnQkFjZ0IsS0FBSztBQUN0QixDQWZDLGdCQWVnQixLQUFLO0FBQ3BCLFVBQVE7QUFDUixzQkFBb0I7QUFDdEI7QUFDQSxDQW5CQyxnQkFtQmdCO0FBQ2YsWUFBVTtBQUNWLFNBQU87QUFDUCxTQUFPO0FBQ1AsV0FBUyxFQUFFLElBQUksRUFBRTtBQUNqQixVQUFRO0FBQ1IsZUFBYTtBQUNiLFdBQVM7QUFDVCxVQUFRO0FBQ1IsVUFBUSxJQUFJLE1BQU0sS0FBSyxFQUFFLEVBQUMsRUFBRSxFQUFDLEVBQUUsRUFBQztBQUNoQyxzQkFBb0I7QUFDWixjQUFZO0FBQ3RCO0FBQ0EsQ0FoQ0MsZ0JBZ0NnQixJQUFJO0FBQ25CLGNBQVksS0FBSyxDQUFDLEVBQUMsQ0FBQyxFQUFDLENBQUMsRUFBQztBQUN6QjtBQUNBLENBbkNDLGdCQW1DZ0IsSUFBSTtBQUNuQixjQUFZLEtBQUssQ0FBQyxFQUFDLENBQUMsRUFBQyxDQUFDLEVBQUM7QUFDekI7QUFDQSxDQXRDQyxnQkFzQ2dCLElBQUk7QUFDbkIsV0FBUztBQUNULFdBQVM7QUFDVCxZQUFVO0FBQ1o7QUFDQSxDQTNDQyxnQkEyQ2dCLElBQUksQ0FBQztBQUNwQixPQUFLO0FBQ0wsaUJBQWU7QUFDakI7QUFDQSxDQS9DQyxnQkErQ2dCLElBQUksQ0FKQyxPQUlPO0FBQzNCLGVBQWEsSUFBSSxNQUFNO0FBQ3ZCLGdCQUFjLElBQUksTUFBTTtBQUN4QixpQkFBZSxJQUFJLE1BQU0sS0FBSyxFQUFFLEVBQUMsRUFBRSxFQUFDLEVBQUUsRUFBQztBQUN2QyxPQUFLO0FBQ1A7QUFDQSxDQXJEQyxnQkFxRGdCLElBQUksQ0FBQztBQUNwQixPQUFLO0FBQ1A7QUFDQSxDQXhEQyxnQkF3RGdCLElBQUksQ0FIQyxTQUdTO0FBQzdCLGVBQWEsSUFBSSxNQUFNO0FBQ3ZCLGdCQUFjLElBQUksTUFBTTtBQUN4QixjQUFZLElBQUksTUFBTSxLQUFLLEVBQUUsRUFBQyxFQUFFLEVBQUMsRUFBRSxFQUFDO0FBQ3BDLE9BQUs7QUFDUDtBQUNBLENBOURDLGdCQThEZ0IsS0FBSztBQUNwQixTQUFPO0FBQ1AsVUFBUTtBQUNWO0FBQ0EsQ0FsRUMsZ0JBa0VnQixLQUFLLElBQUk7QUFDeEIsUUFBTSxLQUFLLENBQUMsRUFBQyxDQUFDLEVBQUMsQ0FBQyxFQUFDO0FBQ25CO0FBQ0EsQ0FyRUMsZUFxRWU7QUFDZCxjQUFZLEtBQUssQ0FBQyxFQUFDLENBQUMsRUFBQyxDQUFDLEVBQUM7QUFDekI7QUFDQSxDQXhFQyxlQXdFZSxPQUFPO0FBQ3JCLFdBQVM7QUFDWDtBQUNBLENBQUM7QUFDQyxhQUFXO0FBQ1gsZUFBYTtBQUNiLGVBQWE7QUFDYixTQUFPO0FBQ1AsWUFBVTtBQUNWLFNBQU87QUFDUCxRQUFNO0FBQ04sV0FBUyxPQUFPLEVBQUUsRUFBRTtBQUNwQixlQUFhO0FBQ2IsVUFBUTtBQUNSLFdBQVM7QUFDVCxjQUFZO0FBQ1oscUJBQW1CLFlBQVksR0FBRyxFQUFFLEdBQUcsRUFBRTtBQUNqQyxhQUFXLFlBQVksR0FBRyxFQUFFLEdBQUcsRUFBRTtBQUMzQztBQUNBLENBaEJDLHdCQWdCd0IsSUFBSSxDQUFDO0FBQzVCLGVBQWE7QUFDYixlQUFhO0FBQ2IsU0FBTztBQUNQLFdBQVM7QUFDVCxlQUFhO0FBQ2IsV0FBUztBQUNYO0FBQ0EsQ0F4QkMsd0JBd0J3QixJQUFJLENBUkMsU0FRUztBQUNyQyxjQUFZLEtBQUssQ0FBQyxFQUFDLENBQUMsRUFBQyxDQUFDLEVBQUM7QUFDekI7QUFDQSxDQTNCQyx3QkEyQndCLENBdEd4QjtBQXVHQyxTQUFPO0FBQ1AsU0FBTztBQUNQLFdBQVM7QUFDWDtBQUNBLENBaENDLHdCQWdDd0IsQ0EzR3hCLGdCQTJHeUMsSUFBSSxDQWhFeEIsT0FnRWdDO0FBQ3BELHVCQUFxQixLQUFLLENBQUMsRUFBQyxDQUFDLEVBQUMsQ0FBQyxFQUFDO0FBQ2xDO0FBQ0EsQ0FuQ0Msd0JBbUN3QixDQTlHeEIsZ0JBOEd5QyxJQUFJLENBekR4QixTQXlEa0M7QUFDdEQsb0JBQWtCLEtBQUssQ0FBQyxFQUFDLENBQUMsRUFBQyxDQUFDLEVBQUM7QUFDL0I7QUFDQSxDQXRDQyx3QkFzQ3dCLEtBQUssQ0FBQztBQUM3QixjQUFZO0FBQ1osc0JBQW9CO0FBQ1osY0FBWTtBQUNwQixTQUFPO0FBQ1AsVUFBUTtBQUNSLFdBQVMsRUFBRSxFQUFFLEVBQUU7QUFDZixVQUFRO0FBQ1IsV0FBUztBQUNULGFBQVc7QUFDWCxlQUFhO0FBQ2IsZUFBYTtBQUNiLGVBQWE7QUFDYixVQUFRO0FBQ1IsVUFBUTtBQUNSLGlCQUFlO0FBQ2Ysa0JBQWdCO0FBQ2hCLHNCQUFvQjtBQUNwQixtQkFBaUI7QUFDakIsY0FBWTtBQUNkO0FBQ0EsQ0EzREMsd0JBMkR3QixLQUFLLENBckJDLFFBcUJRO0FBQ3JDLFdBQVM7QUFDWDtBQUNBLENBOURDLHdCQThEd0IsS0FBSyxDQXhCQyxRQXdCUSxDQUFDO0FBQ3hDLENBL0RDLHdCQStEd0IsS0FBSyxDQXpCQyxRQXlCUSxDQUFDLFNBQVM7QUFDL0MsYUFBVztBQUNYLFNBQU8sS0FBSyxDQUFDLEVBQUMsQ0FBQyxFQUFDLENBQUMsRUFBQztBQUNsQixjQUFZO0FBQ1osa0JBQWdCO0FBQ2xCO0FBQ0EsQ0FyRUMsd0JBcUV3QixDQUFDO0FBQ3hCLGNBQVk7QUFDWixjQUFZO0FBQ1osVUFBUTtBQUNSLGlCQUFlO0FBQ2YsY0FBWTtBQUNaLFNBQU87QUFDUCxVQUFRO0FBQ1IsYUFBVztBQUNYLGVBQWE7QUFDYixlQUFhO0FBQ2IsVUFBUTtBQUNSLGVBQWE7QUFDYixVQUFRLEtBQUssRUFBRSxFQUFFO0FBQ2pCLFdBQVM7QUFDVCxXQUFTLEVBQUUsRUFBRSxFQUFFO0FBQ2YsWUFBVTtBQUNWLGtCQUFnQjtBQUNoQixzQkFBb0I7QUFDcEIsc0JBQW9CO0FBQ3BCLG1CQUFpQjtBQUNqQixTQUFPO0FBQ1Q7QUFDQSxDQTVGQyx3QkE0RndCLENBdkJDLDhCQXVCOEI7QUFDeEQsQ0E3RkMsd0JBNkZ3QixDQXhCQyw4QkF3QjhCO0FBQ3RELFdBQVM7QUFDWDtBQUNBLENBaEdDLHdCQWdHd0IsQ0EzQkMsOEJBMkI4QjtBQUN0RCxjQUFZLEtBQUssQ0FBQyxFQUFDLENBQUMsRUFBQyxDQUFDLEVBQUM7QUFDekI7QUFDQSxDQW5HQyx3QkFtR3dCLENBOUJDLCtCQThCK0IsQ0FBQztBQUN4RCxvQkFBa0I7QUFDbEIsV0FBUztBQUNULFdBQVM7QUFDWDtBQUNBLENBQUM7QUFDQyxjQUFZO0FBQ1osY0FBWTtBQUNaLFlBQVU7QUFDVixTQUFPO0FBQ1AsV0FBUztBQUNULFdBQVM7QUFDVCxXQUFTO0FBQ1QsV0FBUztBQUNULHFCQUFtQjtBQUNuQix1QkFBcUI7QUFDakIsa0JBQWdCO0FBQ1osZUFBYTtBQUNyQixVQUFRO0FBQ1Y7QUFDQSxDQWZDLG1CQWVtQixDQUFDO0FBQ25CLFdBQVM7QUFDVCxXQUFTO0FBQ1QsV0FBUztBQUNULFdBQVM7QUFDVCxvQkFBa0I7QUFDbEIsZ0JBQWM7QUFDVixZQUFVO0FBQ04sUUFBTTtBQUNoQjtBQUNBLElBQUksQ0FBQztBQUNILFVBQVE7QUFDUixhQUFXO0FBQ1gsY0FBWTtBQUNaLFNBQU8sS0FBSyxDQUFDLEVBQUMsQ0FBQyxFQUFDLENBQUMsRUFBQztBQUNsQixlQUFhO0FBQ2IsVUFBUTtBQUNSLGNBQVk7QUFDWixXQUFTO0FBQ1Qsb0JBQWtCO0FBQ2xCLGdCQUFjO0FBQ1YsWUFBVTtBQUNOLFFBQU07QUFDZCxlQUFhO0FBQ2Y7QUFDQSxDQWhaZ0Q7QUFpWmhELENBQUM7QUFDQyxXQUFTLElBQUksRUFBRSxFQUFFO0FBQ25CO0FBQ0EsQ0FwWmdDO0FBcVo5QixZQUFVO0FBQ1YsWUFBVTtBQUNWLFdBQVM7QUFDVCxXQUFTO0FBQ1QsV0FBUztBQUNULFdBQVM7QUFDVCxxQkFBbUI7QUFDbkIsdUJBQXFCO0FBQ2pCLGtCQUFnQjtBQUNaLGVBQWE7QUFDckIsU0FBTztBQUNUO0FBQ0EsQ0FqYWdDLGNBaWFqQjtBQUNiLFdBQVM7QUFDWDtBQUNBLENBcGFnRDtBQXFhOUMsV0FBUztBQUNULFdBQVM7QUFDVCxjQUFZO0FBQ1osU0FBTztBQUNQLGFBQVc7QUFDWCxhQUFXO0FBQ1gsc0JBQW9CO0FBQ1osY0FBWTtBQUNwQixXQUFTO0FBQ1QsV0FBUztBQUNULFdBQVM7QUFDVCxXQUFTO0FBQ1QsV0FBUztBQUNULHFCQUFtQjtBQUNYLGFBQVc7QUFDbkIsaUJBQWU7QUFDZixpQkFBZTtBQUNmLDJCQUF5QjtBQUNqQixtQkFBaUI7QUFDekIscUJBQW1CLFlBQVksR0FBRyxFQUFFLEdBQUcsRUFBRTtBQUNqQyxhQUFXLFlBQVksR0FBRyxFQUFFLEdBQUcsRUFBRTtBQUN6QyxXQUFTO0FBQ1g7QUFDQSxDQTViZ0QsYUE0YmxDLEVBQUUsQ0E1YmdDO0FBNmI5QyxzQkFBb0IsS0FBSyxFQUFFLEVBQUU7QUFDckIsY0FBWSxLQUFLLEVBQUUsRUFBRTtBQUMvQjtBQUNBLENBaGM2RTtBQWljM0UsY0FBWTtBQUNaLFVBQVEsSUFBSSxNQUFNO0FBQ2xCLGlCQUFlO0FBQ2Ysc0JBQW9CO0FBQ1osY0FBWTtBQUNwQixTQUFPO0FBQ1AsVUFBUTtBQUNSLGVBQWE7QUFDYixTQUFPO0FBQ1Asc0JBQW9CO0FBQ2hCLDJCQUF5QjtBQUNyQixjQUFZO0FBQ3BCLGFBQVc7QUFDWCxVQUFRO0FBQ1IsZUFBYTtBQUNiLFVBQVE7QUFDUixXQUFTO0FBQ1QsWUFBVTtBQUNWLG9CQUFrQjtBQUNsQiwyQkFBeUI7QUFDckIsaUJBQWU7QUFDWCxtQkFBaUI7QUFDekIsY0FBWTtBQUNkO0FBQ0EsQ0F6ZDZFLGFBeWQvRCxDQXpkNkU7QUEwZDNGLENBMWQ2RSxhQTBkL0QsQ0FBQyxZQUFZLENBMWRnRTtBQTJkM0YsQ0EzZDZFLGFBMmQvRCxDQUFDLFlBQVksQ0EzZGdFO0FBNGQzRixDQTVkNkUsYUE0ZC9ELENBQUMsS0FBSyxDQTVkdUU7QUE2ZDNGLENBN2Q2RSxhQTZkL0QsQ0FIQyxZQUdZLENBRFosS0FDa0IsQ0E3ZDBEO0FBOGQzRixDQTlkNkUsYUE4ZC9ELENBSEMsWUFHWSxDQUZaLEtBRWtCLENBOWQwRDtBQStkM0YsQ0EvZDZFLGFBK2QvRDtBQUNkLENBaGU2RSxhQWdlL0QsQ0FOQyxZQU1ZO0FBQzNCLENBamU2RSxhQWllL0QsQ0FOQyxZQU1ZO0FBQzNCLENBbGU2RSxhQWtlL0Q7QUFDZCxDQW5lNkUsYUFtZS9ELENBVEMsWUFTWTtBQUMzQixDQXBlNkUsYUFvZS9ELENBVEMsWUFTWTtBQUN6QixVQUFRO0FBQ1IsV0FBUztBQUNULGNBQVk7QUFDWixnQkFBYztBQUNoQjtBQUNBLENBMWU2RSxhQTBlL0QsQ0FkQztBQWViLGdCQUFjO0FBQ2hCO0FBQ0EsQ0E3ZTZFLGFBNmUvRCxDQWpCQyxLQWlCSztBQUNwQixDQTllNkUsYUE4ZS9ELENBbEJDLEtBa0JLO0FBQ2xCLGdCQUFjO0FBQ2QsY0FBWTtBQUNaLFNBQU87QUFDVDtBQUNBLENBbmY2RSxhQW1mL0QsQ0FBQztBQUNmLENBcGY2RSxhQW9mL0QsQ0FBQztBQUNmLENBcmY2RSxhQXFmL0QsQ0FBQztBQUNmLENBdGY2RSxhQXNmL0QsQ0FIQyxRQUdRLENBdGZvRTtBQXVmM0YsQ0F2ZjZFLGFBdWYvRCxDQUhDLFVBR1UsQ0F2ZmtFO0FBd2YzRixDQXhmNkUsYUF3Zi9ELENBSEMsUUFHUSxDQXhmb0U7QUF5ZjNGLENBemY2RSxhQXlmL0QsQ0FOQyxRQU1RO0FBQ3ZCLENBMWY2RSxhQTBmL0QsQ0FOQyxVQU1VO0FBQ3pCLENBM2Y2RSxhQTJmL0QsQ0FOQyxRQU1RO0FBQ3ZCLENBNWY2RSxhQTRmL0QsQ0FUQyxRQVNRO0FBQ3ZCLENBN2Y2RSxhQTZmL0QsQ0FUQyxVQVNVO0FBQ3pCLENBOWY2RSxhQThmL0QsQ0FUQyxRQVNRO0FBQ3ZCLENBL2Y2RSxhQStmL0QsQ0FaQyxRQVlRLENBckNSO0FBc0NmLENBaGdCNkUsYUFnZ0IvRCxDQVpDLFVBWVUsQ0F0Q1Y7QUF1Q2YsQ0FqZ0I2RSxhQWlnQi9ELENBWkMsUUFZUSxDQXZDUjtBQXdDZixDQWxnQjZFLGFBa2dCL0QsQ0FmQyxRQWVRLENBdkNSO0FBd0NmLENBbmdCNkUsYUFtZ0IvRCxDQWZDLFVBZVUsQ0F4Q1Y7QUF5Q2YsQ0FwZ0I2RSxhQW9nQi9ELENBZkMsUUFlUSxDQXpDUjtBQTBDYixjQUFZO0FBQ1osc0JBQW9CO0FBQ1osY0FBWTtBQUNwQixTQUFPO0FBQ1AsZ0JBQWM7QUFDaEI7QUFDQSxDQTNnQjZFLGFBMmdCL0QsQ0F4QkMsUUF3QlEsQ0F2QlI7QUF3QmYsQ0E1Z0I2RSxhQTRnQi9ELENBeEJDLFVBd0JVLENBeEJWO0FBeUJmLENBN2dCNkUsYUE2Z0IvRCxDQXhCQyxRQXdCUSxDQXpCUjtBQTBCYixpQkFBZSxLQUFLLEVBQUUsRUFBRTtBQUMxQjtBQUNBLENBaGhCNkUsYUFnaEIvRCxDQTdCQyxRQTZCUSxDQTNCUjtBQTRCZixDQWpoQjZFLGFBaWhCL0QsQ0E3QkMsVUE2QlUsQ0E1QlY7QUE2QmYsQ0FsaEI2RSxhQWtoQi9ELENBN0JDLFFBNkJRLENBN0JSO0FBOEJiLGlCQUFlLEVBQUUsS0FBSyxLQUFLO0FBQzdCO0FBQ0EsQ0FyaEI2RSxhQXFoQi9ELENBbENDLFFBa0NRLENBakNSLFdBaUNvQixFQUFFLENBaEN0QixRQWdDK0IsS0FBSztBQUNuRCxDQXRoQjZFLGFBc2hCL0QsQ0FsQ0MsVUFrQ1UsQ0FsQ1YsV0FrQ3NCLEVBQUUsQ0FqQ3hCLFFBaUNpQyxLQUFLO0FBQ3JELENBdmhCNkUsYUF1aEIvRCxDQWxDQyxRQWtDUSxDQW5DUixXQW1Db0IsRUFBRSxDQWxDdEIsUUFrQytCLEtBQUs7QUFDakQsc0JBQW9CLE1BQU0sRUFBRSxFQUFFO0FBQ3RCLGNBQVksTUFBTSxFQUFFLEVBQUU7QUFDaEM7QUFDQSxDQTNoQjZFLGFBMmhCL0QsQ0F4Q0MsUUF3Q1EsQ0F2Q1IsVUF1Q21CLENBdENuQjtBQXVDZixDQTVoQjZFLGFBNGhCL0QsQ0F4Q0MsVUF3Q1UsQ0F4Q1YsVUF3Q3FCLENBdkNyQjtBQXdDZixDQTdoQjZFLGFBNmhCL0QsQ0F4Q0MsUUF3Q1EsQ0F6Q1IsVUF5Q21CLENBeENuQjtBQXlDYixpQkFBZTtBQUNqQjtBQUNBLENBaGlCNkUsYUFnaUIvRCxDQWhpQjZFO0FBaWlCekYsaUJBQWU7QUFDZixzQkFBb0IsS0FBSyxFQUFFLEVBQUUsT0FBTyxFQUFFLElBQUksRUFBRSxFQUFFO0FBQ3RDLGNBQVksS0FBSyxFQUFFLEVBQUUsT0FBTyxFQUFFLElBQUksRUFBRSxFQUFFO0FBQ2hEO0FBQ0EsQ0FyaUI2RSxhQXFpQi9ELENBM2EwQjtBQTRheEMsQ0F0aUI2RSxhQXNpQi9ELENBNWEwQixrQkE0YVA7QUFDakMsQ0F2aUI2RSxhQXVpQi9ELENBN0VDO0FBOEVmLENBeGlCNkUsYUF3aUIvRCxDQTdFQztBQThFZixDQXppQjZFLGFBeWlCL0QsQ0FBQztBQUNmLENBMWlCNkUsYUEwaUIvRCxDQURDLFVBQ1UsQ0FoRlY7QUFpRmYsQ0EzaUI2RSxhQTJpQi9ELENBRkMsVUFFVSxDQWhGVjtBQWlGYixTQUFPLEtBQUssRUFBRSxFQUFDLEVBQUUsRUFBQyxFQUFFLEVBQUM7QUFDckIsY0FBWTtBQUNaLGdCQUFjO0FBQ2QsVUFBUTtBQUNWO0FBQ0EsQ0FqakI2RSxhQWlqQi9ELENBdmIwQjtBQXdieEMsQ0FsakI2RSxhQWtqQi9ELENBeGIwQixrQkF3YlA7QUFDL0IsVUFBUTtBQUNSLFNBQU8sS0FBSyxFQUFFLEVBQUMsRUFBRSxFQUFDLEVBQUUsRUFBQztBQUN2QjtBQUNBLENBdGpCNkUsYUFzakIvRCxDQUFDLElBQUksQ0FuRUo7QUFvRWIsaUJBQWU7QUFDZixzQkFBb0IsS0FBSyxFQUFFLEVBQUUsT0FBTyxFQUFFLElBQUksRUFBRSxFQUFFO0FBQ3RDLGNBQVksS0FBSyxFQUFFLEVBQUUsT0FBTyxFQUFFLElBQUksRUFBRSxFQUFFO0FBQ2hEO0FBQ0EsQ0EzakI2RSxhQTJqQi9ELENBQUM7QUFDYixjQUFZO0FBQ2Q7QUFDQSxDQUFDLFVBQVUsQ0E5akJrRTtBQStqQjNFLGNBQVk7QUFDZDtBQUNBLENBQUM7QUFDQyxTQUFPO0FBQ1Q7QUFDQSxDQUhDLHNCQUdzQixDQW5MdEI7QUFvTEMsV0FBUyxFQUFFO0FBQ1gsc0JBQW9CLElBQUksRUFBRSxFQUFFO0FBQ3BCLGNBQVksSUFBSSxFQUFFLEVBQUU7QUFDOUI7QUFDQSxDQVJDLHNCQVFzQixDQXhNbEI7QUF5TUgsU0FBTztBQUNQLFNBQU87QUFDUCxlQUFhO0FBQ2Y7QUFDQSxDQWJDLHNCQWFzQixJQUFJLENBOWtCa0Q7QUEra0I3RSxDQWRDLHNCQWNzQixJQUFJLENBL2tCa0QsYUEra0JwQztBQUN2QyxXQUFTO0FBQ1QsU0FBTztBQUNQLGFBQVc7QUFDWCxTQUFPLEtBQUssRUFBRSxFQUFDLEVBQUUsRUFBQyxFQUFFLEVBQUM7QUFDckIsY0FBWTtBQUNaLFVBQVE7QUFDUixVQUFRO0FBQ1Y7QUFDQSxDQUFDO0FBQ0MsV0FBUztBQUNULFdBQVM7QUFDVCxXQUFTO0FBQ1QsV0FBUztBQUNULFdBQVM7QUFDVCxzQkFBb0I7QUFDWixjQUFZO0FBQ3BCLFlBQVU7QUFDWjtBQUNBLENBQUM7QUFDQyxXQUFTO0FBQ1QsV0FBUztBQUNULHNCQUFvQjtBQUNaLGNBQVk7QUFDdEI7QUFDQSxDQXZsQjZCO0FBd2xCM0IsY0FBWTtBQUNaLFdBQVM7QUFDVCxXQUFTO0FBQ1QsVUFBUTtBQUNSLGVBQWE7QUFDYixjQUFZO0FBQ1osc0JBQW9CO0FBQ1osY0FBWTtBQUNwQixZQUFVO0FBQ1YsV0FBUztBQUNULFdBQVM7QUFDVCxXQUFTO0FBQ1QsV0FBUztBQUNYO0FBQ0EsQ0F0bUI2QixjQXNtQmQ7QUFDYixXQUFTO0FBQ1QsV0FBUztBQUNULFNBQU87QUFDVDtBQUNBLENBM21CNkIsZUEybUJiLENBdmNmO0FBd2NDLG9CQUFrQjtBQUNsQixnQkFBYztBQUNWLFlBQVU7QUFDTixRQUFNO0FBQ2QsU0FBTztBQUNQLFVBQVE7QUFDUixTQUFPO0FBQ1Q7QUFDQSxDQXBuQjZCLGVBb25CYixDQWhkZixnQkFnZGdDLElBQUksQ0FyYWYsT0FxYXVCO0FBQzNDLHVCQUFxQjtBQUN2QjtBQUNBLENBdm5CNkIsZUF1bkJiLENBbmRmLGdCQW1kZ0MsSUFBSSxDQTlaZixTQThaeUI7QUFDN0Msb0JBQWtCO0FBQ3BCO0FBQ0EsQ0ExbkI2QixjQTBuQmQsQ0FBQyxXQUFXLENBdGQxQjtBQXVkQyxTQUFPO0FBQ1Q7QUFDQSxDQTduQjZCLGNBNm5CZCxDQUFDLFNBQVMsQ0F6ZHhCO0FBMGRDLFNBQU87QUFDVDtBQUNBLENBaG9CNkIsZUFnb0JiO0FBQ2QsY0FBWTtBQUNaLHNCQUFvQjtBQUNaLGNBQVk7QUFDcEIsVUFBUTtBQUNSLGlCQUFlO0FBQ2YsY0FBWTtBQUNaLFVBQVE7QUFDUixXQUFTO0FBQ1QsVUFBUTtBQUNSLGVBQWE7QUFDYixTQUFPO0FBQ1AsYUFBVztBQUNYLFlBQVU7QUFDVixzQkFBb0I7QUFDWixjQUFZO0FBQ3BCLHNCQUFvQjtBQUNwQixtQkFBaUI7QUFDakIsY0FBWTtBQUNkO0FBQ0EsQ0FwcEI2QixlQW9wQmIsS0FBSyxDQUFDO0FBQ3BCLGVBQWE7QUFDZjtBQUNBLENBdnBCNkIsZUF1cEJiLEtBQUssQ0FBQztBQUN0QixDQXhwQjZCLGVBd3BCYixLQUFLLENBQUM7QUFDcEIsZUFBYTtBQUNmO0FBQ0EsQ0EzcEI2QixlQTJwQmIsS0FBSztBQUNuQixXQUFTO0FBQ1QsVUFBUTtBQUNWO0FBQ0EsQ0EvcEI2QixlQStwQmIsQ0FBQztBQUNqQixDQWhxQjZCLGVBZ3FCYixDQUFDO0FBQ2YsVUFBUTtBQUNSLFNBQU87QUFDUCxlQUFhO0FBQ2IsU0FBTztBQUNQLGVBQWE7QUFDYixTQUFPO0FBQ1AsdUJBQXFCO0FBQ2xCLG9CQUFrQjtBQUNqQixtQkFBaUI7QUFDYixlQUFhO0FBQ3JCLHNCQUFvQjtBQUNoQix1QkFBcUI7QUFDakIsY0FBWTtBQUN0QjtBQUNBLENBL3FCNkIsZUErcUJiLENBZkM7QUFnQmYsV0FBUztBQUNULFNBQU87QUFDUCxVQUFRO0FBQ1IsY0FBWTtBQUNaLGVBQWE7QUFDZjtBQUNBLENBdHJCNkIsZUFzckJiLEtBQUs7QUFDckIsQ0F2ckI2QixlQXVyQmIsQ0F2QkMsZUF1QmU7QUFDaEMsQ0F4ckI2QixlQXdyQmIsS0FBSztBQUNyQixDQXpyQjZCLGVBeXJCYixDQXpCQyxlQXlCZTtBQUM5QixjQUFZO0FBQ2Q7QUFDQSxDQUFDLGVBQWUsQ0FBQztBQUNmLFVBQVE7QUFDVjtBQUNBLG1CQS90QnFCO0FBZ3VCbkI7QUFDRSxhQUFTO0FBQ1QsdUJBQW1CLFlBQVksQ0FBQyxFQUFFLEtBQUssRUFBRTtBQUNqQyxlQUFXLFlBQVksQ0FBQyxFQUFFLEtBQUssRUFBRTtBQUMzQztBQUNBO0FBQ0UsYUFBUztBQUNULHVCQUFtQixZQUFZLENBQUMsRUFBRSxDQUFDLEVBQUU7QUFDN0IsZUFBVyxZQUFZLENBQUMsRUFBRSxDQUFDLEVBQUU7QUFDdkM7QUFDRjtBQUNBLFdBM3VCcUI7QUE0dUJuQjtBQUNFLGFBQVM7QUFDVCx1QkFBbUIsWUFBWSxDQUFDLEVBQUUsS0FBSyxFQUFFO0FBQ2pDLGVBQVcsWUFBWSxDQUFDLEVBQUUsS0FBSyxFQUFFO0FBQzNDO0FBQ0E7QUFDRSxhQUFTO0FBQ1QsdUJBQW1CLFlBQVksQ0FBQyxFQUFFLENBQUMsRUFBRTtBQUM3QixlQUFXLFlBQVksQ0FBQyxFQUFFLENBQUMsRUFBRTtBQUN2QztBQUNGOzs7QUUxeEJBO0FBQ0ksd0JBQUE7O0FBSUosQ0FBQTtBQU9JLHNCQUFBOztBQUdKLENBQUE7QUFDSSxXQUFBO0FBQ0Esa0JBQUE7QUFDQSxtQkFBQTtBQUNBLE9BQUEsSUFBQTs7QUFFQSxDQU5KLHFCQU1JO0FBQ0ksV0FBQTtBQUNBLGtCQUFBO0FBQ0EsZUFBQTs7QUFFQSxDQVhSLHFCQVdRLE1BQUE7QUFDSSxVQUFBO0FBQ0EsZ0JBQUE7O0FBR0osQ0FoQlIscUJBZ0JRLE1BQUE7QUFDSSxZQUFBO0FBQ0EsYUFBQSxXQUFBOztBQUtaLENBQUE7QUFDSSxTQUFBLElBQUE7QUFDQSxnQkFBQTs7QUFJSixDQUFBLE9BQUEsQ0FBQTtBQUNJLGFBQUEsaUJBQUEsTUFBQSxTQUFBOztBQUVKLFdBRkk7QUFHQTtBQUNJLGFBQUE7QUFDQSxlQUFBLFdBQUEsT0FBQSxNQUFBOztBQUVKO0FBQ0ksYUFBQTtBQUNBLGVBQUEsV0FBQSxPQUFBLE1BQUE7O0FBRUo7QUFDSSxhQUFBO0FBQ0EsZUFBQSxXQUFBLE9BQUEsTUFBQTs7QUFFSjtBQUNJLGFBQUE7QUFDQSxlQUFBLFdBQUEsT0FBQSxNQUFBOzs7QUFNUixDQUFBO0FBQUEsQ0FBQTtBQUFBLENBQUE7QUFBQSxDQUFBO0FBQUEsQ0FBQTtBQUFBLENBQUE7QUFNSSxVQUFBO0FBQ0EsZUFBQTtBQUNBLHVCQUFBO0FBQ0EseUJBQUE7O0FBSUosQ0FBQTtBQUFBLENBQUE7QUFDSSxTQUFBO0FBQ0EsVUFBQTtBQUNBLGtCQUFBO0FBQ0EsZUFBQTtBQUNBLFVBQUE7QUFDQSxlQUFBLElBQUE7QUFDQSxTQUFBLElBQUE7QUFDQSxlQUFBO0FBQ0EsdUJBQUE7QUFDQSx5QkFBQTs7QUFHSixDQUFBLENBYkE7QUFhQSxDQUFBLENBYkE7QUFjSSxtQkFBQTs7QUFHSixDQWpCQSxVQWlCQTtBQUNJLFdBQUE7O0FBR0osQ0FyQkEsY0FxQkE7QUFDSSxXQUFBOztBQUlKLENBQUE7QUFDSSxhQUFBLElBQUE7QUFDQSxlQUFBLElBQUE7QUFDQSxXQUFBLElBQUE7QUFDQSxpQkFBQSxJQUFBO0FBQ0EsU0FBQSxJQUFBO0FBQ0Esb0JBQUEsSUFBQTtBQUNBLGVBQUE7QUFDQSxlQUFBOztBQUdKLENBQUEsYUFBQSxDQUFBO0FBQ0ksbUJBQUE7O0FBR0osQ0FBQTtBQUNJLFlBQUE7O0FBR0osQ0FKQSxnQkFJQSxDQWxGQTtBQW1GSSxZQUFBO0FBQ0EsT0FBQTtBQUNBLFFBQUE7QUFDQSxlQUFBOztBQUdKLENBQUE7QUFDSSxVQUFBOztBQUlKLENBQUEsdUJBQUEsQ0FBQSxpQkFBQSxDQUFBLENBQUE7QUFDSSxXQUFBOztBQUtKLENBQUEsZUFBQSxDQUFBO0FBQ0ksV0FBQTs7QUNqSkosQ0FBQTtBQUNJLG9CQUFBLElBQUE7O0FBSUEsQ0FBQSxVQUFBLENBTEo7QUFNUSxvQkFBQSxJQUFBOztBQUtKLENBQUEsWUFBQSxRQUFBLEVBQUE7QUFFUSxjQUFBOztBQUdSLENBTEEsWUFLQTtBQUNJLFVBQUEsSUFBQTs7QUFHSixDQVRBLFlBU0EsQ0FBQTtBQUNJLFVBQUEsSUFBQSxNQUFBOztBQUdKLENBYkEsWUFhQSxDQUFBO0FBQ0ksbUJBQUE7QUFDQSx5QkFBQTs7QUFLSixDQUFBLGdDQUFBO0FBQ0ksU0FBQTtBQUNBLGNBQUEsS0FBQSxJQUFBLGdCQUFBLEVBQUE7QUFDQSxVQUFBO0FBQ0EsY0FBQTs7QUFJUixDQUFBO0FBQ0ksV0FBQTtBQUNBLHlCQUFBLElBQUEsS0FBQSxLQUFBO0FBQ0EsZ0JBQUE7O0FBRUEsQ0FMSiw2QkFLSSxFQUFBO0FBQ0ksa0JBQUE7QUFDQSxnQkFBQTs7QUFHSixDQVZKLDZCQVVJLENBQUE7QUFDSSxlQUFBOztBQUVBLENBYlIsNkJBYVEsQ0FISixxQ0FHSSxNQUFBLEVBQUE7QUFDSSxhQUFBLElBQUE7QUFDQSxpQkFBQSxJQUFBO0FBQ0EsV0FBQSxJQUFBOztBQUdKLENBbkJSLDZCQW1CUSxDQVRKLHFDQVNJO0FBQ0ksZ0JBQUEsSUFBQTs7QUFHSixDQXZCUiw2QkF1QlEsQ0FiSixxQ0FhSSxLQUFBLE9BQUEsRUFBQTtBQUNJLGNBQUEsRUFBQSxFQUFBLEVBQUEsSUFBQSxJQUFBO0FBQ0EsZ0JBQUEsSUFBQTs7QUFHSixDQTVCUiw2QkE0QlEsQ0FsQkoscUNBa0JJLEtBQUEsU0FBQSxFQUFBO0FBQ0ksZUFBQTs7QUFHSixDQWhDUiw2QkFnQ1EsQ0F0QkoscUNBc0JJLEtBQUEsS0FBQSxVQUFBLEVBQUEsTUFBQSxFQUFBLElBQUE7QUFDSSxVQUFBLFVBQUEsTUFBQSxRQUFBOztBQUtaLENBQUE7QUFDSSxXQUFBO0FBQ0EseUJBQUEsSUFBQSxLQUFBO0FBQ0EsY0FBQTtBQUNBLFdBQUE7QUFDQSxlQUFBOztBQUVBLENBUEosMEJBT0k7QUFDSSxlQUFBOztBQUdKLENBWEosMEJBV0ksQ0FBQTtBQUNJLGFBQUE7O0FBR0osQ0FmSiwwQkFlSSxDQUFBO0FBQ0ksZUFBQTs7QUFHSixDQW5CSiwwQkFtQkksQ0FBQTtBQUNJLGVBQUE7QUFDQSxhQUFBLElBQUE7O0FBR0osQ0F4QkosMEJBd0JJLENBQUE7QUFDSSxxQkFBQTtBQUNBLG1CQUFBOztBQUVBLENBNUJSLDBCQTRCUSxDQUpKLGtCQUlJO0FBQ0ksZUFBQTtBQUNBLE9BQUE7O0FBSVIsQ0FsQ0osMEJBa0NJLENBQUE7QUFDSSxlQUFBOztBQUlSLENBQUE7QUFDSSxXQUFBO0FBQ0EseUJBQUEsSUFBQTtBQUNBLGNBQUE7QUFDQSxXQUFBO0FBQ0EsZUFBQTs7QUFFQSxDQVBKLGlDQU9JLENBQUE7QUFDSSxlQUFBO0FBQ0EsU0FBQTs7QUFHSixDQVpKLGlDQVlJLENBQUE7QUFDSSxlQUFBOztBQUlSLENBQUE7QUFDSSxZQUFBO0FBQ0EsVUFBQTtBQUNBLG9CQUFBLElBQUE7QUFDQSxrQkFBQTtBQUNBLGVBQUE7QUFDQSxXQUFBO0FBQ0EseUJBQUEsSUFBQTtBQUNBLGNBQUE7O0FBRUEsQ0FWSiwyQkFVSSxNQUFBO0FBQ0ksa0JBQUE7QUFDQSxXQUFBOztBQUlSLFFBQUEsV0FBQTtBQUNJLEdBL0dKO0FBZ0hRLDJCQUFBLElBQUEsS0FBQTs7QUFFQSxHQWxIUiw2QkFrSFEsRUFBQTtBQUNJLGNBQUEsQ0FBQSxDQUFBLEtBQUE7OztBQUtaLFFBQUEsV0FBQTtBQUNJLEdBekhKO0FBMEhRLDJCQUFBLElBQUEsS0FBQTs7QUFHSixHQXZGSjtBQXdGUSwyQkFBQTtBQUNBLHVCQUFBOztBQUVBLEdBM0ZSLDBCQTJGUSxDQWhGSjtBQWlGUSxpQkFBQTs7QUFHSixHQS9GUiwwQkErRlEsQ0E1RUo7QUE2RVEsaUJBQUE7O0FBR0osR0FuR1IsMEJBbUdRLENBakVKO0FBa0VRLGlCQUFBOztBQUtKLEdBbEVSLGlDQWtFUTtBQUNJLGlCQUFBOztBQUdKLEdBdEVSLGlDQXNFUSxDQTFESjtBQTJEUSxpQkFBQTs7O0FBS1osUUFBQSxXQUFBO0FBRVEsR0FySFIsMEJBcUhRLENBbkZKO0FBb0ZRLGlCQUFBOztBQUdKLEdBekhSLDBCQXlIUSxFQUFBLENBdEdKO0FBdUdRLGlCQUFBOztBQUlSLEdBcEtKO0FBcUtRLDJCQUFBLElBQUE7O0FBRUEsR0F2S1IsNkJBdUtRLEVBQUE7QUFDSSxjQUFBLENBQUEsQ0FBQSxLQUFBOztBQUlSLEdBL0ZKO0FBZ0dRLDJCQUFBO0FBQ0EsdUJBQUE7OztBQUlSLFFBQUEsV0FBQTtBQUNJLEdBbkxKO0FBb0xRLDJCQUFBOztBQUVBLEdBdExSLDZCQXNMUSxFQUFBO0FBQ0ksY0FBQTs7O0FDOU5aLENBQUE7QUFDSSxlQUFBO0FBRUEsV0FBQTtBQUNBLGFBQUE7QUFDQSxPQUFBOztBQUVKLENBQUE7QUFDSSxXQUFBO0FBQ0Esb0JBQUEsSUFBQTtBQUNBLGNBQUEsSUFBQTtBQUNBLGlCQUFBO0FBQ0EsV0FBQSxJQUFBLElBQUEsSUFBQTs7QUFHSixDQUFBO0FBQ0ksYUFBQSxJQUFBO0FBQ0EsYUFBQTtBQUNBLFlBQUE7QUFDQSxlQUFBO0FBQ0EsaUJBQUE7O0FBR0osQ0FBQTtBQUNJLFdBQUE7QUFDQSxVQUFBO0FBQ0EsVUFBQTtBQUNBLGNBQUE7QUFDQSxpQkFBQTs7QUFHSixDQUFBO0FBQ0ksY0FBQTtBQUNBLFlBQUE7QUFDQSxPQUFBO0FBQ0EsUUFBQTtBQUNBLFdBQUE7QUFDQSxVQUFBO0FBQ0Esb0JBQUEsSUFBQTtBQUNBLFVBQUE7QUFDQSxpQkFBQTtBQUNBLGdCQUFBLElBQUE7QUFDQSxnQkFBQTtBQUNBLFdBQUE7QUFDQSxjQUFBO0FBQ0EsY0FBQTs7QUFHSixDQWpCQSx5QkFpQkE7QUFDSSxXQUFBO0FBQ0EsVUFBQTtBQUNBLGlCQUFBO0FBQ0EsVUFBQTtBQUNBLFdBQUE7QUFDQSxtQkFBQTs7QUFFSixDQXpCQSx5QkF5QkEsR0FBQSxDQUFBO0FBQ0ksWUFBQTtBQUNBLGVBQUE7QUFDQSxpQkFBQTs7QUFHSixDQS9CQSx5QkErQkEsR0FBQSxDQUFBO0FBQ0ksU0FBQTtBQUNBLFlBQUE7QUFDQSxlQUFBO0FBQ0EsaUJBQUE7O0FBR0osQ0F0Q0EseUJBc0NBLEdBQUEsQ0FBQTtBQUNJLFNBQUE7QUFDQSxZQUFBO0FBQ0EsZUFBQTtBQUNBLGlCQUFBO0FBQ0EsY0FBQTtBQUNBLGNBQUE7QUFDQSxTQUFBLElBQUE7O0FBR0osQ0FoREEseUJBZ0RBLEVBQUEsQ0FBQTtBQUNJLG9CQUFBLElBQUE7O0FDaEZKLENBQUE7QUFDSSxrQkFBQTtBQUNBLFNBQUE7O0FBRUEsQ0FKSiw4QkFJSSxDQUFBO0FBQ0ksZ0JBQUEsSUFBQTs7QUFNQSxDRk5KLFVFTUksQ0FYUiw4QkFXUSxDQVBKO0FBUVEsZ0JBQUEsSUFBQTs7QUFLWixDQUFBO0FBQ0ksV0FBQTs7QUFFQSxDQUhKLG9CQUdJLENBQUE7QUFDSSxXQUFBO0FBQ0Esa0JBQUE7O0FBRUEsQ0FQUixvQkFPUSxDQUpKLCtCQUlJO0FBQ0ksV0FBQTtBQUNBLGlCQUFBO0FBRUEsV0FBQTtBQUNBLE9BQUE7O0FBRUEsQ0FkWixvQkFjWSxDQVhSLCtCQVdRLE1BQUEsS0FBQSxDQUFBO0FBQ0ksVUFBQTs7QUFJUixDQW5CUixvQkFtQlEsQ0FoQkosK0JBZ0JJO0FBQ0ksVUFBQSxJQUFBOztBQUlSLENBeEJKLG9CQXdCSSxDQUFBO0FBQ0ksWUFBQTtBQUNBLFVBQUE7QUFFQSxXQUFBO0FBQ0EsbUJBQUE7QUFDQSxPQUFBO0FBQ0EsV0FBQSxLQUFBOztBQ2hEUixDQUFBO0FBRUksU0FBQSxJQUFBO0FBQ0Esb0JBQUEsS0FBQSxJQUFBLGdDQUFBLEVBQUE7O0FBSUosQ0FBQSxlQUFBLENBQUE7QUFDSSxVQUFBLElBQUE7O0FBRUosQ0FIQSxlQUdBLENBSEEsV0FHQSxFQUFBLENBQUE7QUFDSSxjQUFBO0FBQ0EsZUFBQTs7QUFJSixDQVRBLGVBU0EsUUFBQSxFQUFBO0FBQ0ksV0FBQTtBQUNBLFdBQUE7QUFDQSxjQUFBO0FBQ0EsbUJBQUE7QUFDQSxjQUFBO0FBQ0EsMEJBQUE7QUFDQSwyQkFBQTtBQUNBLFVBQUE7QUFDQSxZQUFBOztBQUdKLENBckJBLGVBcUJBLFFBQUEsRUFBQSxPQUFBO0FBQUEsQ0FyQkEsZUFxQkEsUUFBQSxFQUFBLE9BQUE7QUFFSSxXQUFBOztBQUdKLENBMUJBLGVBMEJBLFFBQUEsRUFBQSxRQUFBLEVBQUEsQ0FBQTtBQUNJLFlBQUE7QUFDQSxPQUFBO0FBQ0EsU0FBQTtBQUNBLGFBQUEsV0FBQTtBQUNBLFdBQUE7O0FBR0osQ0FsQ0EsZUFrQ0EsUUFBQSxFQUFBLFFBQUEsRUFBQSxDQVJBLFVBUUEsRUFBQSxDQUFBO0FBQ0ksYUFBQSxPQUFBO0FBQ0EsY0FBQSxVQUFBO0FBQ0Esb0JBQUE7QUFDQSx1QkFBQTtBQUNBLGVBQUE7QUFDQSxxQkFBQTtBQUNBLGFBQUE7QUFDQSxzQkFBQSxJQUFBO0FBQ0EsY0FBQSxJQUFBO0FBQ0EsU0FBQTtBQUNBLFVBQUE7O0FBR0osQ0FoREEsZUFnREEsT0FBQSxDQUFBLE1BQUEsRUFBQSxRQUFBLEVBQUEsQ0F0QkEsVUFzQkEsRUFBQSxDQWRBO0FBZUksYUFBQSxPQUFBOztBQUdKLENBQUEsc0JBQUEsQ0FqREE7QUFrREksVUFBQTtBQUNBLGtCQUFBOztBQUVKLENBSkE7QUFLSSxrQkFBQTs7QUFFSixDQVBBLHFCQU9BLENBQUEsTUFBQSxDQUFBO0FBQUEsQ0FQQSxxQkFPQSxLQUFBLFNBQUEsQ0FBQTtBQUVJLGNBQUE7QUFDQSxpQkFBQSxJQUFBLE1BQUEsSUFBQTs7QUFHSixDQWpFQSxlQWlFQSxDQUFBO0FBQ0ksY0FBQTtBQUNBLGlCQUFBOztBQ3BFQSxDRENKLGVDREksQ0FBQTtBQUNJLFNBQUE7QUFDQSxZQUFBO0FBQ0EsY0FBQSxJQUFBLEtBQUE7O0FBR0EsQ0RMUixlQ0tRLENBTkoscUJBTUksQ0FBQTtBQUNJLFdBQUE7QUFDQSxhQUFBLE9BQUE7O0FBR0osQ0RWUixlQ1VRLENBWEoscUJBV0ksQ0FBQSx3QkFBQTtBQUNJLFdBQUE7QUFDQSxZQUFBO0FBQ0EsT0FBQTtBQUNBLFFBQUE7QUFDQSxTQUFBO0FBQ0EsVUFBQTtBQUNBLG9CQUFBLElBQUE7QUFDQSxpQkFBQTtBQUNBLFdBQUE7O0FBR0osQ0R0QlIsZUNzQlEsQ0F2QkoscUJBdUJJLENBQUEsd0JBQUE7QUFDSSxXQUFBO0FBQ0EsWUFBQTtBQUNBLFVBQUE7QUFDQSxRQUFBO0FBQ0EsU0FBQTtBQUNBLFVBQUE7QUFDQSxvQkFBQSxJQUFBO0FBQ0EsaUJBQUE7QUFDQSxXQUFBOztBQU9KLENEdENSLGVDc0NRLENBQUEsc0JBQUEsQ0FBQTtBQUNJLGFBQUE7O0FBR0EsQ0QxQ1osZUMwQ1ksQ0FKSixzQkFJSSxDQUpKLGlCQUlJLENBQUE7QUFDSSxnQkFBQSxJQUFBO0FBQ0EsZ0JBQUE7O0FBS1IsQ0RqRFIsZUNpRFEsQ0FYQSxzQkFXQSxDQUFBO0FBQ0ksYUFBQTtBQUVBLGFBQUE7QUFDQSxjQUFBO0FBQ0EsZUFBQSxJQUFBO0FBR0EsVUFBQTtBQUNBLGNBQUE7QUFDQSxjQUFBO0FBQ0EsZUFBQTs7QUFHSixDRC9EUixlQytEUSxDQXpCQSxzQkF5QkEsQ0FBQTtBQUNJLGFBQUE7QUFDQSxTQUFBLElBQUE7O0FBRUEsQ0RuRVosZUNtRVksQ0E3Qkosc0JBNkJJLENBSkoseUJBSUk7QUFDSSxTQUFBLElBQUE7O0FBSVIsQ0R4RVIsZUN3RVEsQ0FsQ0Esc0JBa0NBLENBQUE7QUFDSSxhQUFBOztBQUlKLENEN0VSLGVDNkVRLENBdkNBLHNCQXVDQSxDQUFBO0FBQ0ksbUJBQUE7QUFDQSxXQUFBO0FBQ0EseUJBQUEsTUFBQSxJQUFBLEtBQUE7QUFDQSx1QkFBQTtBQUNBLE9BQUE7QUFFQSxlQUFBO0FBSUEsVUFBQSxJQUFBLE1BQUEsSUFBQTtBQUNBLFdBQUE7QUFDQSxvQkFBQSxJQUFBO0FBQ0EsaUJBQUE7O0FBR0EsV0FBQSxDQUFBLFNBQUEsRUFBQTtBQWpCSixHRDdFUixlQzZFUSxDQXZDQSxzQkF1Q0EsQ0FBQTtBQWtCUSwyQkFBQSxJQUFBLElBQUE7QUFDQSx5QkFDRSxrQkFBQTs7QUFHRixHRHBHaEIsZUNvR2dCLENBOURSLHNCQThEUSxDQXZCUixxQkF1QlEsQ0E5RFI7QUFpRVksV0FBQTs7OyIsCiAgIm5hbWVzIjogW10KfQo= */

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should fail when disabled.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should fail when disabled.md
@@ -64,3 +64,17 @@ group by function task.status.type
 ```tasks
 filter by function true
 ```
+
+## Presets
+
+### preset this_folder_only
+
+```tasks
+preset this_folder_only
+```
+
+### {{preset.this_folder_only}}
+
+```tasks
+{{preset.this_folder_only}}
+```

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should fail when disabled.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should fail when disabled.md
@@ -1,0 +1,60 @@
+---
+TQ_extra_instructions: |-
+  limit 1
+  hide toolbar
+  ignore global query
+TQ_explain: true
+---
+
+# Smoke test JS setting - should fail when disabled
+
+See also [[Smoke test JS setting - should work when disabled]].
+
+## Sample task
+
+- [ ] #task hello
+
+## Simple searches
+
+### path includes {{query.file.path.toUpperCase()}}
+
+```tasks
+path includes {{query.file.path.toUpperCase()}}
+```
+
+## Accessing task properties
+
+### sort by function task.lineNumber
+
+```tasks
+sort by function task.lineNumber
+```
+
+### group by function task.file.path
+
+```tasks
+group by function task.file.path
+```
+
+### group by function task.file.path.toUpperCase()
+
+```tasks
+group by function task.file.path.toUpperCase()
+```
+
+### group by function on task status values
+
+```tasks
+group by function task.status.name
+group by function task.status.symbol
+group by function task.status.nextSymbol
+group by function task.status.type
+```
+
+## Other examples
+
+### Hard-coded filter result
+
+```tasks
+filter by function true
+```

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should fail when disabled.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should fail when disabled.md
@@ -22,6 +22,12 @@ See also [[Smoke test JS setting - should work when disabled]].
 path includes {{query.file.path.toUpperCase()}}
 ```
 
+### path includes {{4 + 6}}
+
+```tasks
+path includes {{4 + 6}}
+```
+
 ## Accessing task properties
 
 ### sort by function task.lineNumber

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should fail when disabled.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should fail when disabled.md
@@ -3,7 +3,7 @@ TQ_extra_instructions: |-
   limit 1
   hide toolbar
   ignore global query
-TQ_explain: true
+TQ_explain: false
 ---
 
 # Smoke test JS setting - should fail when disabled

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should work when disabled.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should work when disabled.md
@@ -4,6 +4,7 @@ TQ_extra_instructions: |-
   hide toolbar
   ignore global query
 TQ_explain: false
+task_instruction: not done
 ---
 
 # Smoke test JS setting - should work when disabled
@@ -44,6 +45,12 @@ group by status.type
 
 ```tasks
 path includes {{query.file.path}}
+```
+
+### {{query.file.property("task_instruction")}}
+
+```tasks
+{{query.file.property("task_instruction")}}
 ```
 
 ## Presets

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should work when disabled.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should work when disabled.md
@@ -1,0 +1,61 @@
+---
+TQ_extra_instructions: |-
+  limit 1
+  hide toolbar
+  ignore global query
+TQ_explain: true
+---
+
+# Smoke test JS setting - should work when disabled
+
+See also [[Smoke test JS setting - should fail when disabled]].
+
+## Sample task
+
+- [ ] #task hello
+
+## Simple searches
+
+### Simple path search
+
+```tasks
+path includes Test Data
+```
+
+### Simple path search with continuation line
+
+```tasks
+path includes \
+    Test Data
+```
+
+## Accessing task properties
+
+### group by task status values
+
+```tasks
+group by status.name
+group by status.type
+```
+
+## Placeholders in filters
+
+### path includes {{query.file.path}}
+
+```tasks
+path includes {{query.file.path}}
+```
+
+## Presets
+
+### preset path_includes_test_data
+
+```tasks
+preset path_includes_test_data
+```
+
+### {{preset.path_includes_test_data}}
+
+```tasks
+{{preset.path_includes_test_data}}
+```

--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should work when disabled.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Smoke test JS setting - should work when disabled.md
@@ -3,7 +3,7 @@ TQ_extra_instructions: |-
   limit 1
   hide toolbar
   ignore global query
-TQ_explain: true
+TQ_explain: false
 ---
 
 # Smoke test JS setting - should work when disabled

--- a/src/Config/EnableJsInTasksQueries.ts
+++ b/src/Config/EnableJsInTasksQueries.ts
@@ -6,6 +6,12 @@ export const DEFAULT_ENABLE_JS_IN_TASKS_QUERIES = false;
 /**
  * In-memory representation of whether JavaScript is enabled in Tasks queries.
  *
+ * There are two ways of using this class.
+ * - In production code, call {@link EnableJsInTasksQueries.getInstance()} to obtain
+ *   the single global instance initialised by the plugin.
+ * - Tests can use `new EnableJsInTasksQueries(storage)`, which makes simpler,
+ *   more readable tests that can be run in parallel.
+ *
  * The value is loaded from Obsidian's vault-local app storage when this object is created,
  * then kept in memory for fast reads.
  *
@@ -13,10 +19,40 @@ export const DEFAULT_ENABLE_JS_IN_TASKS_QUERIES = false;
  * to the plugin's data.json settings file.
  */
 export class EnableJsInTasksQueries {
+    private static instance: EnableJsInTasksQueries | undefined;
+
     private value: boolean;
 
+    /**
+     * Creates an instance of the JavaScript-in-Tasks-queries setting.
+     *
+     * Code in the plugin should use {@link getInstance} to access the global instance.
+     */
     constructor(private readonly storage: LocalStorageProvider) {
         this.value = this.loadValue();
+    }
+
+    /**
+     * Initialises the single global instance from Obsidian's vault-local app storage.
+     *
+     * This should be called once during plugin startup.
+     */
+    public static initialise(storage: LocalStorageProvider): EnableJsInTasksQueries {
+        EnableJsInTasksQueries.instance = new EnableJsInTasksQueries(storage);
+        return EnableJsInTasksQueries.instance;
+    }
+
+    /**
+     * Provides access to the single global instance of this setting.
+     *
+     * This should be used in plugin code after the plugin has initialised local storage.
+     */
+    public static getInstance(): EnableJsInTasksQueries {
+        if (!EnableJsInTasksQueries.instance) {
+            throw new Error('EnableJsInTasksQueries has not been initialised.');
+        }
+
+        return EnableJsInTasksQueries.instance;
     }
 
     public get(): boolean {

--- a/src/Config/EnableJsInTasksQueries.ts
+++ b/src/Config/EnableJsInTasksQueries.ts
@@ -55,10 +55,6 @@ export class EnableJsInTasksQueries {
         return EnableJsInTasksQueries.instance;
     }
 
-    public static getHelpMessage() {
-        return 'JavaScript is disabled in Tasks queries';
-    }
-
     public get(): boolean {
         return this.value;
     }

--- a/src/Config/EnableJsInTasksQueries.ts
+++ b/src/Config/EnableJsInTasksQueries.ts
@@ -1,0 +1,40 @@
+import type { LocalStorageProvider } from './LocalStorageProvider';
+
+export const ENABLE_JS_IN_TASKS_QUERIES_KEY = 'enableJsInTasksQueries';
+export const DEFAULT_ENABLE_JS_IN_TASKS_QUERIES = false;
+
+/**
+ * In-memory representation of whether JavaScript is enabled in Tasks queries.
+ *
+ * The value is loaded from Obsidian's vault-local app storage when this object is created,
+ * then kept in memory for fast reads.
+ *
+ * Updates are written back to vault-local app storage, but are intentionally not persisted
+ * to the plugin's data.json settings file.
+ */
+export class EnableJsInTasksQueries {
+    private value: boolean;
+
+    constructor(private readonly storage: LocalStorageProvider) {
+        this.value = this.loadValue();
+    }
+
+    public get(): boolean {
+        return this.value;
+    }
+
+    public set(value: boolean): void {
+        this.value = value;
+        this.storage.save(ENABLE_JS_IN_TASKS_QUERIES_KEY, value);
+    }
+
+    private loadValue(): boolean {
+        const storedValue = this.storage.load(ENABLE_JS_IN_TASKS_QUERIES_KEY);
+
+        if (typeof storedValue === 'boolean') {
+            return storedValue;
+        }
+
+        return DEFAULT_ENABLE_JS_IN_TASKS_QUERIES;
+    }
+}

--- a/src/Config/EnableJsInTasksQueries.ts
+++ b/src/Config/EnableJsInTasksQueries.ts
@@ -55,6 +55,10 @@ export class EnableJsInTasksQueries {
         return EnableJsInTasksQueries.instance;
     }
 
+    public static getHelpMessage() {
+        return 'JavaScript is disabled in Tasks queries';
+    }
+
     public get(): boolean {
         return this.value;
     }

--- a/src/Config/InMemoryLocalStorageProvider.ts
+++ b/src/Config/InMemoryLocalStorageProvider.ts
@@ -1,0 +1,25 @@
+import type { LocalStorageProvider } from './LocalStorageProvider';
+
+/**
+ * Test implementation of {@link LocalStorageProvider}.
+ */
+export class InMemoryLocalStorageProvider implements LocalStorageProvider {
+    private readonly values = new Map<string, unknown>();
+
+    public load(key: string): unknown | null {
+        if (!this.values.has(key)) {
+            return null;
+        }
+
+        return this.values.get(key) ?? null;
+    }
+
+    public save(key: string, value: unknown | null): void {
+        if (value === null) {
+            this.values.delete(key);
+            return;
+        }
+
+        this.values.set(key, value);
+    }
+}

--- a/src/Config/InMemoryLocalStorageProvider.ts
+++ b/src/Config/InMemoryLocalStorageProvider.ts
@@ -6,7 +6,7 @@ import type { LocalStorageProvider } from './LocalStorageProvider';
 export class InMemoryLocalStorageProvider implements LocalStorageProvider {
     private readonly values = new Map<string, unknown>();
 
-    public load(key: string): unknown | null {
+    public load(key: string): unknown {
         if (!this.values.has(key)) {
             return null;
         }
@@ -14,7 +14,7 @@ export class InMemoryLocalStorageProvider implements LocalStorageProvider {
         return this.values.get(key) ?? null;
     }
 
-    public save(key: string, value: unknown | null): void {
+    public save(key: string, value: unknown): void {
         if (value === null) {
             this.values.delete(key);
             return;

--- a/src/Config/LocalStorageProvider.ts
+++ b/src/Config/LocalStorageProvider.ts
@@ -4,7 +4,13 @@
  * This storage is separate from the plugin's data.json settings file.
  */
 export interface LocalStorageProvider {
+    /**
+     * Load a value from the local storage. null means the key is not present.
+     */
     load(key: string): unknown | null;
 
+    /**
+     * Save a value to the local storage. null means remove the key if it was already present.
+     */
     save(key: string, value: unknown | null): void;
 }

--- a/src/Config/LocalStorageProvider.ts
+++ b/src/Config/LocalStorageProvider.ts
@@ -1,0 +1,10 @@
+/**
+ * Abstraction over Obsidian's vault-local app storage.
+ *
+ * This storage is separate from the plugin's data.json settings file.
+ */
+export interface LocalStorageProvider {
+    load(key: string): unknown | null;
+
+    save(key: string, value: unknown | null): void;
+}

--- a/src/Config/LocalStorageProvider.ts
+++ b/src/Config/LocalStorageProvider.ts
@@ -7,10 +7,10 @@ export interface LocalStorageProvider {
     /**
      * Load a value from the local storage. null means the key is not present.
      */
-    load(key: string): unknown | null;
+    load(key: string): unknown;
 
     /**
      * Save a value to the local storage. null means remove the key if it was already present.
      */
-    save(key: string, value: unknown | null): void;
+    save(key: string, value: unknown): void;
 }

--- a/src/Config/ObsidianLocalStorageProvider.ts
+++ b/src/Config/ObsidianLocalStorageProvider.ts
@@ -7,11 +7,11 @@ import type { LocalStorageProvider } from './LocalStorageProvider';
 export class ObsidianLocalStorageProvider implements LocalStorageProvider {
     constructor(private readonly app: App) {}
 
-    public load(key: string): unknown | null {
+    public load(key: string): unknown {
         return this.app.loadLocalStorage(key);
     }
 
-    public save(key: string, value: unknown | null): void {
+    public save(key: string, value: unknown): void {
         this.app.saveLocalStorage(key, value);
     }
 }

--- a/src/Config/ObsidianLocalStorageProvider.ts
+++ b/src/Config/ObsidianLocalStorageProvider.ts
@@ -1,0 +1,17 @@
+import type { App } from 'obsidian';
+import type { LocalStorageProvider } from './LocalStorageProvider';
+
+/**
+ * Implementation of {@link LocalStorageProvider} backed by Obsidian's vault-local app storage.
+ */
+export class ObsidianLocalStorageProvider implements LocalStorageProvider {
+    constructor(private readonly app: App) {}
+
+    public load(key: string): unknown | null {
+        return this.app.loadLocalStorage(key);
+    }
+
+    public save(key: string, value: unknown | null): void {
+        this.app.saveLocalStorage(key, value);
+    }
+}

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -191,11 +191,11 @@ export class SettingsTab extends PluginSettingTab {
 
         // TODO Add translation strings, once the wording is finalised.
         // ---------------------------------------------------------------------------
-        new Setting(containerEl).setName(i18n.t('Searches')).setHeading();
+        new Setting(containerEl).setName(i18n.t('settings.searches.heading')).setHeading();
         // ---------------------------------------------------------------------------
 
         new Setting(containerEl)
-            .setName(i18n.t('Enable custom searches'))
+            .setName('Enable custom searches')
             .setDesc(
                 SettingsTab.createFragmentWithHTML(
                     '<p>Enables "filter by function", "sort by function", and "group by function", which execute JavaScript in Tasks queries.</p>' +

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -198,7 +198,7 @@ export class SettingsTab extends PluginSettingTab {
             .setName(i18n.t('Enable custom searches'))
             .setDesc(
                 i18n.t(
-                    'Enable the "filter by function", "sort by function" and "group by function" instructions. These allow running user-written JavaScript in task searches. This is potentially DANGEROUS, thus it is disabled by default.',
+                    'Enables "filter by function", "sort by function", and "group by function", which execute JavaScript in Tasks queries. Malicious JavaScript in a Tasks query or Markdown file could run inside Obsidian and access or modify your vault contents, local files, or other system resources. Only enable this if you trust the contents of this vault, especially files downloaded, copied, or synced from other people.',
                 ),
             )
             .addToggle((toggle) => {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -200,7 +200,8 @@ export class SettingsTab extends PluginSettingTab {
                 SettingsTab.createFragmentWithHTML(
                     '<p>Enables "filter by function", "sort by function", and "group by function", which execute JavaScript in Tasks queries.</p>' +
                         '<p>Malicious JavaScript in a Tasks query or Markdown file could run inside Obsidian and access or modify your vault contents, local files, or other system resources.</p>' +
-                        '<p><b>Only enable this if you trust the contents of this vault, especially files downloaded, copied, or synced from other people.</b></p>',
+                        '<p><b>Only enable this if you trust the current and future contents of this vault, including files you may later download, copy, or sync from other people.</b></p>' +
+                        '<p>This setting is stored on this device only; enable it separately on each device where you use this vault.</p>',
                 ),
             )
             .addToggle((toggle) => {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -189,7 +189,6 @@ export class SettingsTab extends PluginSettingTab {
                 }),
         );
 
-        // TODO Add translation strings, once the wording is finalised.
         // ---------------------------------------------------------------------------
         new Setting(containerEl).setName(i18n.t('settings.searches.heading')).setHeading();
         // ---------------------------------------------------------------------------

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -22,6 +22,7 @@ import { StatusSettings } from './StatusSettings';
 import { CustomStatusModal } from './CustomStatusModal';
 import { GlobalQuery } from './GlobalQuery';
 import { PresetsSettingsUI } from './PresetsSettingsUI';
+import { EnableJsInTasksQueries } from './EnableJsInTasksQueries';
 
 interface SettingConfiguration {
     name: string;
@@ -187,6 +188,26 @@ export class SettingsTab extends PluginSettingTab {
                         });
                 }),
         );
+
+        // TODO Add translation strings, once the wording is finalised.
+        // ---------------------------------------------------------------------------
+        new Setting(containerEl).setName(i18n.t('Searches')).setHeading();
+        // ---------------------------------------------------------------------------
+
+        new Setting(containerEl)
+            .setName(i18n.t('Enable custom searches'))
+            .setDesc(
+                i18n.t(
+                    'Enable the "filter by function", "sort by function" and "group by function" instructions. These allow running user-written JavaScript in task searches. This is potentially DANGEROUS, thus it is disabled by default.',
+                ),
+            )
+            .addToggle((toggle) => {
+                toggle.setValue(EnableJsInTasksQueries.getInstance().get()).onChange(async (value) => {
+                    EnableJsInTasksQueries.getInstance().set(value);
+
+                    this.events.triggerReloadOpenSearchResults();
+                });
+            });
 
         // ---------------------------------------------------------------------------
         new Setting(containerEl).setName(i18n.t('settings.searchResults.heading')).setHeading();

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -197,8 +197,10 @@ export class SettingsTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName(i18n.t('Enable custom searches'))
             .setDesc(
-                i18n.t(
-                    'Enables "filter by function", "sort by function", and "group by function", which execute JavaScript in Tasks queries. Malicious JavaScript in a Tasks query or Markdown file could run inside Obsidian and access or modify your vault contents, local files, or other system resources. Only enable this if you trust the contents of this vault, especially files downloaded, copied, or synced from other people.',
+                SettingsTab.createFragmentWithHTML(
+                    '<p>Enables "filter by function", "sort by function", and "group by function", which execute JavaScript in Tasks queries.</p>' +
+                        '<p>Malicious JavaScript in a Tasks query or Markdown file could run inside Obsidian and access or modify your vault contents, local files, or other system resources.</p>' +
+                        '<p><b>Only enable this if you trust the contents of this vault, especially files downloaded, copied, or synced from other people.</b></p>',
                 ),
             )
             .addToggle((toggle) => {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -198,7 +198,11 @@ export class SettingsTab extends PluginSettingTab {
             .setName(i18n.t('settings.searches.enableCustomSearches.name'))
             .setDesc(
                 SettingsTab.createFragmentWithHTML(
-                    `<p>${i18n.t('settings.searches.enableCustomSearches.description.line1')}</p>` +
+                    `<p>${i18n.t('settings.searches.enableCustomSearches.description.line1', {
+                        filterByFunction: 'filter by function',
+                        sortByFunction: 'sort by function',
+                        groupByFunction: 'group by function',
+                    })}</p>` +
                         `<p>${i18n.t('settings.searches.enableCustomSearches.description.line2')}</p>` +
                         `<p><b>${i18n.t('settings.searches.enableCustomSearches.description.line3')}</b></p>` +
                         `<p>${i18n.t('settings.searches.enableCustomSearches.description.line4')}</p>`,

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -198,10 +198,10 @@ export class SettingsTab extends PluginSettingTab {
             .setName(i18n.t('settings.searches.enableCustomSearches.name'))
             .setDesc(
                 SettingsTab.createFragmentWithHTML(
-                    '<p>Enables "filter by function", "sort by function", and "group by function", which execute JavaScript in Tasks queries.</p>' +
-                        '<p>Malicious JavaScript in a Tasks query or Markdown file could run inside Obsidian and access or modify your vault contents, local files, or other system resources.</p>' +
-                        '<p><b>Only enable this if you trust the current and future contents of this vault, including files you may later download, copy, or sync from other people.</b></p>' +
-                        '<p>This setting is stored on this device only; enable it separately on each device where you use this vault.</p>',
+                    `<p>${i18n.t('settings.searches.enableCustomSearches.description.line1')}</p>` +
+                        `<p>${i18n.t('settings.searches.enableCustomSearches.description.line2')}</p>` +
+                        `<p><b>${i18n.t('settings.searches.enableCustomSearches.description.line3')}</b></p>` +
+                        `<p>${i18n.t('settings.searches.enableCustomSearches.description.line4')}</p>`,
                 ),
             )
             .addToggle((toggle) => {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -199,9 +199,9 @@ export class SettingsTab extends PluginSettingTab {
             .setDesc(
                 SettingsTab.createFragmentWithHTML(
                     `<p>${i18n.t('settings.searches.enableCustomSearches.description.line1', {
-                        filterByFunction: 'filter by function',
-                        sortByFunction: 'sort by function',
-                        groupByFunction: 'group by function',
+                        filterByFunction: '<code>filter by function</code>',
+                        sortByFunction: '<code>sort by function</code>',
+                        groupByFunction: '<code>group by function</code>',
                     })}</p>` +
                         `<p>${i18n.t('settings.searches.enableCustomSearches.description.line2')}</p>` +
                         `<p><b>${i18n.t('settings.searches.enableCustomSearches.description.line3')}</b></p>` +

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -195,7 +195,7 @@ export class SettingsTab extends PluginSettingTab {
         // ---------------------------------------------------------------------------
 
         new Setting(containerEl)
-            .setName('Enable custom searches')
+            .setName(i18n.t('settings.searches.enableCustomSearches.name'))
             .setDesc(
                 SettingsTab.createFragmentWithHTML(
                     '<p>Enables "filter by function", "sort by function", and "group by function", which execute JavaScript in Tasks queries.</p>' +

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -70,6 +70,10 @@ export class FunctionField extends Field {
             return null;
         }
 
+        if (!EnableJsInTasksQueries.getInstance().get()) {
+            throw new Error(EnableJsInTasksQueries.getHelpMessage());
+        }
+
         const reverse = !!match[1];
         const expression = match[2];
         const taskExpression = new TaskExpression(expression);

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -222,7 +222,7 @@ export class FunctionField extends Field {
         }
 
         if (!EnableJsInTasksQueries.getInstance().get()) {
-            throw new Error(EnableJsInTasksQueries.getHelpMessage());
+            throw new JsInTasksQueriesDisabledError();
         }
 
         const reverse = !!match[1];

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -25,7 +25,7 @@ export class FunctionField extends Field {
 
     createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         if (!EnableJsInTasksQueries.getInstance().get()) {
-            return FilterOrErrorMessage.fromError(line, 'JavaScript is disabled in Tasks queries');
+            return FilterOrErrorMessage.fromError(line, EnableJsInTasksQueries.getHelpMessage());
         }
 
         const match = Field.getMatch(this.filterRegExp(), line);

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -219,6 +219,11 @@ export class FunctionField extends Field {
         if (match === null) {
             return null;
         }
+
+        if (!EnableJsInTasksQueries.getInstance().get()) {
+            throw new Error(EnableJsInTasksQueries.getHelpMessage());
+        }
+
         const reverse = !!match[1];
         const args = match[2];
         return new Grouper(line, 'function', createGrouperFunctionFromLine(args), reverse);

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -8,6 +8,7 @@ import type { SearchInfo } from '../SearchInfo';
 import { Sorter } from '../Sort/Sorter';
 import { compareByDate } from '../../DateTime/DateTools';
 import { getValueType } from '../../lib/TypeDetection';
+import { EnableJsInTasksQueries } from '../../Config/EnableJsInTasksQueries';
 import { Field } from './Field';
 import { Filter, type FilterFunction } from './Filter';
 import { FilterOrErrorMessage } from './FilterOrErrorMessage';
@@ -23,6 +24,10 @@ export class FunctionField extends Field {
     // -----------------------------------------------------------------------------------------------------------------
 
     createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
+        if (!EnableJsInTasksQueries.getInstance().get()) {
+            return FilterOrErrorMessage.fromError(line, 'JavaScript is disabled in Tasks queries');
+        }
+
         const match = Field.getMatch(this.filterRegExp(), line);
         if (match === null) {
             return FilterOrErrorMessage.fromError(line, 'Unable to parse line');

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -26,7 +26,7 @@ export class FunctionField extends Field {
 
     createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         if (!EnableJsInTasksQueries.getInstance().get()) {
-            return FilterOrErrorMessage.fromError(line, EnableJsInTasksQueries.getHelpMessage());
+            return FilterOrErrorMessage.fromError(line, JsInTasksQueriesDisabledError.helpMessage);
         }
 
         const match = Field.getMatch(this.filterRegExp(), line);

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -9,6 +9,7 @@ import { Sorter } from '../Sort/Sorter';
 import { compareByDate } from '../../DateTime/DateTools';
 import { getValueType } from '../../lib/TypeDetection';
 import { EnableJsInTasksQueries } from '../../Config/EnableJsInTasksQueries';
+import { JsInTasksQueriesDisabledError } from '../../Scripting/JsInTasksQueriesDisabledError';
 import { Field } from './Field';
 import { Filter, type FilterFunction } from './Filter';
 import { FilterOrErrorMessage } from './FilterOrErrorMessage';
@@ -71,7 +72,7 @@ export class FunctionField extends Field {
         }
 
         if (!EnableJsInTasksQueries.getInstance().get()) {
-            throw new Error(EnableJsInTasksQueries.getHelpMessage());
+            throw new JsInTasksQueriesDisabledError();
         }
 
         const reverse = !!match[1];

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -468,7 +468,15 @@ ${statement.explainStatement('    ')}
      * @private
      */
     private parseGroupBy(line: string, statement: Statement): boolean {
-        const groupingMaybe = FilterParser.parseGrouper(line);
+        let groupingMaybe: Grouper | null;
+        try {
+            groupingMaybe = FilterParser.parseGrouper(line);
+        } catch (e) {
+            const message = e instanceof Error ? e.message : 'Unknown error';
+            this.setError(message, statement);
+            return true;
+        }
+
         if (groupingMaybe) {
             groupingMaybe.setStatement(statement);
             this._grouping.push(groupingMaybe);

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -443,7 +443,15 @@ ${statement.explainStatement('    ')}
     }
 
     private parseSortBy(line: string, statement: Statement): boolean {
-        const sortingMaybe = FilterParser.parseSorter(line);
+        let sortingMaybe: Sorter | null = null;
+        try {
+            sortingMaybe = FilterParser.parseSorter(line);
+        } catch (e) {
+            const message = e instanceof Error ? e.message : 'Unknown error';
+            this.setError(message, statement);
+            return true;
+        }
+
         if (sortingMaybe) {
             sortingMaybe.setStatement(statement);
             this._sorting.push(sortingMaybe);
@@ -451,7 +459,6 @@ ${statement.explainStatement('    ')}
         }
         return false;
     }
-
     /**
      * Parsing of `group by` lines, for grouping that is implemented in the {@link Field}
      * classes.

--- a/src/Scripting/ExpandPlaceholders.ts
+++ b/src/Scripting/ExpandPlaceholders.ts
@@ -76,11 +76,7 @@ function evaluateAnyFunctionCalls(template: string, view: any) {
             if (knownPlaceholder.resolved) {
                 const result = knownPlaceholder.value;
                 if (result === null) {
-                    throw Error(
-                        `Invalid placeholder result 'null'.
-    Check for missing file property in this expression:
-        {{${reconstructed}}}`,
-                    );
+                    throwInvalidPlaceholderError(reconstructed);
                 }
                 if (result !== undefined) {
                     return String(result);
@@ -119,6 +115,14 @@ function evaluateAnyFunctionCalls(template: string, view: any) {
 
 function isQueryContext(view: any): view is QueryContext {
     return view?.query?.file !== undefined;
+}
+
+function throwInvalidPlaceholderError(reconstructed: string): void {
+    throw Error(
+        `Invalid placeholder result 'null'.
+    Check for missing file property in this expression:
+        {{${reconstructed}}}`,
+    );
 }
 
 function isPlainMustachePlaceholder(reconstructed: string): boolean {

--- a/src/Scripting/ExpandPlaceholders.ts
+++ b/src/Scripting/ExpandPlaceholders.ts
@@ -80,6 +80,8 @@ function evaluateAnyFunctionCalls(template: string, view: any) {
                     throwInvalidPlaceholderError(reconstructed);
                 }
                 if (result !== undefined) {
+                    // Existing placeholder behaviour intentionally uses JavaScript string coercion.
+                    // This preserves - for now - compatibility, including existing handling of object results.
                     return String(result);
                 }
             }

--- a/src/Scripting/ExpandPlaceholders.ts
+++ b/src/Scripting/ExpandPlaceholders.ts
@@ -1,5 +1,6 @@
 import Mustache from 'mustache';
 import proxyData from 'mustache-validator';
+import { EnableJsInTasksQueries } from '../Config/EnableJsInTasksQueries';
 import { type ExpressionParameter, evaluateExpression, parseExpression } from './Expression';
 
 // https://github.com/janl/mustache.js
@@ -67,7 +68,15 @@ const PLACEHOLDER_REGEX = new RegExp(
 );
 
 function evaluateAnyFunctionCalls(template: string, view: any) {
-    return template.replace(PLACEHOLDER_REGEX, (_match, reconstructed) => {
+    return template.replace(PLACEHOLDER_REGEX, (_match, reconstructed: string) => {
+        if (!EnableJsInTasksQueries.getInstance().get()) {
+            if (isPlainMustachePlaceholder(reconstructed)) {
+                return _match;
+            }
+
+            throw Error(EnableJsInTasksQueries.getHelpMessage());
+        }
+
         const paramsArgs: ExpressionParameter[] = createExpressionParameters(view);
         const functionOrError = parseExpression(paramsArgs, reconstructed);
         if (functionOrError.isValid()) {
@@ -84,20 +93,21 @@ function evaluateAnyFunctionCalls(template: string, view: any) {
             }
         }
 
-        if (shouldReportExpressionParseError(reconstructed)) {
-            throw Error(functionOrError.error ?? `Problem parsing placeholder expression: {{${reconstructed}}}`);
-        }
-
         // Fall back on returning the raw string, including {{ and }} - and get Mustache to report the error.
         return _match;
     });
 }
 
-function shouldReportExpressionParseError(reconstructed: string): boolean {
-    // Plain Mustache placeholders such as {{query.file.path}} should still work when
-    // JavaScript is disabled. Placeholders containing parentheses are treated as
-    // JavaScript expression placeholders, so preserve parse errors for them.
-    return reconstructed.includes('(') || reconstructed.includes(')');
+function isPlainMustachePlaceholder(reconstructed: string): boolean {
+    // Allow only simple dotted property lookups, such as
+    //   query.file.path
+    //   preset.this_file
+    //
+    // These can be resolved by Mustache without evaluating JavaScript.
+    // Anything else, such as "4 + 6", "query.file.path.toUpperCase()" or
+    // "query.file.property('task_instruction')", requires JavaScript expression
+    // evaluation and is therefore blocked when JavaScript is disabled.
+    return /^[A-Za-z_$][\w$]*(\.[A-Za-z_$][\w$]*)*$/.test(reconstructed.trim());
 }
 
 function createExpressionParameters(view: any): ExpressionParameter[] {

--- a/src/Scripting/ExpandPlaceholders.ts
+++ b/src/Scripting/ExpandPlaceholders.ts
@@ -51,7 +51,7 @@ The error message was:
 
 The problem is in:
     ${template}`;
-        throw Error(message);
+        throw new Error(message);
     }
 }
 

--- a/src/Scripting/ExpandPlaceholders.ts
+++ b/src/Scripting/ExpandPlaceholders.ts
@@ -84,9 +84,20 @@ function evaluateAnyFunctionCalls(template: string, view: any) {
             }
         }
 
+        if (shouldReportExpressionParseError(reconstructed)) {
+            throw Error(functionOrError.error ?? `Problem parsing placeholder expression: {{${reconstructed}}}`);
+        }
+
         // Fall back on returning the raw string, including {{ and }} - and get Mustache to report the error.
         return _match;
     });
+}
+
+function shouldReportExpressionParseError(reconstructed: string): boolean {
+    // Plain Mustache placeholders such as {{query.file.path}} should still work when
+    // JavaScript is disabled. Placeholders containing parentheses are treated as
+    // JavaScript expression placeholders, so preserve parse errors for them.
+    return reconstructed.includes('(') || reconstructed.includes(')');
 }
 
 function createExpressionParameters(view: any): ExpressionParameter[] {

--- a/src/Scripting/ExpandPlaceholders.ts
+++ b/src/Scripting/ExpandPlaceholders.ts
@@ -97,11 +97,7 @@ function evaluateAnyFunctionCalls(template: string, view: any) {
         if (functionOrError.isValid()) {
             const result = evaluateExpression(functionOrError.queryComponent!, paramsArgs);
             if (result === null) {
-                throw Error(
-                    `Invalid placeholder result 'null'.
-    Check for missing file property in this expression:
-        {{${reconstructed}}}`,
-                );
+                throwInvalidPlaceholderError(reconstructed);
             }
             if (result !== undefined) {
                 return String(result);

--- a/src/Scripting/ExpandPlaceholders.ts
+++ b/src/Scripting/ExpandPlaceholders.ts
@@ -2,6 +2,8 @@ import Mustache from 'mustache';
 import proxyData from 'mustache-validator';
 import { EnableJsInTasksQueries } from '../Config/EnableJsInTasksQueries';
 import { type ExpressionParameter, evaluateExpression, parseExpression } from './Expression';
+import type { QueryContext } from './QueryContext';
+import { resolveKnownPlaceholder } from './KnownPlaceholderResolver';
 
 // https://github.com/janl/mustache.js
 
@@ -69,6 +71,23 @@ const PLACEHOLDER_REGEX = new RegExp(
 
 function evaluateAnyFunctionCalls(template: string, view: any) {
     return template.replace(PLACEHOLDER_REGEX, (_match, reconstructed: string) => {
+        if (isQueryContext(view)) {
+            const knownPlaceholder = resolveKnownPlaceholder(reconstructed, view);
+            if (knownPlaceholder.resolved) {
+                const result = knownPlaceholder.value;
+                if (result === null) {
+                    throw Error(
+                        `Invalid placeholder result 'null'.
+    Check for missing file property in this expression:
+        {{${reconstructed}}}`,
+                    );
+                }
+                if (result !== undefined) {
+                    return String(result);
+                }
+            }
+        }
+
         if (!EnableJsInTasksQueries.getInstance().get()) {
             if (isPlainMustachePlaceholder(reconstructed)) {
                 return _match;
@@ -89,13 +108,17 @@ function evaluateAnyFunctionCalls(template: string, view: any) {
                 );
             }
             if (result !== undefined) {
-                return result;
+                return String(result);
             }
         }
 
         // Fall back on returning the raw string, including {{ and }} - and get Mustache to report the error.
         return _match;
     });
+}
+
+function isQueryContext(view: any): view is QueryContext {
+    return view?.query?.file !== undefined;
 }
 
 function isPlainMustachePlaceholder(reconstructed: string): boolean {

--- a/src/Scripting/ExpandPlaceholders.ts
+++ b/src/Scripting/ExpandPlaceholders.ts
@@ -4,6 +4,7 @@ import { EnableJsInTasksQueries } from '../Config/EnableJsInTasksQueries';
 import { type ExpressionParameter, evaluateExpression, parseExpression } from './Expression';
 import type { QueryContext } from './QueryContext';
 import { resolveKnownPlaceholder } from './KnownPlaceholderResolver';
+import { JsInTasksQueriesDisabledError } from './JsInTasksQueriesDisabledError';
 
 // https://github.com/janl/mustache.js
 
@@ -89,7 +90,7 @@ function evaluateAnyFunctionCalls(template: string, view: any) {
                 return _match;
             }
 
-            throw Error(EnableJsInTasksQueries.getHelpMessage());
+            throw new JsInTasksQueriesDisabledError();
         }
 
         const paramsArgs: ExpressionParameter[] = createExpressionParameters(view);

--- a/src/Scripting/ExpandPlaceholders.ts
+++ b/src/Scripting/ExpandPlaceholders.ts
@@ -115,7 +115,7 @@ function isQueryContext(view: any): view is QueryContext {
 }
 
 function throwInvalidPlaceholderError(reconstructed: string): void {
-    throw Error(
+    throw new Error(
         `Invalid placeholder result 'null'.
     Check for missing file property in this expression:
         {{${reconstructed}}}`,

--- a/src/Scripting/ExpandPlaceholders.ts
+++ b/src/Scripting/ExpandPlaceholders.ts
@@ -99,14 +99,17 @@ function evaluateAnyFunctionCalls(template: string, view: any) {
 }
 
 function isPlainMustachePlaceholder(reconstructed: string): boolean {
-    // Allow only simple dotted property lookups, such as
+    // This recognises placeholders that Mustache can resolve as ordinary dotted
+    // property lookups, without evaluating JavaScript, such as:
     //   query.file.path
     //   preset.this_file
     //
-    // These can be resolved by Mustache without evaluating JavaScript.
-    // Anything else, such as "4 + 6", "query.file.path.toUpperCase()" or
-    // "query.file.property('task_instruction')", requires JavaScript expression
-    // evaluation and is therefore blocked when JavaScript is disabled.
+    // This is only a conservative subset of the documented placeholder API.
+    // Some documented query.file placeholders, such as
+    //   query.file.property('task_instruction')
+    //   query.file.hasProperty('task_instruction')
+    // are also safe in principle, but need explicit handling because their syntax
+    // looks like JavaScript function calls.
     return /^[A-Za-z_$][\w$]*(\.[A-Za-z_$][\w$]*)*$/.test(reconstructed.trim());
 }
 

--- a/src/Scripting/Expression.ts
+++ b/src/Scripting/Expression.ts
@@ -1,5 +1,7 @@
 import { QueryComponentOrError } from '../Query/QueryComponentOrError';
 import { errorMessageForException } from '../lib/ExceptionTools';
+import { EnableJsInTasksQueries } from '../Config/EnableJsInTasksQueries';
+import { JsInTasksQueriesDisabledError } from './JsInTasksQueriesDisabledError';
 
 export class FunctionOrError extends QueryComponentOrError<Function> {}
 
@@ -17,9 +19,9 @@ export type ExpressionParameter = [name: string, value: any];
  * @see evaluateExpressionOrCatch
  */
 export function parseExpression(paramsArgs: ExpressionParameter[], arg: string): FunctionOrError {
-    // if (!EnableJsInTasksQueries.getInstance().get()) {
-    //     return FunctionOrError.fromError(arg, JsInTasksQueriesDisabledError.helpMessage);
-    // }
+    if (!EnableJsInTasksQueries.getInstance().get()) {
+        throw new JsInTasksQueriesDisabledError();
+    }
 
     try {
         const parameterNames = paramsArgs.map(([name]) => name);
@@ -44,6 +46,10 @@ export function parseExpression(paramsArgs: ExpressionParameter[], arg: string):
  * @see evaluateExpressionOrCatch
  */
 export function evaluateExpression(expression: Function, paramsArgs: ExpressionParameter[]) {
+    if (!EnableJsInTasksQueries.getInstance().get()) {
+        throw new JsInTasksQueriesDisabledError();
+    }
+
     const parameterValues = paramsArgs.map(([_, value]) => value);
     return expression(...parameterValues);
 }

--- a/src/Scripting/Expression.ts
+++ b/src/Scripting/Expression.ts
@@ -1,6 +1,5 @@
 import { QueryComponentOrError } from '../Query/QueryComponentOrError';
 import { errorMessageForException } from '../lib/ExceptionTools';
-import { EnableJsInTasksQueries } from '../Config/EnableJsInTasksQueries';
 
 export class FunctionOrError extends QueryComponentOrError<Function> {}
 
@@ -18,9 +17,9 @@ export type ExpressionParameter = [name: string, value: any];
  * @see evaluateExpressionOrCatch
  */
 export function parseExpression(paramsArgs: ExpressionParameter[], arg: string): FunctionOrError {
-    if (!EnableJsInTasksQueries.getInstance().get()) {
-        return FunctionOrError.fromError(arg, EnableJsInTasksQueries.getHelpMessage());
-    }
+    // if (!EnableJsInTasksQueries.getInstance().get()) {
+    //     return FunctionOrError.fromError(arg, EnableJsInTasksQueries.getHelpMessage());
+    // }
 
     try {
         const parameterNames = paramsArgs.map(([name]) => name);

--- a/src/Scripting/Expression.ts
+++ b/src/Scripting/Expression.ts
@@ -18,7 +18,7 @@ export type ExpressionParameter = [name: string, value: any];
  */
 export function parseExpression(paramsArgs: ExpressionParameter[], arg: string): FunctionOrError {
     // if (!EnableJsInTasksQueries.getInstance().get()) {
-    //     return FunctionOrError.fromError(arg, EnableJsInTasksQueries.getHelpMessage());
+    //     return FunctionOrError.fromError(arg, JsInTasksQueriesDisabledError.helpMessage);
     // }
 
     try {

--- a/src/Scripting/Expression.ts
+++ b/src/Scripting/Expression.ts
@@ -1,5 +1,6 @@
 import { QueryComponentOrError } from '../Query/QueryComponentOrError';
 import { errorMessageForException } from '../lib/ExceptionTools';
+import { EnableJsInTasksQueries } from '../Config/EnableJsInTasksQueries';
 
 export class FunctionOrError extends QueryComponentOrError<Function> {}
 
@@ -17,6 +18,10 @@ export type ExpressionParameter = [name: string, value: any];
  * @see evaluateExpressionOrCatch
  */
 export function parseExpression(paramsArgs: ExpressionParameter[], arg: string): FunctionOrError {
+    if (!EnableJsInTasksQueries.getInstance().get()) {
+        return FunctionOrError.fromError(arg, EnableJsInTasksQueries.getHelpMessage());
+    }
+
     try {
         const parameterNames = paramsArgs.map(([name]) => name);
         const input = arg.includes('return') ? arg : `return ${arg}`;

--- a/src/Scripting/JsInTasksQueriesDisabledError.ts
+++ b/src/Scripting/JsInTasksQueriesDisabledError.ts
@@ -1,6 +1,6 @@
 export class JsInTasksQueriesDisabledError extends Error {
     public static readonly helpMessage =
-        'JavaScript is now disabled in Tasks queries.\n' +
+        'JavaScript is now disabled in Tasks queries by default.\n' +
         '    This query uses JavaScript, for example via "filter by function", "sort by function", or "group by function".\n' +
         '    JavaScript can run inside Obsidian and access or modify vault contents, local files, or other system resources.\n' +
         '    Read the Tasks documentation page "JavaScript in Tasks Queries" before deciding whether to enable it:\n' +

--- a/src/Scripting/JsInTasksQueriesDisabledError.ts
+++ b/src/Scripting/JsInTasksQueriesDisabledError.ts
@@ -1,6 +1,10 @@
 export class JsInTasksQueriesDisabledError extends Error {
-    public static readonly helpMessage = 'JavaScript is disabled in Tasks queries';
-
+    public static readonly helpMessage =
+        'JavaScript is now disabled in Tasks queries.\n' +
+        '    This query uses JavaScript, for example via "filter by function", "sort by function", or "group by function".\n' +
+        '    JavaScript can run inside Obsidian and access or modify vault contents, local files, or other system resources.\n' +
+        '    Read the Tasks documentation page "JavaScript in Tasks Queries" before deciding whether to enable it:\n' +
+        '    https://publish.obsidian.md/tasks/Scripting/JavaScript+in+Tasks+Queries';
     constructor() {
         super(JsInTasksQueriesDisabledError.helpMessage);
         this.name = 'JsInTasksQueriesDisabledError';

--- a/src/Scripting/JsInTasksQueriesDisabledError.ts
+++ b/src/Scripting/JsInTasksQueriesDisabledError.ts
@@ -1,5 +1,5 @@
 export class JsInTasksQueriesDisabledError extends Error {
-    private static readonly helpMessage = 'JavaScript is disabled in Tasks queries';
+    public static readonly helpMessage = 'JavaScript is disabled in Tasks queries';
 
     constructor() {
         super(JsInTasksQueriesDisabledError.helpMessage);

--- a/src/Scripting/JsInTasksQueriesDisabledError.ts
+++ b/src/Scripting/JsInTasksQueriesDisabledError.ts
@@ -1,0 +1,12 @@
+export class JsInTasksQueriesDisabledError extends Error {
+    private static readonly helpMessage = 'JavaScript is disabled in Tasks queries';
+
+    constructor() {
+        super(JsInTasksQueriesDisabledError.helpMessage);
+        this.name = 'JsInTasksQueriesDisabledError';
+    }
+
+    public static message(): string {
+        return JsInTasksQueriesDisabledError.helpMessage;
+    }
+}

--- a/src/Scripting/KnownPlaceholderResolver.ts
+++ b/src/Scripting/KnownPlaceholderResolver.ts
@@ -42,8 +42,7 @@ export function resolveKnownPlaceholder(reconstructed: string, queryContext: Que
     }
 
     const functionName = 'query.file.property';
-    const escapedFunctionName = functionName.replace(/\./g, '\\.');
-    const propertyNameRegex = new RegExp(`^${escapedFunctionName}\\((['"])([^'"]*)\\1\\)$`);
+    const propertyNameRegex = singleStringArgumentRegex(functionName);
     const propertyName = getSingleStringArgument(placeholder, propertyNameRegex);
     if (propertyName !== null) {
         return resolved(queryFile.property(propertyName));
@@ -68,6 +67,12 @@ function notResolved(): KnownPlaceholderResolution {
     return {
         resolved: false,
     };
+}
+
+function singleStringArgumentRegex(functionName: string): RegExp {
+    // escape dots in property name, such as query.file.path
+    const escapedFunctionName = functionName.replace(/\./g, '\\.');
+    return new RegExp(`^${escapedFunctionName}\\((['"])([^'"]*)\\1\\)$`);
 }
 
 function getSingleStringArgument(expression: string, regex: RegExp): string | null {

--- a/src/Scripting/KnownPlaceholderResolver.ts
+++ b/src/Scripting/KnownPlaceholderResolver.ts
@@ -41,7 +41,8 @@ export function resolveKnownPlaceholder(reconstructed: string, queryContext: Que
             return resolved(queryFile.outlinks);
     }
 
-    const propertyName = getSingleStringArgument(placeholder, /^query\.file\.property\((['"])([^'"]*)\1\)$/);
+    const propertyNameRegex = /^query\.file\.property\((['"])([^'"]*)\1\)$/;
+    const propertyName = getSingleStringArgument(placeholder, propertyNameRegex);
     if (propertyName !== null) {
         return resolved(queryFile.property(propertyName));
     }

--- a/src/Scripting/KnownPlaceholderResolver.ts
+++ b/src/Scripting/KnownPlaceholderResolver.ts
@@ -41,7 +41,7 @@ export function resolveKnownPlaceholder(reconstructed: string, queryContext: Que
             return resolved(queryFile.outlinks);
     }
 
-    const propertyNameRegex = /^query\.file\.property\((['"])([^'"]*)\1\)$/;
+    const propertyNameRegex = new RegExp('^query\\.file\\.property\\(([\'"])([^\'"]*)\\1\\)$');
     const propertyName = getSingleStringArgument(placeholder, propertyNameRegex);
     if (propertyName !== null) {
         return resolved(queryFile.property(propertyName));

--- a/src/Scripting/KnownPlaceholderResolver.ts
+++ b/src/Scripting/KnownPlaceholderResolver.ts
@@ -69,8 +69,8 @@ function notResolved(): KnownPlaceholderResolution {
 
 function singleStringArgumentRegex(functionName: string): RegExp {
     // escape dots in property name, such as query.file.path
-    const escapedFunctionName = functionName.replace(/\./g, '\\.');
-    return new RegExp(`^${escapedFunctionName}\\((['"])([^'"]*)\\1\\)$`);
+    const escapedFunctionName = functionName.replace(/\./g, String.raw`\.`);
+    return new RegExp(String.raw`^${escapedFunctionName}\((['"])([^'"]*)\1\)$`);
 }
 
 function getSingleStringArgument(expression: string, regex: RegExp): string | null {

--- a/src/Scripting/KnownPlaceholderResolver.ts
+++ b/src/Scripting/KnownPlaceholderResolver.ts
@@ -43,11 +43,7 @@ export function resolveKnownPlaceholder(reconstructed: string, queryContext: Que
 
     const functionName = 'query.file.property';
     const escapedFunctionName = functionName.replace(/\./g, '\\.');
-    const propertyNameRegex = new RegExp('^query\\.file\\.property\\(([\'"])([^\'"]*)\\1\\)$');
-    const propertyNameRegex2 = new RegExp(`^${escapedFunctionName}\\((['"])([^'"]*)\\1\\)$`);
-    if (propertyNameRegex.source !== propertyNameRegex2.source) {
-        throw new Error('Placeholder regexes must match');
-    }
+    const propertyNameRegex = new RegExp(`^${escapedFunctionName}\\((['"])([^'"]*)\\1\\)$`);
     const propertyName = getSingleStringArgument(placeholder, propertyNameRegex);
     if (propertyName !== null) {
         return resolved(queryFile.property(propertyName));

--- a/src/Scripting/KnownPlaceholderResolver.ts
+++ b/src/Scripting/KnownPlaceholderResolver.ts
@@ -46,7 +46,7 @@ export function resolveKnownPlaceholder(reconstructed: string, queryContext: Que
         return resolved(queryFile.property(propertyName));
     }
 
-    const hasPropertyName = getSingleStringArgument(placeholder, /^query\.file\.hasProperty\((['"])([^'"]*)\1\)$/);
+    const hasPropertyName = getSingleStringArgument(placeholder, singleStringArgumentRegex('query.file.hasProperty'));
     if (hasPropertyName !== null) {
         return resolved(queryFile.hasProperty(hasPropertyName));
     }

--- a/src/Scripting/KnownPlaceholderResolver.ts
+++ b/src/Scripting/KnownPlaceholderResolver.ts
@@ -41,7 +41,13 @@ export function resolveKnownPlaceholder(reconstructed: string, queryContext: Que
             return resolved(queryFile.outlinks);
     }
 
+    const functionName = 'query.file.property';
+    const escapedFunctionName = functionName.replace(/\./g, '\\.');
     const propertyNameRegex = new RegExp('^query\\.file\\.property\\(([\'"])([^\'"]*)\\1\\)$');
+    const propertyNameRegex2 = new RegExp(`^${escapedFunctionName}\\((['"])([^'"]*)\\1\\)$`);
+    if (propertyNameRegex.source !== propertyNameRegex2.source) {
+        throw new Error('Placeholder regexes must match');
+    }
     const propertyName = getSingleStringArgument(placeholder, propertyNameRegex);
     if (propertyName !== null) {
         return resolved(queryFile.property(propertyName));

--- a/src/Scripting/KnownPlaceholderResolver.ts
+++ b/src/Scripting/KnownPlaceholderResolver.ts
@@ -10,19 +10,15 @@ export type KnownPlaceholderResolution =
       };
 
 /**
- * Resolve documented placeholders that are safe to evaluate without JavaScript execution.
+ * Resolve documented query placeholders that are safe to evaluate without JavaScript execution.
  *
  * This intentionally supports only known placeholder expressions. It is not a JavaScript parser.
  * Expressions not recognised here should fall back to JavaScript evaluation only when JavaScript
  * execution is enabled.
  */
-export function resolveKnownPlaceholder(reconstructed: string, view: unknown): KnownPlaceholderResolution {
-    if (!isQueryContext(view)) {
-        return notResolved();
-    }
-
+export function resolveKnownPlaceholder(reconstructed: string, queryContext: QueryContext): KnownPlaceholderResolution {
     const placeholder = reconstructed.trim();
-    const queryFile = view.query.file;
+    const queryFile = queryContext.query.file;
 
     switch (placeholder) {
         case 'query.file.path':
@@ -74,15 +70,4 @@ function notResolved(): KnownPlaceholderResolution {
 function getSingleStringArgument(expression: string, regex: RegExp): string | null {
     const match = expression.match(regex);
     return match?.[2] ?? null;
-}
-
-function isQueryContext(view: unknown): view is QueryContext {
-    return (
-        typeof view === 'object' &&
-        view !== null &&
-        'query' in view &&
-        typeof (view as QueryContext).query === 'object' &&
-        (view as QueryContext).query !== null &&
-        'file' in (view as QueryContext).query
-    );
 }

--- a/src/Scripting/KnownPlaceholderResolver.ts
+++ b/src/Scripting/KnownPlaceholderResolver.ts
@@ -74,6 +74,6 @@ function singleStringArgumentRegex(functionName: string): RegExp {
 }
 
 function getSingleStringArgument(expression: string, regex: RegExp): string | null {
-    const match = expression.match(regex);
+    const match = new RegExp(regex).exec(expression);
     return match?.[2] ?? null;
 }

--- a/src/Scripting/KnownPlaceholderResolver.ts
+++ b/src/Scripting/KnownPlaceholderResolver.ts
@@ -41,9 +41,7 @@ export function resolveKnownPlaceholder(reconstructed: string, queryContext: Que
             return resolved(queryFile.outlinks);
     }
 
-    const functionName = 'query.file.property';
-    const propertyNameRegex = singleStringArgumentRegex(functionName);
-    const propertyName = getSingleStringArgument(placeholder, propertyNameRegex);
+    const propertyName = getSingleStringArgument(placeholder, singleStringArgumentRegex('query.file.property'));
     if (propertyName !== null) {
         return resolved(queryFile.property(propertyName));
     }

--- a/src/Scripting/KnownPlaceholderResolver.ts
+++ b/src/Scripting/KnownPlaceholderResolver.ts
@@ -1,0 +1,88 @@
+import type { QueryContext } from './QueryContext';
+
+export type KnownPlaceholderResolution =
+    | {
+          resolved: true;
+          value: unknown;
+      }
+    | {
+          resolved: false;
+      };
+
+/**
+ * Resolve documented placeholders that are safe to evaluate without JavaScript execution.
+ *
+ * This intentionally supports only known placeholder expressions. It is not a JavaScript parser.
+ * Expressions not recognised here should fall back to JavaScript evaluation only when JavaScript
+ * execution is enabled.
+ */
+export function resolveKnownPlaceholder(reconstructed: string, view: unknown): KnownPlaceholderResolution {
+    if (!isQueryContext(view)) {
+        return notResolved();
+    }
+
+    const placeholder = reconstructed.trim();
+    const queryFile = view.query.file;
+
+    switch (placeholder) {
+        case 'query.file.path':
+            return resolved(queryFile.path);
+        case 'query.file.pathWithoutExtension':
+            return resolved(queryFile.pathWithoutExtension);
+        case 'query.file.root':
+            return resolved(queryFile.root);
+        case 'query.file.folder':
+            return resolved(queryFile.folder);
+        case 'query.file.filename':
+            return resolved(queryFile.filename);
+        case 'query.file.filenameWithoutExtension':
+            return resolved(queryFile.filenameWithoutExtension);
+        case 'query.file.outlinksInProperties':
+            return resolved(queryFile.outlinksInProperties);
+        case 'query.file.outlinksInBody':
+            return resolved(queryFile.outlinksInBody);
+        case 'query.file.outlinks':
+            return resolved(queryFile.outlinks);
+    }
+
+    const propertyName = getSingleStringArgument(placeholder, /^query\.file\.property\((['"])([^'"]*)\1\)$/);
+    if (propertyName !== null) {
+        return resolved(queryFile.property(propertyName));
+    }
+
+    const hasPropertyName = getSingleStringArgument(placeholder, /^query\.file\.hasProperty\((['"])([^'"]*)\1\)$/);
+    if (hasPropertyName !== null) {
+        return resolved(queryFile.hasProperty(hasPropertyName));
+    }
+
+    return notResolved();
+}
+
+function resolved(value: unknown): KnownPlaceholderResolution {
+    return {
+        resolved: true,
+        value,
+    };
+}
+
+function notResolved(): KnownPlaceholderResolution {
+    return {
+        resolved: false,
+    };
+}
+
+function getSingleStringArgument(expression: string, regex: RegExp): string | null {
+    const match = expression.match(regex);
+    return match?.[2] ?? null;
+}
+
+function isQueryContext(view: unknown): view is QueryContext {
+    return (
+        typeof view === 'object' &&
+        view !== null &&
+        'query' in view &&
+        typeof (view as QueryContext).query === 'object' &&
+        (view as QueryContext).query !== null &&
+        'file' in (view as QueryContext).query
+    );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -211,6 +211,9 @@
         "name": "Remove scheduled date on recurrence"
       }
     },
+    "searches": {
+      "heading": "Searches"
+    },
     "searchResults": {
       "heading": "Search results",
       "taskCountLocation": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -215,7 +215,7 @@
       "heading": "Searches",
       "enableCustomSearches": {
         "description": {
-          "line1": "Enables \"filter by function\", \"sort by function\", and \"group by function\", which execute JavaScript in Tasks queries.",
+          "line1": "Enables \"{{filterByFunction}}\", \"{{sortByFunction}}\", and \"{{groupByFunction}}\", which execute JavaScript in Tasks queries.",
           "line2": "Malicious JavaScript in a Tasks query or Markdown file could run inside Obsidian and access or modify your vault contents, local files, or other system resources.",
           "line3": "Only enable this if you trust the current and future contents of this vault, including files you may later download, copy, or sync from other people.",
           "line4": "This setting is stored on this device only; enable it separately on each device where you use this vault."

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -214,6 +214,12 @@
     "searches": {
       "heading": "Searches",
       "enableCustomSearches": {
+        "description": {
+          "line1": "Enables \"filter by function\", \"sort by function\", and \"group by function\", which execute JavaScript in Tasks queries.",
+          "line2": "Malicious JavaScript in a Tasks query or Markdown file could run inside Obsidian and access or modify your vault contents, local files, or other system resources.",
+          "line3": "Only enable this if you trust the current and future contents of this vault, including files you may later download, copy, or sync from other people.",
+          "line4": "This setting is stored on this device only; enable it separately on each device where you use this vault."
+        },
         "name": "Enable custom searches"
       }
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -215,7 +215,7 @@
       "heading": "Searches",
       "enableCustomSearches": {
         "description": {
-          "line1": "Enables \"{{filterByFunction}}\", \"{{sortByFunction}}\", and \"{{groupByFunction}}\", which execute JavaScript in Tasks queries.",
+          "line1": "Enables '{{filterByFunction}}', '{{sortByFunction}}', and '{{groupByFunction}}', which execute JavaScript in Tasks queries.",
           "line2": "Malicious JavaScript in a Tasks query or Markdown file could run inside Obsidian and access or modify your vault contents, local files, or other system resources.",
           "line3": "Only enable this if you trust the current and future contents of this vault, including files you may later download, copy, or sync from other people.",
           "line4": "This setting is stored on this device only; enable it separately on each device where you use this vault."

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -212,7 +212,10 @@
       }
     },
     "searches": {
-      "heading": "Searches"
+      "heading": "Searches",
+      "enableCustomSearches": {
+        "name": "Enable custom searches"
+      }
     },
     "searchResults": {
       "heading": "Search results",

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,8 @@ import { tasksApiV1 } from './Api';
 import { GlobalFilter } from './Config/GlobalFilter';
 import { QueryFileDefaults } from './Query/QueryFileDefaults';
 import { LinkResolver } from './Task/LinkResolver';
+import { ObsidianLocalStorageProvider } from './Config/ObsidianLocalStorageProvider';
+import { EnableJsInTasksQueries } from './Config/EnableJsInTasksQueries';
 
 export default class TasksPlugin extends Plugin {
     private cache: Cache | undefined;
@@ -37,6 +39,8 @@ export default class TasksPlugin extends Plugin {
         log('info', i18n.t('main.loadingPlugin', { name: this.manifest.name, version: this.manifest.version }));
 
         await this.loadSettings();
+
+        EnableJsInTasksQueries.initialise(new ObsidianLocalStorageProvider(this.app));
 
         // Configure logging.
         const { loggingOptions } = getSettings();

--- a/tests/Config/EnableJsInTasksQueries.test.ts
+++ b/tests/Config/EnableJsInTasksQueries.test.ts
@@ -24,7 +24,7 @@ describe('EnableJsInTasksQueries', () => {
         expect(setting.get()).toBe(true);
     });
 
-    it('can be enabled', () => {
+    it('should save the updated value to local storage', () => {
         const storage = new InMemoryLocalStorageProvider();
         const setting = new EnableJsInTasksQueries(storage);
 
@@ -34,7 +34,7 @@ describe('EnableJsInTasksQueries', () => {
         expect(storage.load(ENABLE_JS_IN_TASKS_QUERIES_KEY)).toBe(true);
     });
 
-    it('can be disabled after being enabled', () => {
+    it('should save false after previously saving true', () => {
         const storage = new InMemoryLocalStorageProvider();
         const setting = new EnableJsInTasksQueries(storage);
 

--- a/tests/Config/EnableJsInTasksQueries.test.ts
+++ b/tests/Config/EnableJsInTasksQueries.test.ts
@@ -1,0 +1,69 @@
+import {
+    DEFAULT_ENABLE_JS_IN_TASKS_QUERIES,
+    ENABLE_JS_IN_TASKS_QUERIES_KEY,
+    EnableJsInTasksQueries,
+} from '../../src/Config/EnableJsInTasksQueries';
+import { InMemoryLocalStorageProvider } from '../../src/Config/InMemoryLocalStorageProvider';
+
+describe('EnableJsInTasksQueries', () => {
+    it('should default to false', () => {
+        const storage = new InMemoryLocalStorageProvider();
+        const setting = new EnableJsInTasksQueries(storage);
+
+        expect(setting.get()).toBe(DEFAULT_ENABLE_JS_IN_TASKS_QUERIES);
+        expect(setting.get()).toBe(false);
+    });
+
+    it('should load the initial value from local storage', () => {
+        const storage = new InMemoryLocalStorageProvider();
+
+        storage.save(ENABLE_JS_IN_TASKS_QUERIES_KEY, true);
+
+        const setting = new EnableJsInTasksQueries(storage);
+
+        expect(setting.get()).toBe(true);
+    });
+
+    it('can be enabled', () => {
+        const storage = new InMemoryLocalStorageProvider();
+        const setting = new EnableJsInTasksQueries(storage);
+
+        setting.set(true);
+
+        expect(setting.get()).toBe(true);
+        expect(storage.load(ENABLE_JS_IN_TASKS_QUERIES_KEY)).toBe(true);
+    });
+
+    it('can be disabled after being enabled', () => {
+        const storage = new InMemoryLocalStorageProvider();
+        const setting = new EnableJsInTasksQueries(storage);
+
+        setting.set(true);
+        setting.set(false);
+
+        expect(setting.get()).toBe(false);
+        expect(storage.load(ENABLE_JS_IN_TASKS_QUERIES_KEY)).toBe(false);
+    });
+
+    it('should default to false if local storage contains a non-boolean value', () => {
+        const storage = new InMemoryLocalStorageProvider();
+
+        storage.save(ENABLE_JS_IN_TASKS_QUERIES_KEY, 'true');
+
+        const setting = new EnableJsInTasksQueries(storage);
+
+        expect(setting.get()).toBe(false);
+    });
+
+    it('should keep the value in memory after construction', () => {
+        const storage = new InMemoryLocalStorageProvider();
+
+        storage.save(ENABLE_JS_IN_TASKS_QUERIES_KEY, true);
+
+        const setting = new EnableJsInTasksQueries(storage);
+
+        storage.save(ENABLE_JS_IN_TASKS_QUERIES_KEY, false);
+
+        expect(setting.get()).toBe(true);
+    });
+});

--- a/tests/Config/EnableJsInTasksQueries.test.ts
+++ b/tests/Config/EnableJsInTasksQueries.test.ts
@@ -66,4 +66,28 @@ describe('EnableJsInTasksQueries', () => {
 
         expect(setting.get()).toBe(true);
     });
+
+    it('should provide access to the initialised global instance', () => {
+        const storage = new InMemoryLocalStorageProvider();
+
+        storage.save(ENABLE_JS_IN_TASKS_QUERIES_KEY, true);
+
+        const setting = EnableJsInTasksQueries.initialise(storage);
+
+        expect(EnableJsInTasksQueries.getInstance()).toBe(setting);
+        expect(EnableJsInTasksQueries.getInstance().get()).toBe(true);
+    });
+
+    it('should replace the global instance when initialised again', () => {
+        const firstStorage = new InMemoryLocalStorageProvider();
+        const secondStorage = new InMemoryLocalStorageProvider();
+
+        firstStorage.save(ENABLE_JS_IN_TASKS_QUERIES_KEY, true);
+        secondStorage.save(ENABLE_JS_IN_TASKS_QUERIES_KEY, false);
+
+        EnableJsInTasksQueries.initialise(firstStorage);
+        EnableJsInTasksQueries.initialise(secondStorage);
+
+        expect(EnableJsInTasksQueries.getInstance().get()).toBe(false);
+    });
 });

--- a/tests/Config/InMemoryLocalStorageProvider.test.ts
+++ b/tests/Config/InMemoryLocalStorageProvider.test.ts
@@ -1,0 +1,52 @@
+import { InMemoryLocalStorageProvider } from '../../src/Config/InMemoryLocalStorageProvider';
+
+describe('InMemoryLocalStorageProvider', () => {
+    it('should return null for a missing key', () => {
+        const storage = new InMemoryLocalStorageProvider();
+
+        expect(storage.load('missing')).toBeNull();
+    });
+
+    it('should load a saved boolean value', () => {
+        const storage = new InMemoryLocalStorageProvider();
+
+        storage.save('enabled', true);
+
+        expect(storage.load('enabled')).toBe(true);
+    });
+
+    it('should load a saved string value', () => {
+        const storage = new InMemoryLocalStorageProvider();
+
+        storage.save('name', 'Tasks');
+
+        expect(storage.load('name')).toBe('Tasks');
+    });
+
+    it('should load a saved object value', () => {
+        const storage = new InMemoryLocalStorageProvider();
+        const value = { enabled: true, count: 3 };
+
+        storage.save('settings', value);
+
+        expect(storage.load('settings')).toEqual(value);
+    });
+
+    it('should replace an existing value', () => {
+        const storage = new InMemoryLocalStorageProvider();
+
+        storage.save('enabled', true);
+        storage.save('enabled', false);
+
+        expect(storage.load('enabled')).toBe(false);
+    });
+
+    it('should clear a saved value when null is saved', () => {
+        const storage = new InMemoryLocalStorageProvider();
+
+        storage.save('enabled', true);
+        storage.save('enabled', null);
+
+        expect(storage.load('enabled')).toBeNull();
+    });
+});

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -24,6 +24,7 @@ import { TasksDate } from '../../../src/DateTime/TasksDate';
 import { Priority } from '../../../src/Task/Priority';
 import { TasksFile } from '../../../src/Scripting/TasksFile';
 import { EnableJsInTasksQueries } from '../../../src/Config/EnableJsInTasksQueries';
+import { JsInTasksQueriesDisabledError } from '../../../src/Scripting/JsInTasksQueriesDisabledError';
 
 window.moment = moment;
 
@@ -55,7 +56,7 @@ describe('FunctionField - disabling execution', () => {
     });
 
     function checkQueryErrorMessage(query: Query, instruction: string): void {
-        expect(query.error).toContain(EnableJsInTasksQueries.getHelpMessage());
+        expect(query.error).toContain(JsInTasksQueriesDisabledError.helpMessage);
         expect(query.error).toContain(instruction);
     }
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -24,7 +24,7 @@ import { TasksDate } from '../../../src/DateTime/TasksDate';
 import { Priority } from '../../../src/Task/Priority';
 import { TasksFile } from '../../../src/Scripting/TasksFile';
 import { EnableJsInTasksQueries } from '../../../src/Config/EnableJsInTasksQueries';
-import { JsInTasksQueriesDisabledError } from '../../../src/Scripting/JsInTasksQueriesDisabledError';
+import { checkQueryErrorMessage } from '../../Scripting/ScriptingTestHelpers';
 
 window.moment = moment;
 
@@ -54,11 +54,6 @@ describe('FunctionField - disabling execution', () => {
     afterEach(() => {
         EnableJsInTasksQueries.getInstance().set(true);
     });
-
-    function checkQueryErrorMessage(query: Query, instruction: string): void {
-        expect(query.error).toContain(JsInTasksQueriesDisabledError.helpMessage);
-        expect(query.error).toContain(instruction);
-    }
 
     it('"filter by function" should have meaningful parse-time error', () => {
         const instruction = 'filter by function true';

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -24,7 +24,7 @@ import { TasksDate } from '../../../src/DateTime/TasksDate';
 import { Priority } from '../../../src/Task/Priority';
 import { TasksFile } from '../../../src/Scripting/TasksFile';
 import { EnableJsInTasksQueries } from '../../../src/Config/EnableJsInTasksQueries';
-import { checkQueryErrorMessage } from '../../Scripting/ScriptingTestHelpers';
+import { expectQueryErrorToMentionDisabledJavaScript } from '../../Scripting/ScriptingTestHelpers';
 
 window.moment = moment;
 
@@ -58,19 +58,19 @@ describe('FunctionField - disabling execution', () => {
     it('"filter by function" should have meaningful parse-time error', () => {
         const instruction = 'filter by function true';
         const query = new Query(instruction);
-        checkQueryErrorMessage(query, instruction);
+        expectQueryErrorToMentionDisabledJavaScript(query, instruction);
     });
 
     it('"sort by function" should have meaningful parse-time error', () => {
         const instruction = 'sort by function 5';
         const query = new Query(instruction);
-        checkQueryErrorMessage(query, instruction);
+        expectQueryErrorToMentionDisabledJavaScript(query, instruction);
     });
 
     it('"group by function" should have meaningful parse-time error', () => {
         const instruction = 'group by function "hello"';
         const query = new Query(instruction);
-        checkQueryErrorMessage(query, instruction);
+        expectQueryErrorToMentionDisabledJavaScript(query, instruction);
     });
 });
 

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -23,6 +23,7 @@ import { Query } from '../../../src/Query/Query';
 import { TasksDate } from '../../../src/DateTime/TasksDate';
 import { Priority } from '../../../src/Task/Priority';
 import { TasksFile } from '../../../src/Scripting/TasksFile';
+import { EnableJsInTasksQueries } from '../../../src/Config/EnableJsInTasksQueries';
 
 window.moment = moment;
 
@@ -38,6 +39,43 @@ const undated = new TasksDate(null);
 beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date(today));
+});
+
+// -----------------------------------------------------------------------------------------------------------------
+// Disabling JavaScript execution
+// -----------------------------------------------------------------------------------------------------------------
+
+describe('FunctionField - disabling execution', () => {
+    beforeEach(() => {
+        EnableJsInTasksQueries.getInstance().set(false);
+    });
+
+    afterEach(() => {
+        EnableJsInTasksQueries.getInstance().set(true);
+    });
+
+    function checkQueryErrorMessage(query: Query, instruction: string): void {
+        expect(query.error).toContain(EnableJsInTasksQueries.getHelpMessage());
+        expect(query.error).toContain(instruction);
+    }
+
+    it('"filter by function" should have meaningful parse-time error', () => {
+        const instruction = 'filter by function true';
+        const query = new Query(instruction);
+        checkQueryErrorMessage(query, instruction);
+    });
+
+    it('"sort by function" should have meaningful parse-time error', () => {
+        const instruction = 'sort by function 5';
+        const query = new Query(instruction);
+        checkQueryErrorMessage(query, instruction);
+    });
+
+    it('"group by function" should have meaningful parse-time error', () => {
+        const instruction = 'group by function "hello"';
+        const query = new Query(instruction);
+        checkQueryErrorMessage(query, instruction);
+    });
 });
 
 // -----------------------------------------------------------------------------------------------------------------

--- a/tests/Query/Presets/Presets.test.ts
+++ b/tests/Query/Presets/Presets.test.ts
@@ -9,7 +9,7 @@ import { TasksFile } from '../../../src/Scripting/TasksFile';
 import type { Statement } from '../../../src/Query/Statement';
 import { type PresetsMap, defaultPresets } from '../../../src/Query/Presets/Presets';
 import { EnableJsInTasksQueries } from '../../../src/Config/EnableJsInTasksQueries';
-import { checkQueryErrorMessage } from '../../Scripting/ScriptingTestHelpers';
+import { expectQueryErrorToMentionDisabledJavaScript } from '../../Scripting/ScriptingTestHelpers';
 
 window.moment = moment;
 
@@ -584,6 +584,6 @@ describe('FunctionField - disabling execution', () => {
     it('should refuse run presets that execute JS, if JS execution is disabled', () => {
         const instruction = 'preset this_folder_only';
         const query = new Query(instruction);
-        checkQueryErrorMessage(query, instruction);
+        expectQueryErrorToMentionDisabledJavaScript(query, instruction);
     });
 });

--- a/tests/Query/Presets/Presets.test.ts
+++ b/tests/Query/Presets/Presets.test.ts
@@ -9,6 +9,7 @@ import { TasksFile } from '../../../src/Scripting/TasksFile';
 import type { Statement } from '../../../src/Query/Statement';
 import { type PresetsMap, defaultPresets } from '../../../src/Query/Presets/Presets';
 import { EnableJsInTasksQueries } from '../../../src/Config/EnableJsInTasksQueries';
+import { JsInTasksQueriesDisabledError } from '../../../src/Scripting/JsInTasksQueriesDisabledError';
 
 window.moment = moment;
 
@@ -581,7 +582,7 @@ describe('FunctionField - disabling execution', () => {
     });
 
     function checkQueryErrorMessage(query: Query, instruction: string): void {
-        expect(query.error).toContain(EnableJsInTasksQueries.getHelpMessage());
+        expect(query.error).toContain(JsInTasksQueriesDisabledError.helpMessage);
         expect(query.error).toContain(instruction);
     }
 

--- a/tests/Query/Presets/Presets.test.ts
+++ b/tests/Query/Presets/Presets.test.ts
@@ -8,6 +8,7 @@ import { Query } from '../../../src/Query/Query';
 import { TasksFile } from '../../../src/Scripting/TasksFile';
 import type { Statement } from '../../../src/Query/Statement';
 import { type PresetsMap, defaultPresets } from '../../../src/Query/Presets/Presets';
+import { EnableJsInTasksQueries } from '../../../src/Config/EnableJsInTasksQueries';
 
 window.moment = moment;
 
@@ -567,5 +568,26 @@ describe('include settings tests', () => {
 
         const query = new Query(instructions, new TasksFile('anywhere.md'));
         expect(query.error).toBeUndefined();
+    });
+});
+
+describe('FunctionField - disabling execution', () => {
+    beforeEach(() => {
+        EnableJsInTasksQueries.getInstance().set(false);
+    });
+
+    afterEach(() => {
+        EnableJsInTasksQueries.getInstance().set(true);
+    });
+
+    function checkQueryErrorMessage(query: Query, instruction: string): void {
+        expect(query.error).toContain(EnableJsInTasksQueries.getHelpMessage());
+        expect(query.error).toContain(instruction);
+    }
+
+    it('should refuse run presets that execute JS, if JS execution is disabled', () => {
+        const instruction = 'preset this_folder_only';
+        const query = new Query(instruction);
+        checkQueryErrorMessage(query, instruction);
     });
 });

--- a/tests/Query/Presets/Presets.test.ts
+++ b/tests/Query/Presets/Presets.test.ts
@@ -9,7 +9,7 @@ import { TasksFile } from '../../../src/Scripting/TasksFile';
 import type { Statement } from '../../../src/Query/Statement';
 import { type PresetsMap, defaultPresets } from '../../../src/Query/Presets/Presets';
 import { EnableJsInTasksQueries } from '../../../src/Config/EnableJsInTasksQueries';
-import { JsInTasksQueriesDisabledError } from '../../../src/Scripting/JsInTasksQueriesDisabledError';
+import { checkQueryErrorMessage } from '../../Scripting/ScriptingTestHelpers';
 
 window.moment = moment;
 
@@ -580,11 +580,6 @@ describe('FunctionField - disabling execution', () => {
     afterEach(() => {
         EnableJsInTasksQueries.getInstance().set(true);
     });
-
-    function checkQueryErrorMessage(query: Query, instruction: string): void {
-        expect(query.error).toContain(JsInTasksQueriesDisabledError.helpMessage);
-        expect(query.error).toContain(instruction);
-    }
 
     it('should refuse run presets that execute JS, if JS execution is disabled', () => {
         const instruction = 'preset this_folder_only';

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -589,11 +589,11 @@ description includes \
         });
 
         it('"filter by function" should have meaningful parse-time error', () => {
-            const query = new Query('filter by function true');
-            expect(query.error).toMatchInlineSnapshot(`
-                "JavaScript is disabled in Tasks queries
-                Problem line: "filter by function true""
-            `);
+            const instruction = 'filter by function true';
+            const query = new Query(instruction);
+
+            expect(query.error).toContain(EnableJsInTasksQueries.getHelpMessage());
+            expect(query.error).toContain(instruction);
         });
     });
 

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -595,24 +595,6 @@ description includes \
             expect(query.error).toContain(instruction);
         }
 
-        it('"filter by function" should have meaningful parse-time error', () => {
-            const instruction = 'filter by function true';
-            const query = new Query(instruction);
-            checkQueryErrorMessage(query, instruction);
-        });
-
-        it('"sort by function" should have meaningful parse-time error', () => {
-            const instruction = 'sort by function 5';
-            const query = new Query(instruction);
-            checkQueryErrorMessage(query, instruction);
-        });
-
-        it('"group by function" should have meaningful parse-time error', () => {
-            const instruction = 'group by function "hello"';
-            const query = new Query(instruction);
-            checkQueryErrorMessage(query, instruction);
-        });
-
         it('"{{query.file.path}}" should work when JS execution disabled', () => {
             const instruction = 'path includes {{query.file.path}}';
             const query = new Query(instruction, tasksFile);

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -604,6 +604,12 @@ description includes \
             const query = new Query(instruction);
             checkQueryErrorMessage(query, instruction);
         });
+
+        it('"group by function" should have meaningful parse-time error', () => {
+            const instruction = 'group by function "hello"';
+            const query = new Query(instruction);
+            checkQueryErrorMessage(query, instruction);
+        });
     });
 
     it('should allow spaces between show or hide and a Query option', () => {

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -23,6 +23,7 @@ import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { Priority } from '../../src/Task/Priority';
 import { TaskLayoutComponent } from '../../src/Layout/TaskLayoutOptions';
 import { getTasksFileFromMockData } from '../TestingTools/MockDataHelpers';
+import { EnableJsInTasksQueries } from '../../src/Config/EnableJsInTasksQueries';
 
 window.moment = moment;
 
@@ -575,6 +576,24 @@ description includes \
 
             // Assert
             expect(query.error).toBeUndefined();
+        });
+    });
+
+    describe('disabling JavaScript execution', () => {
+        beforeEach(() => {
+            EnableJsInTasksQueries.getInstance().set(false);
+        });
+
+        afterEach(() => {
+            EnableJsInTasksQueries.getInstance().set(true);
+        });
+
+        it('"filter by function" should have meaningful parse-time error', () => {
+            const query = new Query('filter by function true');
+            expect(query.error).toMatchInlineSnapshot(`
+                "JavaScript is disabled in Tasks queries
+                Problem line: "filter by function true""
+            `);
         });
     });
 

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -588,6 +588,8 @@ description includes \
             EnableJsInTasksQueries.getInstance().set(true);
         });
 
+        const tasksFile = new TasksFile('anywhere.md');
+
         function checkQueryErrorMessage(query: Query, instruction: string): void {
             expect(query.error).toContain(EnableJsInTasksQueries.getHelpMessage());
             expect(query.error).toContain(instruction);
@@ -608,6 +610,24 @@ description includes \
         it('"group by function" should have meaningful parse-time error', () => {
             const instruction = 'group by function "hello"';
             const query = new Query(instruction);
+            checkQueryErrorMessage(query, instruction);
+        });
+
+        it('"{{query.file.path}}" should work when JS execution disabled', () => {
+            const instruction = 'path includes {{query.file.path}}';
+            const query = new Query(instruction, tasksFile);
+            expect(query.error).toBeUndefined();
+        });
+
+        it('"{{query.file.path.toUpperCase()}}" should have meaningful parse-time error', () => {
+            const instruction = 'path includes {{query.file.path.toUpperCase()}}';
+            const query = new Query(instruction, tasksFile);
+            checkQueryErrorMessage(query, instruction);
+        });
+
+        it.failing('"{{4 + 6}}" should have meaningful parse-time error', () => {
+            const instruction = 'path includes {{4 + 6}}';
+            const query = new Query(instruction, tasksFile);
             checkQueryErrorMessage(query, instruction);
         });
     });

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -598,6 +598,12 @@ description includes \
             const query = new Query(instruction);
             checkQueryErrorMessage(query, instruction);
         });
+
+        it('"sort by function" should have meaningful parse-time error', () => {
+            const instruction = 'sort by function 5';
+            const query = new Query(instruction);
+            checkQueryErrorMessage(query, instruction);
+        });
     });
 
     it('should allow spaces between show or hide and a Query option', () => {

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -23,7 +23,6 @@ import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { Priority } from '../../src/Task/Priority';
 import { TaskLayoutComponent } from '../../src/Layout/TaskLayoutOptions';
 import { getTasksFileFromMockData } from '../TestingTools/MockDataHelpers';
-import { EnableJsInTasksQueries } from '../../src/Config/EnableJsInTasksQueries';
 
 window.moment = moment;
 
@@ -576,41 +575,6 @@ description includes \
 
             // Assert
             expect(query.error).toBeUndefined();
-        });
-    });
-
-    describe('disabling JavaScript execution', () => {
-        beforeEach(() => {
-            EnableJsInTasksQueries.getInstance().set(false);
-        });
-
-        afterEach(() => {
-            EnableJsInTasksQueries.getInstance().set(true);
-        });
-
-        const tasksFile = new TasksFile('anywhere.md');
-
-        function checkQueryErrorMessage(query: Query, instruction: string): void {
-            expect(query.error).toContain(EnableJsInTasksQueries.getHelpMessage());
-            expect(query.error).toContain(instruction);
-        }
-
-        it('"{{query.file.path}}" should work when JS execution disabled', () => {
-            const instruction = 'path includes {{query.file.path}}';
-            const query = new Query(instruction, tasksFile);
-            expect(query.error).toBeUndefined();
-        });
-
-        it('"{{query.file.path.toUpperCase()}}" should have meaningful parse-time error', () => {
-            const instruction = 'path includes {{query.file.path.toUpperCase()}}';
-            const query = new Query(instruction, tasksFile);
-            checkQueryErrorMessage(query, instruction);
-        });
-
-        it.failing('"{{4 + 6}}" should have meaningful parse-time error', () => {
-            const instruction = 'path includes {{4 + 6}}';
-            const query = new Query(instruction, tasksFile);
-            checkQueryErrorMessage(query, instruction);
         });
     });
 

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -588,12 +588,15 @@ description includes \
             EnableJsInTasksQueries.getInstance().set(true);
         });
 
+        function checkQueryErrorMessage(query: Query, instruction: string): void {
+            expect(query.error).toContain(EnableJsInTasksQueries.getHelpMessage());
+            expect(query.error).toContain(instruction);
+        }
+
         it('"filter by function" should have meaningful parse-time error', () => {
             const instruction = 'filter by function true';
             const query = new Query(instruction);
-
-            expect(query.error).toContain(EnableJsInTasksQueries.getHelpMessage());
-            expect(query.error).toContain(instruction);
+            checkQueryErrorMessage(query, instruction);
         });
     });
 

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -35,6 +35,11 @@ describe('Placeholders - disabling execution', () => {
         worksWithoutJsExecution(instruction);
     });
 
+    it.failing('"{{query.file.path}}" should work when JS execution disabled', () => {
+        const instruction = 'path includes {{query.file.property("project")}}';
+        worksWithoutJsExecution(instruction);
+    });
+
     it('"{{query.file.path.toUpperCase()}}" should have meaningful parse-time error', () => {
         const instruction = 'path includes {{query.file.path.toUpperCase()}}';
         failsWithoutJsExecution(instruction);

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -32,7 +32,7 @@ describe('Placeholders - disabling execution', () => {
         checkQueryErrorMessage(query, instruction);
     });
 
-    it.failing('"{{4 + 6}}" should have meaningful parse-time error', () => {
+    it('"{{4 + 6}}" should have meaningful parse-time error', () => {
         const instruction = 'path includes {{4 + 6}}';
         const query = new Query(instruction, tasksFile);
         checkQueryErrorMessage(query, instruction);

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -4,7 +4,7 @@ import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Query } from '../../src/Query/Query';
 import { EnableJsInTasksQueries } from '../../src/Config/EnableJsInTasksQueries';
 import { getTasksFileFromMockData } from '../TestingTools/MockDataHelpers';
-import { JsInTasksQueriesDisabledError } from '../../src/Scripting/JsInTasksQueriesDisabledError';
+import { checkQueryErrorMessage } from './ScriptingTestHelpers';
 
 describe('Placeholders - disabling execution', () => {
     beforeEach(() => {
@@ -16,11 +16,6 @@ describe('Placeholders - disabling execution', () => {
     });
 
     const tasksFile = getTasksFileFromMockData('yaml_all_property_types_populated');
-
-    function checkQueryErrorMessage(query: Query, instruction: string): void {
-        expect(query.error).toContain(JsInTasksQueriesDisabledError.helpMessage);
-        expect(query.error).toContain(instruction);
-    }
 
     function worksWithoutJsExecution(instruction: string): void {
         const query = new Query(instruction, tasksFile);

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -25,6 +25,11 @@ describe('Placeholders - disabling execution', () => {
         expect(query.error).toBeUndefined();
     }
 
+    function failsWithoutJsExecution(instruction: string): void {
+        const query = new Query(instruction, tasksFile);
+        checkQueryErrorMessage(query, instruction);
+    }
+
     it('"{{query.file.path}}" should work when JS execution disabled', () => {
         const instruction = 'path includes {{query.file.path}}';
         worksWithoutJsExecution(instruction);
@@ -32,14 +37,12 @@ describe('Placeholders - disabling execution', () => {
 
     it('"{{query.file.path.toUpperCase()}}" should have meaningful parse-time error', () => {
         const instruction = 'path includes {{query.file.path.toUpperCase()}}';
-        const query = new Query(instruction, tasksFile);
-        checkQueryErrorMessage(query, instruction);
+        failsWithoutJsExecution(instruction);
     });
 
     it('"{{4 + 6}}" should have meaningful parse-time error', () => {
         const instruction = 'path includes {{4 + 6}}';
-        const query = new Query(instruction, tasksFile);
-        checkQueryErrorMessage(query, instruction);
+        failsWithoutJsExecution(instruction);
     });
 });
 

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -4,7 +4,7 @@ import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Query } from '../../src/Query/Query';
 import { EnableJsInTasksQueries } from '../../src/Config/EnableJsInTasksQueries';
 import { getTasksFileFromMockData } from '../TestingTools/MockDataHelpers';
-import { checkQueryErrorMessage } from './ScriptingTestHelpers';
+import { expectQueryErrorToMentionDisabledJavaScript } from './ScriptingTestHelpers';
 
 describe('Placeholders - disabling execution', () => {
     beforeEach(() => {
@@ -24,7 +24,7 @@ describe('Placeholders - disabling execution', () => {
 
     function failsWithoutJsExecution(instruction: string): void {
         const query = new Query(instruction, tasksFile);
-        checkQueryErrorMessage(query, instruction);
+        expectQueryErrorToMentionDisabledJavaScript(query, instruction);
     }
 
     it('"{{query.file.path}}" should work when JS execution disabled', () => {

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -4,6 +4,7 @@ import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Query } from '../../src/Query/Query';
 import { EnableJsInTasksQueries } from '../../src/Config/EnableJsInTasksQueries';
 import { getTasksFileFromMockData } from '../TestingTools/MockDataHelpers';
+import { JsInTasksQueriesDisabledError } from '../../src/Scripting/JsInTasksQueriesDisabledError';
 
 describe('Placeholders - disabling execution', () => {
     beforeEach(() => {
@@ -17,7 +18,7 @@ describe('Placeholders - disabling execution', () => {
     const tasksFile = getTasksFileFromMockData('yaml_all_property_types_populated');
 
     function checkQueryErrorMessage(query: Query, instruction: string): void {
-        expect(query.error).toContain(EnableJsInTasksQueries.getHelpMessage());
+        expect(query.error).toContain(JsInTasksQueriesDisabledError.helpMessage);
         expect(query.error).toContain(instruction);
     }
 

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -3,6 +3,7 @@ import { makeQueryContext } from '../../src/Scripting/QueryContext';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Query } from '../../src/Query/Query';
 import { EnableJsInTasksQueries } from '../../src/Config/EnableJsInTasksQueries';
+import { getTasksFileFromMockData } from '../TestingTools/MockDataHelpers';
 
 describe('Placeholders - disabling execution', () => {
     beforeEach(() => {
@@ -13,7 +14,7 @@ describe('Placeholders - disabling execution', () => {
         EnableJsInTasksQueries.getInstance().set(true);
     });
 
-    const tasksFile = new TasksFile('anywhere.md');
+    const tasksFile = getTasksFileFromMockData('yaml_all_property_types_populated');
 
     function checkQueryErrorMessage(query: Query, instruction: string): void {
         expect(query.error).toContain(EnableJsInTasksQueries.getHelpMessage());
@@ -35,8 +36,8 @@ describe('Placeholders - disabling execution', () => {
         worksWithoutJsExecution(instruction);
     });
 
-    it.failing('"{{query.file.path}}" should work when JS execution disabled', () => {
-        const instruction = 'path includes {{query.file.property("project")}}';
+    it('"{{query.file.property()}} - with existent property" should work when JS execution disabled', () => {
+        const instruction = 'path includes {{query.file.property("sample_number_property")}}';
         worksWithoutJsExecution(instruction);
     });
 

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -41,6 +41,32 @@ describe('Placeholders - disabling execution', () => {
         worksWithoutJsExecution(instruction);
     });
 
+    it('"{{query.file.hasProperty()}}" should work when JS execution disabled', () => {
+        const instruction = 'description includes {{query.file.hasProperty("sample_number_property")}}';
+        worksWithoutJsExecution(instruction);
+    });
+
+    it('"{{query.file.property()}} - with missing property" should preserve the existing null placeholder error when JS execution disabled', () => {
+        const instruction = 'path includes {{query.file.property("non_existent_property")}}';
+        const query = new Query(instruction, tasksFile);
+
+        expect(query.error).toContain("Invalid placeholder result 'null'");
+        expect(query.error).toContain(instruction);
+    });
+
+    it('"{{query.file.property()}} - with expression argument" should have meaningful parse-time error when JS execution disabled', () => {
+        const instruction = 'path includes {{query.file.property("sample_" + "number_property")}}';
+        failsWithoutJsExecution(instruction);
+    });
+
+    it('"{{query.file.noSuchProperty}}" should preserve the existing unknown property error when JS execution disabled', () => {
+        const instruction = 'path includes {{query.file.noSuchProperty}}';
+        const query = new Query(instruction, tasksFile);
+
+        expect(query.error).toContain('Unknown property: query.file.noSuchProperty');
+        expect(query.error).toContain(instruction);
+    });
+
     it('"{{query.file.path.toUpperCase()}}" should have meaningful parse-time error', () => {
         const instruction = 'path includes {{query.file.path.toUpperCase()}}';
         failsWithoutJsExecution(instruction);

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -194,6 +194,13 @@ describe('ExpandTemplate with functions', () => {
             });
             expect(output).toEqual('Result: 16');
         });
+
+        it('Objects use default stringification format', () => {
+            // Note: This is not necessarily the "correct" behaviour:
+            //       it is just demonstrating the "current" behaviour.
+            const output = expandPlaceholders('{{ { path: "x.md" } }}', {});
+            expect(output).toEqual('[object Object]');
+        });
     });
 
     describe('Complex Nested Paths', () => {

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -20,10 +20,14 @@ describe('Placeholders - disabling execution', () => {
         expect(query.error).toContain(instruction);
     }
 
-    it('"{{query.file.path}}" should work when JS execution disabled', () => {
-        const instruction = 'path includes {{query.file.path}}';
+    function worksWithoutJsExecution(instruction: string): void {
         const query = new Query(instruction, tasksFile);
         expect(query.error).toBeUndefined();
+    }
+
+    it('"{{query.file.path}}" should work when JS execution disabled', () => {
+        const instruction = 'path includes {{query.file.path}}';
+        worksWithoutJsExecution(instruction);
     });
 
     it('"{{query.file.path.toUpperCase()}}" should have meaningful parse-time error', () => {

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -1,6 +1,43 @@
 import { expandPlaceholders } from '../../src/Scripting/ExpandPlaceholders';
 import { makeQueryContext } from '../../src/Scripting/QueryContext';
 import { TasksFile } from '../../src/Scripting/TasksFile';
+import { Query } from '../../src/Query/Query';
+import { EnableJsInTasksQueries } from '../../src/Config/EnableJsInTasksQueries';
+
+describe('Placeholders - disabling execution', () => {
+    beforeEach(() => {
+        EnableJsInTasksQueries.getInstance().set(false);
+    });
+
+    afterEach(() => {
+        EnableJsInTasksQueries.getInstance().set(true);
+    });
+
+    const tasksFile = new TasksFile('anywhere.md');
+
+    function checkQueryErrorMessage(query: Query, instruction: string): void {
+        expect(query.error).toContain(EnableJsInTasksQueries.getHelpMessage());
+        expect(query.error).toContain(instruction);
+    }
+
+    it('"{{query.file.path}}" should work when JS execution disabled', () => {
+        const instruction = 'path includes {{query.file.path}}';
+        const query = new Query(instruction, tasksFile);
+        expect(query.error).toBeUndefined();
+    });
+
+    it('"{{query.file.path.toUpperCase()}}" should have meaningful parse-time error', () => {
+        const instruction = 'path includes {{query.file.path.toUpperCase()}}';
+        const query = new Query(instruction, tasksFile);
+        checkQueryErrorMessage(query, instruction);
+    });
+
+    it.failing('"{{4 + 6}}" should have meaningful parse-time error', () => {
+        const instruction = 'path includes {{4 + 6}}';
+        const query = new Query(instruction, tasksFile);
+        checkQueryErrorMessage(query, instruction);
+    });
+});
 
 describe('ExpandTemplate', () => {
     const tasksFile = new TasksFile('a/b/path with space.md');

--- a/tests/Scripting/Expression.test.ts
+++ b/tests/Scripting/Expression.test.ts
@@ -10,11 +10,40 @@ import { continueLinesFlattened } from '../../src/Query/Scanner';
 import { constructArguments, parseAndEvaluateExpression } from '../../src/Scripting/TaskExpression';
 import { makeQueryContext } from '../../src/Scripting/QueryContext';
 import { TasksFile } from '../../src/Scripting/TasksFile';
+import { EnableJsInTasksQueries } from '../../src/Config/EnableJsInTasksQueries';
+import { JsInTasksQueriesDisabledError } from '../../src/Scripting/JsInTasksQueriesDisabledError';
 import { formatToRepresentType } from './ScriptingTestHelpers';
 
 window.moment = moment;
 
 describe('Expression', () => {
+    describe('Expression - disabling execution', () => {
+        beforeEach(() => {
+            EnableJsInTasksQueries.getInstance().set(false);
+        });
+
+        afterEach(() => {
+            EnableJsInTasksQueries.getInstance().set(true);
+        });
+
+        it('parsing expressions should throw exception if JS execution disabled', () => {
+            expect(() => parseExpression([], '42')).toThrow(JsInTasksQueriesDisabledError);
+        });
+
+        it('evaluating expressions should throw exception if JS execution disabled', () => {
+            // Turn on JS expression to allow parsing.
+            EnableJsInTasksQueries.getInstance().set(true);
+            const functionOrError = parseExpression([], '42');
+            expect(functionOrError.queryComponent).toBeDefined();
+            const func: Function = functionOrError.queryComponent!;
+
+            // Turn off JS execution, so we can test evaluation fails.
+            EnableJsInTasksQueries.getInstance().set(false);
+
+            expect(() => evaluateExpression(func, [])).toThrow(JsInTasksQueriesDisabledError);
+        });
+    });
+
     describe('support simple calculations', () => {
         it('should calculate simple expression', () => {
             expect('1 + 1').toEvaluateAs(2);

--- a/tests/Scripting/KnownPlaceholderResolver.test.ts
+++ b/tests/Scripting/KnownPlaceholderResolver.test.ts
@@ -1,9 +1,9 @@
 import { resolveKnownPlaceholder } from '../../src/Scripting/KnownPlaceholderResolver';
 import { makeQueryContext } from '../../src/Scripting/QueryContext';
-import { TasksFile } from '../../src/Scripting/TasksFile';
+import { getTasksFileFromMockData } from '../TestingTools/MockDataHelpers';
 
 describe('KnownPlaceholderResolver', () => {
-    const tasksFile = new TasksFile('root/sub-folder/file containing query.md');
+    const tasksFile = getTasksFileFromMockData('yaml_all_property_types_populated');
     const queryContext = makeQueryContext(tasksFile);
 
     function expectResolvedPlaceholderToBe(placeholder: string, expectedValue: unknown) {
@@ -23,39 +23,45 @@ describe('KnownPlaceholderResolver', () => {
 
     describe('query.file properties', () => {
         it('resolves query.file.path', () => {
-            expectResolvedPlaceholderToBe('query.file.path', 'root/sub-folder/file containing query.md');
+            expectResolvedPlaceholderToBe('query.file.path', 'Test Data/yaml_all_property_types_populated.md');
         });
 
         it('resolves query.file.pathWithoutExtension', () => {
-            expectResolvedPlaceholderToBe('query.file.pathWithoutExtension', 'root/sub-folder/file containing query');
+            expectResolvedPlaceholderToBe(
+                'query.file.pathWithoutExtension',
+                'Test Data/yaml_all_property_types_populated',
+            );
         });
 
         it('resolves query.file.root', () => {
-            expectResolvedPlaceholderToBe('query.file.root', 'root/');
+            expectResolvedPlaceholderToBe('query.file.root', 'Test Data/');
         });
 
         it('resolves query.file.folder', () => {
-            expectResolvedPlaceholderToBe('query.file.folder', 'root/sub-folder/');
+            expectResolvedPlaceholderToBe('query.file.folder', 'Test Data/');
         });
 
         it('resolves query.file.filename', () => {
-            expectResolvedPlaceholderToBe('query.file.filename', 'file containing query.md');
+            expectResolvedPlaceholderToBe('query.file.filename', 'yaml_all_property_types_populated.md');
         });
 
         it('resolves query.file.filenameWithoutExtension', () => {
-            expectResolvedPlaceholderToBe('query.file.filenameWithoutExtension', 'file containing query');
+            expectResolvedPlaceholderToBe('query.file.filenameWithoutExtension', 'yaml_all_property_types_populated');
         });
 
         it('resolves query.file.outlinksInProperties', () => {
-            expectResolvedPlaceholderToBe('query.file.outlinksInProperties', []);
+            expectResolvedPlaceholderToBe(
+                'query.file.outlinksInProperties',
+                queryContext.query.file.outlinksInProperties,
+            );
         });
 
         it('resolves query.file.outlinksInBody', () => {
-            expectResolvedPlaceholderToBe('query.file.outlinksInBody', []);
+            expectResolvedPlaceholderToBe('query.file.outlinksInBody', queryContext.query.file.outlinksInBody);
         });
 
         it('resolves query.file.outlinks', () => {
-            expectResolvedPlaceholderToBe('query.file.outlinks', []);
+            expectResolvedPlaceholderToBe('query.file.outlinks', queryContext.query.file.outlinks);
         });
     });
 
@@ -65,7 +71,7 @@ describe('KnownPlaceholderResolver', () => {
         });
 
         it('resolves query.file.hasProperty() with double quotes', () => {
-            expectResolvedPlaceholderToBe('query.file.hasProperty("non_existent_property")', false);
+            expectResolvedPlaceholderToBe('query.file.hasProperty("sample_link_property")', true);
         });
 
         it('resolves query.file.property() with single quotes', () => {
@@ -73,7 +79,7 @@ describe('KnownPlaceholderResolver', () => {
         });
 
         it('resolves query.file.property() with double quotes', () => {
-            expectResolvedPlaceholderToBe('query.file.property("non_existent_property")', null);
+            expectResolvedPlaceholderToBe('query.file.property("sample_number_property")', 246);
         });
     });
 
@@ -101,7 +107,7 @@ describe('KnownPlaceholderResolver', () => {
 
     describe('formatting', () => {
         it('ignores whitespace around placeholder expression', () => {
-            expectResolvedPlaceholderToBe(' query.file.path ', 'root/sub-folder/file containing query.md');
+            expectResolvedPlaceholderToBe(' query.file.path ', 'Test Data/yaml_all_property_types_populated.md');
         });
     });
 });

--- a/tests/Scripting/KnownPlaceholderResolver.test.ts
+++ b/tests/Scripting/KnownPlaceholderResolver.test.ts
@@ -97,12 +97,6 @@ describe('KnownPlaceholderResolver', () => {
         it('does not resolve non-query placeholders', () => {
             expectPlaceholderNotToBeResolved('preset.this_file');
         });
-
-        it('does not resolve placeholders if the view is not a QueryContext', () => {
-            expect(resolveKnownPlaceholder('query.file.path', { query: {} })).toEqual({
-                resolved: false,
-            });
-        });
     });
 
     describe('formatting', () => {

--- a/tests/Scripting/KnownPlaceholderResolver.test.ts
+++ b/tests/Scripting/KnownPlaceholderResolver.test.ts
@@ -1,0 +1,113 @@
+import { resolveKnownPlaceholder } from '../../src/Scripting/KnownPlaceholderResolver';
+import { makeQueryContext } from '../../src/Scripting/QueryContext';
+import { TasksFile } from '../../src/Scripting/TasksFile';
+
+describe('KnownPlaceholderResolver', () => {
+    const tasksFile = new TasksFile('root/sub-folder/file containing query.md');
+    const queryContext = makeQueryContext(tasksFile);
+
+    function expectResolvedPlaceholderToBe(placeholder: string, expectedValue: unknown) {
+        const resolution = resolveKnownPlaceholder(placeholder, queryContext);
+
+        expect(resolution.resolved).toEqual(true);
+        if (resolution.resolved) {
+            expect(resolution.value).toEqual(expectedValue);
+        }
+    }
+
+    function expectPlaceholderNotToBeResolved(placeholder: string) {
+        expect(resolveKnownPlaceholder(placeholder, queryContext)).toEqual({
+            resolved: false,
+        });
+    }
+
+    describe('query.file properties', () => {
+        it('resolves query.file.path', () => {
+            expectResolvedPlaceholderToBe('query.file.path', 'root/sub-folder/file containing query.md');
+        });
+
+        it('resolves query.file.pathWithoutExtension', () => {
+            expectResolvedPlaceholderToBe('query.file.pathWithoutExtension', 'root/sub-folder/file containing query');
+        });
+
+        it('resolves query.file.root', () => {
+            expectResolvedPlaceholderToBe('query.file.root', 'root/');
+        });
+
+        it('resolves query.file.folder', () => {
+            expectResolvedPlaceholderToBe('query.file.folder', 'root/sub-folder/');
+        });
+
+        it('resolves query.file.filename', () => {
+            expectResolvedPlaceholderToBe('query.file.filename', 'file containing query.md');
+        });
+
+        it('resolves query.file.filenameWithoutExtension', () => {
+            expectResolvedPlaceholderToBe('query.file.filenameWithoutExtension', 'file containing query');
+        });
+
+        it('resolves query.file.outlinksInProperties', () => {
+            expectResolvedPlaceholderToBe('query.file.outlinksInProperties', []);
+        });
+
+        it('resolves query.file.outlinksInBody', () => {
+            expectResolvedPlaceholderToBe('query.file.outlinksInBody', []);
+        });
+
+        it('resolves query.file.outlinks', () => {
+            expectResolvedPlaceholderToBe('query.file.outlinks', []);
+        });
+    });
+
+    describe('query.file property methods', () => {
+        it('resolves query.file.hasProperty() with single quotes', () => {
+            expectResolvedPlaceholderToBe("query.file.hasProperty('non_existent_property')", false);
+        });
+
+        it('resolves query.file.hasProperty() with double quotes', () => {
+            expectResolvedPlaceholderToBe('query.file.hasProperty("non_existent_property")', false);
+        });
+
+        it('resolves query.file.property() with single quotes', () => {
+            expectResolvedPlaceholderToBe("query.file.property('non_existent_property')", null);
+        });
+
+        it('resolves query.file.property() with double quotes', () => {
+            expectResolvedPlaceholderToBe('query.file.property("non_existent_property")', null);
+        });
+    });
+
+    describe('unsupported expressions', () => {
+        it('does not resolve arbitrary expressions', () => {
+            expectPlaceholderNotToBeResolved('4 + 6');
+        });
+
+        it('does not resolve non-approved method calls', () => {
+            expectPlaceholderNotToBeResolved('query.file.path.toUpperCase()');
+        });
+
+        it('does not resolve query.file.property() with an expression argument', () => {
+            expectPlaceholderNotToBeResolved("query.file.property('task_' + 'instruction')");
+        });
+
+        it('does not resolve unknown query.file properties', () => {
+            expectPlaceholderNotToBeResolved('query.file.noSuchProperty');
+        });
+
+        it('does not resolve non-query placeholders', () => {
+            expectPlaceholderNotToBeResolved('preset.this_file');
+        });
+
+        it('does not resolve placeholders if the view is not a QueryContext', () => {
+            expect(resolveKnownPlaceholder('query.file.path', { query: {} })).toEqual({
+                resolved: false,
+            });
+        });
+    });
+
+    describe('formatting', () => {
+        it('ignores whitespace around placeholder expression', () => {
+            expectResolvedPlaceholderToBe(' query.file.path ', 'root/sub-folder/file containing query.md');
+        });
+    });
+});

--- a/tests/Scripting/ScriptingTestHelpers.ts
+++ b/tests/Scripting/ScriptingTestHelpers.ts
@@ -6,7 +6,7 @@ import { Link } from '../../src/Task/Link';
 import type { Query } from '../../src/Query/Query';
 import { JsInTasksQueriesDisabledError } from '../../src/Scripting/JsInTasksQueriesDisabledError';
 
-export function checkQueryErrorMessage(query: Query, instruction: string): void {
+export function expectQueryErrorToMentionDisabledJavaScript(query: Query, instruction: string): void {
     expect(query.error).toContain(JsInTasksQueriesDisabledError.helpMessage);
     expect(query.error).toContain(instruction);
 }

--- a/tests/Scripting/ScriptingTestHelpers.ts
+++ b/tests/Scripting/ScriptingTestHelpers.ts
@@ -3,6 +3,13 @@ import { TasksDate } from '../../src/DateTime/TasksDate';
 import { TaskRegularExpressions } from '../../src/Task/TaskRegularExpressions';
 import { Task } from '../../src/Task/Task';
 import { Link } from '../../src/Task/Link';
+import type { Query } from '../../src/Query/Query';
+import { JsInTasksQueriesDisabledError } from '../../src/Scripting/JsInTasksQueriesDisabledError';
+
+export function checkQueryErrorMessage(query: Query, instruction: string): void {
+    expect(query.error).toContain(JsInTasksQueriesDisabledError.helpMessage);
+    expect(query.error).toContain(instruction);
+}
 
 export function formatToRepresentType(x: any): string {
     if (typeof x === 'string') {

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,0 +1,7 @@
+import { EnableJsInTasksQueries } from '../src/Config/EnableJsInTasksQueries';
+import { InMemoryLocalStorageProvider } from '../src/Config/InMemoryLocalStorageProvider';
+
+// Tests should default to allowing JavaScript in Tasks queries.
+// Production code initialises this singleton separately in main.ts, using Obsidian local storage.
+EnableJsInTasksQueries.initialise(new InMemoryLocalStorageProvider());
+EnableJsInTasksQueries.getInstance().set(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7142,10 +7142,10 @@ obsidian@1.12.3:
     "@types/codemirror" "5.60.8"
     moment "2.29.4"
 
-obsidian@^1.4.0:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/obsidian/-/obsidian-1.7.2.tgz#2d989288742ae7a65760fd87a953d1ff2a402808"
-  integrity sha512-k9hN9brdknJC+afKr5FQzDRuEFGDKbDjfCazJwpgibwCAoZNYHYV8p/s3mM8I6AsnKrPKNXf8xGuMZ4enWelZQ==
+obsidian@1.8.7:
+  version "1.8.7"
+  resolved "https://registry.yarnpkg.com/obsidian/-/obsidian-1.8.7.tgz#601e9ea1724289effa4c9bb3b4e20d327263634f"
+  integrity sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==
   dependencies:
     "@types/codemirror" "5.60.8"
     moment "2.29.4"


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
  - Issue/discussion: None - reported privately
- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: None - issue reported privately to Tasks maintainer and to Obsidian team
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [x] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

This will be a breaking change, released as **Tasks 8.0.0**.

All Tasks instructions that require running arbitrary user-supplied JavaScript now refuse to run by default.

There is a user setting that explains the risks, links to a new docs page, and allows the user to turn on JS execution in the current vault on the current machine, if they wish.

This required increasing the minimum supported Obsidian version to 1.8.7.

## Motivation and Context

This addresses a report from @eskibars that the `filter|sort|group by function` features could be used maliciously if an attacker were able to add or edit user Tasks searches or settings in some way, such as through direct file sharing or syncing via a Git plugin.

The Obsidian team also pointed out that getting someone to click a malicious [Obsidian URI](https://obsidian.md/help/uri) was another possible attack vector.

After discussion with the Obsidian team, the conclusion was that all Tasks facilities that depend on running user-supplied JavaScript code should be disabled by default, and only allowed to run if the user decides to enable the feature.

Most other plugins use the plugin's `data.json` to control whether JS execution is enabled.

Because that file may be synced, and may be similarly prone to malicious remote enabling of the setting, I instead opted to store the new setting in Obsidian's local storage, so it is enabled "per-vault, per-machine".

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- With extensive Jest tests
- With manual testing in the demo vault
- By adding two new smoke-test files to the vault:
    - `Smoke test JS setting - should work when disabled.md`
    - `Smoke test JS setting - should fail when disabled.md`
## Screenshots (if appropriate)

### Searches that won't run if JS is disabled are reported at query parse-time:

<img width="904" height="202" alt="image" src="https://github.com/user-attachments/assets/2fd38715-9538-41d6-a86e-61388aa040cc" />

### The setting

<img width="734" height="238" alt="image" src="https://github.com/user-attachments/assets/02d085e1-8ce0-436c-a619-a7eeeaae17bc" />


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
