### PR TITLE
refactor: Fix all @typescript-eslint/no-floating-promises errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,7 +58,7 @@ const typescriptCommonRules = {
     '@typescript-eslint/no-base-to-string': on_or_off,
     '@typescript-eslint/no-deprecated': 1,
     '@typescript-eslint/no-explicit-any': on_or_off,
-    '@typescript-eslint/no-floating-promises': on_or_off,
+    '@typescript-eslint/no-floating-promises': 1,
     '@typescript-eslint/no-for-in-array': 1,
     '@typescript-eslint/no-implied-eval': on_or_off,
     '@typescript-eslint/no-misused-promises': on_or_off,

--- a/lint.txt
+++ b/lint.txt
@@ -1,9 +1,6 @@
 yarn run v1.22.19
 $ eslint ./src       && eslint ./tests       && tsc --noEmit --pretty && svelte-check
 
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Config/CustomStatusModal.ts
-  171:9  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Config/PresetsSettingsUI.ts
   104:51  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
   105:54  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
@@ -15,12 +12,11 @@ $ eslint ./src       && eslint ./tests       && tsc --noEmit --pretty && svelte-
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Config/SettingsTab.ts
     51:37  warning  The `Function` type accepts any function-like value.
-Prefer explicitly defining any function parameters and return type                                             @typescript-eslint/no-unsafe-function-type
-   633:13  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-   714:17  warning  Unsafe call of a `Function` typed value                                                                                                                             @typescript-eslint/no-unsafe-call
-   821:9   warning  Use 'containerEl.createDiv()' instead of 'containerEl.createEl('div')'                                                                                              obsidianmd/prefer-create-el
-   950:33  warning  Promise-returning function provided to variable where a void return was expected                                                                                    @typescript-eslint/no-misused-promises
-  1009:9   warning  Unsafe call of a type that could not be resolved                                                                                                                    @typescript-eslint/no-unsafe-call
+Prefer explicitly defining any function parameters and return type  @typescript-eslint/no-unsafe-function-type
+   714:17  warning  Unsafe call of a `Function` typed value                                                                                  @typescript-eslint/no-unsafe-call
+   821:9   warning  Use 'containerEl.createDiv()' instead of 'containerEl.createEl('div')'                                                   obsidianmd/prefer-create-el
+   950:33  warning  Promise-returning function provided to variable where a void return was expected                                         @typescript-eslint/no-misused-promises
+  1009:9   warning  Unsafe call of a type that could not be resolved                                                                         @typescript-eslint/no-unsafe-call
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/DateTime/TasksDate.ts
   125:32  warning  Expected an error object to be thrown  @typescript-eslint/only-throw-error
@@ -30,17 +26,9 @@ Prefer explicitly defining any function parameters and return type              
   97:37  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Obsidian/Cache.ts
-  101:13  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  151:17  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  158:13  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  159:17  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  175:13  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  176:17  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  187:13  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  203:13  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  237:64  warning  Promise returned in function argument where a void return was expected                                                                                              @typescript-eslint/no-misused-promises
-  343:28  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  351:12  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
+  238:64  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
+  344:28  warning  Unexpected any. Specify a different type                                @typescript-eslint/no-explicit-any
+  352:12  warning  Unexpected any. Specify a different type                                @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Obsidian/File.ts
   155:9   warning  Use 'activeWindow.setTimeout()' instead of 'setTimeout()' for popout window compatibility  obsidianmd/prefer-active-window-timers
@@ -50,16 +38,13 @@ Prefer explicitly defining any function parameters and return type              
   16:41  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   28:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Obsidian/InlineRenderer.ts
-  33:17  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Obsidian/LivePreviewExtension.ts
   152:13  warning  Use 'activeWindow.setTimeout()' instead of 'setTimeout()' for popout window compatibility  obsidianmd/prefer-active-window-timers
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Obsidian/TaskModal.ts
-  45:31  warning  Use 'createEl('button')' instead of 'document.createElement('button')'                                                                                              obsidianmd/prefer-create-el
-  45:31  warning  Use 'activeDocument' instead of 'document' for popout window compatibility                                                                                          obsidianmd/prefer-active-doc
-  55:21  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
+  45:31  warning  Use 'createEl('button')' instead of 'document.createElement('button')'            obsidianmd/prefer-create-el
+  45:31  warning  Use 'activeDocument' instead of 'document' for popout window compatibility        obsidianmd/prefer-active-doc
+  54:17  warning  Promise-returning function provided to property where a void return was expected  @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Query/Filter/BooleanField.ts
   193:62  warning  Invalid operand for a '+' operation. Operands must each be a number or string, allowing a string + any of: `any`, `boolean`, `null`, `RegExp`, `undefined`. Got `Token`  @typescript-eslint/restrict-plus-operands
@@ -90,34 +75,33 @@ Prefer explicitly defining any function parameters and return type              
   533:44  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/HtmlQueryResultsRenderer.ts
-   50:38  warning  Use 'createDiv()' instead of 'document.createElement('div')'                                                                                                        obsidianmd/prefer-create-el
-   50:38  warning  Use 'activeDocument' instead of 'document' for popout window compatibility                                                                                          obsidianmd/prefer-active-doc
-   52:44  warning  Use 'createEl('li')' instead of 'document.createElement('li')'                                                                                                      obsidianmd/prefer-create-el
-   52:44  warning  Use 'activeDocument' instead of 'document' for popout window compatibility                                                                                          obsidianmd/prefer-active-doc
-  267:40  warning  Promise returned in function argument where a void return was expected                                                                                              @typescript-eslint/no-misused-promises
-  271:44  warning  Promise returned in function argument where a void return was expected                                                                                              @typescript-eslint/no-misused-promises
-  295:13  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  300:48  warning  Promise returned in function argument where a void return was expected                                                                                              @typescript-eslint/no-misused-promises
+   50:38  warning  Use 'createDiv()' instead of 'document.createElement('div')'                obsidianmd/prefer-create-el
+   50:38  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
+   52:44  warning  Use 'createEl('li')' instead of 'document.createElement('li')'              obsidianmd/prefer-create-el
+   52:44  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
+  267:40  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
+  271:44  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
+  292:42  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
+  300:48  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/QueryRenderer.ts
-   47:17  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  162:47  warning  Promise returned in function argument where a void return was expected                                                                                              @typescript-eslint/no-misused-promises
-  165:57  warning  Promise returned in function argument where a void return was expected                                                                                              @typescript-eslint/no-misused-promises
-  241:51  warning  Promise returned in function argument where a void return was expected                                                                                              @typescript-eslint/no-misused-promises
-  257:13  warning  Use 'activeWindow.clearTimeout()' instead of 'clearTimeout()' for popout window compatibility                                                                       obsidianmd/prefer-active-window-timers
-  282:35  warning  Use 'activeWindow.setTimeout()' instead of 'setTimeout()' for popout window compatibility                                                                           obsidianmd/prefer-active-window-timers
-  289:51  warning  Promise returned in function argument where a void return was expected                                                                                              @typescript-eslint/no-misused-promises
-  303:31  warning  Promise returned in function argument where a void return was expected                                                                                              @typescript-eslint/no-misused-promises
-  372:13  warning  Promise-returning function provided to property where a void return was expected                                                                                    @typescript-eslint/no-misused-promises
+  162:47  warning  Promise returned in function argument where a void return was expected                         @typescript-eslint/no-misused-promises
+  165:57  warning  Promise returned in function argument where a void return was expected                         @typescript-eslint/no-misused-promises
+  241:51  warning  Promise returned in function argument where a void return was expected                         @typescript-eslint/no-misused-promises
+  257:13  warning  Use 'activeWindow.clearTimeout()' instead of 'clearTimeout()' for popout window compatibility  obsidianmd/prefer-active-window-timers
+  282:35  warning  Use 'activeWindow.setTimeout()' instead of 'setTimeout()' for popout window compatibility      obsidianmd/prefer-active-window-timers
+  289:51  warning  Promise returned in function argument where a void return was expected                         @typescript-eslint/no-misused-promises
+  303:31  warning  Promise returned in function argument where a void return was expected                         @typescript-eslint/no-misused-promises
+  372:13  warning  Promise-returning function provided to property where a void return was expected               @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/QueryResultsRenderer.ts
   241:46  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/TaskLineRenderer.ts
-   52:42  warning  Use 'createEl(tagName)' instead of 'document.createElement(tagName)'                                                                                                obsidianmd/prefer-create-el
-   52:42  warning  Use 'activeDocument' instead of 'document' for popout window compatibility                                                                                          obsidianmd/prefer-active-doc
-  207:17  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  502:17  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
+   52:42  warning  Use 'createEl(tagName)' instead of 'document.createElement(tagName)'        obsidianmd/prefer-create-el
+   52:42  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
+  198:48  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
+  493:48  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/ExpandPlaceholders.ts
    27:60  warning  Unexpected any. Specify a different type                                                                @typescript-eslint/no-explicit-any
@@ -163,19 +147,18 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   253:48  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Suggestor/EditorSuggestorPopup.ts
-   95:15  warning  Unsafe assignment of an error typed value                                                                                                                           @typescript-eslint/no-unsafe-assignment
-  115:9   warning  Unsafe return of a value of type error                                                                                                                              @typescript-eslint/no-unsafe-return
-  115:16  warning  Unsafe call of a type that could not be resolved                                                                                                                    @typescript-eslint/no-unsafe-call
-  115:26  warning  Unsafe member access .state on a type that cannot be resolved                                                                                                       @typescript-eslint/no-unsafe-member-access
-  118:44  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  126:5   warning  Promise-returning method provided where a void return was expected by extended/implemented type 'EditorSuggest<SuggestInfoWithContext>'                             @typescript-eslint/no-misused-promises
-  136:13  warning  Unsafe call of an `any` typed value                                                                                                                                 @typescript-eslint/no-unsafe-call
-  136:24  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  136:30  warning  Unsafe member access .cm on an `any` value                                                                                                                          @typescript-eslint/no-unsafe-member-access
-  182:21  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  211:15  warning  Unsafe assignment of an error typed value                                                                                                                           @typescript-eslint/no-unsafe-assignment
-  213:19  warning  Unsafe call of a type that could not be resolved                                                                                                                    @typescript-eslint/no-unsafe-call
-  213:36  warning  Unsafe member access .save on a type that cannot be resolved                                                                                                        @typescript-eslint/no-unsafe-member-access
+   95:15  warning  Unsafe assignment of an error typed value                                                                                                @typescript-eslint/no-unsafe-assignment
+  115:9   warning  Unsafe return of a value of type error                                                                                                   @typescript-eslint/no-unsafe-return
+  115:16  warning  Unsafe call of a type that could not be resolved                                                                                         @typescript-eslint/no-unsafe-call
+  115:26  warning  Unsafe member access .state on a type that cannot be resolved                                                                            @typescript-eslint/no-unsafe-member-access
+  118:44  warning  Unexpected any. Specify a different type                                                                                                 @typescript-eslint/no-explicit-any
+  126:5   warning  Promise-returning method provided where a void return was expected by extended/implemented type 'EditorSuggest<SuggestInfoWithContext>'  @typescript-eslint/no-misused-promises
+  136:13  warning  Unsafe call of an `any` typed value                                                                                                      @typescript-eslint/no-unsafe-call
+  136:24  warning  Unexpected any. Specify a different type                                                                                                 @typescript-eslint/no-explicit-any
+  136:30  warning  Unsafe member access .cm on an `any` value                                                                                               @typescript-eslint/no-unsafe-member-access
+  211:15  warning  Unsafe assignment of an error typed value                                                                                                @typescript-eslint/no-unsafe-assignment
+  213:19  warning  Unsafe call of a type that could not be resolved                                                                                         @typescript-eslint/no-unsafe-call
+  213:36  warning  Unsafe member access .save on a type that cannot be resolved                                                                             @typescript-eslint/no-unsafe-member-access
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Suggestor/Suggestor.ts
    35:1   warning  Avoid using 'globalThis'. Use 'activeDocument' for popout window compatibility  obsidianmd/prefer-active-doc
@@ -216,31 +199,28 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   5:37  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/lib/logging.ts
-   36:14  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  142:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console            obsidianmd/rule-custom-message
-  148:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console            obsidianmd/rule-custom-message
-  157:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console            obsidianmd/rule-custom-message
-  213:61  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  221:13  warning  Unsafe assignment of an `any` value                                                                                                                                 @typescript-eslint/no-unsafe-assignment
-  241:45  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  244:45  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  247:44  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  250:44  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  253:45  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  262:84  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  270:13  warning  Unsafe assignment of an `any` value                                                                                                                                 @typescript-eslint/no-unsafe-assignment
-  277:68  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  280:68  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  283:67  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  286:67  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  289:68  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  311:33  warning  Prefer using the primitive `object` as a type name, rather than the upper-cased `Object`                                                                            @typescript-eslint/no-wrapper-object-types
-  314:43  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  346:30  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  350:53  warning  Unexpected any. Specify a different type                                                                                                                            @typescript-eslint/no-explicit-any
-  419:13  warning  Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
-  424:5   warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console            obsidianmd/rule-custom-message
-  425:5   warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console            obsidianmd/rule-custom-message
+   35:14  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  141:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console  obsidianmd/rule-custom-message
+  147:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console  obsidianmd/rule-custom-message
+  156:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console  obsidianmd/rule-custom-message
+  212:61  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  220:13  warning  Unsafe assignment of an `any` value                                                                                                                       @typescript-eslint/no-unsafe-assignment
+  240:45  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  243:45  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  246:44  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  249:44  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  252:45  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  261:84  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  269:13  warning  Unsafe assignment of an `any` value                                                                                                                       @typescript-eslint/no-unsafe-assignment
+  276:68  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  279:68  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  282:67  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  285:67  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  288:68  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  310:33  warning  Prefer using the primitive `object` as a type name, rather than the upper-cased `Object`                                                                  @typescript-eslint/no-wrapper-object-types
+  313:43  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  345:30  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
+  349:53  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/main.ts
    98:13  warning  Unsafe assignment of an `any` value                                                @typescript-eslint/no-unsafe-assignment
@@ -267,7 +247,7 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   79:20  warning  Use 'activeDocument' instead of 'document' for popout window compatibility        obsidianmd/prefer-active-doc
   84:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 189 problems (0 errors, 189 warnings)
+✖ 173 problems (0 errors, 173 warnings)
   0 errors and 66 warnings potentially fixable with the `--fix` option.
 
 
@@ -277,4 +257,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 20.56s.
+Done in 25.70s.

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -40,7 +40,7 @@ export class CustomStatusModal extends Modal {
         );
     }
 
-    async display() {
+    display() {
         const { contentEl } = this;
 
         contentEl.empty();

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -630,7 +630,7 @@ export class SettingsTab extends PluginSettingTab {
         detailsContainer.ontoggle = () => {
             headingOpened[heading.text] = detailsContainer.open;
             updateSettings({ headingOpened: headingOpened });
-            this.plugin.saveSettings();
+            void this.plugin.saveSettings();
         };
         const summary = detailsContainer.createEl('summary');
         new Setting(summary).setHeading().setName(heading.text);

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -164,15 +164,13 @@ export class Cache {
         this.logger.debug('Cache.subscribeToVault()');
         const { useFilenameAsScheduledDate } = getSettings();
 
-        const createdEventReference = this.vault.on('create', (file: TAbstractFile) => {
+        const createdEventReference = this.vault.on('create', async (file: TAbstractFile) => {
             if (!(file instanceof TFile)) {
                 return;
             }
             this.logger.debug(`Cache.subscribeToVault.createdEventReference() ${file.path}`);
 
-            this.tasksMutex.runExclusive(() => {
-                this.indexFile(file);
-            });
+            await this.tasksMutex.runExclusive(() => this.indexFile(file));
         });
         this.vaultEventReferences.push(createdEventReference);
 

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -154,8 +154,8 @@ export class Cache {
         this.metadataCacheEventReferences.push(resolvedEventeReference);
 
         // Does not fire when starting up obsidian and only works for changes.
-        const changedEventReference = this.metadataCache.on('changed', (file: TFile) => {
-            this.tasksMutex.runExclusive(() => this.indexFile(file));
+        const changedEventReference = this.metadataCache.on('changed', async (file: TFile) => {
+            await this.tasksMutex.runExclusive(() => this.indexFile(file));
         });
         this.metadataCacheEventReferences.push(changedEventReference);
     }

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -174,13 +174,13 @@ export class Cache {
         });
         this.vaultEventReferences.push(createdEventReference);
 
-        const deletedEventReference = this.vault.on('delete', (file: TAbstractFile) => {
+        const deletedEventReference = this.vault.on('delete', async (file: TAbstractFile) => {
             if (!(file instanceof TFile)) {
                 return;
             }
             this.logger.debug(`Cache.subscribeToVault.deletedEventReference() ${file.path}`);
 
-            this.tasksMutex.runExclusive(() => {
+            await this.tasksMutex.runExclusive(() => {
                 this.tasks = this.tasks.filter((task: Task) => {
                     return task.path !== file.path;
                 });

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -155,9 +155,7 @@ export class Cache {
 
         // Does not fire when starting up obsidian and only works for changes.
         const changedEventReference = this.metadataCache.on('changed', (file: TFile) => {
-            this.tasksMutex.runExclusive(() => {
-                this.indexFile(file);
-            });
+            this.tasksMutex.runExclusive(() => this.indexFile(file));
         });
         this.metadataCacheEventReferences.push(changedEventReference);
     }

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -148,7 +148,12 @@ export class Cache {
             // We only want to initialize if we haven't already.
             if (!this.loadedAfterFirstResolve) {
                 this.loadedAfterFirstResolve = true;
-                this.loadVault();
+                // eslint revealed a possibly missing await here.
+                // But in testing, we found that commenting out this line prevented the usual double-reading
+                // of all files in the vault during start-up.
+                // For now, we are marking the promise as void, in order to be able to leave
+                // @typescript-eslint/no-floating-promises turned on, to catch future promise errors.
+                void this.loadVault();
             }
         });
         this.metadataCacheEventReferences.push(resolvedEventeReference);

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -96,9 +96,9 @@ export class Cache {
         // Subscribe to vault and load cache later when workspace is ready,
         // prevents create events for every file, but loadVault cover all files anyway.
         // For details see: https://docs.obsidian.md/Reference/TypeScript+API/Vault/on('create')
-        this.workspace.onLayoutReady(() => {
+        this.workspace.onLayoutReady(async () => {
             this.subscribeToVault();
-            this.loadVault();
+            await this.loadVault();
         });
 
         this.subscribeToEvents();

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -190,13 +190,13 @@ export class Cache {
         });
         this.vaultEventReferences.push(deletedEventReference);
 
-        const renamedEventReference = this.vault.on('rename', (file: TAbstractFile, oldPath: string) => {
+        const renamedEventReference = this.vault.on('rename', async (file: TAbstractFile, oldPath: string) => {
             if (!(file instanceof TFile)) {
                 return;
             }
             this.logger.debug(`Cache.subscribeToVault.renamedEventReference() ${file.path}`);
 
-            this.tasksMutex.runExclusive(() => {
+            await this.tasksMutex.runExclusive(() => {
                 const fileCache = this.metadataCache.getFileCache(file);
                 // TODO What if the file has been renamed but the cache not yet updated?
                 const tasksFile = new TasksFile(file.path, fileCache ?? undefined);

--- a/src/Obsidian/InlineRenderer.ts
+++ b/src/Obsidian/InlineRenderer.ts
@@ -29,8 +29,8 @@ export class InlineRenderer {
         this.app = app;
 
         plugin.registerMarkdownPostProcessor((el, ctx) => {
-            plugin.app.workspace.onLayoutReady(() => {
-                this.markdownPostProcessor(el, ctx);
+            plugin.app.workspace.onLayoutReady(async () => {
+                await this.markdownPostProcessor(el, ctx);
             });
         });
     }

--- a/src/Obsidian/TaskModal.ts
+++ b/src/Obsidian/TaskModal.ts
@@ -51,9 +51,7 @@ export class TaskModal extends Modal {
         optionsButton.onclick = () => {
             const optionsModal = new OptionsModal({
                 app: this.app,
-                onSave: () => {
-                    this.onSaveSettings();
-                },
+                onSave: () => this.onSaveSettings(),
             });
             optionsModal.open();
         };

--- a/src/Renderer/HtmlQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlQueryResultsRenderer.ts
@@ -289,10 +289,10 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
         }
         button.title = buttonTooltipText;
 
-        button.addEventListener('click', (ev: MouseEvent) => {
+        button.addEventListener('click', async (ev: MouseEvent) => {
             ev.preventDefault(); // suppress the default click behavior
             ev.stopPropagation(); // suppress further event propagation
-            PostponeMenu.postponeOnClickCallback(button, task, amount, timeUnit);
+            await PostponeMenu.postponeOnClickCallback(button, task, amount, timeUnit);
         });
 
         /** Open a context menu on right-click.

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -43,8 +43,8 @@ export class QueryRenderer {
         this.events = events;
 
         plugin.registerMarkdownCodeBlockProcessor('tasks', (source, el, ctx) => {
-            plugin.app.workspace.onLayoutReady(() => {
-                this.addQueryRenderChild(source, el, ctx);
+            plugin.app.workspace.onLayoutReady(async () => {
+                await this.addQueryRenderChild(source, el, ctx);
             });
         });
     }

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -485,11 +485,12 @@ export class TaskLineRenderer {
 
     public async renderListItem(li: HTMLLIElement, listItem: ListItem, listItemIndex: number): Promise<HTMLLIElement> {
         if (listItem.statusCharacter) {
+            // special case: handle toggling of task lines without the global query, in Tasks search results
             const checkbox = createAndAppendElement('input', li);
             checkbox.classList.add('task-list-item-checkbox');
             checkbox.type = 'checkbox';
 
-            checkbox.addEventListener('click', (event: MouseEvent) => {
+            checkbox.addEventListener('click', async (event: MouseEvent) => {
                 event.preventDefault();
                 // It is required to stop propagation so that obsidian won't write the file with the
                 // checkbox (un)checked. Obsidian would write after us and overwrite our change.
@@ -499,7 +500,7 @@ export class TaskLineRenderer {
                 checkbox.disabled = true;
 
                 const checkedOrUncheckedListItem = listItem.checkOrUncheck();
-                replaceTaskWithTasks({ originalTask: listItem, newTasks: checkedOrUncheckedListItem });
+                await replaceTaskWithTasks({ originalTask: listItem, newTasks: checkedOrUncheckedListItem });
             });
 
             if (listItem.statusCharacter !== ' ') {

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -195,7 +195,7 @@ export class TaskLineRenderer {
         // See https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2130
         const addEventListeners = task.taskLocation.hasKnownPath;
         if (addEventListeners) {
-            checkbox.addEventListener('click', (event: MouseEvent) => {
+            checkbox.addEventListener('click', async (event: MouseEvent) => {
                 event.preventDefault();
                 // It is required to stop propagation so that obsidian won't write the file with the
                 // checkbox (un)checked. Obsidian would write after us and overwrite our change.
@@ -204,7 +204,7 @@ export class TaskLineRenderer {
                 // Should be re-rendered as enabled after update in file.
                 checkbox.disabled = true;
                 const toggledTasks = task.toggleWithRecurrenceInUsersOrder();
-                replaceTaskWithTasks({
+                await replaceTaskWithTasks({
                     originalTask: task,
                     newTasks: toggledTasks,
                 });

--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -179,7 +179,7 @@ file: '${newTask.path}'
                     value.context.editor.replaceRange(newTask.toFileLineString(), start, end);
                 } else {
                     // Replace Task in File Context
-                    replaceTaskWithTasks({ originalTask: value.taskItDependsOn, newTasks: newTask });
+                    await replaceTaskWithTasks({ originalTask: value.taskItDependsOn, newTasks: newTask });
                 }
             }
         }

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -1,4 +1,3 @@
-import { Platform, Plugin } from 'obsidian';
 /*
  * EventEmitter2 is an implementation of the EventEmitter module found in Node.js.
  * In addition to having a better benchmark performance than EventEmitter and being
@@ -392,36 +391,4 @@ export function log(logLevel: TLogLevelName, message: string) {
         default:
             break;
     }
-}
-
-/**
- * This allows the plugin to be debugged in a mobile application
- * add it when debugging on a device. Not meant to be used by
- * end users. Add it into main.ts and remove before you commit.
- *
- * @param {Plugin} plugin
- * @return {*}
- */
-export function monkeyPatchConsole(plugin: Plugin) {
-    if (!Platform.isMobile) {
-        return;
-    }
-
-    const logFile = `${plugin.manifest.dir}/tasks-logs.txt`;
-    const logs: string[] = [];
-    const logMessages =
-        (prefix: string) =>
-        (...messages: unknown[]) => {
-            logs.push(`\n[${prefix}]`);
-            for (const message of messages) {
-                logs.push(String(message));
-            }
-            plugin.app.vault.adapter.write(logFile, logs.join(' '));
-        };
-
-    console.debug = logMessages('debug');
-    console.error = logMessages('error');
-    console.info = logMessages('info');
-    console.log = logMessages('log');
-    console.warn = logMessages('warn');
 }


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Done by pairing with @ilandikov.

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

Fix all `@typescript-eslint/no-floating-promises` ESLint errors.

The fixes will show up on the public [Tasks plugin `Scorecard`](https://community.obsidian.md/plugins/obsidian-tasks-plugin) when I do the next release.

## Motivation and Context

Code quality improvement driven by the Obsidian Community scanning system.

## How has this been tested?

Manual testing:

1. Break the existing code, build the plugin, confirm we understand its existing purpose
2. Update the code to fix the warning, build the plugin, confirm we have not changed the original behaviour.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
    - Not all areas had automated tests, so we had to do a lot of manual testing.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
