### PR TITLE
fix: Preserve Obsidian & other plugins' classes & data- attributes on tasks in Reading View

### DIFF
--- a/src/Obsidian/InlineRenderer.ts
+++ b/src/Obsidian/InlineRenderer.ts
@@ -5,7 +5,7 @@ import { TaskLayoutOptions } from '../Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from '../Layout/QueryLayoutOptions';
 import { TasksFile } from '../Scripting/TasksFile';
 import { Task } from '../Task/Task';
-import { TaskLineRenderer, createAndAppendElement } from '../Renderer/TaskLineRenderer';
+import { TaskLineRenderer, createAndAppendElement, reconcileReplacementTask } from '../Renderer/TaskLineRenderer';
 import { TaskLocation } from '../Task/TaskLocation';
 
 /**
@@ -166,7 +166,7 @@ export class InlineRenderer {
                 }
             }
 
-            renderedElement.replaceWith(taskElement);
+            reconcileReplacementTask(renderedElement, taskElement);
         }
     }
 }

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -58,15 +58,25 @@ export function createAndAppendElement<K extends keyof HTMLElementTagNameMap>(
  * Replace the original list item that Obsidian rendered in Reading View with the one
  * that Tasks has rendered.
  *
- * Any classes added to the original element by Obsidian or other plugins' Markdown post-processors
- * prior to this plugin's Markdown post-processor running are copied onto the replacement so that
- * they are not lost when Tasks swaps in its own rendered element.
+ * Any classes and data attributes added to the original element by Obsidian or other plugins'
+ * Markdown post-processors prior to this plugin's Markdown post-processor running are copied onto
+ * the replacement so that they are not lost when Tasks swaps in its own rendered element.
+ *
+ * Data attributes that the replacement already has (those that Tasks set when rendering) take
+ * precedence and are not overwritten by the original's values.
  *
  * @param original - the list item rendered by Obsidian, which is being replaced.
  * @param replacement - the list item rendered by Tasks, which takes its place.
  */
 export function reconcileReplacementTask(original: HTMLElement, replacement: HTMLElement): void {
     original.classList.forEach((cls) => replacement.classList.add(cls)); // Copy classes from original to replacement
+
+    // Copy data attributes from original to replacement, without overwriting those Tasks has set
+    original.getAttributeNames().forEach((name) => {
+        if (name.startsWith('data-') && !replacement.hasAttribute(name)) {
+            replacement.setAttribute(name, original.getAttribute(name)!);
+        }
+    });
 
     original.replaceWith(replacement);
 }

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -55,6 +55,17 @@ export function createAndAppendElement<K extends keyof HTMLElementTagNameMap>(
 }
 
 /**
+ * Replace the original list item that Obsidian rendered in Reading View with the one
+ * that Tasks has rendered.
+ *
+ * @param original - the list item rendered by Obsidian, which is being replaced.
+ * @param replacement - the list item rendered by Tasks, which takes its place.
+ */
+export function reconcileReplacementTask(original: HTMLElement, replacement: HTMLElement): void {
+    original.replaceWith(replacement);
+}
+
+/**
  * `TaskLineRenderer` is responsible for rendering task details as HTML list items with
  * various customization options.
  *

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -58,10 +58,16 @@ export function createAndAppendElement<K extends keyof HTMLElementTagNameMap>(
  * Replace the original list item that Obsidian rendered in Reading View with the one
  * that Tasks has rendered.
  *
+ * Any classes added to the original element by Obsidian or other plugins' Markdown post-processors
+ * prior to this plugin's Markdown post-processor running are copied onto the replacement so that
+ * they are not lost when Tasks swaps in its own rendered element.
+ *
  * @param original - the list item rendered by Obsidian, which is being replaced.
  * @param replacement - the list item rendered by Tasks, which takes its place.
  */
 export function reconcileReplacementTask(original: HTMLElement, replacement: HTMLElement): void {
+    original.classList.forEach((cls) => replacement.classList.add(cls)); // Copy classes from original to replacement
+
     original.replaceWith(replacement);
 }
 

--- a/tests/Renderer/TaskLineRenderer.test.ts
+++ b/tests/Renderer/TaskLineRenderer.test.ts
@@ -610,6 +610,17 @@ describe('task line rendering - preserving classes and data attributes', () => {
         expect(replacement.getAttribute('data-custom')).toBe('value');
     });
 
+    it('does not copy pre-existing non-data attributes from the original onto the replacement', () => {
+        const { original, replacement } = originalAndReplacement();
+        original.setAttribute('test-attr', 'value');
+        original.setAttribute('aria-label', 'a task');
+
+        reconcileReplacementTask(original, replacement);
+
+        expect(replacement.hasAttribute('test-attr')).toBe(false);
+        expect(replacement.hasAttribute('aria-label')).toBe(false);
+    });
+
     /*
      * Create an original list item, along with a parent element,
      * and a fully rendered task list item, so it carries the classes

--- a/tests/Renderer/TaskLineRenderer.test.ts
+++ b/tests/Renderer/TaskLineRenderer.test.ts
@@ -10,7 +10,11 @@ import { QueryLayoutOptions } from '../../src/Layout/QueryLayoutOptions';
 import { TaskLayoutComponent, TaskLayoutOptions, taskLayoutComponents } from '../../src/Layout/TaskLayoutOptions';
 import { DateParser } from '../../src/DateTime/DateParser';
 import type { TextRenderer } from '../../src/Renderer/TaskLineRenderer';
-import { TaskLineRenderer, createAndAppendElement } from '../../src/Renderer/TaskLineRenderer';
+import {
+    TaskLineRenderer,
+    createAndAppendElement,
+    reconcileReplacementTask,
+} from '../../src/Renderer/TaskLineRenderer';
 import type { Task } from '../../src/Task/Task';
 import { TaskRegularExpressions } from '../../src/Task/TaskRegularExpressions';
 import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
@@ -567,5 +571,42 @@ ${task.toFileLineString()}
 
     it('Minimal task - short mode', async () => {
         await renderAndVerifyHTML(minimalTask, layoutOptionsShortMode());
+    });
+});
+
+describe('task line rendering - preserving classes and data attributes', () => {
+    /*
+     * Create an original list item, along with a parent element,
+     * and a separate replacement list item.
+     * Note the plain li elements will only be used by tests that check
+     * persistence of pre-existing classes and attributes during the
+     * replacement
+     */
+    const originalAndReplacement = () => {
+        const list = document.createElement('ul');
+        const original = createAndAppendElement('li', list);
+        const replacement = document.createElement('li');
+        return { original, replacement };
+    };
+
+    it.failing('copies pre-existing classes from the original onto the replacement', () => {
+        const { original, replacement } = originalAndReplacement();
+        original.classList.add('test-plugin-class', 'another-plugin-class');
+
+        reconcileReplacementTask(original, replacement);
+
+        expect(replacement.classList.contains('test-plugin-class')).toBe(true);
+        expect(replacement.classList.contains('another-plugin-class')).toBe(true);
+    });
+
+    it.failing('copies pre-existing data attributes from the original onto the replacement', () => {
+        const { original, replacement } = originalAndReplacement();
+        original.setAttribute('data-test-color', 'red');
+        original.setAttribute('data-custom', 'value');
+
+        reconcileReplacementTask(original, replacement);
+
+        expect(replacement.getAttribute('data-test-color')).toBe('red');
+        expect(replacement.getAttribute('data-custom')).toBe('value');
     });
 });

--- a/tests/Renderer/TaskLineRenderer.test.ts
+++ b/tests/Renderer/TaskLineRenderer.test.ts
@@ -589,7 +589,7 @@ describe('task line rendering - preserving classes and data attributes', () => {
         return { original, replacement };
     };
 
-    it.failing('copies pre-existing classes from the original onto the replacement', () => {
+    it('copies pre-existing classes from the original onto the replacement', () => {
         const { original, replacement } = originalAndReplacement();
         original.classList.add('test-plugin-class', 'another-plugin-class');
 

--- a/tests/Renderer/TaskLineRenderer.test.ts
+++ b/tests/Renderer/TaskLineRenderer.test.ts
@@ -609,4 +609,50 @@ describe('task line rendering - preserving classes and data attributes', () => {
         expect(replacement.getAttribute('data-test-color')).toBe('red');
         expect(replacement.getAttribute('data-custom')).toBe('value');
     });
+
+    /*
+     * Create an original list item, along with a parent element,
+     * and a fully rendered task list item, so it carries the classes
+     * and data attributes that Tasks itself adds
+     */
+    const originalAndRenderedReplacement = async (taskLine: string) => {
+        const replacement = await renderListItem(fromLine({ line: taskLine }));
+        const list = document.createElement('ul');
+        const original = createAndAppendElement('li', list);
+        return { original, replacement };
+    };
+
+    it("should have the Tasks plugin's own classes after the replacement", async () => {
+        const { original, replacement } = await originalAndRenderedReplacement('- [x] A complete task');
+        original.classList.add('test-plugin-class');
+
+        reconcileReplacementTask(original, replacement);
+
+        expect(replacement.classList.contains('task-list-item')).toBe(true);
+        expect(replacement.classList.contains('is-checked')).toBe(true);
+        expect(replacement.classList.contains('plugin-tasks-list-item')).toBe(true);
+    });
+
+    it("should have the Tasks plugin's own data attributes after the replacement", async () => {
+        const { original, replacement } = await originalAndRenderedReplacement('- [x] A complete task');
+        original.setAttribute('data-custom', 'value');
+
+        reconcileReplacementTask(original, replacement);
+
+        expect(replacement.hasAttribute('data-task')).toBe(true);
+        expect(replacement.hasAttribute('data-line')).toBe(true);
+        expect(replacement.hasAttribute('data-task-status-name')).toBe(true);
+        expect(replacement.hasAttribute('data-task-status-type')).toBe(true);
+    });
+
+    it("should not overwrite the replacement's own data attributes with the original's", async () => {
+        const { original, replacement } = await originalAndRenderedReplacement('- [x] A complete task');
+        original.setAttribute('data-task', ' ');
+        original.setAttribute('data-line', '99');
+
+        reconcileReplacementTask(original, replacement);
+
+        expect(replacement.getAttribute('data-task')).toBe('x');
+        expect(replacement.getAttribute('data-line')).toBe('0');
+    });
 });

--- a/tests/Renderer/TaskLineRenderer.test.ts
+++ b/tests/Renderer/TaskLineRenderer.test.ts
@@ -599,7 +599,7 @@ describe('task line rendering - preserving classes and data attributes', () => {
         expect(replacement.classList.contains('another-plugin-class')).toBe(true);
     });
 
-    it.failing('copies pre-existing data attributes from the original onto the replacement', () => {
+    it('copies pre-existing data attributes from the original onto the replacement', () => {
         const { original, replacement } = originalAndReplacement();
         original.setAttribute('data-test-color', 'red');
         original.setAttribute('data-custom', 'value');


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3898 

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->
When the Tasks plugin renders a task in Reading View it now preserves the task list item element's classes and `data-*` attributes that were already on the item prior to the Tasks plugin's Markdown post-processor running. This includes anything not accounted for by the Tasks plugin that were originally added by Obsidian as well as anything added by other plugins' Markdown post-processor.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3898.

When Tasks rebuilds a task's list item in Reading View, it previously discarded the classes and `data-*` attributes already on it. Tasks recreates some of these itself while rebuilding, specifically Obsidian's `task-list-item` class, `is-checked` class (when needed), as well as the `data-task` and `data-line` attributes, so those were effectively retained, but anything Tasks does not recreate was lost. 

This specifically affects other plugins that may add classes or `data-*` attributes to the task list item, which made it impossible for them to style or augment Tasks' task lines. A reproduction vault is attached and a link to a workaround implemented by the Vertical Timeline List plugin is mentioned in the #3898 issue.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests for the extracted helper were created covering the following:
- pre-existing classes and `data-*` attributes from the original element are retained on the replacement
- Tasks plugin's own classes and `data-*` attribute values are not overwritten

Class and `data-*` attribute retention was verified manually using the reproduction vault attached to #3898. Obsidian v1.12.7 was used.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
