### PR TITLE
feat: add TasksApiV2

### DIFF
--- a/contributing/Architecture Decisions/ADR-003 - TasksApiV2 Public API.md
+++ b/contributing/Architecture Decisions/ADR-003 - TasksApiV2 Public API.md
@@ -1,0 +1,224 @@
+---
+publish: true
+---
+
+# ADR-003 - TasksApiV2 Public API
+
+## Status
+
+**PROPOSED** - Decision drafted on 2026-07-01
+
+## Context
+
+The Tasks plugin currently exposes `apiV1`, implemented as a TypeScript interface plus factory function. It is not a runtime class hierarchy.
+
+`apiV1` exposes modal helpers and task-line transformations:
+
+- `createTaskLineModal()` returns a markdown task line string and does not write to the vault.
+- `editTaskLineModal(taskLine)` returns an edited markdown task line string and does not write to the vault.
+- `executeToggleTaskDoneCommand(line, path)` returns an updated task line string.
+
+This API is useful for integrations such as QuickAdd, where the other plugin chooses the destination file and insertion behavior. It does not expose a stable task data model, query execution, or vault-writing task creation and editing.
+
+The internal plugin already has capabilities that a V2 API can reuse:
+
+- Cached task access through the plugin cache.
+- Query parsing and execution through the existing query engine.
+- Task parsing and serialization through the selected task serializer.
+- Global filter handling.
+- Safe replacement of existing task lines in markdown files.
+
+A public V2 API must avoid exposing internal classes such as `Task`, `Status`, `Recurrence`, `TasksFile`, `TaskLocation`, `QueryResult`, or `Moment`, because those are implementation details and are not suitable as compatibility-stable API objects.
+
+## Decision
+
+Add `TasksApiV2` as a new versioned public API that extends `TasksApiV1` at the TypeScript interface level:
+
+```ts
+export interface TasksApiV2 extends TasksApiV1 {
+    queryTasks(query: string): TaskV1[];
+    createTask(
+        destination: TaskCreationDestinationV1,
+        description: string,
+        taskData?: Partial<TaskV1>,
+    ): Promise<TaskV1>;
+    editTask(taskId: string, taskData: Partial<TaskV1>): Promise<TaskV1>;
+    ensureTaskHasUniqueId(task: TaskV1): TaskV1;
+}
+```
+
+Expose it from the plugin through a new `apiV2` getter. Leave `apiV1` unchanged.
+
+### Public Task DTO
+
+Expose tasks as a stable `TaskV1` data transfer object. `TaskV1` contains primitives and strings only:
+
+```ts
+export interface TaskV1 {
+    id: string;
+    description: string;
+    status: string;
+    priority: string;
+    createdDate: string | null;
+    startDate: string | null;
+    scheduledDate: string | null;
+    dueDate: string | null;
+    doneDate: string | null;
+    cancelledDate: string | null;
+    recurrenceRule: string;
+    onCompletion: string;
+    dependsOn: string[];
+    tags: string[];
+    blockLink: string;
+    originalMarkdown: string;
+    path: string;
+    lineNumber: number;
+}
+```
+
+Dates use `YYYY-MM-DD` strings or `null`. `status` is the status symbol. Location fields are returned for caller context, but task edits are ID-based.
+
+### Task Creation Destination
+
+`createTask()` writes to the vault and takes an explicit destination object:
+
+```ts
+export interface TaskCreationDestinationV1 {
+    path: string;
+    line?: number;
+    placement?: 'before' | 'after' | 'replace' | 'append';
+}
+```
+
+If `line` and `placement` are supplied, insert relative to that line:
+
+- `before`: insert before the line.
+- `after`: insert after the line.
+- `replace`: replace the line.
+- `append`: append to the end of the file, ignoring `line`.
+
+If `line` and `placement` are omitted, locate an existing task list in the file and append the new task to that list. If no task list exists, append to EOF.
+
+The task-list fallback is deterministic:
+
+1. Read the target markdown file.
+2. Use cache/list-item metadata where available to identify Tasks-recognized task lines.
+3. Choose the last recognized task line in the file.
+4. Insert after that task's contiguous list block so nested children are not split.
+5. If no recognized task exists, append to EOF.
+
+For created tasks, prepend the configured global filter when it is non-empty and absent from the description as a separate word. If no global filter is configured, leave the description unchanged.
+
+### Query Behavior
+
+`queryTasks(query: string): TaskV1[]` uses the existing `Query` engine against `plugin.getTasks()` and returns flattened `TaskV1[]`.
+
+If parsing or execution fails, throw an `Error` containing the query engine message. Do not return partial results for failed queries.
+
+### Edit Behavior
+
+`editTask(taskId: string, taskData: Partial<TaskV1>): Promise<TaskV1>` finds the task by ID in the current cache.
+
+Rules:
+
+- If no task has `taskId`, throw.
+- If more than one task has `taskId`, throw.
+- Merge `taskData` over the matched task.
+- Preserve source location and fields not included in `taskData`.
+- Serialize through the existing task serializer.
+- Persist by reusing the existing safe task replacement path.
+- Return the saved `TaskV1`.
+
+Callers that need line-level writes can use `createTask()` with `placement: 'replace'`.
+
+### Unique ID Behavior
+
+`ensureTaskHasUniqueId(task: TaskV1): TaskV1` is pure:
+
+- If `task.id` is non-empty, return the task unchanged.
+- If `task.id` is empty, return a copy with a generated ID that does not exist in the current cache.
+- Do not write to the vault.
+
+ID generation must use the valid character set accepted by the current serializer.
+
+## Alternatives Considered
+
+### Expose the internal `Task` class
+
+Rejected. The internal `Task` class contains implementation details such as `Moment`, `Status`, task location, recurrence objects, and serializer-specific behavior. Exposing it would make later refactoring much harder and create avoidable compatibility risk.
+
+### Keep V2 as a pure transformation API
+
+Rejected for this version. `apiV1` already covers non-writing modal and line-transformation workflows. The requested V2 use case is vault-writing task creation and editing.
+
+### Add a Tasks-owned default destination setting
+
+Rejected. The current convention is that Tasks does not choose a destination file for externally-created tasks. Existing integrations such as QuickAdd own file selection and insertion behavior. `TasksApiV2` should accept explicit destinations instead of introducing a new global default destination setting.
+
+### Require exact line placement for every created task
+
+Rejected. Requiring a line for every creation call is precise but unnecessarily awkward for inbox-style integrations. The selected design supports exact placement while providing a deterministic default that appends to an existing task list or EOF.
+
+## Consequences
+
+### Positive
+
+- Preserves `apiV1` compatibility.
+- Gives integrations a stable task DTO rather than internal objects.
+- Adds query execution without exposing internal query result types.
+- Supports vault-writing creation and editing through explicit, testable contracts.
+- Keeps destination choice in the API call, matching current integration conventions.
+
+### Negative
+
+- `TaskV1` becomes a compatibility surface and must be versioned carefully.
+- Vault-writing APIs need robust error handling for missing files, stale cache data, duplicate IDs, and write failures.
+- Smart insertion into existing task lists adds implementation complexity.
+
+### Neutral
+
+- User-facing API documentation must be updated in `docs/Advanced/Tasks Api.md`.
+- Tests should cover DTO mapping, query behavior, insertion placement, global filter handling, edit-by-ID behavior, and unique ID generation.
+- The implementation may add helper modules under `src/Api/` to keep mapping, query, and persistence behavior separated.
+
+## Implementation Notes
+
+Required failure cases:
+
+- Target file does not exist.
+- Target file is not markdown.
+- Target line is outside file bounds.
+- Query parse or execution error.
+- Edit target ID missing.
+- Edit target ID duplicated.
+- Task data cannot be converted to an internal task.
+- File write fails.
+
+Required tests:
+
+- `TasksApiV2` preserves `TasksApiV1` methods.
+- `apiV2` getter exists on the plugin.
+- `TaskV1` mapping does not expose internal task objects.
+- `queryTasks()` returns flattened `TaskV1[]`.
+- `queryTasks()` throws on query errors.
+- `createTask()` inserts before, after, replace, and append.
+- `createTask()` defaults to appending to the existing task list.
+- `createTask()` falls back to EOF when no task list exists.
+- `createTask()` prepends the global filter only when configured and absent.
+- `editTask()` updates exactly one task by ID.
+- `editTask()` throws for missing or duplicate IDs.
+- `ensureTaskHasUniqueId()` preserves existing IDs and generates unique missing IDs.
+
+## Out of Scope
+
+- New Tasks settings for a default task destination.
+- Exposing internal `Task`, `QueryResult`, `Status`, or `Moment` types.
+- Batch create/edit APIs.
+- Rich result metadata for query grouping.
+- API support for query placeholders that require a query file context.
+
+---
+
+**Decision made by:** George Rolfe
+**Date:** 2026-07-01
+**ADR Number:** 003

--- a/docs/Advanced/Tasks Api.md
+++ b/docs/Advanced/Tasks Api.md
@@ -18,6 +18,9 @@ The Tasks API is available from `app.plugins.plugins['obsidian-tasks-plugin'].ap
 where `app` is the Obsidian App. A reference to the Obsidian App is usually available via `this.app`,
 however, this depends on the context of the executing script.
 
+Tasks also exposes `apiV2`, which includes all `apiV1` methods and adds versioned task objects,
+task search, task creation, task editing, and task ID generation.
+
 This is the interface the API exposes:
 
 <!-- snippet: TasksApiV1.ts -->
@@ -56,6 +59,130 @@ export interface TasksApiV1 {
 }
 ```
 <!-- endSnippet -->
+
+## Tasks API V2 Interface
+
+Use `app.plugins.plugins['obsidian-tasks-plugin'].apiV2` to access V2.
+
+V2 returns `TaskV1` objects instead of the internal Tasks `Task` class.
+Date fields are strings in `YYYY-MM-DD` format or `null`.
+Line numbers are zero-based, matching Obsidian's editor and cache positions.
+
+```ts
+interface TaskV1 {
+    id: string;
+    description: string;
+    status: string;
+    priority: string;
+    createdDate: string | null;
+    startDate: string | null;
+    scheduledDate: string | null;
+    dueDate: string | null;
+    doneDate: string | null;
+    cancelledDate: string | null;
+    recurrenceRule: string;
+    onCompletion: string;
+    dependsOn: string[];
+    tags: string[];
+    blockLink: string;
+    originalMarkdown: string;
+    path: string;
+    lineNumber: number;
+}
+
+interface TaskCreationDestinationV1 {
+    path: string;
+    line?: number;
+    placement?: 'before' | 'after' | 'replace' | 'append';
+}
+
+interface TasksApiV2 extends TasksApiV1 {
+    queryTasks(query: string): TaskV1[];
+    createTask(
+        destination: TaskCreationDestinationV1,
+        description: string,
+        taskData?: Partial<TaskV1>,
+    ): Promise<TaskV1>;
+    editTask(taskId: string, taskData: Partial<TaskV1>): Promise<TaskV1>;
+    ensureTaskHasUniqueId(task: TaskV1): TaskV1;
+}
+```
+
+## `queryTasks(query: string): TaskV1[];`
+
+Runs a Tasks query over the current task cache and returns matching tasks as `TaskV1` objects.
+Invalid queries throw an error.
+Query strings use the same syntax as Tasks code blocks.
+See [[About Queries]], [[Filters]], [[Combining Filters]], and [[Regular Expressions]] for the full query language.
+
+```javascript
+const tasksApi = this.app.plugins.plugins['obsidian-tasks-plugin'].apiV2;
+const dueSoon = tasksApi.queryTasks('not done\ndue before tomorrow');
+```
+
+Find open tasks in a project tag or work folder:
+
+```javascript
+const projectTasks = tasksApi.queryTasks('not done\n(description includes #project) OR (path includes Work/)');
+```
+
+Find high-priority tasks:
+
+```javascript
+const highPriorityTasks = tasksApi.queryTasks('priority is high');
+```
+
+Find tasks whose descriptions match a regular expression:
+
+```javascript
+const waitingTasks = tasksApi.queryTasks('description regex matches /waiting|blocked/i');
+```
+
+## `createTask(destination, description, taskData?): Promise<TaskV1>;`
+
+Creates a task in an existing Markdown file and returns the created task as `TaskV1`.
+`taskData` can override fields such as `status`, `priority`, dates, dependencies, `id`, and tags.
+
+If `destination.line` is supplied, `placement` defaults to `after`.
+If `placement` is `append`, the task is written at the end of the file.
+If neither `line` nor `placement` is supplied, Tasks appends after the last existing task line in that file;
+if the file has no task lines, Tasks appends at EOF.
+
+If a global filter is configured and the description does not already include it,
+Tasks prepends the global filter before writing the task.
+The returned `TaskV1.description` omits the configured global filter; `originalMarkdown` contains the exact written line.
+
+```javascript
+const tasksApi = this.app.plugins.plugins['obsidian-tasks-plugin'].apiV2;
+const task = await tasksApi.createTask(
+    { path: 'Tasks.md', line: 4, placement: 'after' },
+    'Book flights',
+    { dueDate: '2026-08-01', priority: '1' },
+);
+```
+
+## `editTask(taskId: string, taskData: Partial<TaskV1>): Promise<TaskV1>;`
+
+Edits the task with the supplied ID and returns the edited task as `TaskV1`.
+The task ID must be non-empty and must match exactly one task in the current Tasks cache.
+
+```javascript
+const tasksApi = this.app.plugins.plugins['obsidian-tasks-plugin'].apiV2;
+const task = await tasksApi.editTask('abc123', {
+    description: 'Book flights and hotel',
+    dueDate: '2026-08-02',
+});
+```
+
+## `ensureTaskHasUniqueId(task: TaskV1): TaskV1;`
+
+Returns the same task object if it already has a non-empty ID.
+Otherwise, returns a copy with a generated ID that does not collide with current task IDs.
+
+```javascript
+const tasksApi = this.app.plugins.plugins['obsidian-tasks-plugin'].apiV2;
+const taskWithId = tasksApi.ensureTaskHasUniqueId(task);
+```
 
 ## `createTaskLineModal(): Promise<string>;`
 
@@ -179,8 +306,6 @@ This can be used, for example, to display the Auto-Suggest on non-task lines. [S
 
 - Auto Suggest:
   - It is not yet possible for [[auto-suggest]] to add [[Task Dependencies|dependencies]] when Auto-Suggest is used in [[Kanban plugin]] cards - or any other plugins that use the [[Tasks Api#Auto-Suggest Integration|Auto-Suggest Integration]]. We are tracking this in [issue #3274](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3274).
-- Searching tasks:
-  - It is not yet possible to run Tasks searches via the API. We are tracking this in [issue #2459](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/2459).
 - Ambiguity when `editTaskLineModal()` returns empty string:
   - `editTaskLineModal()` returns an empty string in both these situations:
         1. the user clicked Cancel

--- a/src/Api/TaskV1.ts
+++ b/src/Api/TaskV1.ts
@@ -64,8 +64,14 @@ const descriptionWithTags = (description: string, tags: string[] | undefined): s
 
 export type { TaskV1 } from './TasksApiV2';
 
+const taskIdCharacters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_';
+const taskIdLength = 8;
+
 const randomId = (): string => {
-    return Math.random().toString(36).slice(2, 10);
+    const randomValues = new Uint8Array(taskIdLength);
+    globalThis.crypto.getRandomValues(randomValues);
+
+    return Array.from(randomValues, (value) => taskIdCharacters[value % taskIdCharacters.length]).join('');
 };
 
 /**
@@ -196,7 +202,7 @@ export const ensureTaskHasUniqueId = (task: TaskV1, allTasks: Task[]): TaskV1 =>
 
     const existingIds = new Set(allTasks.map((existingTask) => existingTask.id).filter((id) => id !== ''));
     let id = randomId();
-    while (id === '' || existingIds.has(id)) {
+    while (existingIds.has(id)) {
         id = randomId();
     }
 

--- a/src/Api/TaskV1.ts
+++ b/src/Api/TaskV1.ts
@@ -1,0 +1,207 @@
+import { GlobalFilter } from '../Config/GlobalFilter';
+import { taskFromLine } from '../Commands/CreateOrEditTaskParser';
+import { Occurrence } from '../Task/Occurrence';
+import { parseOnCompletionValue } from '../Task/OnCompletion';
+import { Priority } from '../Task/Priority';
+import { Task } from '../Task/Task';
+import { TaskRegularExpressions } from '../Task/TaskRegularExpressions';
+import { Recurrence } from '../Task/Recurrence';
+import { StatusRegistry } from '../Statuses/StatusRegistry';
+import type { TaskV1 } from './TasksApiV2';
+
+const formatDate = (date: Moment | null): string | null => {
+    return date?.isValid() ? date.format(TaskRegularExpressions.dateFormat) : null;
+};
+
+const parseDate = (date: string | null | undefined, fieldName: string): Moment | null | undefined => {
+    if (date === undefined) {
+        return undefined;
+    }
+    if (date === null) {
+        return null;
+    }
+
+    const parsedDate = window.moment(date, TaskRegularExpressions.dateFormat, true);
+    if (!parsedDate.isValid()) {
+        throw new Error(`Invalid TaskV1 ${fieldName}: '${date}'. Expected YYYY-MM-DD.`);
+    }
+    return parsedDate;
+};
+
+const parsePriority = (priority: string | undefined): Priority | undefined => {
+    if (priority === undefined) {
+        return undefined;
+    }
+
+    if (Object.values(Priority).includes(priority as Priority)) {
+        return priority as Priority;
+    }
+
+    throw new Error(`Invalid TaskV1 priority: '${priority}'.`);
+};
+
+const descriptionWithGlobalFilter = (description: string): string => {
+    const globalFilter = GlobalFilter.getInstance();
+    if (globalFilter.isEmpty() || globalFilter.includedIn(description)) {
+        return description;
+    }
+
+    return globalFilter.prependTo(description);
+};
+
+const publicDescription = (description: string): string => {
+    return GlobalFilter.getInstance().removeAsWordFrom(description);
+};
+
+const descriptionWithTags = (description: string, tags: string[] | undefined): string => {
+    if (tags === undefined) {
+        return description;
+    }
+
+    const descriptionWithoutTags = description.replace(TaskRegularExpressions.hashTags, '').replace(/\s+/g, ' ').trim();
+    return [descriptionWithoutTags, ...tags].filter((part) => part !== '').join(' ');
+};
+
+export type { TaskV1 } from './TasksApiV2';
+
+const randomId = (): string => {
+    return Math.random().toString(36).slice(2, 10);
+};
+
+/**
+ * Converts an internal {@link Task} to its public API v2 representation.
+ *
+ * @param task The internal task to convert
+ * @returns A public {@link TaskV1} object
+ */
+export const taskToTaskV1 = (task: Task): TaskV1 => {
+    return {
+        id: task.id,
+        description: publicDescription(task.description),
+        status: task.status.symbol,
+        priority: task.priority.toString(),
+        createdDate: formatDate(task.createdDate),
+        startDate: formatDate(task.startDate),
+        scheduledDate: formatDate(task.scheduledDate),
+        dueDate: formatDate(task.dueDate),
+        doneDate: formatDate(task.doneDate),
+        cancelledDate: formatDate(task.cancelledDate),
+        recurrenceRule: task.recurrenceRule,
+        onCompletion: task.onCompletion,
+        dependsOn: [...task.dependsOn],
+        tags: [...task.tags],
+        blockLink: task.blockLink,
+        originalMarkdown: task.originalMarkdown,
+        path: task.path,
+        lineNumber: task.lineNumber,
+    };
+};
+
+/**
+ * Creates an internal {@link Task} from a description and optional public API v2 task fields.
+ *
+ * @param description The task description to use unless overridden by taskData.description
+ * @param path The vault-relative path where the task will be written
+ * @param taskData Optional public task fields that override parser defaults
+ * @returns An internal task ready to serialize
+ */
+export const taskFromTaskV1 = ({
+    description,
+    path,
+    taskData = {},
+}: {
+    description: string;
+    path: string;
+    taskData?: Partial<TaskV1>;
+}): Task => {
+    const requestedDescription = taskData.description ?? description;
+    const filteredDescription = descriptionWithGlobalFilter(descriptionWithTags(requestedDescription, taskData.tags));
+    const baseTask = taskFromLine({
+        line: `- [ ] ${filteredDescription}`,
+        path,
+    });
+
+    return taskWithTaskV1Data(baseTask, taskData);
+};
+
+/**
+ * Applies public API v2 task fields to an existing internal task.
+ *
+ * @param baseTask The internal task that supplies defaults and file/list metadata
+ * @param taskData Public task fields to apply
+ * @returns A new internal task with the supplied fields applied
+ */
+export const taskWithTaskV1Data = (baseTask: Task, taskData: Partial<TaskV1>): Task => {
+    const requestedDescription = taskData.description ?? baseTask.description;
+    const filteredDescription = descriptionWithGlobalFilter(descriptionWithTags(requestedDescription, taskData.tags));
+    const createdDate = parseDate(taskData.createdDate, 'createdDate');
+    const startDate = parseDate(taskData.startDate, 'startDate');
+    const scheduledDate = parseDate(taskData.scheduledDate, 'scheduledDate');
+    const dueDate = parseDate(taskData.dueDate, 'dueDate');
+    const doneDate = parseDate(taskData.doneDate, 'doneDate');
+    const cancelledDate = parseDate(taskData.cancelledDate, 'cancelledDate');
+
+    const taskStartDate = startDate === undefined ? baseTask.startDate : startDate;
+    const taskScheduledDate = scheduledDate === undefined ? baseTask.scheduledDate : scheduledDate;
+    const taskDueDate = dueDate === undefined ? baseTask.dueDate : dueDate;
+    const recurrence =
+        taskData.recurrenceRule === undefined
+            ? baseTask.recurrence
+            : Recurrence.fromText({
+                  recurrenceRuleText: taskData.recurrenceRule,
+                  occurrence: new Occurrence({
+                      startDate: taskStartDate,
+                      scheduledDate: taskScheduledDate,
+                      dueDate: taskDueDate,
+                  }),
+              });
+
+    return new Task({
+        ...baseTask,
+        description: filteredDescription,
+        status:
+            taskData.status === undefined
+                ? baseTask.status
+                : StatusRegistry.getInstance().bySymbolOrCreate(taskData.status),
+        priority: parsePriority(taskData.priority) ?? baseTask.priority,
+        createdDate: createdDate === undefined ? baseTask.createdDate : createdDate,
+        startDate: taskStartDate,
+        scheduledDate: taskScheduledDate,
+        dueDate: taskDueDate,
+        doneDate: doneDate === undefined ? baseTask.doneDate : doneDate,
+        cancelledDate: cancelledDate === undefined ? baseTask.cancelledDate : cancelledDate,
+        recurrence,
+        onCompletion:
+            taskData.onCompletion === undefined ? baseTask.onCompletion : parseOnCompletionValue(taskData.onCompletion),
+        dependsOn: taskData.dependsOn === undefined ? baseTask.dependsOn : [...taskData.dependsOn],
+        id: taskData.id ?? baseTask.id,
+        blockLink: taskData.blockLink ?? baseTask.blockLink,
+        tags: taskData.tags === undefined ? Task.extractHashtags(filteredDescription) : [...taskData.tags],
+        originalMarkdown: '',
+        scheduledDateIsInferred: scheduledDate === undefined ? baseTask.scheduledDateIsInferred : false,
+    });
+};
+
+/**
+ * Ensures that a public API v2 task object has a unique ID.
+ *
+ * @param task The task to inspect
+ * @param allTasks All current internal tasks, used to avoid ID collisions
+ * @returns The same task object if it already has an ID, otherwise a copy with a generated unique ID
+ */
+export const ensureTaskHasUniqueId = (task: TaskV1, allTasks: Task[]): TaskV1 => {
+    if (task.id !== '') {
+        return task;
+    }
+
+    const existingIds = new Set(allTasks.map((existingTask) => existingTask.id).filter((id) => id !== ''));
+    let id = randomId();
+    while (id === '' || existingIds.has(id)) {
+        id = randomId();
+    }
+
+    return {
+        ...task,
+        id,
+    };
+};

--- a/src/Api/TasksApiV2.ts
+++ b/src/Api/TasksApiV2.ts
@@ -1,0 +1,150 @@
+import type { TasksApiV1 } from './TasksApiV1';
+
+/**
+ * Public representation of a Tasks task for API v2.
+ *
+ * This interface deliberately avoids exposing the internal {@link Task} class.
+ */
+export interface TaskV1 {
+    /** Unique task identifier, or an empty string if the task has no ID. */
+    id: string;
+
+    /** Task description, excluding the configured global filter and including tags present in the task line. */
+    description: string;
+
+    /** The status symbol inside the task checkbox, such as ' ', 'x', or '/'. */
+    status: string;
+
+    /** Priority value, as defined by {@link Priority}. */
+    priority: string;
+
+    /** Created date in YYYY-MM-DD format, or null if no created date is set. */
+    createdDate: string | null;
+
+    /** Start date in YYYY-MM-DD format, or null if no start date is set. */
+    startDate: string | null;
+
+    /** Scheduled date in YYYY-MM-DD format, or null if no scheduled date is set. */
+    scheduledDate: string | null;
+
+    /** Due date in YYYY-MM-DD format, or null if no due date is set. */
+    dueDate: string | null;
+
+    /** Done date in YYYY-MM-DD format, or null if no done date is set. */
+    doneDate: string | null;
+
+    /** Cancelled date in YYYY-MM-DD format, or null if no cancelled date is set. */
+    cancelledDate: string | null;
+
+    /** Recurrence rule text, or an empty string if no recurrence is set. */
+    recurrenceRule: string;
+
+    /** On Completion action, or an empty string if no action is set. */
+    onCompletion: string;
+
+    /** IDs of tasks that this task depends on. */
+    dependsOn: string[];
+
+    /** Tags extracted from the task description. */
+    tags: string[];
+
+    /** Block link suffix, including the leading space, or an empty string if none is set. */
+    blockLink: string;
+
+    /** Full original Markdown line for this task. */
+    originalMarkdown: string;
+
+    /** Vault-relative path to the Markdown file containing this task. */
+    path: string;
+
+    /** Zero-based line number of the task in its file. */
+    lineNumber: number;
+}
+
+/**
+ * Destination for creating a task through API v2.
+ */
+export interface TaskCreationDestinationV1 {
+    /** Vault-relative path to the Markdown file where the task should be created. */
+    path: string;
+
+    /** Zero-based line number used with {@link placement}. */
+    line?: number;
+
+    /**
+     * Placement relative to {@link line}.
+     *
+     * If line is supplied and placement is omitted, the task is inserted after the line.
+     * If neither line nor placement is supplied, Tasks appends after the last existing task line
+     * in the file, or at end of file if the file contains no task lines.
+     */
+    placement?: 'before' | 'after' | 'replace' | 'append';
+}
+
+/**
+ * Tasks API v2 interface.
+ *
+ * API v2 includes all API v1 methods and adds versioned task objects, task search,
+ * vault-writing task creation and editing, and task ID generation.
+ */
+export interface TasksApiV2 extends TasksApiV1 {
+    /**
+     * Runs a Tasks query against the current task cache.
+     * Query strings use the same syntax as Tasks code blocks.
+     *
+     * @see docs/Queries/About Queries.md
+     * @see docs/Queries/Filters.md
+     * @see docs/Queries/Combining Filters.md
+     * @see docs/Queries/Regular Expressions.md
+     *
+     * @example
+     * ```ts
+     * const dueSoon = tasksApi.queryTasks('not done\ndue before tomorrow');
+     * ```
+     *
+     * @example
+     * ```ts
+     * const projectTasks = tasksApi.queryTasks('not done\n(description includes #project) OR (path includes Work/)');
+     * ```
+     *
+     * @example
+     * ```ts
+     * const waitingTasks = tasksApi.queryTasks('description regex matches /waiting|blocked/i');
+     * ```
+     *
+     * @param query The Tasks query instructions to run
+     * @returns Matching tasks as public {@link TaskV1} objects
+     */
+    queryTasks(query: string): TaskV1[];
+
+    /**
+     * Creates a task in an existing Markdown file.
+     *
+     * @param destination The file and optional line placement for the new task
+     * @param description The task description to use unless overridden by taskData.description
+     * @param taskData Optional task fields that override creation defaults
+     * @returns A promise that contains the created task as a public {@link TaskV1} object
+     */
+    createTask(
+        destination: TaskCreationDestinationV1,
+        description: string,
+        taskData?: Partial<TaskV1>,
+    ): Promise<TaskV1>;
+
+    /**
+     * Edits the task with the supplied task ID.
+     *
+     * @param taskId The non-empty task ID to edit
+     * @param taskData Task fields to apply to the existing task
+     * @returns A promise that contains the edited task as a public {@link TaskV1} object
+     */
+    editTask(taskId: string, taskData: Partial<TaskV1>): Promise<TaskV1>;
+
+    /**
+     * Ensures that a public task object has a unique ID.
+     *
+     * @param task The task to inspect
+     * @returns The same task object if it already has an ID, otherwise a copy with a generated unique ID
+     */
+    ensureTaskHasUniqueId(task: TaskV1): TaskV1;
+}

--- a/src/Api/createTask.ts
+++ b/src/Api/createTask.ts
@@ -1,0 +1,122 @@
+import type { App } from 'obsidian';
+import { TasksFile } from '../Scripting/TasksFile';
+import { Task } from '../Task/Task';
+import { TaskLocation } from '../Task/TaskLocation';
+import { TaskRegularExpressions } from '../Task/TaskRegularExpressions';
+import { taskFromTaskV1, taskToTaskV1 } from './TaskV1';
+import type { TaskCreationDestinationV1, TaskV1 } from './TasksApiV2';
+
+const splitFileContent = (content: string): string[] => {
+    return content === '' ? [] : content.split('\n');
+};
+
+const listItemIndentation = (line: string): number | undefined => {
+    const listItemMatch = line.match(TaskRegularExpressions.listItemRegex);
+    return listItemMatch === null ? undefined : listItemMatch[1].length;
+};
+
+const lineAfterTaskListBlock = (fileLines: string[], taskLineNumber: number): number => {
+    const taskIndentation = Task.extractTaskComponents(fileLines[taskLineNumber])?.indentation.length ?? 0;
+    let lineNumber = taskLineNumber + 1;
+
+    while (lineNumber < fileLines.length) {
+        const childIndentation = listItemIndentation(fileLines[lineNumber]);
+        if (childIndentation === undefined || childIndentation <= taskIndentation) {
+            break;
+        }
+
+        lineNumber++;
+    }
+
+    return lineNumber;
+};
+
+const lineAfterLastTaskListBlock = (fileLines: string[]): number | undefined => {
+    for (let lineNumber = fileLines.length - 1; lineNumber >= 0; lineNumber--) {
+        if (Task.extractTaskComponents(fileLines[lineNumber]) !== null) {
+            return lineAfterTaskListBlock(fileLines, lineNumber);
+        }
+    }
+
+    return undefined;
+};
+
+const insertionLine = (destination: TaskCreationDestinationV1, fileLines: string[]): number => {
+    if (destination.placement === 'append') {
+        return fileLines.length;
+    }
+
+    if (destination.line === undefined) {
+        return lineAfterLastTaskListBlock(fileLines) ?? fileLines.length;
+    }
+
+    if (destination.line < 0 || destination.line >= fileLines.length) {
+        throw new Error(`TasksApiV2.createTask line ${destination.line} is outside '${destination.path}'.`);
+    }
+
+    switch (destination.placement ?? 'after') {
+        case 'before':
+            return destination.line;
+        case 'after':
+            return destination.line + 1;
+        case 'replace':
+            return destination.line;
+    }
+};
+
+const writeTaskLine = (
+    fileLines: string[],
+    lineNumber: number,
+    placement: TaskCreationDestinationV1['placement'],
+    taskLine: string,
+) => {
+    if (placement === 'replace') {
+        return [...fileLines.slice(0, lineNumber), taskLine, ...fileLines.slice(lineNumber + 1)];
+    }
+
+    return [...fileLines.slice(0, lineNumber), taskLine, ...fileLines.slice(lineNumber)];
+};
+
+const taskAtLine = (task: Task, path: string, lineNumber: number): Task => {
+    const originalMarkdown = task.toFileLineString();
+    return new Task({
+        ...task,
+        taskLocation: new TaskLocation(new TasksFile(path), lineNumber, lineNumber, 0, null),
+        originalMarkdown,
+    });
+};
+
+/**
+ * Creates a task in an existing Markdown file.
+ *
+ * @param app The Obsidian app, used to read and modify the target vault file
+ * @param destination The file and optional line placement for the new task
+ * @param description The task description to use unless overridden by taskData.description
+ * @param taskData Optional public task fields that override creation defaults
+ * @returns A promise that contains the created task as a public {@link TaskV1} object
+ */
+export const createTask = async (
+    app: App,
+    destination: TaskCreationDestinationV1,
+    description: string,
+    taskData?: Partial<TaskV1>,
+): Promise<TaskV1> => {
+    const file = app.vault.getFileByPath(destination.path);
+    if (file === null) {
+        throw new Error(`TasksApiV2.createTask could not find file '${destination.path}'.`);
+    }
+
+    const task = taskFromTaskV1({
+        description,
+        path: destination.path,
+        taskData,
+    });
+    const taskLine = task.toFileLineString();
+    const fileLines = splitFileContent(await app.vault.read(file));
+    const lineNumber = insertionLine(destination, fileLines);
+    const updatedFileLines = writeTaskLine(fileLines, lineNumber, destination.placement, taskLine);
+
+    await app.vault.modify(file, updatedFileLines.join('\n'));
+
+    return taskToTaskV1(taskAtLine(task, destination.path, lineNumber));
+};

--- a/src/Api/editTask.ts
+++ b/src/Api/editTask.ts
@@ -1,0 +1,81 @@
+import type { App } from 'obsidian';
+import { TasksFile } from '../Scripting/TasksFile';
+import { Task } from '../Task/Task';
+import { TaskLocation } from '../Task/TaskLocation';
+import { taskToTaskV1, taskWithTaskV1Data } from './TaskV1';
+import type { TaskV1 } from './TasksApiV2';
+
+const splitFileContent = (content: string): string[] => {
+    return content === '' ? [] : content.split('\n');
+};
+
+const lineNumberForTask = (task: Task, fileLines: string[]): number => {
+    const originalLineNumber = task.lineNumber;
+    if (originalLineNumber >= 0 && originalLineNumber < fileLines.length) {
+        if (fileLines[originalLineNumber] === task.originalMarkdown) {
+            return originalLineNumber;
+        }
+    }
+
+    const matchingLineNumbers = fileLines
+        .map((line, lineNumber) => ({ line, lineNumber }))
+        .filter(({ line }) => line === task.originalMarkdown)
+        .map(({ lineNumber }) => lineNumber);
+
+    if (matchingLineNumbers.length === 1) {
+        return matchingLineNumbers[0];
+    }
+
+    throw new Error(`TasksApiV2.editTask could not find task '${task.id}' in '${task.path}'.`);
+};
+
+const taskAtLine = (task: Task, lineNumber: number): Task => {
+    return new Task({
+        ...task,
+        taskLocation: new TaskLocation(new TasksFile(task.path), lineNumber, lineNumber, 0, null),
+        originalMarkdown: task.toFileLineString(),
+    });
+};
+
+/**
+ * Edits an existing task by public task ID.
+ *
+ * @param app The Obsidian app, used to read and modify the task's vault file
+ * @param tasks All current internal tasks, used to locate the task ID
+ * @param taskId The non-empty task ID to edit
+ * @param taskData Public task fields to apply to the existing task
+ * @returns A promise that contains the edited task as a public {@link TaskV1} object
+ */
+export const editTask = async (app: App, tasks: Task[], taskId: string, taskData: Partial<TaskV1>): Promise<TaskV1> => {
+    if (taskId === '') {
+        throw new Error('TasksApiV2.editTask requires a non-empty taskId.');
+    }
+
+    const matchingTasks = tasks.filter((task) => task.id === taskId);
+    if (matchingTasks.length === 0) {
+        throw new Error(`TasksApiV2.editTask could not find task '${taskId}'.`);
+    }
+    if (matchingTasks.length > 1) {
+        throw new Error(`TasksApiV2.editTask found multiple tasks with id '${taskId}'.`);
+    }
+
+    const originalTask = matchingTasks[0];
+    const file = app.vault.getFileByPath(originalTask.path);
+    if (file === null) {
+        throw new Error(`TasksApiV2.editTask could not find file '${originalTask.path}'.`);
+    }
+
+    const updatedTask = taskWithTaskV1Data(originalTask, taskData);
+    const fileLines = splitFileContent(await app.vault.read(file));
+    const lineNumber = lineNumberForTask(originalTask, fileLines);
+    const updatedTaskAtLine = taskAtLine(updatedTask, lineNumber);
+    const updatedFileLines = [
+        ...fileLines.slice(0, lineNumber),
+        updatedTaskAtLine.toFileLineString(),
+        ...fileLines.slice(lineNumber + 1),
+    ];
+
+    await app.vault.modify(file, updatedFileLines.join('\n'));
+
+    return taskToTaskV1(updatedTaskAtLine);
+};

--- a/src/Api/index.ts
+++ b/src/Api/index.ts
@@ -1,8 +1,13 @@
 import type TasksPlugin from '../main';
 import { toggleLine } from '../Commands/ToggleDone';
+import { createTask } from './createTask';
 import { createTaskLineModal } from './createTaskLineModal';
 import type { TasksApiV1 } from './TasksApiV1';
+import type { TasksApiV2 } from './TasksApiV2';
+import { ensureTaskHasUniqueId } from './TaskV1';
 import { editTaskLineModal } from './editTaskLineModal';
+import { editTask } from './editTask';
+import { queryTasks } from './queryTasks';
 
 /**
  * Factory method for API v1
@@ -21,5 +26,15 @@ export const tasksApiV1 = (plugin: TasksPlugin): TasksApiV1 => {
             return editTaskLineModal(app, taskLine, plugin.getTasks(), onSaveSettings);
         },
         executeToggleTaskDoneCommand: (line: string, path: string) => toggleLine(line, path).text,
+    };
+};
+
+export const tasksApiV2 = (plugin: TasksPlugin): TasksApiV2 => {
+    return {
+        ...tasksApiV1(plugin),
+        queryTasks: (query: string) => queryTasks(query, plugin.getTasks()),
+        createTask: (destination, description, taskData) => createTask(plugin.app, destination, description, taskData),
+        editTask: (taskId, taskData) => editTask(plugin.app, plugin.getTasks(), taskId, taskData),
+        ensureTaskHasUniqueId: (task) => ensureTaskHasUniqueId(task, plugin.getTasks()),
     };
 };

--- a/src/Api/queryTasks.ts
+++ b/src/Api/queryTasks.ts
@@ -1,0 +1,25 @@
+import { Query } from '../Query/Query';
+import type { Task } from '../Task/Task';
+import type { TaskV1 } from './TasksApiV2';
+import { taskToTaskV1 } from './TaskV1';
+
+/**
+ * Runs a Tasks query against the supplied internal tasks.
+ *
+ * @param querySource The Tasks query instructions to run
+ * @param tasks The internal tasks to query
+ * @returns Matching tasks as public {@link TaskV1} objects
+ */
+export const queryTasks = (querySource: string, tasks: Task[]): TaskV1[] => {
+    const query = new Query(querySource);
+    if (query.error !== undefined) {
+        throw new Error(query.error);
+    }
+
+    const result = query.applyQueryToTasks(tasks);
+    if (result.searchErrorMessage !== undefined) {
+        throw new Error(result.searchErrorMessage);
+    }
+
+    return [...new Set(result.groups.flatMap((group) => group.tasks))].map(taskToTaskV1);
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import { StatusRegistry } from './Statuses/StatusRegistry';
 import { log, logging } from './lib/logging';
 import { EditorSuggestor } from './Suggestor/EditorSuggestorPopup';
 import { StatusSettings } from './Config/StatusSettings';
-import { tasksApiV1 } from './Api';
+import { tasksApiV1, tasksApiV2 } from './Api';
 import { GlobalFilter } from './Config/GlobalFilter';
 import { QueryFileDefaults } from './Query/QueryFileDefaults';
 import { LinkResolver } from './Task/LinkResolver';
@@ -30,6 +30,10 @@ export default class TasksPlugin extends Plugin {
 
     get apiV1() {
         return tasksApiV1(this);
+    }
+
+    get apiV2() {
+        return tasksApiV2(this);
     }
 
     async onload() {

--- a/tests/Api/TaskV1.test.ts
+++ b/tests/Api/TaskV1.test.ts
@@ -1,0 +1,195 @@
+import moment from 'moment';
+import { taskFromTaskV1, taskToTaskV1 } from '../../src/Api/TaskV1';
+import { GlobalFilter } from '../../src/Config/GlobalFilter';
+import { OnCompletion } from '../../src/Task/OnCompletion';
+import { Priority } from '../../src/Task/Priority';
+import { Task } from '../../src/Task/Task';
+import { Status } from '../../src/Statuses/Status';
+import { RecurrenceBuilder } from '../TestingTools/RecurrenceBuilder';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
+
+window.moment = moment;
+
+describe('TaskV1 mapping', () => {
+    afterEach(() => {
+        GlobalFilter.getInstance().reset();
+    });
+
+    it('maps task fields to TaskV1', () => {
+        const task = new TaskBuilder()
+            .description('Do the thing')
+            .status(Status.IN_PROGRESS)
+            .id('task-id')
+            .dependsOn(['first-id', 'second-id'])
+            .path('folder/file.md')
+            .lineNumber(42)
+            .tags(['#alpha', '#beta'])
+            .priority(Priority.High)
+            .recurrence(new RecurrenceBuilder().rule('every day').build())
+            .onCompletion(OnCompletion.Delete)
+            .blockLink(' ^block-id')
+            .build();
+
+        const taskV1 = taskToTaskV1(task);
+
+        expect(taskV1).toMatchObject({
+            id: 'task-id',
+            description: 'Do the thing #alpha #beta',
+            status: '/',
+            dependsOn: ['first-id', 'second-id'],
+            path: 'folder/file.md',
+            lineNumber: 42,
+            originalMarkdown: task.originalMarkdown,
+            tags: ['#alpha', '#beta'],
+            priority: '1',
+            recurrenceRule: task.recurrenceRule,
+            onCompletion: OnCompletion.Delete,
+            blockLink: ' ^block-id',
+            createdDate: null,
+            startDate: null,
+            scheduledDate: null,
+            dueDate: null,
+            doneDate: null,
+            cancelledDate: null,
+        });
+    });
+
+    it('removes the global filter from the public description but keeps original markdown unchanged', () => {
+        GlobalFilter.getInstance().set('#task');
+        const task = new TaskBuilder().description('#task Do the thing').build();
+
+        const taskV1 = taskToTaskV1(task);
+
+        expect(taskV1.description).toBe('Do the thing');
+        expect(taskV1.originalMarkdown).toBe('- [ ] #task Do the thing');
+    });
+
+    it('maps valid dates to YYYY-MM-DD', () => {
+        const task = new TaskBuilder().dueDate('2026-02-03').build();
+
+        const taskV1 = taskToTaskV1(task);
+
+        expect(taskV1.dueDate).toBe('2026-02-03');
+    });
+
+    it('maps invalid dates to null', () => {
+        const task = new TaskBuilder().build();
+        const taskWithInvalidDueDate = new Task({
+            ...task,
+            dueDate: moment.invalid(),
+        });
+
+        const taskV1 = taskToTaskV1(taskWithInvalidDueDate);
+
+        expect(taskV1.dueDate).toBeNull();
+    });
+
+    it('copies array fields', () => {
+        const task = new TaskBuilder().dependsOn(['first-id']).tags(['#alpha']).build();
+
+        const taskV1 = taskToTaskV1(task);
+        taskV1.dependsOn.push('second-id');
+        taskV1.tags.push('#beta');
+
+        expect(task.dependsOn).toEqual(['first-id']);
+        expect(task.tags).toEqual(['#alpha']);
+    });
+
+    it('creates an internal task from a description with parser defaults', () => {
+        const task = taskFromTaskV1({
+            description: 'Do the thing',
+            path: 'tasks.md',
+        });
+
+        expect(task.toFileLineString()).toBe('- [ ] Do the thing');
+        expect(task.description).toBe('Do the thing');
+        expect(task.status).toBe(Status.TODO);
+        expect(task.path).toBe('tasks.md');
+    });
+
+    it('applies TaskV1 fields as overrides when creating an internal task', () => {
+        const task = taskFromTaskV1({
+            description: 'Default description',
+            path: 'tasks.md',
+            taskData: {
+                description: 'Overridden description',
+                status: '/',
+                priority: Priority.High,
+                createdDate: '2026-01-02',
+                startDate: '2026-01-03',
+                scheduledDate: '2026-01-04',
+                dueDate: '2026-01-05',
+                doneDate: '2026-01-06',
+                cancelledDate: '2026-01-07',
+                recurrenceRule: 'every day',
+                onCompletion: OnCompletion.Delete,
+                dependsOn: ['abc123'],
+                id: 'def456',
+                tags: ['#alpha', '#beta'],
+                blockLink: ' ^block-id',
+            },
+        });
+
+        expect(taskToTaskV1(task)).toMatchObject({
+            description: 'Overridden description #alpha #beta',
+            status: '/',
+            priority: Priority.High,
+            createdDate: '2026-01-02',
+            startDate: '2026-01-03',
+            scheduledDate: '2026-01-04',
+            dueDate: '2026-01-05',
+            doneDate: '2026-01-06',
+            cancelledDate: '2026-01-07',
+            recurrenceRule: 'every day',
+            onCompletion: OnCompletion.Delete,
+            dependsOn: ['abc123'],
+            id: 'def456',
+            tags: ['#alpha', '#beta'],
+            blockLink: ' ^block-id',
+        });
+    });
+
+    it('prepends the global filter when creating an internal task', () => {
+        GlobalFilter.getInstance().set('#task');
+
+        const task = taskFromTaskV1({
+            description: 'Do the thing',
+            path: 'tasks.md',
+        });
+
+        expect(task.description).toBe('#task Do the thing');
+        expect(taskToTaskV1(task).description).toBe('Do the thing');
+        expect(task.toFileLineString()).toBe('- [ ] #task Do the thing');
+    });
+
+    it('does not duplicate the global filter when creating an internal task', () => {
+        GlobalFilter.getInstance().set('#task');
+
+        const task = taskFromTaskV1({
+            description: '#task Do the thing',
+            path: 'tasks.md',
+        });
+
+        expect(task.description).toBe('#task Do the thing');
+    });
+
+    it('rejects invalid TaskV1 dates', () => {
+        expect(() =>
+            taskFromTaskV1({
+                description: 'Do the thing',
+                path: 'tasks.md',
+                taskData: { dueDate: 'not-a-date' },
+            }),
+        ).toThrow("Invalid TaskV1 dueDate: 'not-a-date'. Expected YYYY-MM-DD.");
+    });
+
+    it('rejects invalid TaskV1 priorities', () => {
+        expect(() =>
+            taskFromTaskV1({
+                description: 'Do the thing',
+                path: 'tasks.md',
+                taskData: { priority: 'urgent' },
+            }),
+        ).toThrow("Invalid TaskV1 priority: 'urgent'.");
+    });
+});

--- a/tests/Api/TaskV1Id.test.ts
+++ b/tests/Api/TaskV1Id.test.ts
@@ -1,0 +1,91 @@
+import { ensureTaskHasUniqueId } from '../../src/Api/TaskV1';
+import type { TaskV1 } from '../../src/Api/TasksApiV2';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
+
+const makeTaskV1 = (overrides: Partial<TaskV1> = {}): TaskV1 => ({
+    id: '',
+    description: 'Do the thing',
+    status: ' ',
+    priority: '',
+    createdDate: null,
+    startDate: null,
+    scheduledDate: null,
+    dueDate: null,
+    doneDate: null,
+    cancelledDate: null,
+    recurrenceRule: '',
+    onCompletion: '',
+    dependsOn: [],
+    tags: [],
+    blockLink: '',
+    originalMarkdown: '- [ ] Do the thing',
+    path: 'tasks.md',
+    lineNumber: 1,
+    ...overrides,
+});
+
+const generatedIdFor = (randomValue: number): string => randomValue.toString(36).slice(2, 10);
+
+describe('ensureTaskHasUniqueId', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('returns the same object when the task already has a non-empty id', () => {
+        const task = makeTaskV1({ id: 'existing-id' });
+
+        const result = ensureTaskHasUniqueId(task, []);
+
+        expect(result).toBe(task);
+    });
+
+    it('returns a copy with a new unique id when the task has no id', () => {
+        const task = makeTaskV1();
+        const existingTask = new TaskBuilder().id('existing-id').build();
+
+        const result = ensureTaskHasUniqueId(task, [existingTask]);
+
+        expect(result).not.toBe(task);
+        expect(result.id).not.toBe('');
+        expect(result.id).not.toBe(existingTask.id);
+        expect(result.id).toMatch(/^[a-zA-Z0-9-_]+$/);
+    });
+
+    it('retries when the generated id already belongs to an existing task', () => {
+        const firstRandomValue = 0.5;
+        const secondRandomValue = 0.25;
+        const existingId = generatedIdFor(firstRandomValue);
+        const uniqueId = generatedIdFor(secondRandomValue);
+        jest.spyOn(Math, 'random').mockReturnValueOnce(firstRandomValue).mockReturnValueOnce(secondRandomValue);
+        const task = makeTaskV1();
+        const existingTask = new TaskBuilder().id(existingId).build();
+
+        const result = ensureTaskHasUniqueId(task, [existingTask]);
+
+        expect(result.id).toBe(uniqueId);
+        expect(result.id).not.toBe(existingId);
+        expect(Math.random).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries when the generated id is empty', () => {
+        const validRandomValue = 0.25;
+        const validId = generatedIdFor(validRandomValue);
+        jest.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(validRandomValue);
+        const task = makeTaskV1();
+
+        const result = ensureTaskHasUniqueId(task, []);
+
+        expect(result.id).toBe(validId);
+        expect(result.id).not.toBe('');
+        expect(Math.random).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not mutate the original task when generating an id', () => {
+        const task = makeTaskV1();
+
+        const result = ensureTaskHasUniqueId(task, []);
+
+        expect(result.id).not.toBe('');
+        expect(task.id).toBe('');
+    });
+});

--- a/tests/Api/TaskV1Id.test.ts
+++ b/tests/Api/TaskV1Id.test.ts
@@ -2,6 +2,8 @@ import { ensureTaskHasUniqueId } from '../../src/Api/TaskV1';
 import type { TaskV1 } from '../../src/Api/TasksApiV2';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 
+const originalCrypto = globalThis.crypto;
+
 const makeTaskV1 = (overrides: Partial<TaskV1> = {}): TaskV1 => ({
     id: '',
     description: 'Do the thing',
@@ -24,11 +26,27 @@ const makeTaskV1 = (overrides: Partial<TaskV1> = {}): TaskV1 => ({
     ...overrides,
 });
 
-const generatedIdFor = (randomValue: number): string => randomValue.toString(36).slice(2, 10);
+const mockCryptoValues = (...values: number[][]) => {
+    const getRandomValues = jest.fn((array: Uint8Array) => {
+        array.set(values.shift() ?? []);
+        return array;
+    });
+
+    Object.defineProperty(globalThis, 'crypto', {
+        value: { getRandomValues },
+        configurable: true,
+    });
+
+    return getRandomValues;
+};
 
 describe('ensureTaskHasUniqueId', () => {
     afterEach(() => {
         jest.restoreAllMocks();
+        Object.defineProperty(globalThis, 'crypto', {
+            value: originalCrypto,
+            configurable: true,
+        });
     });
 
     it('returns the same object when the task already has a non-empty id', () => {
@@ -52,32 +70,15 @@ describe('ensureTaskHasUniqueId', () => {
     });
 
     it('retries when the generated id already belongs to an existing task', () => {
-        const firstRandomValue = 0.5;
-        const secondRandomValue = 0.25;
-        const existingId = generatedIdFor(firstRandomValue);
-        const uniqueId = generatedIdFor(secondRandomValue);
-        jest.spyOn(Math, 'random').mockReturnValueOnce(firstRandomValue).mockReturnValueOnce(secondRandomValue);
+        const getRandomValues = mockCryptoValues([0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15]);
         const task = makeTaskV1();
-        const existingTask = new TaskBuilder().id(existingId).build();
+        const existingTask = new TaskBuilder().id('abcdefgh').build();
 
         const result = ensureTaskHasUniqueId(task, [existingTask]);
 
-        expect(result.id).toBe(uniqueId);
-        expect(result.id).not.toBe(existingId);
-        expect(Math.random).toHaveBeenCalledTimes(2);
-    });
-
-    it('retries when the generated id is empty', () => {
-        const validRandomValue = 0.25;
-        const validId = generatedIdFor(validRandomValue);
-        jest.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(validRandomValue);
-        const task = makeTaskV1();
-
-        const result = ensureTaskHasUniqueId(task, []);
-
-        expect(result.id).toBe(validId);
-        expect(result.id).not.toBe('');
-        expect(Math.random).toHaveBeenCalledTimes(2);
+        expect(result.id).toBe('ijklmnop');
+        expect(result.id).not.toBe(existingTask.id);
+        expect(getRandomValues).toHaveBeenCalledTimes(2);
     });
 
     it('does not mutate the original task when generating an id', () => {

--- a/tests/Api/createTask.test.ts
+++ b/tests/Api/createTask.test.ts
@@ -1,0 +1,165 @@
+import type { App } from 'obsidian';
+import moment from 'moment';
+import { createTask } from '../../src/Api/createTask';
+import { GlobalFilter } from '../../src/Config/GlobalFilter';
+import { Priority } from '../../src/Task/Priority';
+
+window.moment = moment;
+
+const mockAppWithFile = (content: string) => {
+    const file = { path: 'tasks.md' };
+    const app = {
+        vault: {
+            getFileByPath: jest.fn().mockReturnValue(file),
+            read: jest.fn().mockResolvedValue(content),
+            modify: jest.fn().mockResolvedValue(undefined),
+        },
+    } as unknown as App;
+
+    return { app, file };
+};
+
+describe('TasksApiV2 createTask', () => {
+    afterEach(() => {
+        GlobalFilter.getInstance().reset();
+    });
+
+    it('inserts a task after the requested line by default', async () => {
+        const { app, file } = mockAppWithFile(['# Heading', '- [ ] Existing task'].join('\n'));
+
+        const task = await createTask(app, { path: 'tasks.md', line: 0 }, 'New task');
+
+        expect(app.vault.modify).toHaveBeenCalledWith(
+            file,
+            ['# Heading', '- [ ] New task', '- [ ] Existing task'].join('\n'),
+        );
+        expect(task).toMatchObject({
+            description: 'New task',
+            path: 'tasks.md',
+            lineNumber: 1,
+            originalMarkdown: '- [ ] New task',
+        });
+    });
+
+    it('inserts a task before the requested line', async () => {
+        const { app, file } = mockAppWithFile(['# Heading', '- [ ] Existing task'].join('\n'));
+
+        await createTask(app, { path: 'tasks.md', line: 1, placement: 'before' }, 'New task');
+
+        expect(app.vault.modify).toHaveBeenCalledWith(
+            file,
+            ['# Heading', '- [ ] New task', '- [ ] Existing task'].join('\n'),
+        );
+    });
+
+    it('replaces the requested line', async () => {
+        const { app, file } = mockAppWithFile(['# Heading', '- [ ] Existing task'].join('\n'));
+
+        const task = await createTask(app, { path: 'tasks.md', line: 1, placement: 'replace' }, 'Replacement');
+
+        expect(app.vault.modify).toHaveBeenCalledWith(file, ['# Heading', '- [ ] Replacement'].join('\n'));
+        expect(task.lineNumber).toBe(1);
+    });
+
+    it('appends a task to the end of the file', async () => {
+        const { app, file } = mockAppWithFile(['# Heading', '- [ ] Existing task'].join('\n'));
+
+        const task = await createTask(app, { path: 'tasks.md', placement: 'append' }, 'New task', {
+            priority: Priority.High,
+        });
+
+        expect(app.vault.modify).toHaveBeenCalledWith(
+            file,
+            ['# Heading', '- [ ] Existing task', '- [ ] New task ⏫'].join('\n'),
+        );
+        expect(task).toMatchObject({
+            description: 'New task',
+            priority: Priority.High,
+            lineNumber: 2,
+        });
+    });
+
+    it('appends after the last existing task when line and placement are omitted', async () => {
+        const originalLines = ['# Heading', '- [ ] First task', '- [x] Second task', '', 'Notes after the task list'];
+        const updatedLines = [
+            '# Heading',
+            '- [ ] First task',
+            '- [x] Second task',
+            '- [ ] New task',
+            '',
+            'Notes after the task list',
+        ];
+        const { app, file } = mockAppWithFile(originalLines.join('\n'));
+
+        const task = await createTask(app, { path: 'tasks.md' }, 'New task');
+
+        expect(app.vault.modify).toHaveBeenCalledWith(file, updatedLines.join('\n'));
+        expect(task.lineNumber).toBe(3);
+    });
+
+    it('appends after the last existing task list block when line and placement are omitted', async () => {
+        const originalLines = [
+            '# Heading',
+            '- [ ] Parent task',
+            '  - [ ] Child task',
+            '    - Child detail',
+            '',
+            'Notes after the task list',
+        ];
+        const updatedLines = [
+            '# Heading',
+            '- [ ] Parent task',
+            '  - [ ] Child task',
+            '    - Child detail',
+            '- [ ] New task',
+            '',
+            'Notes after the task list',
+        ];
+        const { app, file } = mockAppWithFile(originalLines.join('\n'));
+
+        const task = await createTask(app, { path: 'tasks.md' }, 'New task');
+
+        expect(app.vault.modify).toHaveBeenCalledWith(file, updatedLines.join('\n'));
+        expect(task.lineNumber).toBe(4);
+    });
+
+    it('uses EOF when line and placement are omitted and the file has no task list', async () => {
+        const { app, file } = mockAppWithFile(['# Heading', 'Notes only'].join('\n'));
+
+        const task = await createTask(app, { path: 'tasks.md' }, 'New task');
+
+        expect(app.vault.modify).toHaveBeenCalledWith(file, ['# Heading', 'Notes only', '- [ ] New task'].join('\n'));
+        expect(task.lineNumber).toBe(2);
+    });
+
+    it('prepends the global filter to created task lines', async () => {
+        GlobalFilter.getInstance().set('#task');
+        const { app, file } = mockAppWithFile('');
+
+        const task = await createTask(app, { path: 'tasks.md' }, 'New task');
+
+        expect(app.vault.modify).toHaveBeenCalledWith(file, '- [ ] #task New task');
+        expect(task.description).toBe('New task');
+        expect(task.originalMarkdown).toBe('- [ ] #task New task');
+    });
+
+    it('throws when the destination file does not exist', async () => {
+        const app = {
+            vault: {
+                getFileByPath: jest.fn().mockReturnValue(null),
+            },
+        } as unknown as App;
+
+        await expect(createTask(app, { path: 'missing.md' }, 'New task')).rejects.toThrow(
+            "TasksApiV2.createTask could not find file 'missing.md'.",
+        );
+    });
+
+    it('throws when the requested line is outside the file', async () => {
+        const { app } = mockAppWithFile('- [ ] Existing task');
+
+        await expect(createTask(app, { path: 'tasks.md', line: 3 }, 'New task')).rejects.toThrow(
+            "TasksApiV2.createTask line 3 is outside 'tasks.md'.",
+        );
+    });
+});

--- a/tests/Api/editTask.test.ts
+++ b/tests/Api/editTask.test.ts
@@ -1,0 +1,129 @@
+import type { App } from 'obsidian';
+import moment from 'moment';
+import { editTask } from '../../src/Api/editTask';
+import { GlobalFilter } from '../../src/Config/GlobalFilter';
+import { Priority } from '../../src/Task/Priority';
+import type { Task } from '../../src/Task/Task';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
+
+window.moment = moment;
+
+const mockAppWithFile = (content: string) => {
+    const file = { path: 'tasks.md' };
+    const app = {
+        vault: {
+            getFileByPath: jest.fn().mockReturnValue(file),
+            read: jest.fn().mockResolvedValue(content),
+            modify: jest.fn().mockResolvedValue(undefined),
+        },
+    } as unknown as App;
+
+    return { app, file };
+};
+
+describe('TasksApiV2 editTask', () => {
+    afterEach(() => {
+        GlobalFilter.getInstance().reset();
+    });
+
+    it('edits the task with the requested id', async () => {
+        const existingTask = new TaskBuilder()
+            .id('abc123')
+            .description('Existing task')
+            .path('tasks.md')
+            .lineNumber(1)
+            .build();
+        const { app, file } = mockAppWithFile(['# Heading', existingTask.originalMarkdown].join('\n'));
+
+        const task = await editTask(app, [existingTask], 'abc123', {
+            description: 'Updated task',
+            dueDate: '2026-02-03',
+            priority: Priority.High,
+        });
+
+        const expectedMarkdown = '- [ ] Updated task 🆔 abc123 ⏫ 📅 2026-02-03';
+        expect(app.vault.modify).toHaveBeenCalledWith(file, ['# Heading', expectedMarkdown].join('\n'));
+        expect(task).toMatchObject({
+            id: 'abc123',
+            description: 'Updated task',
+            dueDate: '2026-02-03',
+            priority: Priority.High,
+            lineNumber: 1,
+            originalMarkdown: expectedMarkdown,
+        });
+    });
+
+    it('preserves indentation and list marker when editing', async () => {
+        const existingTask = new TaskBuilder()
+            .id('abc123')
+            .description('Existing task')
+            .indentation('  ')
+            .listMarker('*')
+            .path('tasks.md')
+            .lineNumber(0)
+            .build();
+        const { app, file } = mockAppWithFile(existingTask.originalMarkdown);
+
+        await editTask(app, [existingTask], 'abc123', { description: 'Updated task' });
+
+        expect(app.vault.modify).toHaveBeenCalledWith(file, '  * [ ] Updated task 🆔 abc123');
+    });
+
+    it('prepends the global filter when editing', async () => {
+        GlobalFilter.getInstance().set('#task');
+        const existingTask = new TaskBuilder()
+            .id('abc123')
+            .description('Existing task')
+            .path('tasks.md')
+            .lineNumber(0)
+            .build();
+        const { app, file } = mockAppWithFile(existingTask.originalMarkdown);
+
+        const task = await editTask(app, [existingTask], 'abc123', { description: 'Updated task' });
+
+        expect(app.vault.modify).toHaveBeenCalledWith(file, '- [ ] #task Updated task 🆔 abc123');
+        expect(task.description).toBe('Updated task');
+        expect(task.originalMarkdown).toBe('- [ ] #task Updated task 🆔 abc123');
+    });
+
+    it('finds a unique matching original markdown line if the original line number has moved', async () => {
+        const existingTask = new TaskBuilder()
+            .id('abc123')
+            .description('Existing task')
+            .path('tasks.md')
+            .lineNumber(0)
+            .build();
+        const { app, file } = mockAppWithFile(['# New heading', existingTask.originalMarkdown].join('\n'));
+
+        const task = await editTask(app, [existingTask], 'abc123', { description: 'Updated task' });
+
+        expect(app.vault.modify).toHaveBeenCalledWith(
+            file,
+            ['# New heading', '- [ ] Updated task 🆔 abc123'].join('\n'),
+        );
+        expect(task.lineNumber).toBe(1);
+    });
+
+    it('throws when the task id is empty', async () => {
+        const { app } = mockAppWithFile('');
+
+        await expect(editTask(app, [], '', {})).rejects.toThrow('TasksApiV2.editTask requires a non-empty taskId.');
+    });
+
+    it('throws when no task matches the requested id', async () => {
+        const { app } = mockAppWithFile('');
+
+        await expect(editTask(app, [], 'missing-id', {})).rejects.toThrow(
+            "TasksApiV2.editTask could not find task 'missing-id'.",
+        );
+    });
+
+    it('throws when multiple tasks match the requested id', async () => {
+        const tasks: Task[] = [new TaskBuilder().id('abc123').build(), new TaskBuilder().id('abc123').build()];
+        const { app } = mockAppWithFile('');
+
+        await expect(editTask(app, tasks, 'abc123', {})).rejects.toThrow(
+            "TasksApiV2.editTask found multiple tasks with id 'abc123'.",
+        );
+    });
+});

--- a/tests/Api/index.test.ts
+++ b/tests/Api/index.test.ts
@@ -3,7 +3,7 @@ import type TasksPlugin from '../../src/main';
 import type { Task } from '../../src/Task/Task';
 import { createTaskLineModal } from '../../src/Api/createTaskLineModal';
 import { editTaskLineModal } from '../../src/Api/editTaskLineModal';
-import { tasksApiV1 } from '../../src/Api/index';
+import { tasksApiV1, tasksApiV2 } from '../../src/Api/index';
 
 jest.mock('../../src/Api/createTaskLineModal', () => ({
     createTaskLineModal: jest.fn(),
@@ -43,5 +43,35 @@ describe('definition of public Api', () => {
 
         await publicApi.editTaskLineModal(taskLine);
         expect(editTaskLineModal).toHaveBeenCalledWith(app, taskLine, tasks, expect.any(Function));
+    });
+
+    it('should preserve apiV1 methods in tasksApiV2', async () => {
+        const task = jest.fn();
+        const app = {} as App; // Mock the app object
+        const tasks = [task as Partial<Task>];
+        const mockPlugin = {
+            getTasks: () => tasks,
+            app,
+        } as Partial<TasksPlugin> as TasksPlugin;
+
+        const publicApi = tasksApiV2(mockPlugin);
+
+        await publicApi.createTaskLineModal();
+        expect(createTaskLineModal).toHaveBeenCalledWith(app, tasks, expect.any(Function));
+        expect(publicApi.executeToggleTaskDoneCommand).toEqual(expect.any(Function));
+    });
+
+    it('should expose tasksApiV2 methods', async () => {
+        const mockPlugin = {
+            getTasks: () => [],
+            app: {} as App,
+        } as Partial<TasksPlugin> as TasksPlugin;
+
+        const publicApi = tasksApiV2(mockPlugin);
+
+        expect(publicApi.queryTasks).toEqual(expect.any(Function));
+        expect(publicApi.createTask).toEqual(expect.any(Function));
+        expect(publicApi.editTask).toEqual(expect.any(Function));
+        expect(publicApi.ensureTaskHasUniqueId).toEqual(expect.any(Function));
     });
 });

--- a/tests/Api/queryTasks.test.ts
+++ b/tests/Api/queryTasks.test.ts
@@ -1,0 +1,27 @@
+import { queryTasks } from '../../src/Api/queryTasks';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
+
+describe('queryTasks', () => {
+    it('returns matching tasks as TaskV1 objects', () => {
+        const matchingTask = new TaskBuilder().description('Do this').tags(['#work']).build();
+        const otherTask = new TaskBuilder().description('Ignore this').build();
+
+        const result = queryTasks('description includes Do', [matchingTask, otherTask]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].description).toBe('Do this #work');
+    });
+
+    it('returns each matching task only once when grouped by multiple tags', () => {
+        const task = new TaskBuilder().description('Do this').tags(['#a', '#b']).build();
+
+        const result = queryTasks('description includes Do\ngroup by tags', [task]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].description).toBe('Do this #a #b');
+    });
+
+    it('throws query parser errors', () => {
+        expect(() => queryTasks('not a valid instruction', [])).toThrow(/do not understand query/);
+    });
+});


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: #3922
  - **WARNING: If the link is absent, the PR may be closed without review**, due to the workload that such reviews usually require.
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
- [ ] **Translation** (prefix: `i18n` - additions or improvements to the translations - see [Support a new language](https://publish.obsidian.md/tasks-contributing/Translation/Support+a+new+language))
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [x] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

Adds a versioned `apiV2` surface alongside the existing `apiV1`.

The new API exposes public `TaskV1` data objects and helper methods to query tasks with the existing Tasks query language, create a task at an explicit vault path and line placement, edit a task by Tasks ID, and generate a unique missing ID.

The implementation keeps `apiV1` unchanged and avoids exposing internal implementation types such as `Task`, `Status`, `Recurrence`, `TasksFile`, `TaskLocation`, query result classes, or Moment-specific internals.

This also updates the user-facing Tasks API documentation and records ADR-003 for the public `TasksApiV2` shape.

## Motivation and Context

Closes #3922.

Integrations currently have access to `apiV1`, which is useful for modal/string-based workflows but does not provide a stable public task DTO, query API, or create/edit API for vault-backed tasks.

`apiV2` gives third-party integrations a narrower, versioned contract for common automation use cases while keeping the internal Tasks domain model private.

Contributor guidance referenced while preparing this PR:

- `contributing/Contributing/Updating code.md`
- `contributing/Code/Structure of the code.md`
- `contributing/Code/How do I use Moment in src.md`
- `contributing/Documentation/About Documentation.md`
- `contributing/Architecture Decisions/About Architecture Decisions.md`

## How has this been tested?

Verified from the clean PR branch/worktree:

- `..\..\node_modules\.bin\jest.cmd --ci --runInBand tests/Api` - passed, 9 suites / 49 tests.
- `..\..\node_modules\.bin\eslint.cmd src\Api tests\Api` - passed.
- `..\..\node_modules\.bin\tsc.cmd --noEmit --pretty` - passed.
- `npm run build` - passed.

Coverage includes `TaskV1` mapping, task ID handling, query behavior, create placement behavior including nested task list blocks, edit behavior for unique/missing/duplicate task IDs, and unique ID generation.

Note: the clean nested worktree initially resolved a local TypeScript 5.9.3 install, which is incompatible with the current repo `tsconfig` options. The verification commands above were run against the repository dependency set and passed.

## Screenshots (if appropriate)

Not applicable. This is API behavior and documentation, with Jest coverage for the user-visible behavior.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [ ] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [ ] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)