### PR TITLE
feat: add 'hide/show nested backlink' option

### DIFF
--- a/docs/Queries/Backlinks.md
+++ b/docs/Queries/Backlinks.md
@@ -38,8 +38,8 @@ You can click on a backlink to navigate directly to the task's source line.
 You can control backlinks in search results with these query instructions:
 
 - `hide backlink` removes backlinks from all tasks. See [[Layout]].
-- `hide nested backlink` keeps the full backlink on top-level tasks but replaces the repeated
-  backlink on nested tasks (when using `show tree`) with a compact `🔗` link.
+- `hide nested backlink` keeps the full backlink on top-level tasks but hides the repeated
+  backlink on nested tasks (when using `show tree`).
   See [[Layout#Hide and Show Nested Backlink|Nested Backlink]].
 
 ## Support

--- a/docs/Queries/Backlinks.md
+++ b/docs/Queries/Backlinks.md
@@ -33,6 +33,15 @@ You can click on a backlink to navigate directly to the task's source line.
 > [!released]
 > Navigating directly to the task line was introduced in Tasks 3.4.0.
 
+## Hiding and shortening backlinks
+
+You can control backlinks in search results with these query instructions:
+
+- `hide backlink` removes backlinks from all tasks. See [[Layout]].
+- `hide nested backlink` keeps the full backlink on top-level tasks but replaces the repeated
+  backlink on nested tasks (when using `show tree`) with a compact `🔗` link.
+  See [[Layout#Hide and Show Nested Backlink|Nested Backlink]].
+
 ## Support
 
 We use the label `scope: backlinks` to track feedback on backlinks:

--- a/docs/Queries/Backlinks.md
+++ b/docs/Queries/Backlinks.md
@@ -33,13 +33,13 @@ You can click on a backlink to navigate directly to the task's source line.
 > [!released]
 > Navigating directly to the task line was introduced in Tasks 3.4.0.
 
-## Hiding and shortening backlinks
+## Hiding backlinks
 
 You can control backlinks in search results with these query instructions:
 
-- `hide backlink` removes backlinks from all tasks. See [[Layout]].
-- `hide nested backlink` keeps the full backlink on top-level tasks but hides the repeated
-  backlink on nested tasks (when using `show tree`).
+- `hide backlink` removes the backlink from top-level tasks. See [[Layout]].
+- `show nested backlink` shows the backlink on nested tasks too (when using `show tree`).
+  Nested backlinks are hidden by default, to avoid repeating the parent task's filename and heading.
   See [[Layout#Hide and Show Nested Backlink|Nested Backlink]].
 
 ## Support

--- a/docs/Queries/Layout.md
+++ b/docs/Queries/Layout.md
@@ -68,8 +68,8 @@ The following query elements exist:
 | `tree`            | Hidden  | Task parent/child relationships | [[#Hide and Show Tree\|Tree]] |
 | `edit button`     | Shown   | Edit task button                | [[Create or edit Task]]       |
 | `postpone button` | Shown   | Postpone button on dates        | [[Postponing]]                |
-| `backlink`        | Shown   | Task backlink for tasks         | [[Backlinks]]                 |
-| `nested backlink` | Shown   | Backlink on nested tasks        | [[#Hide and Show Nested Backlink\|Nested Backlink]] |
+| `backlink`        | Shown   | Backlink on top-level tasks     | [[Backlinks]]                 |
+| `nested backlink` | Hidden  | Backlink on nested tasks        | [[#Hide and Show Nested Backlink\|Nested Backlink]] |
 | `urgency`         | Hidden  | Task urgency score              | [[Urgency]]                   |
 | `task count`      | Shown   | Total number of tasks           |                               |
 
@@ -80,8 +80,9 @@ The following query elements exist:
 > - `toolbar` was introduced in Tasks 7.23.0.
 > - `nested backlink` was introduced in Tasks X.Y.Z.
 
-All of these query elements except `urgency` and `tree` are shown by default, so you will use the command `hide`
-if you do not want to show any of them, or the command `show` to show the urgency score or tree view.
+All of these query elements except `urgency`, `tree` and `nested backlink` are shown by default, so you will use the
+command `hide` if you do not want to show any of them, or the command `show` to show the urgency score, tree view or
+nested backlinks.
 
 For example:
 
@@ -191,11 +192,11 @@ The `show tree` instruction enables us to see the parent/child relationships in 
 > [!released]
 > `nested backlink` was introduced in Tasks X.Y.Z.
 
-When you use `show tree`, every nested task shows its own [[Backlinks|backlink]], which repeats the
-same filename and heading as its top-level parent task. This can add a lot of repeated text to the results.
+When you use `show tree`, nested tasks can show their own [[Backlinks|backlink]], which repeats the
+same filename and heading as their top-level parent task. This can add a lot of repeated text to the results.
 
-The `hide nested backlink` instruction removes that repetition by **hiding the backlink on nested tasks
-entirely**, whilst the **top-level tasks keep their full backlink**.
+To avoid this repetition, **nested backlinks are hidden by default**, whilst **top-level tasks keep their full
+backlink**. The `show nested backlink` instruction shows the backlink on nested tasks as well:
 
 ````text
 ```tasks
@@ -203,15 +204,18 @@ not done
 filename includes Party Planner
 
 show tree
-hide nested backlink
+show nested backlink
 ```
 ````
 
 > [!Note]
-> `hide nested backlink` only affects nested tasks, so it only has a visible effect together with `show tree`.
+> `nested backlink` only affects nested tasks, so it only has a visible effect together with `show tree`.
 > In the default flat layout there are no nested tasks, so the instruction does nothing.
 >
-> To hide backlinks on **all** tasks, including the top-level ones, use `hide backlink` instead.
+> `backlink` and `nested backlink` are independent:
+>
+> - `backlink` controls the backlink on top-level tasks (shown by default). Use `hide backlink` to hide it.
+> - `nested backlink` controls the backlink on nested tasks (hidden by default). Use `show nested backlink` to show it.
 
 ## Example of show and hide
 

--- a/docs/Queries/Layout.md
+++ b/docs/Queries/Layout.md
@@ -69,7 +69,7 @@ The following query elements exist:
 | `edit button`     | Shown   | Edit task button                | [[Create or edit Task]]       |
 | `postpone button` | Shown   | Postpone button on dates        | [[Postponing]]                |
 | `backlink`        | Shown   | Task backlink for tasks         | [[Backlinks]]                 |
-| `nested backlink` | Shown   | Full backlink on nested tasks   | [[#Hide and Show Nested Backlink\|Nested Backlink]] |
+| `nested backlink` | Shown   | Backlink on nested tasks        | [[#Hide and Show Nested Backlink\|Nested Backlink]] |
 | `urgency`         | Hidden  | Task urgency score              | [[Urgency]]                   |
 | `task count`      | Shown   | Total number of tasks           |                               |
 
@@ -194,9 +194,8 @@ The `show tree` instruction enables us to see the parent/child relationships in 
 When you use `show tree`, every nested task shows its own [[Backlinks|backlink]], which repeats the
 same filename and heading as its top-level parent task. This can add a lot of repeated text to the results.
 
-The `hide nested backlink` instruction removes that repetition: nested tasks are instead given a
-compact `🔗` link to their source line (the same compact link used by [[#Short Mode]]), whilst the
-**top-level tasks keep their full backlink**.
+The `hide nested backlink` instruction removes that repetition by **hiding the backlink on nested tasks
+entirely**, whilst the **top-level tasks keep their full backlink**.
 
 ````text
 ```tasks
@@ -209,11 +208,8 @@ hide nested backlink
 ````
 
 > [!Note]
-> `hide nested backlink` only has a visible effect together with `show tree`.
+> `hide nested backlink` only affects nested tasks, so it only has a visible effect together with `show tree`.
 > In the default flat layout there are no nested tasks, so the instruction does nothing.
->
-> In `short mode` ([[#Short Mode]]), all backlinks are in the `🔗` compact mode, so `hide nested backlink`
-> has no visible effect.
 >
 > To hide backlinks on **all** tasks, including the top-level ones, use `hide backlink` instead.
 

--- a/docs/Queries/Layout.md
+++ b/docs/Queries/Layout.md
@@ -212,6 +212,9 @@ hide nested backlink
 > `hide nested backlink` only has a visible effect together with `show tree`.
 > In the default flat layout there are no nested tasks, so the instruction does nothing.
 >
+> In `short mode` ([[#Short Mode]]), all backlinks are in the `🔗` compact mode, so `hide nested backlink`
+> has no visible effect.
+>
 > To hide backlinks on **all** tasks, including the top-level ones, use `hide backlink` instead.
 
 ## Example of show and hide

--- a/docs/Queries/Layout.md
+++ b/docs/Queries/Layout.md
@@ -69,6 +69,7 @@ The following query elements exist:
 | `edit button`     | Shown   | Edit task button                | [[Create or edit Task]]       |
 | `postpone button` | Shown   | Postpone button on dates        | [[Postponing]]                |
 | `backlink`        | Shown   | Task backlink for tasks         | [[Backlinks]]                 |
+| `nested backlink` | Shown   | Full backlink on nested tasks   | [[#Hide and Show Nested Backlink\|Nested Backlink]] |
 | `urgency`         | Hidden  | Task urgency score              | [[Urgency]]                   |
 | `task count`      | Shown   | Total number of tasks           |                               |
 
@@ -77,6 +78,7 @@ The following query elements exist:
 > - `urgency` was introduced in Tasks 1.14.0.
 > - `tree` was introduced in Tasks 7.12.0.
 > - `toolbar` was introduced in Tasks 7.23.0.
+> - `nested backlink` was introduced in Tasks X.Y.Z.
 
 All of these query elements except `urgency` and `tree` are shown by default, so you will use the command `hide`
 if you do not want to show any of them, or the command `show` to show the urgency score or tree view.
@@ -183,6 +185,34 @@ The `show tree` instruction enables us to see the parent/child relationships in 
   - Child tasks and list items are displayed in the order that they appear in the file. They are not affected by any `sort by` instructions.
 - For now, the **tree layout is turned off by default**, whilst we explore how it should interact with the filtering instructions.
   - We hope to make it the default behaviour in a future release.
+
+### Hide and Show Nested Backlink
+
+> [!released]
+> `nested backlink` was introduced in Tasks X.Y.Z.
+
+When you use `show tree`, every nested task shows its own [[Backlinks|backlink]], which repeats the
+same filename and heading as its top-level parent task. This can add a lot of repeated text to the results.
+
+The `hide nested backlink` instruction removes that repetition: nested tasks are instead given a
+compact `🔗` link to their source line (the same compact link used by [[#Short Mode]]), whilst the
+**top-level tasks keep their full backlink**.
+
+````text
+```tasks
+not done
+filename includes Party Planner
+
+show tree
+hide nested backlink
+```
+````
+
+> [!Note]
+> `hide nested backlink` only has a visible effect together with `show tree`.
+> In the default flat layout there are no nested tasks, so the instruction does nothing.
+>
+> To hide backlinks on **all** tasks, including the top-level ones, use `hide backlink` instead.
 
 ## Example of show and hide
 

--- a/src/Layout/QueryLayoutOptions.ts
+++ b/src/Layout/QueryLayoutOptions.ts
@@ -8,6 +8,7 @@ export class QueryLayoutOptions {
     hidePostponeButton: boolean = false;
     hideTaskCount: boolean = false;
     hideBacklinks: boolean = false;
+    hideNestedBacklinks: boolean = false;
     hideEditButton: boolean = false;
     hideUrgency: boolean = true;
     hideTree: boolean = true;
@@ -28,6 +29,7 @@ export function parseQueryShowHideOptions(queryLayoutOptions: QueryLayoutOptions
         // Alphabetical order
         ['backlink', 'hideBacklinks'],
         ['edit button', 'hideEditButton'],
+        ['nested backlink', 'hideNestedBacklinks'],
         ['postpone button', 'hidePostponeButton'],
         ['task count', 'hideTaskCount'],
         ['toolbar', 'hideToolbar'],

--- a/src/Layout/QueryLayoutOptions.ts
+++ b/src/Layout/QueryLayoutOptions.ts
@@ -8,7 +8,7 @@ export class QueryLayoutOptions {
     hidePostponeButton: boolean = false;
     hideTaskCount: boolean = false;
     hideBacklinks: boolean = false;
-    hideNestedBacklinks: boolean = false;
+    hideNestedBacklinks: boolean = true;
     hideEditButton: boolean = false;
     hideUrgency: boolean = true;
     hideTree: boolean = true;

--- a/src/Renderer/HtmlQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlQueryResultsRenderer.ts
@@ -176,7 +176,11 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
         const shortMode = this.query.queryLayoutOptions.shortMode;
 
         if (!this.query.queryLayoutOptions.hideBacklinks) {
-            this.addBacklinks(extrasSpan, task, shortMode, isFilenameUnique);
+            // Nested tasks always have the same backlink as their top-level parent, so when
+            // 'hide nested backlink' is set we render them with the compact 🔗 link (as in short mode).
+            const isNested = this.nestingLevel > 0;
+            const useShortBacklink = shortMode || (this.query.queryLayoutOptions.hideNestedBacklinks && isNested);
+            this.addBacklinks(extrasSpan, task, useShortBacklink, isFilenameUnique);
         }
 
         if (!this.query.queryLayoutOptions.hideEditButton) {

--- a/src/Renderer/HtmlQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlQueryResultsRenderer.ts
@@ -175,12 +175,10 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
 
         const shortMode = this.query.queryLayoutOptions.shortMode;
 
-        // hide backlink when `hide backlinks` is set
-        // or when `hide nested backlinks` is set and the task is nested
         const isNested = this.nestingLevel > 0;
         const hideBacklink =
-            this.query.queryLayoutOptions.hideBacklinks ||
-            (this.query.queryLayoutOptions.hideNestedBacklinks && isNested);
+            (isNested && this.query.queryLayoutOptions.hideNestedBacklinks) ||
+            (!isNested && this.query.queryLayoutOptions.hideBacklinks);
 
         if (!hideBacklink) {
             this.addBacklinks(extrasSpan, task, shortMode, isFilenameUnique);

--- a/src/Renderer/HtmlQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlQueryResultsRenderer.ts
@@ -175,12 +175,15 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
 
         const shortMode = this.query.queryLayoutOptions.shortMode;
 
-        if (!this.query.queryLayoutOptions.hideBacklinks) {
-            // Nested tasks always have the same backlink as their top-level parent, so when
-            // 'hide nested backlink' is set we render them with the compact 🔗 link (as in short mode).
-            const isNested = this.nestingLevel > 0;
-            const useShortBacklink = shortMode || (this.query.queryLayoutOptions.hideNestedBacklinks && isNested);
-            this.addBacklinks(extrasSpan, task, useShortBacklink, isFilenameUnique);
+        // hide backlink when `hide backlinks` is set
+        // or when `hide nested backlinks` is set and the task is nested
+        const isNested = this.nestingLevel > 0;
+        const hideBacklink =
+            this.query.queryLayoutOptions.hideBacklinks ||
+            (this.query.queryLayoutOptions.hideNestedBacklinks && isNested);
+
+        if (!hideBacklink) {
+            this.addBacklinks(extrasSpan, task, shortMode, isFilenameUnique);
         }
 
         if (!this.query.queryLayoutOptions.hideEditButton) {

--- a/src/Renderer/QueryResultsRendererBase.ts
+++ b/src/Renderer/QueryResultsRendererBase.ts
@@ -17,6 +17,12 @@ export abstract class QueryResultsRendererBase {
 
     protected readonly addedListItems: Set<ListItem> = new Set<ListItem>();
 
+    /**
+     * The current depth in the rendered task tree: 0 for top-level (outermost) tasks,
+     * and 1 or more for tasks rendered recursively as children. See {@link addChildren}.
+     */
+    protected nestingLevel = 0;
+
     protected constructor(source: string, tasksFile: TasksFile, query: IQuery) {
         this.source = source;
         this.tasksFile = tasksFile;
@@ -104,6 +110,7 @@ export abstract class QueryResultsRendererBase {
             await this.addGroupHeadings(group.groupHeadings);
 
             this.addedListItems.clear();
+            this.nestingLevel = 0;
             await this.addTaskList(group.tasks);
         }
     }
@@ -215,7 +222,12 @@ export abstract class QueryResultsRendererBase {
 
     private async addChildren(children: ListItem[]) {
         if (children.length > 0) {
-            await this.addTaskList(children);
+            this.nestingLevel += 1;
+            try {
+                await this.addTaskList(children);
+            } finally {
+                this.nestingLevel -= 1;
+            }
         }
     }
 

--- a/tests/Layout/QueryLayoutOptions.test.ts
+++ b/tests/Layout/QueryLayoutOptions.test.ts
@@ -10,7 +10,7 @@ describe('parsing query show/hide layout options', () => {
         // Alphabetical order
         ['backlink', 'hideBacklinks', false],
         ['edit button', 'hideEditButton', false],
-        ['nested backlink', 'hideNestedBacklinks', false],
+        ['nested backlink', 'hideNestedBacklinks', true],
         ['postpone button', 'hidePostponeButton', false],
         ['task count', 'hideTaskCount', false],
         ['toolbar', 'hideToolbar', false],

--- a/tests/Layout/QueryLayoutOptions.test.ts
+++ b/tests/Layout/QueryLayoutOptions.test.ts
@@ -10,6 +10,7 @@ describe('parsing query show/hide layout options', () => {
         // Alphabetical order
         ['backlink', 'hideBacklinks', false],
         ['edit button', 'hideEditButton', false],
+        ['nested backlink', 'hideNestedBacklinks', false],
         ['postpone button', 'hidePostponeButton', false],
         ['task count', 'hideTaskCount', false],
         ['toolbar', 'hideToolbar', false],

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_hide_nested_backlinks_-_flat_is_a_no-op.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_hide_nested_backlinks_-_flat_is_a_no-op.approved.html
@@ -1,0 +1,146 @@
+<!--
+- [ ] #task parent task
+    - [ ] #task child task 1
+        - [ ] #task grandchild 1
+    - [ ] #task child task 2
+        - [ ] #task grandchild 2
+- [ ] #task sibling
+-->
+
+<div>
+  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="0"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>#task parent task</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">
+            inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+          </a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="1"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="1" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>#task child task 1</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">
+            inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+          </a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="2"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="2" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>#task grandchild 1</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">
+            inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+          </a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="3"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="3" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>#task child task 2</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">
+            inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+          </a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="4"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="4" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>#task grandchild 2</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">
+            inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+          </a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="5"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="5" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>#task sibling</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">
+            inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+          </a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
+  </ul>
+  <div class="task-count">6 tasks</div>
+</div>

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_hide_nested_backlinks_-_tree.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_hide_nested_backlinks_-_tree.approved.html
@@ -42,12 +42,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>#task child task 1</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              <a rel="noopener" target="_blank" class="internal-link internal-link-short-mode">🔗</a>
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li
               class="task-list-item plugin-tasks-list-item"
@@ -60,12 +55,7 @@
               <span class="tasks-list-text">
                 <span class="task-description"><span>#task grandchild 1</span></span>
               </span>
-              <span class="task-extras">
-                <span class="tasks-backlink">
-                  <a rel="noopener" target="_blank" class="internal-link internal-link-short-mode">🔗</a>
-                </span>
-                <a class="tasks-edit" title="Edit task" href="#"></a>
-              </span>
+              <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
             </li>
           </ul>
         </li>
@@ -80,12 +70,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>#task child task 2</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              <a rel="noopener" target="_blank" class="internal-link internal-link-short-mode">🔗</a>
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li
               class="task-list-item plugin-tasks-list-item"
@@ -98,12 +83,7 @@
               <span class="tasks-list-text">
                 <span class="task-description"><span>#task grandchild 2</span></span>
               </span>
-              <span class="task-extras">
-                <span class="tasks-backlink">
-                  <a rel="noopener" target="_blank" class="internal-link internal-link-short-mode">🔗</a>
-                </span>
-                <a class="tasks-edit" title="Edit task" href="#"></a>
-              </span>
+              <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
             </li>
           </ul>
         </li>

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_hide_nested_backlinks_-_tree.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_hide_nested_backlinks_-_tree.approved.html
@@ -1,0 +1,136 @@
+<!--
+- [ ] #task parent task
+    - [ ] #task child task 1
+        - [ ] #task grandchild 1
+    - [ ] #task child task 2
+        - [ ] #task grandchild 2
+- [ ] #task sibling
+-->
+
+<div>
+  <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="0"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>#task parent task</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">
+            inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+          </a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="normal"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>#task child task 1</span></span>
+          </span>
+          <span class="task-extras">
+            <span class="tasks-backlink">
+              <a rel="noopener" target="_blank" class="internal-link internal-link-short-mode">🔗</a>
+            </span>
+            <a class="tasks-edit" title="Edit task" href="#"></a>
+          </span>
+          <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+            <li
+              class="task-list-item plugin-tasks-list-item"
+              data-task-priority="normal"
+              data-task=""
+              data-line="0"
+              data-task-status-name="Todo"
+              data-task-status-type="TODO">
+              <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+              <span class="tasks-list-text">
+                <span class="task-description"><span>#task grandchild 1</span></span>
+              </span>
+              <span class="task-extras">
+                <span class="tasks-backlink">
+                  <a rel="noopener" target="_blank" class="internal-link internal-link-short-mode">🔗</a>
+                </span>
+                <a class="tasks-edit" title="Edit task" href="#"></a>
+              </span>
+            </li>
+          </ul>
+        </li>
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="normal"
+          data-task=""
+          data-line="1"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="1" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>#task child task 2</span></span>
+          </span>
+          <span class="task-extras">
+            <span class="tasks-backlink">
+              <a rel="noopener" target="_blank" class="internal-link internal-link-short-mode">🔗</a>
+            </span>
+            <a class="tasks-edit" title="Edit task" href="#"></a>
+          </span>
+          <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+            <li
+              class="task-list-item plugin-tasks-list-item"
+              data-task-priority="normal"
+              data-task=""
+              data-line="0"
+              data-task-status-name="Todo"
+              data-task-status-type="TODO">
+              <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="0" />
+              <span class="tasks-list-text">
+                <span class="task-description"><span>#task grandchild 2</span></span>
+              </span>
+              <span class="task-extras">
+                <span class="tasks-backlink">
+                  <a rel="noopener" target="_blank" class="internal-link internal-link-short-mode">🔗</a>
+                </span>
+                <a class="tasks-edit" title="Edit task" href="#"></a>
+              </span>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="5"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="5" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>#task sibling</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">
+            inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+          </a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
+  </ul>
+  <div class="task-count">6 tasks</div>
+</div>

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_parent-child_items.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_parent-child_items.approved.html
@@ -40,14 +40,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>child 1</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              (
-              <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-              )
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li
               class="task-list-item plugin-tasks-list-item"
@@ -60,14 +53,7 @@
               <span class="tasks-list-text">
                 <span class="task-description"><span>grandchild 1</span></span>
               </span>
-              <span class="task-extras">
-                <span class="tasks-backlink">
-                  (
-                  <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-                  )
-                </span>
-                <a class="tasks-edit" title="Edit task" href="#"></a>
-              </span>
+              <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
               <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
                 <li><span>list item grand grand child</span></li>
               </ul>
@@ -85,14 +71,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>child 2</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              (
-              <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-              )
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li>
               <span>non task grandchild</span>
@@ -112,14 +91,7 @@
                   <span class="tasks-list-text">
                     <span class="task-description"><span>grand grand child</span></span>
                   </span>
-                  <span class="task-extras">
-                    <span class="tasks-backlink">
-                      (
-                      <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-                      )
-                    </span>
-                    <a class="tasks-edit" title="Edit task" href="#"></a>
-                  </span>
+                  <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
                 </li>
               </ul>
             </li>

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_parent-child_items_reverse_sorted.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_parent-child_items_reverse_sorted.approved.html
@@ -60,14 +60,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>child 1</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              (
-              <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-              )
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li
               class="task-list-item plugin-tasks-list-item"
@@ -80,14 +73,7 @@
               <span class="tasks-list-text">
                 <span class="task-description"><span>grandchild 1</span></span>
               </span>
-              <span class="task-extras">
-                <span class="tasks-backlink">
-                  (
-                  <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-                  )
-                </span>
-                <a class="tasks-edit" title="Edit task" href="#"></a>
-              </span>
+              <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
               <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
                 <li><span>list item grand grand child</span></li>
               </ul>
@@ -105,14 +91,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>child 2</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              (
-              <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-              )
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li>
               <span>non task grandchild</span>
@@ -132,14 +111,7 @@
                   <span class="tasks-list-text">
                     <span class="task-description"><span>grand grand child</span></span>
                   </span>
-                  <span class="task-extras">
-                    <span class="tasks-backlink">
-                      (
-                      <a rel="noopener" target="_blank" class="internal-link">inheritance_rendering_sample</a>
-                      )
-                    </span>
-                    <a class="tasks-edit" title="Edit task" href="#"></a>
-                  </span>
+                  <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
                 </li>
               </ul>
             </li>

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_should_indent_nested_tasks.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_should_indent_nested_tasks.approved.html
@@ -42,16 +42,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>#task child task 1</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              (
-              <a rel="noopener" target="_blank" class="internal-link">
-                inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
-              </a>
-              )
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li
               class="task-list-item plugin-tasks-list-item"
@@ -64,16 +55,7 @@
               <span class="tasks-list-text">
                 <span class="task-description"><span>#task grandchild 1</span></span>
               </span>
-              <span class="task-extras">
-                <span class="tasks-backlink">
-                  (
-                  <a rel="noopener" target="_blank" class="internal-link">
-                    inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
-                  </a>
-                  )
-                </span>
-                <a class="tasks-edit" title="Edit task" href="#"></a>
-              </span>
+              <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
             </li>
           </ul>
         </li>
@@ -88,16 +70,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>#task child task 2</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              (
-              <a rel="noopener" target="_blank" class="internal-link">
-                inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
-              </a>
-              )
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li
               class="task-list-item plugin-tasks-list-item"
@@ -110,16 +83,7 @@
               <span class="tasks-list-text">
                 <span class="task-description"><span>#task grandchild 2</span></span>
               </span>
-              <span class="task-extras">
-                <span class="tasks-backlink">
-                  (
-                  <a rel="noopener" target="_blank" class="internal-link">
-                    inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
-                  </a>
-                  )
-                </span>
-                <a class="tasks-edit" title="Edit task" href="#"></a>
-              </span>
+              <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
             </li>
           </ul>
         </li>

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_should_render_grandchildren_once_and_on_the_same_level_as_parent.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_should_render_grandchildren_once_and_on_the_same_level_as_parent.approved.html
@@ -80,16 +80,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>#task child task 1</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              (
-              <a rel="noopener" target="_blank" class="internal-link">
-                inheritance_1parent2children2grandchildren1sibling
-              </a>
-              )
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency"></ul>
         </li>
         <li
@@ -103,16 +94,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>#task child task 2</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              (
-              <a rel="noopener" target="_blank" class="internal-link">
-                inheritance_1parent2children2grandchildren1sibling
-              </a>
-              )
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency"></ul>
         </li>
       </ul>

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_should_render_non_task_check_box_when_global_filter_is_enabled.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_should_render_non_task_check_box_when_global_filter_is_enabled.approved.html
@@ -36,14 +36,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>#task task child</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              (
-              <a rel="noopener" target="_blank" class="internal-link">inheritance_non_task_child</a>
-              )
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
         </li>
         <li class="task-list-item" data-task="" data-line="1">
           <input class="task-list-item-checkbox" type="checkbox" />

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_show_nested_backlinks_-_tree.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.HtmlQueryResultsRenderer_tests_show_nested_backlinks_-_tree.approved.html
@@ -23,7 +23,9 @@
       <span class="task-extras">
         <span class="tasks-backlink">
           (
-          <a rel="noopener" target="_blank" class="internal-link">inheritance_1parent2children2grandchildren1sibling</a>
+          <a rel="noopener" target="_blank" class="internal-link">
+            inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+          </a>
           )
         </span>
         <a class="tasks-edit" title="Edit task" href="#"></a>
@@ -40,7 +42,16 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>#task child task 1</span></span>
           </span>
-          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
+          <span class="task-extras">
+            <span class="tasks-backlink">
+              (
+              <a rel="noopener" target="_blank" class="internal-link">
+                inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+              </a>
+              )
+            </span>
+            <a class="tasks-edit" title="Edit task" href="#"></a>
+          </span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li
               class="task-list-item plugin-tasks-list-item"
@@ -53,7 +64,16 @@
               <span class="tasks-list-text">
                 <span class="task-description"><span>#task grandchild 1</span></span>
               </span>
-              <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
+              <span class="task-extras">
+                <span class="tasks-backlink">
+                  (
+                  <a rel="noopener" target="_blank" class="internal-link">
+                    inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+                  </a>
+                  )
+                </span>
+                <a class="tasks-edit" title="Edit task" href="#"></a>
+              </span>
             </li>
           </ul>
         </li>
@@ -68,7 +88,16 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>#task child task 2</span></span>
           </span>
-          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
+          <span class="task-extras">
+            <span class="tasks-backlink">
+              (
+              <a rel="noopener" target="_blank" class="internal-link">
+                inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+              </a>
+              )
+            </span>
+            <a class="tasks-edit" title="Edit task" href="#"></a>
+          </span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li
               class="task-list-item plugin-tasks-list-item"
@@ -81,12 +110,43 @@
               <span class="tasks-list-text">
                 <span class="task-description"><span>#task grandchild 2</span></span>
               </span>
-              <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
+              <span class="task-extras">
+                <span class="tasks-backlink">
+                  (
+                  <a rel="noopener" target="_blank" class="internal-link">
+                    inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+                  </a>
+                  )
+                </span>
+                <a class="tasks-edit" title="Edit task" href="#"></a>
+              </span>
             </li>
           </ul>
         </li>
       </ul>
     </li>
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="5"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" title="Right-click for options" data-line="5" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>#task sibling</span></span>
+      </span>
+      <span class="task-extras">
+        <span class="tasks-backlink">
+          (
+          <a rel="noopener" target="_blank" class="internal-link">
+            inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
+          </a>
+          )
+        </span>
+        <a class="tasks-edit" title="Edit task" href="#"></a>
+      </span>
+    </li>
   </ul>
-  <div class="task-count">3 tasks</div>
+  <div class="task-count">6 tasks</div>
 </div>

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.Reusing_HtmlQueryResultsRenderer_should_render_the_same_thing_twice_-_tree.approved.html
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.Reusing_HtmlQueryResultsRenderer_should_render_the_same_thing_twice_-_tree.approved.html
@@ -42,16 +42,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>#task child task 1</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              (
-              <a rel="noopener" target="_blank" class="internal-link">
-                inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
-              </a>
-              )
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li
               class="task-list-item plugin-tasks-list-item"
@@ -64,16 +55,7 @@
               <span class="tasks-list-text">
                 <span class="task-description"><span>#task grandchild 1</span></span>
               </span>
-              <span class="task-extras">
-                <span class="tasks-backlink">
-                  (
-                  <a rel="noopener" target="_blank" class="internal-link">
-                    inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
-                  </a>
-                  )
-                </span>
-                <a class="tasks-edit" title="Edit task" href="#"></a>
-              </span>
+              <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
             </li>
           </ul>
         </li>
@@ -88,16 +70,7 @@
           <span class="tasks-list-text">
             <span class="task-description"><span>#task child task 2</span></span>
           </span>
-          <span class="task-extras">
-            <span class="tasks-backlink">
-              (
-              <a rel="noopener" target="_blank" class="internal-link">
-                inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
-              </a>
-              )
-            </span>
-            <a class="tasks-edit" title="Edit task" href="#"></a>
-          </span>
+          <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
           <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
             <li
               class="task-list-item plugin-tasks-list-item"
@@ -110,16 +83,7 @@
               <span class="tasks-list-text">
                 <span class="task-description"><span>#task grandchild 2</span></span>
               </span>
-              <span class="task-extras">
-                <span class="tasks-backlink">
-                  (
-                  <a rel="noopener" target="_blank" class="internal-link">
-                    inheritance_1parent2children2grandchildren1sibling_start_with_heading &gt; Test heading
-                  </a>
-                  )
-                </span>
-                <a class="tasks-edit" title="Edit task" href="#"></a>
-              </span>
+              <span class="task-extras"><a class="tasks-edit" title="Edit task" href="#"></a></span>
             </li>
           </ul>
         </li>

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.ts
@@ -181,7 +181,7 @@ group by function 'level4'
 
     it('hide nested backlinks - tree', async () => {
         // Top-level tasks (parent and sibling) keep their full backlink,
-        // while every nested task is rendered with the compact 🔗 link instead.
+        // while every nested task has its backlink hidden entirely.
         const allTasks = readTasksFromSimulatedFile(
             'inheritance_1parent2children2grandchildren1sibling_start_with_heading',
         );

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.ts
@@ -188,6 +188,14 @@ group by function 'level4'
         await verifyRenderedHtml(allTasks, showTree + 'hide nested backlink\nsort by function task.lineNumber');
     });
 
+    it('show nested backlinks - tree', async () => {
+        // With 'show nested backlink', nested tasks render their full backlink too (not just top-level).
+        const allTasks = readTasksFromSimulatedFile(
+            'inheritance_1parent2children2grandchildren1sibling_start_with_heading',
+        );
+        await verifyRenderedHtml(allTasks, showTree + 'show nested backlink\nsort by function task.lineNumber');
+    });
+
     it('hide nested backlinks - flat is a no-op', async () => {
         // Without 'show tree' there are no nested tasks, so 'hide nested backlink' changes nothing:
         // all tasks keep their full backlink.

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.ts
@@ -179,6 +179,24 @@ group by function 'level4'
         await verifyRenderedHtml(allTasks, 'show tree');
     });
 
+    it('hide nested backlinks - tree', async () => {
+        // Top-level tasks (parent and sibling) keep their full backlink,
+        // while every nested task is rendered with the compact 🔗 link instead.
+        const allTasks = readTasksFromSimulatedFile(
+            'inheritance_1parent2children2grandchildren1sibling_start_with_heading',
+        );
+        await verifyRenderedHtml(allTasks, showTree + 'hide nested backlink\nsort by function task.lineNumber');
+    });
+
+    it('hide nested backlinks - flat is a no-op', async () => {
+        // Without 'show tree' there are no nested tasks, so 'hide nested backlink' changes nothing:
+        // all tasks keep their full backlink.
+        const allTasks = readTasksFromSimulatedFile(
+            'inheritance_1parent2children2grandchildren1sibling_start_with_heading',
+        );
+        await verifyRenderedHtml(allTasks, hideTree + 'hide nested backlink\nsort by function task.lineNumber');
+    });
+
     it('should render grandchildren once under the parent', async () => {
         const allTasks = readTasksFromSimulatedFile('inheritance_1parent2children2grandchildren1sibling');
         await verifyRenderedHtml(


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3515

## Description

Adds a new opt-in query layout instructions: **`hide nested backlink` and `show nested backlink`** (default is show - to not change existing queries).

When a query uses `show tree`, every nested (child/grandchild) task currently repeats the full
backlink (`(filename > heading)`) of its top-level parent. With `hide nested backlink`, nested tasks
instead render the compact `🔗` link to their own source line — the same compact link already used by
`short mode` — while **top-level tasks keep their full backlink unchanged**. The instruction has no
effect without `show tree`.

Implementation:

- `src/Layout/QueryLayoutOptions.ts` — new `hideNestedBacklinks` field and a `'nested backlink'`
  entry in `parseQueryShowHideOptions`.
- `src/Renderer/QueryResultsRendererBase.ts` — track render-tree depth with a `nestingLevel`
  counter, incremented/decremented around the child recursion in `addChildren()` and reset per group.
    - Note: new `nestingLevel` needs to be used rather than the existing `task.isRoot`, because a matched task nested under a non-matching parent renders at the top of the tree yet has a non-null `parent` - see screenshot at the bottom, `child 2` task)
- `src/Renderer/HtmlQueryResultsRenderer.ts` — in `addTask()`, render the backlink in compact mode
  when `hideNestedBacklinks` is set and `nestingLevel > 0`. This reuses the existing
  `addBacklinks(..., shortMode = true, ...)` path, so the `🔗` markup and click/mousedown handlers
  are unchanged.

## Motivation and Context

In `show tree` results, the backlink on a nested task is always identical to its parent's, so
repeating the full path is redundant. Short link is used instead to allow going directly to child tasks easily.

https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3515

Note: The initial proposal states to remove the backlinks entirely for children. I think adding the short link keeps minimal changes in the code while being useful (link directly to the child task in the source file).

## How has this been tested?

- Two new approval tests verify the rendered HTML:
    - `hide nested backlinks - tree` - top-level parent and sibling keep the full `(filename > heading)` backlink. Every nested task renders `<a class="internal link internal-link-short-mode">🔗</a>`
    - `hide nested backlinks - flat is a no-op` - without `show tree` the `hide nested backlinks` option is a no-op.


## Screenshots (if appropriate)

Following screenshow shows the behavior with the following task query:
```tasks
happens on or before 2026-01-02
group by happens
hide toolbar
show tree
hide nested backlinks
```

<img width="966" height="1018" alt="Screenshot From 2026-05-30 11-19-17" src="https://github.com/user-attachments/assets/0b6eaa59-082e-4bfe-8b39-6541e31cb819" />


## AI disclosure

I have created this PR with the help of AI (claude code, Opus4.8). I manually went through the generated code, understood it and made changes.