### PR TITLE
tests: Improve i18n tests, with finer granularity

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,7 @@ module.exports = {
     setupFilesAfterEnv: [
         '<rootDir>/tests/jest.setup.ts',
         '<rootDir>/tests/CustomMatchers/jest.custom_matchers.setup.ts',
+        'jest-sorted',
     ],
     globalSetup: './tests/global-setup.js',
 };

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "i18next-parser": "^9.1.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.2.0",
+    "jest-sorted": "^1.0.15",
     "madge": "^8.0.0",
     "markdownlint-cli2": "^0.21.0",
     "moment": "^2.29.4",

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,5 +1,7 @@
 import i18next from 'i18next';
 import { getLanguage } from 'obsidian';
+
+// alphabetical order:
 import be from './locales/be.json';
 import de from './locales/de.json';
 import en from './locales/en.json';

--- a/tests/CustomMatchers/CustomMatchersForSorting.ts
+++ b/tests/CustomMatchers/CustomMatchersForSorting.ts
@@ -9,6 +9,7 @@ import { TasksFile } from '../../src/Scripting/TasksFile';
 declare global {
     namespace jest {
         interface Matchers<R> {
+            toBeSorted(): R; // see https://www.npmjs.com/package/jest-sorted
             toGiveCompareToResult(expected: number): R;
             toCompareTasksWithResult(expected: number): R;
         }

--- a/tests/CustomMatchers/jest.custom_matchers.setup.ts
+++ b/tests/CustomMatchers/jest.custom_matchers.setup.ts
@@ -68,6 +68,11 @@ expect.extend({
 });
 
 // ---------------------------------------------------------------------
+// CustomMatchersForSorting
+// ---------------------------------------------------------------------
+import './CustomMatchersForSorting';
+
+// ---------------------------------------------------------------------
 // CustomMatchersForTaskBuilder
 // ---------------------------------------------------------------------
 import { toBeIdenticalTo } from './CustomMatchersForTaskBuilder';

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-function readI18nJsonImports(): string[] {
+function readI18nJsonImports(): Readonly<string[]> {
     // Find the names of JSON locale files imported by the plugin:
     const i18nSource = fs.readFileSync(path.resolve(__dirname, '../../src/i18n/i18n.ts'), 'utf-8');
     return [...i18nSource.matchAll(/^import\s+\w+\s+from\s+'.*\/(\w+)\.json'/gm)].map((m) => m[1]);

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import i18next from 'i18next';
 import { initializeI18n } from '../../src/i18n/i18n';
 
 function readI18nJsonImports(): Readonly<string[]> {
@@ -24,6 +25,15 @@ describe('i18n locale consistency', () => {
 
     it('"i18n.ts" should list Json imports in alphabetical order', () => {
         expect(i18nImports).toEqual([...i18nImports].sort());
+    });
+
+    it('"i18n.ts" should list resources imports in alphabetical order', () => {
+        // initializeI18n() must have been called before accessing i18next.store.data
+        // In Jest, beforeAll() runs after the describe() callback body has been evaluated,
+        // but before the tests inside that 'describe' are executed.
+        // This means we have to get the i18next keys inside an 'it' block.
+        const i18nResourceNames = Object.keys(i18next.store.data);
+        expect(i18nResourceNames).toEqual([...i18nResourceNames].sort());
     });
 
     it('"i18next-parser.config.js" should list locales in alphabetical order', () => {

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -7,7 +7,7 @@ function readI18nJsonImports(): Readonly<string[]> {
     return [...i18nSource.matchAll(/^import\s+\w+\s+from\s+'.*\/(\w+)\.json'/gm)].map((m) => m[1]);
 }
 
-function getI18nextParserLocales(): any {
+function getI18nextParserLocales(): Readonly<string[]> {
     // Find the locales used by 'yarn extract-i18n'
     const parserConfig = require('../../i18next-parser.config.js');
     return parserConfig.locales;

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -35,12 +35,14 @@ describe('i18n locale consistency', () => {
     const i18nImports = readI18nJsonImports();
     const parserLocales = getI18nextParserLocales();
 
-    it('"i18n.ts" should list Json imports in alphabetical order', () => {
-        expect(i18nImports).toBeSorted();
-    });
+    describe('"i18n.ts" imports', () => {
+        it('should list Json imports in alphabetical order', () => {
+            expect(i18nImports).toBeSorted();
+        });
 
-    it('"i18n.ts" should should import all JSON files', () => {
-        expect(i18nImports).toEqual(allJsonLocaleFileBaseNames);
+        it('should should import all JSON files', () => {
+            expect(i18nImports).toEqual(allJsonLocaleFileBaseNames);
+        });
     });
 
     it('"i18n.ts" should list resources imports in alphabetical order', () => {

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -15,8 +15,10 @@ function getI18nextParserLocales(): Readonly<string[]> {
     return parserConfig.locales;
 }
 
+let i18nResourceNames: ReadonlyArray<string>;
 beforeAll(async () => {
     await initializeI18n();
+    i18nResourceNames = Object.keys(i18next.store.data);
 });
 
 describe('i18n locale consistency', () => {
@@ -28,11 +30,6 @@ describe('i18n locale consistency', () => {
     });
 
     it('"i18n.ts" should list resources imports in alphabetical order', () => {
-        // initializeI18n() must have been called before accessing i18next.store.data
-        // In Jest, beforeAll() runs after the describe() callback body has been evaluated,
-        // but before the tests inside that 'describe' are executed.
-        // This means we have to get the i18next keys inside an 'it' block.
-        const i18nResourceNames = Object.keys(i18next.store.data);
         expect(i18nResourceNames).toEqual([...i18nResourceNames].sort());
     });
 

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -59,11 +59,13 @@ describe('i18n locale consistency', () => {
         });
     });
 
-    it('"i18next-parser.config.js" should list locales in alphabetical order', () => {
-        expect(parserLocales).toBeSorted();
-    });
+    describe('"i18next-parser.config.js"', () => {
+        it('should list locales in alphabetical order', () => {
+            expect(parserLocales).toBeSorted();
+        });
 
-    it('"i18next-parser.config.js" should reference all JSON files', () => {
-        expect(parserLocales).toEqual(allJsonLocaleFileBaseNames);
+        it('should reference all JSON files', () => {
+            expect(parserLocales).toEqual(allJsonLocaleFileBaseNames);
+        });
     });
 });

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -3,6 +3,15 @@ import * as path from 'node:path';
 import i18next from 'i18next';
 import { initializeI18n } from '../../src/i18n/i18n';
 
+function getAllLocaleJsonFileBaseNames(): string[] {
+    const localesDir = path.resolve(__dirname, '../../src/i18n/locales');
+    return fs
+        .readdirSync(localesDir)
+        .filter((file) => file.endsWith('.json'))
+        .sort()
+        .map((file) => file.replace('.json', ''));
+}
+
 function readI18nJsonImports(): Readonly<string[]> {
     // Find the names of JSON locale files imported by the plugin:
     const i18nSource = fs.readFileSync(path.resolve(__dirname, '../../src/i18n/i18n.ts'), 'utf-8');
@@ -22,6 +31,7 @@ beforeAll(async () => {
 });
 
 describe('i18n locale consistency', () => {
+    const allJsonLocaleFileBaseNames = getAllLocaleJsonFileBaseNames();
     const i18nImports = readI18nJsonImports();
     const parserLocales = getI18nextParserLocales();
 
@@ -29,12 +39,28 @@ describe('i18n locale consistency', () => {
         expect(i18nImports).toBeSorted();
     });
 
+    it('"i18n.ts" should should import all JSON files', () => {
+        expect(i18nImports).toEqual(allJsonLocaleFileBaseNames);
+    });
+
     it('"i18n.ts" should list resources imports in alphabetical order', () => {
         expect(i18nResourceNames).toBeSorted();
     });
 
+    it('"i18n.ts" resources should reference all JSON files', () => {
+        // The resource names may differ from the JSON file names:
+        //     "pt_br" vs "pt-BR"
+        //     "zh_cn" vs "zh"
+        // So we just check the number of entries, rather than the string values:
+        expect(i18nResourceNames.length).toEqual(allJsonLocaleFileBaseNames.length);
+    });
+
     it('"i18next-parser.config.js" should list locales in alphabetical order', () => {
         expect(parserLocales).toBeSorted();
+    });
+
+    it('"i18next-parser.config.js" should reference all JSON files', () => {
+        expect(parserLocales).toEqual(allJsonLocaleFileBaseNames);
     });
 
     it('should have the same locales in i18n.ts and i18next-parser.config.js', () => {

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -45,16 +45,18 @@ describe('i18n locale consistency', () => {
         });
     });
 
-    it('"i18n.ts" should list resources imports in alphabetical order', () => {
-        expect(i18nResourceNames).toBeSorted();
-    });
+    describe('"i18n.ts" resources', () => {
+        it('should list resources imports in alphabetical order', () => {
+            expect(i18nResourceNames).toBeSorted();
+        });
 
-    it('"i18n.ts" resources should reference all JSON files', () => {
-        // The resource names may differ from the JSON file names:
-        //     "pt_br" vs "pt-BR"
-        //     "zh_cn" vs "zh"
-        // So we just check the number of entries, rather than the string values:
-        expect(i18nResourceNames.length).toEqual(allJsonLocaleFileBaseNames.length);
+        it('resources should reference all JSON files', () => {
+            // The resource names may differ from the JSON file names:
+            //     "pt_br" vs "pt-BR"
+            //     "zh_cn" vs "zh"
+            // So we just check the number of entries, rather than the string values:
+            expect(i18nResourceNames.length).toEqual(allJsonLocaleFileBaseNames.length);
+        });
     });
 
     it('"i18next-parser.config.js" should list locales in alphabetical order', () => {

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -18,7 +18,7 @@ function getI18nextParserLocales(): Readonly<string[]> {
 let i18nResourceNames: ReadonlyArray<string>;
 beforeAll(async () => {
     await initializeI18n();
-    i18nResourceNames = Object.keys(i18next.store.data);
+    i18nResourceNames = Object.freeze(Object.keys(i18next.store.data));
 });
 
 describe('i18n locale consistency', () => {

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -21,6 +21,10 @@ describe('i18n locale consistency', () => {
         expect(i18nImports).toEqual([...i18nImports].sort());
     });
 
+    it('"i18next-parser.config.js" should list locales in alphabetical order', () => {
+        expect(parserLocales).toEqual([...parserLocales].sort());
+    });
+
     it('should have the same locales in i18n.ts and i18next-parser.config.js', () => {
         expect(parserLocales).toEqual(i18nImports);
     });

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -26,15 +26,15 @@ describe('i18n locale consistency', () => {
     const parserLocales = getI18nextParserLocales();
 
     it('"i18n.ts" should list Json imports in alphabetical order', () => {
-        expect(i18nImports).toEqual([...i18nImports].sort());
+        expect(i18nImports).toBeSorted();
     });
 
     it('"i18n.ts" should list resources imports in alphabetical order', () => {
-        expect(i18nResourceNames).toEqual([...i18nResourceNames].sort());
+        expect(i18nResourceNames).toBeSorted();
     });
 
     it('"i18next-parser.config.js" should list locales in alphabetical order', () => {
-        expect(parserLocales).toEqual([...parserLocales].sort());
+        expect(parserLocales).toBeSorted();
     });
 
     it('should have the same locales in i18n.ts and i18next-parser.config.js', () => {

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -62,8 +62,4 @@ describe('i18n locale consistency', () => {
     it('"i18next-parser.config.js" should reference all JSON files', () => {
         expect(parserLocales).toEqual(allJsonLocaleFileBaseNames);
     });
-
-    it('should have the same locales in i18n.ts and i18next-parser.config.js', () => {
-        expect(parserLocales).toEqual(i18nImports);
-    });
 });

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -32,10 +32,10 @@ beforeAll(async () => {
 
 describe('i18n locale consistency', () => {
     const allJsonLocaleFileBaseNames = getAllLocaleJsonFileBaseNames();
-    const i18nImports = readI18nJsonImports();
-    const parserLocales = getI18nextParserLocales();
 
     describe('"i18n.ts" imports', () => {
+        const i18nImports = readI18nJsonImports();
+
         it('should list Json imports in alphabetical order', () => {
             expect(i18nImports).toBeSorted();
         });
@@ -60,6 +60,8 @@ describe('i18n locale consistency', () => {
     });
 
     describe('"i18next-parser.config.js"', () => {
+        const parserLocales = getI18nextParserLocales();
+
         it('should list locales in alphabetical order', () => {
             expect(parserLocales).toBeSorted();
         });

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -10,6 +10,10 @@ function readI18nJsonImports(): Readonly<string[]> {
 describe('i18n locale consistency', () => {
     const i18nImports = readI18nJsonImports();
 
+    it('"i18n.ts" should list Json imports in alphabetical order', () => {
+        expect(i18nImports).toEqual([...i18nImports].sort());
+    });
+
     it('should have the same locales in i18n.ts and i18next-parser.config.js', () => {
         // Find the locales used by 'yarn extract-i18n'
         const parserConfig = require('../../i18next-parser.config.js');

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -5,12 +5,12 @@ describe('i18n locale consistency', () => {
     it('should have the same locales in i18n.ts and i18next-parser.config.js', () => {
         // Find the names of JSON locale files imported by the plugin:
         const i18nSource = fs.readFileSync(path.resolve(__dirname, '../../src/i18n/i18n.ts'), 'utf-8');
-        const i18nLocales = [...i18nSource.matchAll(/^import\s+\w+\s+from\s+'.*\/(\w+)\.json'/gm)].map((m) => m[1]);
+        const i18nImports = [...i18nSource.matchAll(/^import\s+\w+\s+from\s+'.*\/(\w+)\.json'/gm)].map((m) => m[1]);
 
         // Find the locales used by 'yarn extract-i18n'
         const parserConfig = require('../../i18next-parser.config.js');
         const parserLocales = parserConfig.locales;
 
-        expect(parserLocales).toEqual(i18nLocales);
+        expect(parserLocales).toEqual(i18nImports);
     });
 });

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -8,9 +8,9 @@ function readI18nJsonImports(): string[] {
 }
 
 describe('i18n locale consistency', () => {
-    it('should have the same locales in i18n.ts and i18next-parser.config.js', () => {
-        const i18nImports = readI18nJsonImports();
+    const i18nImports = readI18nJsonImports();
 
+    it('should have the same locales in i18n.ts and i18next-parser.config.js', () => {
         // Find the locales used by 'yarn extract-i18n'
         const parserConfig = require('../../i18next-parser.config.js');
         const parserLocales = parserConfig.locales;

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -15,14 +15,13 @@ function getI18nextParserLocales(): any {
 
 describe('i18n locale consistency', () => {
     const i18nImports = readI18nJsonImports();
+    const parserLocales = getI18nextParserLocales();
 
     it('"i18n.ts" should list Json imports in alphabetical order', () => {
         expect(i18nImports).toEqual([...i18nImports].sort());
     });
 
     it('should have the same locales in i18n.ts and i18next-parser.config.js', () => {
-        const parserLocales = getI18nextParserLocales();
-
         expect(parserLocales).toEqual(i18nImports);
     });
 });

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -7,6 +7,12 @@ function readI18nJsonImports(): Readonly<string[]> {
     return [...i18nSource.matchAll(/^import\s+\w+\s+from\s+'.*\/(\w+)\.json'/gm)].map((m) => m[1]);
 }
 
+function getI18nextParserLocales(): any {
+    // Find the locales used by 'yarn extract-i18n'
+    const parserConfig = require('../../i18next-parser.config.js');
+    return parserConfig.locales;
+}
+
 describe('i18n locale consistency', () => {
     const i18nImports = readI18nJsonImports();
 
@@ -15,9 +21,7 @@ describe('i18n locale consistency', () => {
     });
 
     it('should have the same locales in i18n.ts and i18next-parser.config.js', () => {
-        // Find the locales used by 'yarn extract-i18n'
-        const parserConfig = require('../../i18next-parser.config.js');
-        const parserLocales = parserConfig.locales;
+        const parserLocales = getI18nextParserLocales();
 
         expect(parserLocales).toEqual(i18nImports);
     });

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -1,11 +1,15 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+function readI18nJsonImports(): string[] {
+    // Find the names of JSON locale files imported by the plugin:
+    const i18nSource = fs.readFileSync(path.resolve(__dirname, '../../src/i18n/i18n.ts'), 'utf-8');
+    return [...i18nSource.matchAll(/^import\s+\w+\s+from\s+'.*\/(\w+)\.json'/gm)].map((m) => m[1]);
+}
+
 describe('i18n locale consistency', () => {
     it('should have the same locales in i18n.ts and i18next-parser.config.js', () => {
-        // Find the names of JSON locale files imported by the plugin:
-        const i18nSource = fs.readFileSync(path.resolve(__dirname, '../../src/i18n/i18n.ts'), 'utf-8');
-        const i18nImports = [...i18nSource.matchAll(/^import\s+\w+\s+from\s+'.*\/(\w+)\.json'/gm)].map((m) => m[1]);
+        const i18nImports = readI18nJsonImports();
 
         // Find the locales used by 'yarn extract-i18n'
         const parserConfig = require('../../i18next-parser.config.js');

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { initializeI18n } from '../../src/i18n/i18n';
 
 function readI18nJsonImports(): Readonly<string[]> {
     // Find the names of JSON locale files imported by the plugin:
@@ -12,6 +13,10 @@ function getI18nextParserLocales(): Readonly<string[]> {
     const parserConfig = require('../../i18next-parser.config.js');
     return parserConfig.locales;
 }
+
+beforeAll(async () => {
+    await initializeI18n();
+});
 
 describe('i18n locale consistency', () => {
     const i18nImports = readI18nJsonImports();

--- a/tests/i18n/i18n.test.ts
+++ b/tests/i18n/i18n.test.ts
@@ -50,7 +50,7 @@ describe('i18n locale consistency', () => {
             expect(i18nResourceNames).toBeSorted();
         });
 
-        it('resources should reference all JSON files', () => {
+        it('should reference all JSON files', () => {
             // The resource names may differ from the JSON file names:
             //     "pt_br" vs "pt-BR"
             //     "zh_cn" vs "zh"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5937,6 +5937,11 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
+jest-sorted@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/jest-sorted/-/jest-sorted-1.0.15.tgz#a765fd5f5bffded920e4975b0fb4d594c26a1049"
+  integrity sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==
+
 jest-util@30.2.0:
   version "30.2.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-30.2.0.tgz#5142adbcad6f4e53c2776c067a4db3c14f913705"


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

1. This breaks down the existing i18n tests in to smaller chunks, so individual failures are easier to understand.
2. I also added a new test assertion `toBeSorted()` by using the "jest-sorted" package, for more readable tests.

## Motivation and Context

The existing test was failing in #3876, and there was more than one location not properly sorted, so I was struggling to identify the locations that needed fixing.

## How has this been tested?

1. By making each test fail first, during its development
3. With lots of use of `toMatchInlineSnapshot()` to see the array values. I decided not to keep those lines, as it would not be easier for those contributing new translations to update the values.


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
