### PR TITLE
fix: Stop status setting edits jumping to top

### DIFF
--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -71,7 +71,14 @@ export class SettingsTab extends PluginSettingTab {
         await this.plugin.saveSettings();
 
         if (update) {
+            // Rebuilding the settings tab resets it to the top, so restore how far down it was.
+            const previousDistanceFromTop = this.containerEl.scrollTop;
+
             this.display();
+
+            requestAnimationFrame(() => {
+                this.containerEl.scrollTo({ top: previousDistanceFromTop });
+            });
         }
     }
 

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -65,7 +65,7 @@ export class SettingsTab extends PluginSettingTab {
         this.events = events;
     }
 
-    private static createFragmentWithHTML = (html: string) => sanitizeHTMLToDom(html);
+    private static readonly createFragmentWithHTML = (html: string) => sanitizeHTMLToDom(html);
 
     public async saveSettings(update?: boolean): Promise<void> {
         await this.plugin.saveSettings();

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -67,7 +67,7 @@ export class SettingsTab extends PluginSettingTab {
 
     private static readonly createFragmentWithHTML = (html: string) => sanitizeHTMLToDom(html);
 
-    public async saveSettings(update?: boolean): Promise<void> {
+    public async saveSettingsAndRebuildSettingsTab(update?: boolean): Promise<void> {
         await this.plugin.saveSettings();
 
         if (update) {
@@ -987,7 +987,7 @@ async function updateAndSaveStatusSettings(statusTypes: StatusSettings, settings
     // This saves the user from having to restart Obsidian in order to apply the changed status(es).
     StatusSettings.applyToStatusRegistry(statusTypes, StatusRegistry.getInstance());
 
-    await settings.saveSettings(true);
+    await settings.saveSettingsAndRebuildSettingsTab(true);
 }
 
 function makeMultilineTextSetting(setting: Setting) {


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: The jumping to the top was mentioned in discussion in the following:
    - #3908

## Description

Stop the Tasks settings pain jumping to the top whenever editing any statuses.

## Motivation and Context

This has been annoying me for a while, but then it was reported by a user, in a comment on a different matter:

Source: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3908#issuecomment-4763625308

> whenever i used "Add New Task Status" and finished it. the page was jumped back to top (it's annoying, tho). I had to scroll down to find the Custom Statues.


## How has this been tested?

Manually

## Screenshots (if appropriate)

Not relevant.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
