### PR TITLE
fix: Address Edit task modal scrolling issues on mobile

### DIFF
--- a/src/Obsidian/TaskModal.scss
+++ b/src/Obsidian/TaskModal.scss
@@ -6,3 +6,34 @@
         padding-bottom: 0;
     }
 }
+
+// On mobile, when a text box has focus, the software keyboard can obscure the
+// bottom of Obsidian modals. The Apply and Cancel buttons are sticky, but the
+// modal content still needs enough extra scrollable space below them for the
+// browser/WebView to scroll the buttons above the keyboard.
+//
+// Apply this only while an element inside the modal has focus, which is when the
+// keyboard is likely to be visible. This avoids adding unnecessary blank space
+// when the modal is merely open.
+//
+// The extra space compensates for viewport UI, not for text size. Experiments
+// with rem-based values were fragile because changing font-size settings also
+// changed the amount of keyboard compensation. Use px for the bounds so the
+// workaround remains independent of Obsidian and OS font-size settings.
+//
+// The values are a bounded heuristic:
+// - 220px is the minimum extra scroll space. It keeps the range from becoming
+//   too small on shorter mobile screens.
+// - 35vh scales with the viewport height, so taller mobile screens get more
+//   scroll space than shorter mobile screens.
+// - 360px is the maximum extra scroll space, preventing very tall screens from
+//   getting an unnecessarily large blank area.
+//
+// This has been validated on an iPhone 17 Pro with Obsidian font sizes 10, 16
+// and 24, including iOS text size set to 135%. It is expected to be safe on
+// Android as well, because it only adds temporary scrollable space while editing.
+.is-mobile .tasks-edit-modal-container:focus-within {
+    .modal-content {
+        padding-bottom: clamp(220px, 35vh, 360px);
+    }
+}

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -73,7 +73,7 @@
         mountComplete = true;
 
         setTimeout(() => {
-            descriptionInput.focus();
+            descriptionInput.focus({ preventScroll: true });
         }, 10);
     });
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3917

## Description

This enables users on mobile to scroll all the way to the bottom of the Edit Task Modal, when a text field has input focus.

## Motivation and Context

Fixes #3917 - more specifically:

- https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3917
- And an unreported issue that the Description field was not necessarily visible when the modal was first loaded - on my iPhone 17 Pro, the "Before this" field was at the top of the screen, instead of the intended "Description" field.

## How has this been tested?

- Lots of testing on an iPhone 17 Pro
    - With Obsidian font sizes 10, 16, 24 and 30.
- Also tested on an iPad M1, without keyboard attached

## Screenshots (if appropriate)

<img width="766" height="1262" alt="image" src="https://github.com/user-attachments/assets/5d3e5b9f-fd79-4d6c-ae52-37b6dbcc5c30" />


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
    - There are not tests for the CSS

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
