### PR TITLE
fix: After renaming files in Reading Mode, tasks can now still be edited

### DIFF
--- a/src/Obsidian/File.ts
+++ b/src/Obsidian/File.ts
@@ -44,6 +44,11 @@ export const initializeFile = ({
  * In addition, this function is meant to be called with reasonable confidence
  * that the {@code originalTask} is unmodified and at the exact same section and
  * sectionIdx in the source file it was originally found in. It will fail otherwise.
+ *
+ * If this might be called in a callback some time after the originalTask object was
+ * created, it is recommended that originalTask's TaskFile has its tFile populated.
+ * This will allow edits to be saved even if the task's Markdown file has been renamed
+ * since the task was originally created.
  */
 export const replaceTaskWithTasks = async ({
     originalTask,

--- a/src/Obsidian/File.ts
+++ b/src/Obsidian/File.ts
@@ -194,7 +194,7 @@ async function getTaskAndFileLines(task: ListItem, vault: Vault): Promise<[numbe
     // Validate our inputs.
     // For permanent failures, return nothing.
     // For failures that might be fixed if we wait for a little while, return retry().
-    const file = vault.getFileByPath(task.path);
+    const file = task.file.tFile || vault.getFileByPath(task.path);
     if (!file) {
         throw new WarningWorthRetrying(`Tasks: No file found for task ${task.description}. Retrying ...`);
     }

--- a/src/Obsidian/File.ts
+++ b/src/Obsidian/File.ts
@@ -46,7 +46,7 @@ export const initializeFile = ({
  * sectionIdx in the source file it was originally found in. It will fail otherwise.
  *
  * If this might be called in a callback some time after the originalTask object was
- * created, it is recommended that originalTask's TaskFile has its tFile populated.
+ * created, it is recommended that originalTask's {@link TasksFile} has its tFile populated.
  * This will allow edits to be saved even if the task's Markdown file has been renamed
  * since the task was originally created.
  */

--- a/src/Obsidian/InlineRenderer.ts
+++ b/src/Obsidian/InlineRenderer.ts
@@ -80,6 +80,8 @@ export class InlineRenderer {
         }
 
         const path = context.sourcePath;
+        const tasksFile = new TasksFile(path);
+
         const section = context.getSectionInfo(element);
 
         if (section === null) {
@@ -100,7 +102,6 @@ export class InlineRenderer {
             }
 
             const precedingHeader = null; // We don't need the preceding header for in-line rendering.
-            const tasksFile = new TasksFile(path);
             const task = Task.fromLine({
                 line,
                 taskLocation: new TaskLocation(tasksFile, lineNumber, section.lineStart, sectionIndex, precedingHeader),

--- a/src/Obsidian/InlineRenderer.ts
+++ b/src/Obsidian/InlineRenderer.ts
@@ -80,7 +80,8 @@ export class InlineRenderer {
         }
 
         const path = context.sourcePath;
-        const tasksFile = new TasksFile(path);
+        const file = this.app.vault.getFileByPath(path) || undefined;
+        const tasksFile = new TasksFile(path, {}, file);
 
         const section = context.getSectionInfo(element);
 

--- a/src/Obsidian/InlineRenderer.ts
+++ b/src/Obsidian/InlineRenderer.ts
@@ -100,15 +100,10 @@ export class InlineRenderer {
             }
 
             const precedingHeader = null; // We don't need the preceding header for in-line rendering.
+            const tasksFile = new TasksFile(path);
             const task = Task.fromLine({
                 line,
-                taskLocation: new TaskLocation(
-                    new TasksFile(path),
-                    lineNumber,
-                    section.lineStart,
-                    sectionIndex,
-                    precedingHeader,
-                ),
+                taskLocation: new TaskLocation(tasksFile, lineNumber, section.lineStart, sectionIndex, precedingHeader),
                 fallbackDate: null, // We don't need the fallback date for in-line rendering
             });
             if (task !== null) {

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -1,4 +1,11 @@
-import { type CachedMetadata, type FrontMatterCache, type Reference, getAllTags, parseFrontMatterTags } from 'obsidian';
+import {
+    type CachedMetadata,
+    type FrontMatterCache,
+    type Reference,
+    type TFile,
+    getAllTags,
+    parseFrontMatterTags,
+} from 'obsidian';
 import { Link } from '../Task/Link';
 
 export type OptionalTasksFile = TasksFile | undefined;
@@ -7,7 +14,9 @@ export type OptionalTasksFile = TasksFile | undefined;
  * A simple class to provide access to file information via 'task.file' in scripting code.
  */
 export class TasksFile {
-    private readonly _path: string;
+    private readonly _path: string; // the original path, at the moment of creation.
+    public readonly tFile?: TFile; // the TFile object for the file, needed for reliable writing. Reflects the current path after any renames.
+
     private readonly _cachedMetadata: CachedMetadata;
     // Always make TasksFile.frontmatter.tags exist and be empty, even if no frontmatter present:
     private readonly _frontmatter = { tags: [] } as Record<string, unknown>;
@@ -16,8 +25,10 @@ export class TasksFile {
     private readonly _outlinksInProperties: Readonly<Link[]> = [];
     private readonly _outlinksInBody: Readonly<Link[]> = [];
 
-    constructor(path: string, cachedMetadata: CachedMetadata = {}) {
+    constructor(path: string, cachedMetadata: CachedMetadata = {}, tFile?: TFile) {
         this._path = path;
+        this.tFile = tFile;
+
         this._cachedMetadata = cachedMetadata;
 
         const rawFrontmatter = cachedMetadata.frontmatter;

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -207,6 +207,7 @@ describe('EditableTask tests', () => {
                   "_outlinksInProperties": [],
                   "_path": "some/folder/fileName.md",
                   "_tags": [],
+                  "tFile": undefined,
                 },
               },
             }


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3883 

## Description

This fixes a major category of errors with editing tasks displayed in Reading Mode, if the file was renamed after the tasks were rendered.

This was my 4th attempt at fixing this, over 3 days!

All the earlier attempts were much more complicated - and they either introduced other bugs, or added great complexity to the code.

But in the end, I learned enough to come up with a relatively simple fix.

## Motivation and Context

Fixes #3883

- #3883 

## How has this been tested?

With manual testing.

I was unable to find a way to add unit tests, due to Obsidian not having been designed to be run from test frameworks.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
