### PR TITLE
refactor: Reduce the repetition in creation of `TasksFile` objects

### DIFF
--- a/resources/sample_vaults/Tasks-Demo/Manual Testing/Scheduled Date Implied/Scheduled Implied - 20221105.md
+++ b/resources/sample_vaults/Tasks-Demo/Manual Testing/Scheduled Date Implied/Scheduled Implied - 20221105.md
@@ -1,3 +1,3 @@
 # Scheduled Implied - 20221105
 
-- [ ] #task Scheduled date read from filename which **contains** the built-in format `YYYY-MM-DD`
+- [ ] #task Scheduled date read from filename which **contains** the built-in format `YYYYMMDD`

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -347,7 +347,7 @@ export class Cache {
         logger: Logger,
     ): Task[] {
         const tf = new TasksFile(filePath, fileCache);
-        const fileParser = new FileParser(tf, fileContent, listItems, logger, fileCache, errorReporter);
+        const fileParser = new FileParser(tf, fileContent, listItems, logger, errorReporter);
         return fileParser.parseFileContent();
     }
 

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -295,6 +295,7 @@ export class Cache {
             // Only read the file and process for tasks if there are list items.
             const fileContent = await this.vault.cachedRead(file);
             newTasks = this.getTasksFromFileContent(
+                new TasksFile(file.path, fileCache),
                 fileContent,
                 listItems,
                 fileCache,
@@ -339,14 +340,14 @@ export class Cache {
     }
 
     private getTasksFromFileContent(
+        tasksFile: TasksFile,
         fileContent: string,
         listItems: ListItemCache[],
-        fileCache: CachedMetadata,
-        filePath: string,
+        _fileCache: CachedMetadata,
+        _filePath: string,
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
         logger: Logger,
     ): Task[] {
-        const tasksFile = new TasksFile(filePath, fileCache);
         const fileParser = new FileParser(tasksFile, fileContent, listItems, logger, errorReporter);
         return fileParser.parseFileContent();
     }

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -346,7 +346,8 @@ export class Cache {
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
         logger: Logger,
     ): Task[] {
-        const fileParser = new FileParser(filePath, fileContent, listItems, logger, fileCache, errorReporter);
+        const tf = new TasksFile(filePath, fileCache);
+        const fileParser = new FileParser(tf, filePath, fileContent, listItems, logger, fileCache, errorReporter);
         return fileParser.parseFileContent();
     }
 

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -1,5 +1,4 @@
 import {
-    type CachedMetadata,
     type EventRef,
     type HeadingCache,
     type ListItemCache,
@@ -298,8 +297,6 @@ export class Cache {
                 new TasksFile(file.path, fileCache),
                 fileContent,
                 listItems,
-                fileCache,
-                file.path,
                 this.reportTaskParsingErrorToUser,
                 this.logger,
             );
@@ -343,8 +340,6 @@ export class Cache {
         tasksFile: TasksFile,
         fileContent: string,
         listItems: ListItemCache[],
-        _fileCache: CachedMetadata,
-        _filePath: string,
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
         logger: Logger,
     ): Task[] {

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -347,7 +347,7 @@ export class Cache {
         logger: Logger,
     ): Task[] {
         const tf = new TasksFile(filePath, fileCache);
-        const fileParser = new FileParser(tf, filePath, fileContent, listItems, logger, fileCache, errorReporter);
+        const fileParser = new FileParser(tf, fileContent, listItems, logger, fileCache, errorReporter);
         return fileParser.parseFileContent();
     }
 

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -346,8 +346,8 @@ export class Cache {
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
         logger: Logger,
     ): Task[] {
-        const tf = new TasksFile(filePath, fileCache);
-        const fileParser = new FileParser(tf, fileContent, listItems, logger, errorReporter);
+        const tasksFile = new TasksFile(filePath, fileCache);
+        const fileParser = new FileParser(tasksFile, fileContent, listItems, logger, errorReporter);
         return fileParser.parseFileContent();
     }
 

--- a/src/Obsidian/File.ts
+++ b/src/Obsidian/File.ts
@@ -194,8 +194,8 @@ async function getTaskAndFileLines(task: ListItem, vault: Vault): Promise<[numbe
     // Validate our inputs.
     // For permanent failures, return nothing.
     // For failures that might be fixed if we wait for a little while, return retry().
-    const file = vault.getAbstractFileByPath(task.path);
-    if (!(file instanceof TFile)) {
+    const file = vault.getFileByPath(task.path);
+    if (!file) {
         throw new WarningWorthRetrying(`Tasks: No file found for task ${task.description}. Retrying ...`);
     }
 

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -10,7 +10,7 @@ import { Cache } from './Cache';
 
 export class FileParser {
     private readonly tasksFile: TasksFile;
-    private readonly filePath: string;
+    private readonly _filePath: string;
     private readonly fileContent: string;
     private readonly listItems: ListItemCache[];
     private readonly logger: Logger;
@@ -30,7 +30,7 @@ export class FileParser {
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
     ) {
         this.tasksFile = tasksFile;
-        this.filePath = tasksFile.path;
+        this._filePath = tasksFile.path;
         this.fileContent = fileContent;
         this.listItems = listItems;
         this.logger = logger;
@@ -40,6 +40,10 @@ export class FileParser {
 
         // Lazily store date extracted from filename to avoid parsing more than needed
         this.dateFromFileName = new Lazy(() => DateFallback.fromPath(this.filePath));
+    }
+
+    public get filePath(): string {
+        return this._filePath;
     }
 
     /**

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -56,7 +56,6 @@ export class FileParser {
             return this.tasks;
         }
 
-        const tasksFile = this.tasksFile;
         const linesInFile = this.fileLines.length;
 
         // this.logger.debug(`FileParser.parseFileContent() reading ${this.filePath}`);
@@ -104,7 +103,7 @@ export class FileParser {
             }
 
             const taskLocation = new TaskLocation(
-                tasksFile,
+                this.tasksFile,
                 lineNumber,
                 currentSection.position.start.line,
                 sectionIndex,

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -1,7 +1,7 @@
 import type { CachedMetadata, ListItemCache, SectionCache } from 'obsidian';
 import type { Logger } from '../lib/logging';
 import { Task } from '../Task/Task';
-import { TasksFile } from '../Scripting/TasksFile';
+import type { TasksFile } from '../Scripting/TasksFile';
 import { Lazy } from '../lib/Lazy';
 import { DateFallback } from '../DateTime/DateFallback';
 import { ListItem } from '../Task/ListItem';
@@ -23,6 +23,7 @@ export class FileParser {
     private readonly dateFromFileName: Lazy<moment.Moment | null>;
 
     constructor(
+        tasksFile: TasksFile,
         filePath: string,
         fileContent: string,
         listItems: ListItemCache[],
@@ -30,7 +31,7 @@ export class FileParser {
         fileCache: CachedMetadata,
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
     ) {
-        this.tasksFile = new TasksFile(filePath, fileCache);
+        this.tasksFile = tasksFile;
         this.filePath = filePath;
         this.fileContent = fileContent;
         this.listItems = listItems;

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -27,7 +27,6 @@ export class FileParser {
         fileContent: string,
         listItems: ListItemCache[],
         logger: Logger,
-        fileCache: CachedMetadata,
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
     ) {
         this.tasksFile = tasksFile;
@@ -35,7 +34,7 @@ export class FileParser {
         this.fileContent = fileContent;
         this.listItems = listItems;
         this.logger = logger;
-        this.fileCache = fileCache;
+        this.fileCache = tasksFile.cachedMetadata;
         this.errorReporter = errorReporter;
         this.fileLines = this.fileContent.split('\n');
 

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -13,7 +13,6 @@ export class FileParser {
     private readonly fileContent: string;
     private readonly listItems: ListItemCache[];
     private readonly logger: Logger;
-    private readonly _fileCache: CachedMetadata;
     private readonly errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void;
 
     private readonly fileLines: string[];
@@ -32,7 +31,6 @@ export class FileParser {
         this.fileContent = fileContent;
         this.listItems = listItems;
         this.logger = logger;
-        this._fileCache = tasksFile.cachedMetadata;
         this.errorReporter = errorReporter;
         this.fileLines = this.fileContent.split('\n');
 
@@ -45,7 +43,7 @@ export class FileParser {
     }
 
     public get fileCache(): CachedMetadata {
-        return this._fileCache;
+        return this.tasksFile.cachedMetadata;
     }
 
     /**

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -24,7 +24,6 @@ export class FileParser {
 
     constructor(
         tasksFile: TasksFile,
-        filePath: string,
         fileContent: string,
         listItems: ListItemCache[],
         logger: Logger,
@@ -32,7 +31,7 @@ export class FileParser {
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
     ) {
         this.tasksFile = tasksFile;
-        this.filePath = filePath;
+        this.filePath = tasksFile.path;
         this.fileContent = fileContent;
         this.listItems = listItems;
         this.logger = logger;

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -10,7 +10,6 @@ import { Cache } from './Cache';
 
 export class FileParser {
     private readonly tasksFile: TasksFile;
-    private readonly _filePath: string;
     private readonly fileContent: string;
     private readonly listItems: ListItemCache[];
     private readonly logger: Logger;
@@ -30,7 +29,6 @@ export class FileParser {
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
     ) {
         this.tasksFile = tasksFile;
-        this._filePath = tasksFile.path;
         this.fileContent = fileContent;
         this.listItems = listItems;
         this.logger = logger;
@@ -43,7 +41,7 @@ export class FileParser {
     }
 
     public get filePath(): string {
-        return this._filePath;
+        return this.tasksFile.path;
     }
 
     /**

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -13,7 +13,7 @@ export class FileParser {
     private readonly fileContent: string;
     private readonly listItems: ListItemCache[];
     private readonly logger: Logger;
-    private readonly fileCache: CachedMetadata;
+    private readonly _fileCache: CachedMetadata;
     private readonly errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void;
 
     private readonly fileLines: string[];
@@ -32,7 +32,7 @@ export class FileParser {
         this.fileContent = fileContent;
         this.listItems = listItems;
         this.logger = logger;
-        this.fileCache = tasksFile.cachedMetadata;
+        this._fileCache = tasksFile.cachedMetadata;
         this.errorReporter = errorReporter;
         this.fileLines = this.fileContent.split('\n');
 
@@ -42,6 +42,10 @@ export class FileParser {
 
     public get filePath(): string {
         return this.tasksFile.path;
+    }
+
+    public get fileCache(): CachedMetadata {
+        return this._fileCache;
     }
 
     /**

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -9,6 +9,7 @@ import { TaskLocation } from '../Task/TaskLocation';
 import { Cache } from './Cache';
 
 export class FileParser {
+    private readonly tasksFile: TasksFile;
     private readonly filePath: string;
     private readonly fileContent: string;
     private readonly listItems: ListItemCache[];
@@ -29,6 +30,7 @@ export class FileParser {
         fileCache: CachedMetadata,
         errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
     ) {
+        this.tasksFile = new TasksFile(filePath, fileCache);
         this.filePath = filePath;
         this.fileContent = fileContent;
         this.listItems = listItems;
@@ -51,7 +53,7 @@ export class FileParser {
             return this.tasks;
         }
 
-        const tasksFile = new TasksFile(this.filePath, this.fileCache);
+        const tasksFile = this.tasksFile;
         const linesInFile = this.fileLines.length;
 
         // this.logger.debug(`FileParser.parseFileContent() reading ${this.filePath}`);

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -59,9 +59,9 @@ export class QueryRenderer {
         //    continuation lines.
         const app = this.app;
         const filePath = context.sourcePath;
-        const tFile = app.vault.getAbstractFileByPath(filePath);
+        const tFile = app.vault.getFileByPath(filePath);
         let fileCache: CachedMetadata | null = null;
-        if (tFile && tFile instanceof TFile) {
+        if (tFile) {
             fileCache = app.metadataCache.getFileCache(tFile);
         }
         const tasksFile = new TasksFile(filePath, fileCache ?? {});

--- a/tests/CustomMatchers/CustomMatchersForSorting.ts
+++ b/tests/CustomMatchers/CustomMatchersForSorting.ts
@@ -4,7 +4,7 @@ import type { Sorter } from '../../src/Query/Sort/Sorter';
 import type { Task } from '../../src/Task/Task';
 import { compareByDate } from '../../src/DateTime/DateTools';
 import { SearchInfo } from '../../src/Query/SearchInfo';
-import { TasksFile } from '../../src/Scripting/TasksFile';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 
 declare global {
     namespace jest {
@@ -41,7 +41,7 @@ expect.extend({
         expect(tasks.length).toEqual(2);
         const taskA = tasks[0];
         const taskB = tasks[1];
-        const actual = sorting.comparator(taskA, taskB, new SearchInfo(new TasksFile('dummy path.md'), tasks));
+        const actual = sorting.comparator(taskA, taskB, new SearchInfo(createTestTasksFile('dummy path.md'), tasks));
 
         let pass;
         let expectedDesription: string;

--- a/tests/DateTime/DateFallback.test.ts
+++ b/tests/DateTime/DateFallback.test.ts
@@ -3,12 +3,12 @@
  */
 import type { Moment } from 'moment';
 import moment from 'moment';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Task } from '../../src/Task/Task';
 import { resetSettings, updateSettings } from '../../src/Config/Settings';
 import { DateFallback } from '../../src/DateTime/DateFallback';
 import { TaskLocation } from '../../src/Task/TaskLocation';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 
 jest.mock('obsidian');
 window.moment = moment;
@@ -225,7 +225,7 @@ describe('extract date from filename', () => {
 function constructTaskFromLine(line: string, fallbackDate: string | null) {
     return Task.fromLine({
         line,
-        taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('file.md')), // filename must be parsed before calling Task.fromLine, so irrelevant for these tests
+        taskLocation: TaskLocation.fromUnknownPosition(createTestTasksFile('file.md')), // filename must be parsed before calling Task.fromLine, so irrelevant for these tests
         fallbackDate: date(fallbackDate),
     });
 }
@@ -407,7 +407,7 @@ describe('update fallback date when path is changed', () => {
         // Act
         const updatedTask = DateFallback.updateTaskPath(
             task,
-            task.taskLocation.fromRenamedFile(new TasksFile(newPath)),
+            task.taskLocation.fromRenamedFile(createTestTasksFile(newPath)),
             fallbackDate,
         );
 

--- a/tests/Obsidian/FileParser.test.ts
+++ b/tests/Obsidian/FileParser.test.ts
@@ -60,4 +60,9 @@ describe('FileParser', () => {
         expect(tasks.length).toEqual(1);
         expect(tasks[0].description).toEqual("#task Task line 1 in 'zero_width' - indented by tab character");
     });
+
+    it('readTasksFromSimulatedFile() should preserve file path', () => {
+        const tasks = readTasksFromSimulatedFile('numbered_list_items_with_paren');
+        expect(tasks[0].path).toEqual('Test Data/numbered_list_items_with_paren.md');
+    });
 });

--- a/tests/Obsidian/FileParser.test.ts
+++ b/tests/Obsidian/FileParser.test.ts
@@ -65,4 +65,13 @@ describe('FileParser', () => {
         const tasks = readTasksFromSimulatedFile('numbered_list_items_with_paren');
         expect(tasks[0].path).toEqual('Test Data/numbered_list_items_with_paren.md');
     });
+
+    it('readTasksFromSimulatedFile() should preserve metadata', () => {
+        const tasks = readTasksFromSimulatedFile('yaml_custom_number_property');
+        expect(tasks[0].taskLocation.tasksFile.cachedMetadata.frontmatter).toMatchInlineSnapshot(`
+            {
+              "custom_number_prop": 42,
+            }
+        `);
+    });
 });

--- a/tests/Obsidian/SimulatedFile.ts
+++ b/tests/Obsidian/SimulatedFile.ts
@@ -3,6 +3,7 @@ import type { Task } from 'Task/Task';
 import { logging } from '../../src/lib/logging';
 import { FileParser } from '../../src/Obsidian/FileParser';
 import { MockDataLoader } from '../TestingTools/MockDataLoader';
+import { TasksFile } from '../../src/Scripting/TasksFile';
 import { AllMockDataNames, type MockDataName } from './AllCacheSampleData';
 
 /**
@@ -57,6 +58,7 @@ export function readTasksFromSimulatedFile(filename: MockDataName): Task[] {
     const testData = MockDataLoader.get(filename);
     const logger = logging.getLogger('testCache');
     const fileParser = new FileParser(
+        new TasksFile(testData.filePath, testData.cachedMetadata),
         testData.filePath,
         testData.fileContents,
         testData.cachedMetadata.listItems!,

--- a/tests/Obsidian/SimulatedFile.ts
+++ b/tests/Obsidian/SimulatedFile.ts
@@ -59,7 +59,6 @@ export function readTasksFromSimulatedFile(filename: MockDataName): Task[] {
     const logger = logging.getLogger('testCache');
     const fileParser = new FileParser(
         new TasksFile(testData.filePath, testData.cachedMetadata),
-        testData.filePath,
         testData.fileContents,
         testData.cachedMetadata.listItems!,
         logger,

--- a/tests/Obsidian/SimulatedFile.ts
+++ b/tests/Obsidian/SimulatedFile.ts
@@ -62,7 +62,6 @@ export function readTasksFromSimulatedFile(filename: MockDataName): Task[] {
         testData.fileContents,
         testData.cachedMetadata.listItems!,
         logger,
-        testData.cachedMetadata,
         errorReporter,
     );
     return fileParser.parseFileContent();

--- a/tests/Obsidian/SimulatedFile.ts
+++ b/tests/Obsidian/SimulatedFile.ts
@@ -3,7 +3,7 @@ import type { Task } from 'Task/Task';
 import { logging } from '../../src/lib/logging';
 import { FileParser } from '../../src/Obsidian/FileParser';
 import { MockDataLoader } from '../TestingTools/MockDataLoader';
-import { TasksFile } from '../../src/Scripting/TasksFile';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 import { AllMockDataNames, type MockDataName } from './AllCacheSampleData';
 
 /**
@@ -58,7 +58,7 @@ export function readTasksFromSimulatedFile(filename: MockDataName): Task[] {
     const testData = MockDataLoader.get(filename);
     const logger = logging.getLogger('testCache');
     const fileParser = new FileParser(
-        new TasksFile(testData.filePath, testData.cachedMetadata),
+        createTestTasksFile(testData.filePath, testData.cachedMetadata),
         testData.fileContents,
         testData.cachedMetadata.listItems!,
         logger,

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -9,7 +9,7 @@ import { Query } from '../../../src/Query/Query';
 import { Explainer } from '../../../src/Query/Explain/Explainer';
 import { resetSettings, updateSettings } from '../../../src/Config/Settings';
 import { DebugSettings } from '../../../src/Config/DebugSettings';
-import { TasksFile } from '../../../src/Scripting/TasksFile';
+import { createTestTasksFile } from '../../TestingTools/TasksFileHelpers';
 
 window.moment = moment;
 
@@ -19,7 +19,7 @@ window.moment = moment;
  */
 function makeQueryFromContinuationLines(lines: string[]) {
     const source = lines.join('\\\n');
-    const query = new Query(source, new TasksFile('sample.md'));
+    const query = new Query(source, createTestTasksFile('sample.md'));
     expect(query.error).toBeUndefined();
     return query;
 }
@@ -73,7 +73,7 @@ ignore global query
         // Disable sort instructions
         updateSettings({ debugSettings: new DebugSettings(true) });
 
-        const query = new Query(sampleOfAllInstructionTypes, new TasksFile('sample.md'));
+        const query = new Query(sampleOfAllInstructionTypes, createTestTasksFile('sample.md'));
         expect(explainer.explainQuery(query)).toMatchInlineSnapshot(`
             "ignore global query
 
@@ -127,7 +127,7 @@ ignore global query
         // Disable sort instructions
         updateSettings({ debugSettings: new DebugSettings(true) });
 
-        const query = new Query(sampleOfAllInstructionTypes, new TasksFile('sample.md'));
+        const query = new Query(sampleOfAllInstructionTypes, createTestTasksFile('sample.md'));
         const indentedExplainer = new Explainer('  ');
         expect(indentedExplainer.explainQuery(query)).toMatchInlineSnapshot(`
             "  ignore global query

--- a/tests/Query/Filter/BooleanField.test.ts
+++ b/tests/Query/Filter/BooleanField.test.ts
@@ -9,7 +9,7 @@ import { testFilter } from '../../TestingTools/FilterTestHelpers';
 import { Query } from '../../../src/Query/Query';
 import { Explainer } from '../../../src/Query/Explain/Explainer';
 import { BooleanPreprocessor } from '../../../src/Query/Filter/BooleanPreprocessor';
-import { TasksFile } from '../../../src/Scripting/TasksFile';
+import { createTestTasksFile } from '../../TestingTools/TasksFileHelpers';
 import { verifyBooleanExpressionExplanation, verifyBooleanExpressionPreprocessing } from './BooleanFieldVerify';
 
 window.moment = moment;
@@ -284,7 +284,7 @@ describe('boolean query - explain', () => {
 
     function explainFilters(indentationLevel: number, source: string) {
         const indentation = ' '.repeat(indentationLevel);
-        const tasksFile = new TasksFile('some/sample/note.md');
+        const tasksFile = createTestTasksFile('some/sample/note.md');
         const query1 = new Query(source, tasksFile);
         return new Explainer(indentation).explainFilters(query1);
     }

--- a/tests/Query/Filter/FunctionField.test.ts
+++ b/tests/Query/Filter/FunctionField.test.ts
@@ -22,9 +22,9 @@ import { fromLine } from '../../TestingTools/TestHelpers';
 import { Query } from '../../../src/Query/Query';
 import { TasksDate } from '../../../src/DateTime/TasksDate';
 import { Priority } from '../../../src/Task/Priority';
-import { TasksFile } from '../../../src/Scripting/TasksFile';
 import { EnableJsInTasksQueries } from '../../../src/Config/EnableJsInTasksQueries';
 import { expectQueryErrorToMentionDisabledJavaScript } from '../../Scripting/ScriptingTestHelpers';
+import { createTestTasksFile } from '../../TestingTools/TasksFileHelpers';
 
 window.moment = moment;
 
@@ -94,7 +94,7 @@ describe('FunctionField - filtering', () => {
             'filter by function task.file.path === query.file.path',
         );
         expect(tasksInSameFileAsQuery).toBeValid();
-        const queryTasksFile = new TasksFile('/a/b/query.md');
+        const queryTasksFile = createTestTasksFile('/a/b/query.md');
 
         const taskInQueryFile: Task = new TaskBuilder().path(queryTasksFile.path).build();
         const taskNotInQueryFile: Task = new TaskBuilder().path('some other path.md').build();
@@ -652,8 +652,11 @@ describe('FunctionField - grouping - example functions', () => {
         const line = 'group by function query.file.filename';
         const grouper = createGrouper(line);
         const task = new TaskBuilder().build();
-        toGroupTaskUsingSearchInfo(grouper, task, new SearchInfo(new TasksFile('queries/query file.md'), [task]), [
-            'query file.md',
-        ]);
+        toGroupTaskUsingSearchInfo(
+            grouper,
+            task,
+            new SearchInfo(createTestTasksFile('queries/query file.md'), [task]),
+            ['query file.md'],
+        );
     });
 });

--- a/tests/Query/Group/TaskGroups.test.ts
+++ b/tests/Query/Group/TaskGroups.test.ts
@@ -15,9 +15,9 @@ import { DueDateField } from '../../../src/Query/Filter/DueDateField';
 import { SearchInfo } from '../../../src/Query/SearchInfo';
 import { fromLine, fromLines } from '../../TestingTools/TestHelpers';
 import { TaskBuilder } from '../../TestingTools/TaskBuilder';
-import { TasksFile } from '../../../src/Scripting/TasksFile';
 import { FunctionField } from '../../../src/Query/Filter/FunctionField';
 import type { TaskGroup } from '../../../src/Query/Group/TaskGroup';
+import { createTestTasksFile } from '../../TestingTools/TasksFileHelpers';
 
 window.moment = moment;
 
@@ -101,7 +101,7 @@ describe('Grouping tasks', () => {
         };
         const grouper: Grouper = new Grouper('group by test', 'test', groupByQueryPath, false);
 
-        const tasksFile = new TasksFile('somewhere/anything.md');
+        const tasksFile = createTestTasksFile('somewhere/anything.md');
         const tasks = [new TaskBuilder().build()];
         const searchInfo = new SearchInfo(tasksFile, tasks);
 

--- a/tests/Query/Presets/Presets.test.ts
+++ b/tests/Query/Presets/Presets.test.ts
@@ -5,11 +5,11 @@
 import moment from 'moment';
 import { getSettings, resetSettings, updateSettings } from '../../../src/Config/Settings';
 import { Query } from '../../../src/Query/Query';
-import { TasksFile } from '../../../src/Scripting/TasksFile';
 import type { Statement } from '../../../src/Query/Statement';
 import { type PresetsMap, defaultPresets } from '../../../src/Query/Presets/Presets';
 import { EnableJsInTasksQueries } from '../../../src/Config/EnableJsInTasksQueries';
 import { expectQueryErrorToMentionDisabledJavaScript } from '../../Scripting/ScriptingTestHelpers';
+import { createTestTasksFile } from '../../TestingTools/TasksFileHelpers';
 
 window.moment = moment;
 
@@ -26,7 +26,7 @@ export function makeIncludes(...entries: [string, string][]): PresetsMap {
     return Object.fromEntries(entries);
 }
 
-const tasksFile = new TasksFile('root/folder/stuff.md');
+const tasksFile = createTestTasksFile('root/folder/stuff.md');
 
 function createQuery(source: string, includes: PresetsMap) {
     updateSettings({ presets: includes });
@@ -567,7 +567,7 @@ describe('include settings tests', () => {
         expect(name).toBeDefined();
         expect(instructions).toBeDefined();
 
-        const query = new Query(instructions, new TasksFile('anywhere.md'));
+        const query = new Query(instructions, createTestTasksFile('anywhere.md'));
         expect(query.error).toBeUndefined();
     });
 });

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -3,7 +3,6 @@
  */
 import moment from 'moment';
 import { Query } from '../../src/Query/Query';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Status } from '../../src/Statuses/Status';
 import { Task } from '../../src/Task/Task';
 import { OnCompletion } from '../../src/Task/OnCompletion';
@@ -23,6 +22,7 @@ import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { Priority } from '../../src/Task/Priority';
 import { TaskLayoutComponent } from '../../src/Layout/TaskLayoutOptions';
 import { getTasksFileFromMockData } from '../TestingTools/MockDataHelpers';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 
 window.moment = moment;
 
@@ -44,7 +44,7 @@ function sortInstructionLines(filters: ReadonlyArray<string>) {
 
 function isValidQueryFilter(filter: string) {
     // Arrange
-    const query = new Query(filter, new TasksFile('anywhere.md'));
+    const query = new Query(filter, createTestTasksFile('anywhere.md'));
 
     // Assert
     expect(query.error).toBeUndefined();
@@ -113,7 +113,7 @@ description includes Simple Line
 description includes \
     from a Continuation Line
         `;
-        const query = new Query(source, new TasksFile('test.md'));
+        const query = new Query(source, createTestTasksFile('test.md'));
         expect(query.error).toBeUndefined();
         const statements = query.statements;
         expect(statements.length).toEqual(3);
@@ -627,7 +627,7 @@ description includes \
 
     describe('should include instruction in parsing error messages', () => {
         function getQueryError(source: string) {
-            return new Query(source, new TasksFile('Example Path.md')).error;
+            return new Query(source, createTestTasksFile('Example Path.md')).error;
         }
 
         it('for invalid regular expression filter', () => {
@@ -758,7 +758,7 @@ Problem statement:
         it('should expand placeholder values in filters, but not source', () => {
             // Arrange
             const rawQuery = 'path includes {{query.file.path}}';
-            const tasksFile = new TasksFile('a/b/path with space.md');
+            const tasksFile = createTestTasksFile('a/b/path with space.md');
 
             // Act
             const query = new Query(rawQuery, tasksFile);
@@ -789,7 +789,7 @@ Problem statement:
         it('should report error if non-existent placeholder used', () => {
             // Arrange
             const source = 'path includes {{query.file.noSuchProperty}}';
-            const tasksFile = new TasksFile('a/b/path with space.md');
+            const tasksFile = createTestTasksFile('a/b/path with space.md');
 
             // Act
             const query = new Query(source, tasksFile);
@@ -810,7 +810,7 @@ Problem statement:
         it('should not report error if comment contains a non-existent placeholder', () => {
             // Arrange
             const source = '  #  path includes {{query.file.noSuchProperty}}';
-            const tasksFile = new TasksFile('a/b/path with space.md');
+            const tasksFile = createTestTasksFile('a/b/path with space.md');
 
             // Act
             const query = new Query(source, tasksFile);
@@ -825,7 +825,7 @@ Problem statement:
             const source = `{{error 1}}
 {{error 2}}
 {{error 3}}`;
-            const tasksFile = new TasksFile('a/b/path with space.md');
+            const tasksFile = createTestTasksFile('a/b/path with space.md');
 
             // Act
             const query = new Query(source, tasksFile);
@@ -1005,7 +1005,7 @@ describe('Query', () => {
                 new Task({
                     status: Status.TODO,
                     description: 'description',
-                    taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('Ab/C D')),
+                    taskLocation: TaskLocation.fromUnknownPosition(createTestTasksFile('Ab/C D')),
                     indentation: '',
                     listMarker: '-',
                     priority: Priority.None,
@@ -1027,7 +1027,7 @@ describe('Query', () => {
                 new Task({
                     status: Status.TODO,
                     description: 'description',
-                    taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('FF/C D')),
+                    taskLocation: TaskLocation.fromUnknownPosition(createTestTasksFile('FF/C D')),
                     indentation: '',
                     listMarker: '-',
                     priority: Priority.None,
@@ -1494,7 +1494,7 @@ describe('Query', () => {
     describe('query path and metadata', function () {
         it('should provide access to the path of the query', () => {
             const path = 'query location.md';
-            const query = new Query('not done', new TasksFile(path));
+            const query = new Query('not done', createTestTasksFile(path));
 
             expect(query.filePath).toEqual(path);
         });
@@ -1529,7 +1529,7 @@ describe('Query', () => {
 
         it('should pass the query path through to filter functions', () => {
             // Arrange
-            const queryTasksFile = new TasksFile('this/was/passed/in/correctly.md');
+            const queryTasksFile = createTestTasksFile('this/was/passed/in/correctly.md');
             const query = new Query('', queryTasksFile);
 
             const matchesIfSearchInfoHasCorrectPath = (_task: Task, searchInfo: SearchInfo) => {
@@ -1642,7 +1642,7 @@ describe('Query', () => {
             const source = 'group by function query.file.path';
             const sourceUpper = 'GROUP BY FUNCTION query.file.path';
 
-            const tasksFile = new TasksFile('hello.md');
+            const tasksFile = createTestTasksFile('hello.md');
             const query = new Query(source, tasksFile);
             const queryUpper = new Query(sourceUpper, tasksFile);
 
@@ -1842,7 +1842,7 @@ Problem statement:
         it('should save the source correctly in a Statement object', () => {
             const source = String.raw`(path includes A) OR \
                 (path includes {{query.file.path}})`;
-            const query = new Query(source, new TasksFile('Test.md'));
+            const query = new Query(source, createTestTasksFile('Test.md'));
 
             expect(query.error).toBeUndefined();
             const filter = query.filters[0];

--- a/tests/Query/QueryRendererHelper.test.ts
+++ b/tests/Query/QueryRendererHelper.test.ts
@@ -6,8 +6,8 @@ import { Query } from '../../src/Query/Query';
 import { explainResults, getQueryForQueryRenderer } from '../../src/Query/QueryRendererHelper';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { GlobalQuery } from '../../src/Config/GlobalQuery';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { getTasksFileFromMockData } from '../TestingTools/MockDataHelpers';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 
 window.moment = moment;
 
@@ -207,7 +207,7 @@ describe('query used for QueryRenderer', () => {
         // Arrange
         const querySource = 'description includes world';
         const globalQuerySource = 'description includes hello';
-        const tasksFile = new TasksFile('a/b/c.md');
+        const tasksFile = createTestTasksFile('a/b/c.md');
 
         // Act
         const globalQuery = new GlobalQuery(globalQuerySource);
@@ -221,7 +221,7 @@ describe('query used for QueryRenderer', () => {
     it('should ignore the global query if "ignore global query" is set', () => {
         // Arrange
         const globalQuery = new GlobalQuery('path includes from_global_query');
-        const tasksFile = new TasksFile('a/b/c.md');
+        const tasksFile = createTestTasksFile('a/b/c.md');
 
         // Act
         const query = getQueryForQueryRenderer(

--- a/tests/Query/SearchInfo.test.ts
+++ b/tests/Query/SearchInfo.test.ts
@@ -1,10 +1,10 @@
 import { SearchInfo } from '../../src/Query/SearchInfo';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
-import { TasksFile } from '../../src/Scripting/TasksFile';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 
 describe('SearchInfo', () => {
     const path = 'a/b/c.md';
-    const tasksFile = new TasksFile(path);
+    const tasksFile = createTestTasksFile(path);
 
     it('should not be able to modify SearchInfo.allTasks directly', () => {
         const tasks = [new TaskBuilder().build()];

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.ts
@@ -6,11 +6,12 @@ import { State } from '../../src/Obsidian/Cache';
 import type { Query } from '../../src/Query/Query';
 import { getQueryForQueryRenderer } from '../../src/Query/QueryRendererHelper';
 import { HtmlQueryResultsRenderer } from '../../src/Renderer/HtmlQueryResultsRenderer';
-import { TasksFile } from '../../src/Scripting/TasksFile';
+import type { TasksFile } from '../../src/Scripting/TasksFile';
 import type { Task } from '../../src/Task/Task';
 import { mockApp } from '../__mocks__/obsidian';
 import { readTasksFromSimulatedFile } from '../Obsidian/SimulatedFile';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 import { makeHtmlQueryRendererParameters, mockHTMLRenderer, verifyRenderedTasks } from './RenderingTestHelpers';
 
 window.moment = moment;
@@ -32,7 +33,7 @@ function makeHtmlRenderer(source: string, tasksFile: TasksFile, allTasks: Task[]
 }
 
 async function verifyRenderedHtml(allTasks: Task[], source: string, state: State = State.Warm) {
-    const tasksFile = new TasksFile('query.md');
+    const tasksFile = createTestTasksFile('query.md');
     const { query, renderer } = makeHtmlRenderer(source, tasksFile, allTasks);
 
     const container = document.createElement('div');
@@ -205,7 +206,7 @@ sort by function reverse task.lineNumber
 });
 
 describe('Reusing HtmlQueryResultsRenderer', () => {
-    const tasksFile = new TasksFile('anywhere.md');
+    const tasksFile = createTestTasksFile('anywhere.md');
 
     it('should render the same thing twice - tree', async () => {
         const allTasks = readTasksFromSimulatedFile(
@@ -237,7 +238,7 @@ describe('Reusing HtmlQueryResultsRenderer', () => {
 });
 
 describe('HtmlQueryResultsRenderer - task count location setting', () => {
-    const tasksFile = new TasksFile('query.md');
+    const tasksFile = createTestTasksFile('query.md');
     const source = 'hide toolbar\nhide backlinks\nhide edit button';
     const allTasks = readTasksFromSimulatedFile('inheritance_1parent1child');
 
@@ -308,7 +309,7 @@ For more info: https://publish.obsidian.md/tasks-contributing/Testing/Using+Obsi
 
     async function renderTask(task: Task, queryFilePath: string = 'query.md') {
         const allTasks = [task];
-        const { renderer, query } = makeHtmlRenderer('', new TasksFile(queryFilePath), allTasks);
+        const { renderer, query } = makeHtmlRenderer('', createTestTasksFile(queryFilePath), allTasks);
         const container = document.createElement('div');
 
         renderer.content = container;

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -7,10 +7,11 @@ import { GlobalQuery } from '../../src/Config/GlobalQuery';
 import { resetSettings, updateSettings } from '../../src/Config/Settings';
 import { State } from '../../src/Obsidian/Cache';
 import { QueryResultsRenderer } from '../../src/Renderer/QueryResultsRenderer';
-import { TasksFile } from '../../src/Scripting/TasksFile';
+import type { TasksFile } from '../../src/Scripting/TasksFile';
 import { mockApp } from '../__mocks__/obsidian';
 import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 import {
     makeHtmlQueryRendererParameters,
     mockHTMLRenderer,
@@ -50,7 +51,7 @@ function makeQueryResultsRenderer(source: string, tasksFile: TasksFile, allTasks
 }
 
 async function verifyRenderedHtml(allTasks: Task[], source: string, state: State = State.Warm): Promise<void> {
-    const renderer = makeQueryResultsRenderer(source, new TasksFile('file.md'), allTasks);
+    const renderer = makeQueryResultsRenderer(source, createTestTasksFile('file.md'), allTasks);
     const container = document.createElement('div');
 
     await renderer.render(state, allTasks, container);
@@ -63,14 +64,14 @@ describe('QueryResultsRenderer - accessing results', () => {
     const twoTasks = [...aTask, new TaskBuilder().description('another task').build()];
 
     it('should have empty results before rendering', () => {
-        const renderer = makeQueryResultsRenderer('', new TasksFile('file.md'), aTask);
+        const renderer = makeQueryResultsRenderer('', createTestTasksFile('file.md'), aTask);
 
         expect(renderer.queryResult.totalTasksCount).toEqual(0);
         expect(renderer.filteredQueryResult.totalTasksCount).toEqual(0);
     });
 
     it('should have actual results after rendering', async () => {
-        const renderer = makeQueryResultsRenderer('', new TasksFile('file.md'), aTask);
+        const renderer = makeQueryResultsRenderer('', createTestTasksFile('file.md'), aTask);
 
         await renderer.render(State.Warm, aTask, document.createElement('div'));
 
@@ -79,7 +80,7 @@ describe('QueryResultsRenderer - accessing results', () => {
     });
 
     it('should have actual result after filtering results', async () => {
-        const renderer = makeQueryResultsRenderer('', new TasksFile('file.md'), twoTasks);
+        const renderer = makeQueryResultsRenderer('', createTestTasksFile('file.md'), twoTasks);
 
         await renderer.render(State.Warm, twoTasks, document.createElement('div'));
 
@@ -145,11 +146,11 @@ describe('QueryResultsRenderer - responding to file edits', () => {
     it('should update the query when its file path is changed', () => {
         // Arrange
         const source = 'path includes {{query.file.path}}';
-        const renderer = makeQueryResultsRenderer(source, new TasksFile('oldPath.md'), []);
+        const renderer = makeQueryResultsRenderer(source, createTestTasksFile('oldPath.md'), []);
         expect(renderer.query.explainQuery()).toContain('path includes oldPath.md');
 
         // Act
-        renderer.setTasksFile(new TasksFile('newPath.md'));
+        renderer.setTasksFile(createTestTasksFile('newPath.md'));
 
         // Assert
         expect(renderer.query.explainQuery()).toContain('path includes newPath.md');
@@ -159,7 +160,7 @@ describe('QueryResultsRenderer - responding to file edits', () => {
         // Arrange
         updateSettings({ presets: { CurrentGrouping: 'group by PATH' } });
         const source = 'preset CurrentGrouping';
-        const renderer = makeQueryResultsRenderer(source, new TasksFile('any file.md'), []);
+        const renderer = makeQueryResultsRenderer(source, createTestTasksFile('any file.md'), []);
         expect(renderer.query.explainQuery()).toContain('group by PATH');
 
         // Act
@@ -183,7 +184,7 @@ class RendererStoryboard {
 
     constructor(source: string, allTasks: Task[]) {
         this.allTasks = allTasks;
-        this.renderer = makeQueryResultsRenderer(source, new TasksFile('file.md'), allTasks);
+        this.renderer = makeQueryResultsRenderer(source, createTestTasksFile('file.md'), allTasks);
     }
 
     /**

--- a/tests/Renderer/RenderingTestHelpers.ts
+++ b/tests/Renderer/RenderingTestHelpers.ts
@@ -4,11 +4,11 @@ import type { FilterOrErrorMessage } from '../../src/Query/Filter/FilterOrErrorM
 import { Query } from '../../src/Query/Query';
 import type { HTMLQueryRendererParameters } from '../../src/Renderer/HtmlQueryResultsRenderer';
 import { MarkdownQueryResultsRenderer } from '../../src/Renderer/MarkdownQueryResultsRenderer';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import type { Task } from '../../src/Task/Task';
 import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
 import { prettifyHTML } from '../TestingTools/HTMLHelpers';
 import { toMarkdown } from '../TestingTools/TestHelpers';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 
 export const mockHTMLRenderer = async (_obsidianApp: App, text: string, element: HTMLSpanElement, _path: string) => {
     // Contrary to the default mockTextRenderer(),
@@ -37,7 +37,7 @@ export function makeHtmlQueryRendererParameters(allTasks: Task[]): HTMLQueryRend
 }
 
 export function createMarkdownRenderer(source: string) {
-    const tasksFile = new TasksFile('query.md');
+    const tasksFile = createTestTasksFile('query.md');
     const query = new Query(source, tasksFile);
 
     const renderer = new MarkdownQueryResultsRenderer(source, tasksFile, query);

--- a/tests/Scripting/ExpandPlaceholders.test.ts
+++ b/tests/Scripting/ExpandPlaceholders.test.ts
@@ -1,9 +1,9 @@
 import { expandPlaceholders } from '../../src/Scripting/ExpandPlaceholders';
 import { makeQueryContext } from '../../src/Scripting/QueryContext';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Query } from '../../src/Query/Query';
 import { EnableJsInTasksQueries } from '../../src/Config/EnableJsInTasksQueries';
 import { getTasksFileFromMockData } from '../TestingTools/MockDataHelpers';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 import { expectQueryErrorToMentionDisabledJavaScript } from './ScriptingTestHelpers';
 
 describe('Placeholders - disabling execution', () => {
@@ -75,7 +75,7 @@ describe('Placeholders - disabling execution', () => {
 });
 
 describe('ExpandTemplate', () => {
-    const tasksFile = new TasksFile('a/b/path with space.md');
+    const tasksFile = createTestTasksFile('a/b/path with space.md');
 
     it('hard-coded call', () => {
         const view = {
@@ -148,7 +148,7 @@ The problem is in:
     });
 
     it('should throw an error if unknown template nested field used', () => {
-        const queryContext = makeQueryContext(new TasksFile('stuff.md'));
+        const queryContext = makeQueryContext(createTestTasksFile('stuff.md'));
         const source = '{{ query.file.nonsense }}';
 
         expect(() => expandPlaceholders(source, queryContext)).toThrow(

--- a/tests/Scripting/Expression.test.ts
+++ b/tests/Scripting/Expression.test.ts
@@ -9,9 +9,9 @@ import { verifyMarkdownForDocs } from '../TestingTools/VerifyMarkdown';
 import { continueLinesFlattened } from '../../src/Query/Scanner';
 import { constructArguments, parseAndEvaluateExpression } from '../../src/Scripting/TaskExpression';
 import { makeQueryContext } from '../../src/Scripting/QueryContext';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { EnableJsInTasksQueries } from '../../src/Config/EnableJsInTasksQueries';
 import { JsInTasksQueriesDisabledError } from '../../src/Scripting/JsInTasksQueriesDisabledError';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 import { formatToRepresentType } from './ScriptingTestHelpers';
 
 window.moment = moment;
@@ -84,7 +84,7 @@ describe('Expression', () => {
     });
 
     const task = TaskBuilder.createFullyPopulatedTask();
-    const queryContext = makeQueryContext(new TasksFile('temp.md'));
+    const queryContext = makeQueryContext(createTestTasksFile('temp.md'));
 
     describe('detect errors at parse stage', () => {
         it('should report meaningful error message for parentheses too few parentheses', () => {

--- a/tests/Scripting/QueryContext.test.ts
+++ b/tests/Scripting/QueryContext.test.ts
@@ -6,9 +6,9 @@ import { RootField } from '../../src/Query/Filter/RootField';
 import { makeQueryContext } from '../../src/Scripting/QueryContext';
 import { FunctionField } from '../../src/Query/Filter/FunctionField';
 import { SearchInfo } from '../../src/Query/SearchInfo';
-import { TasksFile } from '../../src/Scripting/TasksFile';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 
-const tasksFile = new TasksFile('a/b/c.md');
+const tasksFile = createTestTasksFile('a/b/c.md');
 const task = new TaskBuilder().path(tasksFile.path).build();
 const queryContext = makeQueryContext(tasksFile);
 

--- a/tests/Scripting/QueryProperties.test.ts
+++ b/tests/Scripting/QueryProperties.test.ts
@@ -5,11 +5,11 @@ import { verifyMarkdownForDocs } from '../TestingTools/VerifyMarkdown';
 import { MarkdownTable } from '../../src/lib/MarkdownTable';
 import { parseAndEvaluateExpression } from '../../src/Scripting/TaskExpression';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { getTasksFileFromMockData } from '../TestingTools/MockDataHelpers';
 import { LinkResolver } from '../../src/Task/LinkResolver';
 import { getFirstLinkpathDestFromData } from '../__mocks__/obsidian';
 import { MockDataLoader } from '../TestingTools/MockDataLoader';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 import { addBackticks, determineExpressionType, formatToRepresentType } from './ScriptingTestHelpers';
 
 beforeEach(() => {});
@@ -30,7 +30,7 @@ describe('query', () => {
             getFirstLinkpathDestFromData(query_using_properties, rawLink),
         );
 
-        const tasksFile = new TasksFile('root/sub-folder/file containing query.md', cachedMetadata);
+        const tasksFile = createTestTasksFile('root/sub-folder/file containing query.md', cachedMetadata);
         const task = new TaskBuilder()
             .description('... an array with all the Tasks-tracked tasks in the vault ...')
             .build();

--- a/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
+++ b/tests/Scripting/ScriptingReference/VerifyFunctionFieldSamples.ts
@@ -9,7 +9,8 @@ import { splitSourceHonouringLineContinuations } from '../../../src/Query/Scanne
 import { SearchInfo } from '../../../src/Query/SearchInfo';
 import { Sort } from '../../../src/Query/Sort/Sort';
 import { toLines } from '../../TestingTools/TestHelpers';
-import { TasksFile } from '../../../src/Scripting/TasksFile';
+import type { TasksFile } from '../../../src/Scripting/TasksFile';
+import { createTestTasksFile } from '../../TestingTools/TasksFileHelpers';
 
 /** For example, 'task.due' */
 type TaskPropertyName = string;
@@ -88,7 +89,7 @@ export function verifyFunctionFieldFilterSamplesOnTasks(filters: QueryInstructio
         const instruction = filter[0];
         const comment = filter.slice(1);
 
-        const tasksFile = new TasksFile('a/b.md');
+        const tasksFile = createTestTasksFile('a/b.md');
         const expandedInstruction = preprocessSingleInstruction(instruction, tasksFile);
         const filterOrErrorMessage = new FunctionField().createFilterOrErrorMessage(expandedInstruction);
         expect(filterOrErrorMessage).toBeValid();
@@ -126,7 +127,7 @@ export function verifyFunctionFieldSortSamplesOnTasks(
         const instruction = filter[0];
         const comment = filter.slice(1);
 
-        const tasksFile = new TasksFile('a/b.md');
+        const tasksFile = createTestTasksFile('a/b.md');
         const expandedInstruction = preprocessSingleInstruction(instruction, tasksFile);
         const sorter = new FunctionField().createSorterFromLine(expandedInstruction);
         expect(sorter).not.toBeNull();
@@ -158,7 +159,7 @@ export function verifyFunctionFieldGrouperSamplesOnTasks(
         const instruction = group[0];
         const comment = group.slice(1);
 
-        const tasksFile = new TasksFile('a/b.md');
+        const tasksFile = createTestTasksFile('a/b.md');
         const expandedInstruction = preprocessSingleInstruction(instruction, tasksFile);
         const grouper = new FunctionField().createGrouperFromLine(expandedInstruction);
         expect(grouper).not.toBeNull();

--- a/tests/Scripting/TaskExpression.test.ts
+++ b/tests/Scripting/TaskExpression.test.ts
@@ -1,18 +1,18 @@
 import { TaskExpression, constructArguments, parseAndEvaluateExpression } from '../../src/Scripting/TaskExpression';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { makeQueryContext } from '../../src/Scripting/QueryContext';
-import { TasksFile } from '../../src/Scripting/TasksFile';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 
 describe('TaskExpression', () => {
     describe('low level functions', () => {
         it('should allow passing QueryContext or null to constructArguments()', () => {
             const task = new TaskBuilder().build();
             constructArguments(task, null);
-            constructArguments(task, makeQueryContext(new TasksFile('dummy.md')));
+            constructArguments(task, makeQueryContext(createTestTasksFile('dummy.md')));
         });
 
         it('should calculate an expression value from a QueryContext', () => {
-            const queryContext = makeQueryContext(new TasksFile('test.md'));
+            const queryContext = makeQueryContext(createTestTasksFile('test.md'));
             const task = new TaskBuilder().build();
             const result = parseAndEvaluateExpression(task, 'query.file.path', queryContext);
             expect(result).toEqual('test.md');
@@ -70,7 +70,7 @@ describe('TaskExpression', () => {
     });
 
     describe('evaluating', () => {
-        const queryContext = makeQueryContext(new TasksFile('dummy.md'));
+        const queryContext = makeQueryContext(createTestTasksFile('dummy.md'));
         it('should evaluate a valid task property and give correct result', () => {
             // Arrange
             const taskExpression = new TaskExpression('task.description');

--- a/tests/Scripting/TaskProperties.test.ts
+++ b/tests/Scripting/TaskProperties.test.ts
@@ -10,11 +10,11 @@ import { verifyMarkdownForDocs } from '../TestingTools/VerifyMarkdown';
 import { parseAndEvaluateExpression } from '../../src/Scripting/TaskExpression';
 import { MarkdownTable } from '../../src/lib/MarkdownTable';
 import { makeQueryContextWithTasks } from '../../src/Scripting/QueryContext';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import type { Task } from '../../src/Task/Task';
 import { readTasksFromSimulatedFile } from '../Obsidian/SimulatedFile';
 import { LinkResolver } from '../../src/Task/LinkResolver';
 import { getFirstLinkpathDest } from '../__mocks__/obsidian';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 import { addBackticks, determineExpressionType, formatToRepresentType } from './ScriptingTestHelpers';
 
 window.moment = moment;
@@ -42,7 +42,7 @@ describe('task', () => {
         });
         const markdownTable = new MarkdownTable(headings);
 
-        const queryContext = makeQueryContextWithTasks(new TasksFile(tasks[0].path), tasks);
+        const queryContext = makeQueryContextWithTasks(createTestTasksFile(tasks[0].path), tasks);
         for (const field of fields) {
             const cells = [addBackticks(field)];
             for (const task of tasks) {

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -22,41 +22,47 @@ describe('TasksFile', () => {
 
     it('should provide access to path without extension', () => {
         const path = 'a/b/c/d.md';
-        const file = new TasksFile(path);
+        const file = createTestTasksFile(path);
         expect(file.pathWithoutExtension).toEqual('a/b/c/d');
-        expect(new TasksFile('/root/folder.mds/file.md').pathWithoutExtension).toStrictEqual('/root/folder.mds/file');
+        expect(createTestTasksFile('/root/folder.mds/file.md').pathWithoutExtension).toStrictEqual(
+            '/root/folder.mds/file',
+        );
     });
 
     it('should provide access to the root', () => {
-        expect(new TasksFile('').root).toStrictEqual('/');
-        expect(new TasksFile('outside/inside/A.md').root).toStrictEqual('outside/');
-        expect(new TasksFile('a_b/_c_d_/B.md').root).toStrictEqual('a_b/');
-        expect(new TasksFile('/root/SeArch_Text/search_text.md').root).toStrictEqual('root/');
+        expect(createTestTasksFile('').root).toStrictEqual('/');
+        expect(createTestTasksFile('outside/inside/A.md').root).toStrictEqual('outside/');
+        expect(createTestTasksFile('a_b/_c_d_/B.md').root).toStrictEqual('a_b/');
+        expect(createTestTasksFile('/root/SeArch_Text/search_text.md').root).toStrictEqual('root/');
     });
 
     it('should provide access to the folder', () => {
-        expect(new TasksFile('').folder).toStrictEqual('/');
-        expect(new TasksFile('outside/inside/file.md').folder).toStrictEqual('outside/inside/');
-        expect(new TasksFile('a_b/_c_d_/file.md').folder).toStrictEqual('a_b/_c_d_/');
+        expect(createTestTasksFile('').folder).toStrictEqual('/');
+        expect(createTestTasksFile('outside/inside/file.md').folder).toStrictEqual('outside/inside/');
+        expect(createTestTasksFile('a_b/_c_d_/file.md').folder).toStrictEqual('a_b/_c_d_/');
     });
 
     it('should provide access to the filename', () => {
-        expect(new TasksFile('').filename).toEqual('');
-        expect(new TasksFile('file in root.md').filename).toEqual('file in root.md');
-        expect(new TasksFile('directory name/file in sub-directory.md').filename).toEqual('file in sub-directory.md');
+        expect(createTestTasksFile('').filename).toEqual('');
+        expect(createTestTasksFile('file in root.md').filename).toEqual('file in root.md');
+        expect(createTestTasksFile('directory name/file in sub-directory.md').filename).toEqual(
+            'file in sub-directory.md',
+        );
     });
 
     it('should provide access to the filename without extension', () => {
-        expect(new TasksFile('').filenameWithoutExtension).toEqual('');
-        expect(new TasksFile('file in root.md').filenameWithoutExtension).toEqual('file in root');
-        expect(new TasksFile('directory name/file in sub-directory.md').filenameWithoutExtension).toEqual(
+        expect(createTestTasksFile('').filenameWithoutExtension).toEqual('');
+        expect(createTestTasksFile('file in root.md').filenameWithoutExtension).toEqual('file in root');
+        expect(createTestTasksFile('directory name/file in sub-directory.md').filenameWithoutExtension).toEqual(
             'file in sub-directory',
         );
         // Check it only replaces the last .md
-        expect(new TasksFile('1.md.only-replace.2.md').filenameWithoutExtension).toEqual('1.md.only-replace.2');
+        expect(createTestTasksFile('1.md.only-replace.2.md').filenameWithoutExtension).toEqual('1.md.only-replace.2');
 
         // Check it escapes the '.' in the file extension
-        expect(new TasksFile('1.md.only-replace.2,md').filenameWithoutExtension).toEqual('1.md.only-replace.2,md');
+        expect(createTestTasksFile('1.md.only-replace.2,md').filenameWithoutExtension).toEqual(
+            '1.md.only-replace.2,md',
+        );
     });
 });
 
@@ -287,7 +293,7 @@ describe('TasksFile - reading tags', () => {
     it('should return empty tag list if frontmatter not supplied', () => {
         // This confirms that accessing tags via TasksFile behaves reasonably
         // in tests of tasks that were created without CachedMetadata (as is the case with the majority of tests)
-        const tasksFile = new TasksFile('somewhere.md');
+        const tasksFile = createTestTasksFile('somewhere.md');
         expect(tasksFile.tags).toEqual([]);
         expect(tasksFile.frontmatter.tags).toEqual([]);
     });

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -6,15 +6,12 @@ import { LinkResolver } from '../../src/Task/LinkResolver';
 import type { MockDataName } from '../Obsidian/AllCacheSampleData';
 import { getAllTags, getFirstLinkpathDest, parseFrontMatterTags } from '../__mocks__/obsidian';
 import { MockDataLoader } from '../TestingTools/MockDataLoader';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 import { determineExpressionType, formatToRepresentType } from './ScriptingTestHelpers';
 
 afterEach(() => {
     LinkResolver.getInstance().resetGetFirstLinkpathDestFn();
 });
-
-function createTestTasksFile(path: string): TasksFile {
-    return new TasksFile(path);
-}
 
 describe('TasksFile', () => {
     it('should provide access to path', () => {

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -12,10 +12,14 @@ afterEach(() => {
     LinkResolver.getInstance().resetGetFirstLinkpathDestFn();
 });
 
+function createTestTasksFile(path: string): TasksFile {
+    return new TasksFile(path);
+}
+
 describe('TasksFile', () => {
     it('should provide access to path', () => {
         const path = 'a/b/c/d.md';
-        const file = new TasksFile(path);
+        const file = createTestTasksFile(path);
         expect(file.path).toEqual(path);
     });
 

--- a/tests/Scripting/TasksFile.test.ts
+++ b/tests/Scripting/TasksFile.test.ts
@@ -1,6 +1,5 @@
 import { verifyAsJson } from 'approvals/lib/Providers/Jest/JestApprovals';
 import type { Reference } from 'obsidian';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { getTasksFileFromMockData, listPathAndData } from '../TestingTools/MockDataHelpers';
 import { LinkResolver } from '../../src/Task/LinkResolver';
 import type { MockDataName } from '../Obsidian/AllCacheSampleData';
@@ -105,7 +104,7 @@ describe('TasksFile - raw frontmatter - identicalTo', () => {
 
 describe('TasksFile - reading frontmatter', () => {
     it('should read file if not given CachedMetadata', () => {
-        const tasksFile = new TasksFile('some path.md', {});
+        const tasksFile = createTestTasksFile('some path.md', {});
 
         expect(tasksFile.cachedMetadata.frontmatter).toBeUndefined();
         expect(tasksFile.frontmatter).toEqual({ tags: [] });
@@ -451,14 +450,14 @@ describe('TasksFile - identicalTo', () => {
     const cachedMetadata = {};
 
     it('should detect identical objects', () => {
-        const lhs = new TasksFile(path, cachedMetadata);
-        const rhs = new TasksFile(path, cachedMetadata);
+        const lhs = createTestTasksFile(path, cachedMetadata);
+        const rhs = createTestTasksFile(path, cachedMetadata);
         expect(lhs.identicalTo(rhs)).toEqual(true);
     });
 
     it('should check path', () => {
-        const lhs = new TasksFile(path, cachedMetadata);
-        const rhs = new TasksFile('somewhere else.md', cachedMetadata);
+        const lhs = createTestTasksFile(path, cachedMetadata);
+        const rhs = createTestTasksFile('somewhere else.md', cachedMetadata);
         expect(lhs.identicalTo(rhs)).toEqual(false);
     });
 

--- a/tests/Statuses/StatusRegistry.test.ts
+++ b/tests/Statuses/StatusRegistry.test.ts
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { StatusRegistry } from '../../src/Statuses/StatusRegistry';
 import { Status } from '../../src/Statuses/Status';
 import { StatusConfiguration, StatusType } from '../../src/Statuses/StatusConfiguration';
@@ -12,6 +11,7 @@ import type { StatusCollection, StatusCollectionEntry } from '../../src/Statuses
 import * as TestHelpers from '../TestingTools/TestHelpers';
 import * as StatusExamples from '../TestingTools/StatusExamples';
 import { constructStatuses } from '../TestingTools/StatusesTestHelpers';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 
 jest.mock('obsidian');
 window.moment = moment;
@@ -377,7 +377,7 @@ describe('StatusRegistry', () => {
         const sectionIndex = 1209;
         const precedingHeader = 'Eloquent Section';
         const taskLocation = new TaskLocation(
-            new TasksFile(path),
+            createTestTasksFile(path),
             lineNumber,
             sectionStart,
             sectionIndex,

--- a/tests/Task/Link.test.ts
+++ b/tests/Task/Link.test.ts
@@ -1,4 +1,3 @@
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Link } from '../../src/Task/Link';
 
 import { AllMockDataNames, type MockDataName } from '../Obsidian/AllCacheSampleData';
@@ -8,6 +7,7 @@ import { verifyMarkdown } from '../TestingTools/VerifyMarkdown';
 import { LinkResolver } from '../../src/Task/LinkResolver';
 import { getFirstLinkpathDest, getFirstLinkpathDestFromData } from '../__mocks__/obsidian';
 import { MockDataLoader } from '../TestingTools/MockDataLoader';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 
 function getLink(testDataName: MockDataName, index: number) {
     const data = MockDataLoader.get(testDataName);
@@ -292,10 +292,12 @@ describe('linkClass', () => {
             const linkToAFolder = getLink('link_in_task_wikilink', 2);
             expect(linkToAFolder.originalMarkdown).toMatchInlineSnapshot('"[[Test Data/link_in_task_wikilink]]"');
 
-            expect(linkToAFolder.linksTo(new TasksFile('Test Data/link_in_task_wikilink.md'))).toEqual(true);
-            expect(linkToAFolder.linksTo(new TasksFile('link_in_task_wikilink.md'))).toEqual(false);
-            expect(linkToAFolder.linksTo(new TasksFile('Wrong Test Data/link_in_task_wikilink.md'))).toEqual(false);
-            expect(linkToAFolder.linksTo(new TasksFile('something_obviously_different.md'))).toEqual(false);
+            expect(linkToAFolder.linksTo(createTestTasksFile('Test Data/link_in_task_wikilink.md'))).toEqual(true);
+            expect(linkToAFolder.linksTo(createTestTasksFile('link_in_task_wikilink.md'))).toEqual(false);
+            expect(linkToAFolder.linksTo(createTestTasksFile('Wrong Test Data/link_in_task_wikilink.md'))).toEqual(
+                false,
+            );
+            expect(linkToAFolder.linksTo(createTestTasksFile('something_obviously_different.md'))).toEqual(false);
         });
     });
 });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -4,7 +4,6 @@
 import moment from 'moment/moment';
 
 import type { Reference } from 'obsidian';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { ListItem } from '../../src/Task/ListItem';
 import { Task } from '../../src/Task/Task';
 import { TaskLocation } from '../../src/Task/TaskLocation';
@@ -12,11 +11,12 @@ import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { fromLine } from '../TestingTools/TestHelpers';
 import { readTasksFromSimulatedFile } from '../Obsidian/SimulatedFile';
 import { LinkResolver } from '../../src/Task/LinkResolver';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 import { createChildListItem } from './ListItemHelpers';
 
 window.moment = moment;
 
-const taskLocation = TaskLocation.fromUnknownPosition(new TasksFile('anything.md'));
+const taskLocation = TaskLocation.fromUnknownPosition(createTestTasksFile('anything.md'));
 
 afterEach(() => {
     LinkResolver.getInstance().resetGetFirstLinkpathDestFn();
@@ -53,7 +53,7 @@ describe('list item tests', () => {
         const parentListItem = ListItem.fromListItemLine('- parent item', null, taskLocation)!;
         const firstReadTask = Task.fromLine({
             line: '    - [ ] child task',
-            taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
+            taskLocation: TaskLocation.fromUnknownPosition(createTestTasksFile('x.md')),
             fallbackDate: null,
         });
 
@@ -67,7 +67,7 @@ describe('list item tests', () => {
     it('should create a list item child for a task parent', () => {
         const parentTask = Task.fromLine({
             line: '- [ ] parent task',
-            taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('x.md')),
+            taskLocation: TaskLocation.fromUnknownPosition(createTestTasksFile('x.md')),
             fallbackDate: null,
         });
         const childListItem = ListItem.fromListItemLine('    - child item', parentTask, taskLocation)!;
@@ -302,12 +302,12 @@ describe('identicalTo', () => {
         const item1 = ListItem.fromListItemLine(
             '- same',
             null,
-            TaskLocation.fromUnknownPosition(new TasksFile('anything.md')),
+            TaskLocation.fromUnknownPosition(createTestTasksFile('anything.md')),
         )!;
         const item2 = ListItem.fromListItemLine(
             '- same',
             null,
-            TaskLocation.fromUnknownPosition(new TasksFile('something.md')),
+            TaskLocation.fromUnknownPosition(createTestTasksFile('something.md')),
         )!;
 
         expect(item2.identicalTo(item1)).toEqual(false);

--- a/tests/Task/Task.test.ts
+++ b/tests/Task/Task.test.ts
@@ -5,7 +5,6 @@ import moment from 'moment';
 import type { Moment } from 'moment';
 
 import { verifyAll } from 'approvals/lib/Providers/Jest/JestApprovals';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Status } from '../../src/Statuses/Status';
 import { Task } from '../../src/Task/Task';
 import { resetSettings, updateSettings } from '../../src/Config/Settings';
@@ -22,6 +21,7 @@ import { SampleTasks } from '../TestingTools/SampleTasks';
 import { booleanToEmoji } from '../TestingTools/FilterTestHelpers';
 import type { TasksDate } from '../../src/DateTime/TasksDate';
 import { OnCompletion } from '../../src/Task/OnCompletion';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 import { createChildListItem } from './ListItemHelpers';
 
 window.moment = moment;
@@ -488,7 +488,7 @@ describe('parsing tags', () => {
             // Act
             const task = Task.fromLine({
                 line: markdownTask,
-                taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('file.md')),
+                taskLocation: TaskLocation.fromUnknownPosition(createTestTasksFile('file.md')),
                 fallbackDate: null,
             });
 

--- a/tests/Task/TaskLocation.test.ts
+++ b/tests/Task/TaskLocation.test.ts
@@ -1,5 +1,6 @@
-import { TasksFile } from '../../src/Scripting/TasksFile';
+import type { TasksFile } from '../../src/Scripting/TasksFile';
 import { TaskLocation } from '../../src/Task/TaskLocation';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
 
 describe('TaskLocation', () => {
     it('should store the full task location', () => {
@@ -12,7 +13,7 @@ describe('TaskLocation', () => {
 
         // Act
         const taskLocation = new TaskLocation(
-            new TasksFile(path),
+            createTestTasksFile(path),
             lineNumber,
             sectionStart,
             sectionIndex,
@@ -33,7 +34,7 @@ describe('TaskLocation', () => {
         const path = 'a/b/c.md';
 
         // Act
-        const taskLocation = TaskLocation.fromUnknownPosition(new TasksFile(path));
+        const taskLocation = TaskLocation.fromUnknownPosition(createTestTasksFile(path));
 
         // Assert
         expect(taskLocation.path).toStrictEqual(path);
@@ -51,7 +52,7 @@ describe('TaskLocation', () => {
         const sectionIndex = 10;
         const precedingHeader = 'My Previous Header';
         const taskLocation = new TaskLocation(
-            new TasksFile(path),
+            createTestTasksFile(path),
             lineNumber,
             sectionStart,
             sectionIndex,
@@ -60,7 +61,7 @@ describe('TaskLocation', () => {
 
         // Act
         const newPath = 'd/e/f.md';
-        const newLocation = taskLocation.fromRenamedFile(new TasksFile(newPath));
+        const newLocation = taskLocation.fromRenamedFile(createTestTasksFile(newPath));
 
         // Assert
         expect(newLocation.path).toStrictEqual(newPath);
@@ -71,13 +72,13 @@ describe('TaskLocation', () => {
     });
 
     it('should recognise unknown paths', () => {
-        expect(TaskLocation.fromUnknownPosition(new TasksFile('x.md')).hasKnownPath).toBe(true);
-        expect(TaskLocation.fromUnknownPosition(new TasksFile('')).hasKnownPath).toBe(false);
+        expect(TaskLocation.fromUnknownPosition(createTestTasksFile('x.md')).hasKnownPath).toBe(true);
+        expect(TaskLocation.fromUnknownPosition(createTestTasksFile('')).hasKnownPath).toBe(false);
     });
 });
 
 describe('TaskLocation - identicalTo', function () {
-    const tasksFile: TasksFile = new TasksFile('x.md');
+    const tasksFile: TasksFile = createTestTasksFile('x.md');
     const lineNumber: number = 40;
     const sectionStart: number = 30;
     const sectionIndex: number = 3;
@@ -91,7 +92,13 @@ describe('TaskLocation - identicalTo', function () {
     });
 
     it('should check tasksFile', () => {
-        const rhs = new TaskLocation(new TasksFile('y.md'), lineNumber, sectionStart, sectionIndex, precedingHeader);
+        const rhs = new TaskLocation(
+            createTestTasksFile('y.md'),
+            lineNumber,
+            sectionStart,
+            sectionIndex,
+            precedingHeader,
+        );
         expect(lhs.identicalTo(rhs)).toEqual(false);
     });
 

--- a/tests/TestingTools/ApprovalTestHelpers.ts
+++ b/tests/TestingTools/ApprovalTestHelpers.ts
@@ -5,8 +5,9 @@ import type { GlobalQuery } from '../../src/Config/GlobalQuery';
 import { Query } from '../../src/Query/Query';
 import { explainResults } from '../../src/Query/QueryRendererHelper';
 import type { Task } from '../../src/Task/Task';
-import { type OptionalTasksFile, TasksFile } from '../../src/Scripting/TasksFile';
+import type { OptionalTasksFile } from '../../src/Scripting/TasksFile';
 import { verifyMarkdown } from './VerifyMarkdown';
+import { createTestTasksFile } from './TasksFileHelpers';
 
 export function printIteration<T1>(func: <T1>(t1: T1) => any, params1: T1[]): string {
     const EMPTY_ENTRY = {};
@@ -94,7 +95,7 @@ export function verifyTaskBlockExplanation(
     globalFilter: GlobalFilter,
     globalQuery: GlobalQuery,
     options?: Options,
-    tasksFile: OptionalTasksFile = new TasksFile('some/sample/file path.md'),
+    tasksFile: OptionalTasksFile = createTestTasksFile('some/sample/file path.md'),
 ): void {
     const explanation = explainResults(instructions, globalFilter, globalQuery, tasksFile);
 

--- a/tests/TestingTools/FilterTestHelpers.ts
+++ b/tests/TestingTools/FilterTestHelpers.ts
@@ -1,10 +1,10 @@
 import type { FilterOrErrorMessage } from '../../src/Query/Filter/FilterOrErrorMessage';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Task } from '../../src/Task/Task';
 import { Query } from '../../src/Query/Query';
 import { TaskLocation } from '../../src/Task/TaskLocation';
 import { SearchInfo } from '../../src/Query/SearchInfo';
 import type { TaskBuilder } from './TaskBuilder';
+import { createTestTasksFile } from './TasksFileHelpers';
 
 /**
  * Convenience function to test a Filter on a single Task
@@ -79,7 +79,7 @@ export function shouldSupportFiltering(
         (taskLine) =>
             Task.fromLine({
                 line: taskLine,
-                taskLocation: TaskLocation.fromUnknownPosition(new TasksFile('')),
+                taskLocation: TaskLocation.fromUnknownPosition(createTestTasksFile('')),
                 fallbackDate: null, // For tests scheduled date needs to be set explicitly
             }) as Task,
     );

--- a/tests/TestingTools/MockDataHelpers.ts
+++ b/tests/TestingTools/MockDataHelpers.ts
@@ -1,7 +1,8 @@
-import { TasksFile } from '../../src/Scripting/TasksFile';
+import type { TasksFile } from '../../src/Scripting/TasksFile';
 import type { SimulatedFile } from '../Obsidian/SimulatedFile';
 import type { MockDataName } from '../Obsidian/AllCacheSampleData';
 import { MockDataLoader } from './MockDataLoader';
+import { createTestTasksFile } from './TasksFileHelpers';
 
 /**
  * @file This file provides functions for testing {@link TasksFile} from data in `tests/Obsidian/__test_data__`.
@@ -27,7 +28,7 @@ import { MockDataLoader } from './MockDataLoader';
 export function getTasksFileFromMockData(testDataName: MockDataName) {
     const data = MockDataLoader.get(testDataName);
     const cachedMetadata = data.cachedMetadata;
-    return new TasksFile(data.filePath, cachedMetadata);
+    return createTestTasksFile(data.filePath, cachedMetadata);
 }
 
 /**

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -6,9 +6,9 @@ import moment from 'moment';
 import type { Task } from '../../src/Task/Task';
 import { ListItem } from '../../src/Task/ListItem';
 import { TaskLocation } from '../../src/Task/TaskLocation';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { TaskBuilder } from './TaskBuilder';
 import { MockDataLoader } from './MockDataLoader';
+import { createTestTasksFile } from './TasksFileHelpers';
 
 export {};
 
@@ -28,7 +28,7 @@ describe('TaskBuilder', () => {
     });
 
     it('should allow parent to be supplied', () => {
-        const location = TaskLocation.fromUnknownPosition(new TasksFile('somewhere.md'));
+        const location = TaskLocation.fromUnknownPosition(createTestTasksFile('somewhere.md'));
         const parent = ListItem.fromListItemLine('- any old list item', null, location);
         const builder = new TaskBuilder();
         const task = builder.parent(parent).build();

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -1,6 +1,5 @@
 // Builder
 import type { Moment } from 'moment';
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Status } from '../../src/Statuses/Status';
 import { OnCompletion } from '../../src/Task/OnCompletion';
 import { Occurrence } from '../../src/Task/Occurrence';
@@ -14,6 +13,7 @@ import type { ListItem } from '../../src/Task/ListItem';
 import type { SimulatedFile } from '../Obsidian/SimulatedFile';
 import type { MockDataName } from '../Obsidian/AllCacheSampleData';
 import { MockDataLoader } from './MockDataLoader';
+import { createTestTasksFile } from './TasksFileHelpers';
 
 /**
  * A fluent class for creating tasks for tests.
@@ -85,7 +85,7 @@ export class TaskBuilder {
             status: this._status,
             description: description,
             taskLocation: new TaskLocation(
-                new TasksFile(this._path, cachedMetadata),
+                createTestTasksFile(this._path, cachedMetadata),
                 this._lineNumber,
                 this._sectionStart,
                 this._sectionIndex,

--- a/tests/TestingTools/TasksFileHelpers.ts
+++ b/tests/TestingTools/TasksFileHelpers.ts
@@ -1,0 +1,5 @@
+import { TasksFile } from '../../src/Scripting/TasksFile';
+
+export function createTestTasksFile(path: string): TasksFile {
+    return new TasksFile(path);
+}

--- a/tests/TestingTools/TasksFileHelpers.ts
+++ b/tests/TestingTools/TasksFileHelpers.ts
@@ -1,5 +1,6 @@
+import type { CachedMetadata } from 'obsidian';
 import { TasksFile } from '../../src/Scripting/TasksFile';
 
-export function createTestTasksFile(path: string): TasksFile {
-    return new TasksFile(path);
+export function createTestTasksFile(path: string, cachedMetadata: CachedMetadata = {}): TasksFile {
+    return new TasksFile(path, cachedMetadata);
 }

--- a/tests/TestingTools/TestHelpers.ts
+++ b/tests/TestingTools/TestHelpers.ts
@@ -1,6 +1,6 @@
-import { TasksFile } from '../../src/Scripting/TasksFile';
 import { Task } from '../../src/Task/Task';
 import { TaskLocation } from '../../src/Task/TaskLocation';
+import { createTestTasksFile } from './TasksFileHelpers';
 
 /**
  * @see fromLines
@@ -17,7 +17,7 @@ export function fromLine({
 }) {
     return Task.fromLine({
         line,
-        taskLocation: new TaskLocation(new TasksFile(path), 0, 0, 0, precedingHeader),
+        taskLocation: new TaskLocation(createTestTasksFile(path), 0, 0, 0, precedingHeader),
         fallbackDate: null,
     })!;
 }
@@ -77,7 +77,7 @@ export function createTasksFromMarkdown(tasksAsMarkdown: string, path: string, p
     for (const line of taskLines) {
         const task = Task.fromLine({
             line: line,
-            taskLocation: new TaskLocation(new TasksFile(path), 0, 0, 0, precedingHeader),
+            taskLocation: new TaskLocation(createTestTasksFile(path), 0, 0, 0, precedingHeader),
             fallbackDate: null,
         });
         if (task) {


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

In order to fix #3883, I need to change how `TasksFile` instances are created. They will need to store `TFile` instead of `path: string`.

That turned out to require a lot changes, especially in the tests.

So this tidies up the `TasksFile` use in lots of small ways, so that the later fix will be relatively easy to make and to understand.

Specifically, where previously a `TFile.path` was passed in to a function that then created a `TasksFile`, I am now creating the `TasksFile` in the same scope as the `TFile`.

Whilst here, I fixed a typo in a task description in the test vault.

## Motivation and Context

Preparation for fixing #3883:

- #3883

## How has this been tested?

- Added a few new tests.
- I generally checked that changes were covered by tests.
- I also did some exporatory testing to make sure that:
    - Search results were updated if I renamed the files containing tasks in search results
    - The `scheduled date` files in `resources/sample_vaults/Tasks-Demo/Manual Testing/Scheduled Date Implied` all still got updated correctly if I added or removed the date from the file name.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
