### PR TITLE
refactor: Add new view instruction - rendering not yet supported

### DIFF
--- a/src/IQuery.ts
+++ b/src/IQuery.ts
@@ -3,6 +3,7 @@ import type { QueryLayoutOptions } from './Layout/QueryLayoutOptions';
 import type { Task } from './Task/Task';
 import type { Grouper } from './Query/Group/Grouper';
 import type { QueryResult } from './Query/QueryResult';
+import type { ViewLayoutOptions } from './Layout/ViewLayoutOptions';
 
 /**
  * Standard interface for the query engine used by Tasks, multiple
@@ -51,6 +52,11 @@ export interface IQuery {
      * @type {QueryLayoutOptions}
      */
     queryLayoutOptions: QueryLayoutOptions;
+
+    /**
+     * The view mode for displayed results, such as List or Columns/Kanban.
+     */
+    viewLayoutOptions: ViewLayoutOptions;
 
     /**
      * Main method for executing the query. This will be called by the

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -15,20 +15,39 @@ export function parseQueryViewMode(
     viewLayoutOptions: ViewLayoutOptions,
     viewMode: string,
 ): ParseViewLayoutOptionResult {
-    if (viewMode.toLowerCase() === 'list') {
+    const { mode, remainder } = splitViewInstruction(viewMode);
+
+    if (mode.toLowerCase() === 'list') {
         viewLayoutOptions.viewMode = 'list';
         return { success: true };
     }
 
-    if (viewMode.toLowerCase().startsWith('columns')) {
+    if (mode.toLowerCase() === 'columns') {
         viewLayoutOptions.viewMode = 'columns';
         // Make a copy of the viewMode string, with initial columns word replaced by 'group'
-        const groupInstruction = viewMode.replace(/^columns/, 'group');
+        const groupInstruction = 'group ' + remainder;
         viewLayoutOptions.grouper = parseGrouper(groupInstruction);
         return { success: true };
     }
 
     return unknownViewModeError(viewMode);
+}
+
+function splitViewInstruction(viewMode: string): { mode: string; remainder: string } {
+    const trimmedViewMode = viewMode.trim();
+    const firstSpace = trimmedViewMode.indexOf(' ');
+
+    if (firstSpace === -1) {
+        return {
+            mode: trimmedViewMode,
+            remainder: '',
+        };
+    }
+
+    return {
+        mode: trimmedViewMode.slice(0, firstSpace),
+        remainder: trimmedViewMode.slice(firstSpace + 1).trim(),
+    };
 }
 
 function unknownViewModeError(viewMode: string): ParseViewLayoutOptionResult {

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -1,3 +1,4 @@
+import { parseGrouper } from '../Query/FilterParser';
 import type { Grouper } from '../Query/Group/Grouper';
 
 export const queryViewModes = ['list', 'columns'] as const;
@@ -19,8 +20,11 @@ export function parseQueryViewMode(
         return { success: true };
     }
 
-    if (viewMode.toLowerCase() === 'columns') {
+    if (viewMode.toLowerCase().startsWith('columns')) {
         viewLayoutOptions.viewMode = 'columns';
+        // Make a copy of the viewMode string, with initial columns word replaced by 'group'
+        const groupInstruction = viewMode.replace(/^columns/, 'group');
+        viewLayoutOptions.grouper = parseGrouper(groupInstruction);
         return { success: true };
     }
 

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -18,7 +18,7 @@ export function parseQueryViewMode(
     const { mode, remainder } = splitViewInstruction(viewMode);
 
     if (mode === 'list') {
-        return parseListViewMode(viewLayoutOptions);
+        return parseListViewMode(viewLayoutOptions, viewMode, remainder);
     }
 
     if (mode === 'columns') {
@@ -45,7 +45,15 @@ function splitViewInstruction(viewMode: string): { mode: string; remainder: stri
     };
 }
 
-function parseListViewMode(viewLayoutOptions: ViewLayoutOptions): ParseViewLayoutOptionResult {
+function parseListViewMode(
+    viewLayoutOptions: ViewLayoutOptions,
+    viewMode: string,
+    remainder: string,
+): ParseViewLayoutOptionResult {
+    if (remainder !== '') {
+        return unknownViewModeError(viewMode);
+    }
+
     viewLayoutOptions.viewMode = 'list';
     return { success: true };
 }

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -47,11 +47,31 @@ function splitViewInstruction(viewMode: string): { mode: string; remainder: stri
 }
 
 function parseColumnsViewMode(viewLayoutOptions: ViewLayoutOptions, remainder: string): ParseViewLayoutOptionResult {
+    if (remainder === '') {
+        return missingColumnsGroupingError();
+    }
+
     viewLayoutOptions.viewMode = 'columns';
     // Make a copy of the viewMode string, with initial columns word replaced by 'group'
     const groupInstruction = 'group ' + remainder;
     viewLayoutOptions.grouper = parseGrouper(groupInstruction);
     return { success: true };
+}
+
+function missingColumnsGroupingError(): ParseViewLayoutOptionResult {
+    return {
+        success: false,
+        error: `columns view requires a grouping expression
+
+${columnsViewExamples()}`,
+    };
+}
+
+function columnsViewExamples(): string {
+    return `For example:
+    view columns by priority
+    view columns by root
+    view columns by status.type reverse`;
 }
 
 function unknownViewModeError(viewMode: string): ParseViewLayoutOptionResult {

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -17,12 +17,12 @@ export function parseQueryViewMode(
 ): ParseViewLayoutOptionResult {
     const { mode, remainder } = splitViewInstruction(viewMode);
 
-    if (mode.toLowerCase() === 'list') {
+    if (mode === 'list') {
         viewLayoutOptions.viewMode = 'list';
         return { success: true };
     }
 
-    if (mode.toLowerCase() === 'columns') {
+    if (mode === 'columns') {
         viewLayoutOptions.viewMode = 'columns';
         // Make a copy of the viewMode string, with initial columns word replaced by 'group'
         const groupInstruction = 'group ' + remainder;
@@ -39,13 +39,13 @@ function splitViewInstruction(viewMode: string): { mode: string; remainder: stri
 
     if (firstSpace === -1) {
         return {
-            mode: trimmedViewMode,
+            mode: trimmedViewMode.toLowerCase(),
             remainder: '',
         };
     }
 
     return {
-        mode: trimmedViewMode.slice(0, firstSpace),
+        mode: trimmedViewMode.slice(0, firstSpace).toLowerCase(),
         remainder: trimmedViewMode.slice(firstSpace + 1).trim(),
     };
 }

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -18,8 +18,7 @@ export function parseQueryViewMode(
     const { mode, remainder } = splitViewInstruction(viewMode);
 
     if (mode === 'list') {
-        viewLayoutOptions.viewMode = 'list';
-        return { success: true };
+        return parseListViewMode(viewLayoutOptions);
     }
 
     if (mode === 'columns') {
@@ -44,6 +43,11 @@ function splitViewInstruction(viewMode: string): { mode: string; remainder: stri
         mode: trimmedViewMode.slice(0, firstSpace).toLowerCase(),
         remainder: trimmedViewMode.slice(firstSpace + 1).trim(),
     };
+}
+
+function parseListViewMode(viewLayoutOptions: ViewLayoutOptions): ParseViewLayoutOptionResult {
+    viewLayoutOptions.viewMode = 'list';
+    return { success: true };
 }
 
 function parseColumnsViewMode(viewLayoutOptions: ViewLayoutOptions, remainder: string): ParseViewLayoutOptionResult {

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -1,3 +1,5 @@
+import type { Grouper } from '../Query/Group/Grouper';
+
 export const queryViewModes = ['list', 'columns'] as const;
 export type QueryViewMode = (typeof queryViewModes)[number];
 
@@ -5,7 +7,9 @@ export type ParseViewLayoutOptionResult = { success: true } | { success: false; 
 
 export class ViewLayoutOptions {
     viewMode: QueryViewMode = 'list';
+    grouper: Grouper | null = null;
 }
+
 export function parseQueryViewMode(
     viewLayoutOptions: ViewLayoutOptions,
     viewMode: string,

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -1,0 +1,6 @@
+export const queryViewModes = ['list', 'columns'] as const;
+export type QueryViewMode = (typeof queryViewModes)[number];
+
+export class ViewLayoutOptions {
+    viewMode: QueryViewMode = 'list';
+}

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -4,3 +4,16 @@ export type QueryViewMode = (typeof queryViewModes)[number];
 export class ViewLayoutOptions {
     viewMode: QueryViewMode = 'list';
 }
+export function parseQueryViewMode(viewLayoutOptions: ViewLayoutOptions, viewMode: string): boolean {
+    if (viewMode === 'list') {
+        viewLayoutOptions.viewMode = 'list';
+        return true;
+    }
+
+    if (viewMode === 'columns') {
+        viewLayoutOptions.viewMode = 'columns';
+        return true;
+    }
+
+    return false;
+}

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -1,19 +1,37 @@
 export const queryViewModes = ['list', 'columns'] as const;
 export type QueryViewMode = (typeof queryViewModes)[number];
 
+export type ParseViewLayoutOptionResult = { success: true } | { success: false; error: string };
+
 export class ViewLayoutOptions {
     viewMode: QueryViewMode = 'list';
 }
-export function parseQueryViewMode(viewLayoutOptions: ViewLayoutOptions, viewMode: string): boolean {
+export function parseQueryViewMode(
+    viewLayoutOptions: ViewLayoutOptions,
+    viewMode: string,
+): ParseViewLayoutOptionResult {
     if (viewMode === 'list') {
         viewLayoutOptions.viewMode = 'list';
-        return true;
+        return { success: true };
     }
 
     if (viewMode === 'columns') {
         viewLayoutOptions.viewMode = 'columns';
-        return true;
+        return { success: true };
     }
 
-    return false;
+    return unknownViewModeError(viewMode);
+}
+
+function unknownViewModeError(viewMode: string): ParseViewLayoutOptionResult {
+    return {
+        success: false,
+        error: `do not understand view mode "${viewMode}"
+
+The available view modes are:
+${queryViewModes.map((mode) => `    ${mode}`).join('\n')}
+
+For example:
+    view ${queryViewModes[0]}`,
+    };
 }

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -23,11 +23,7 @@ export function parseQueryViewMode(
     }
 
     if (mode === 'columns') {
-        viewLayoutOptions.viewMode = 'columns';
-        // Make a copy of the viewMode string, with initial columns word replaced by 'group'
-        const groupInstruction = 'group ' + remainder;
-        viewLayoutOptions.grouper = parseGrouper(groupInstruction);
-        return { success: true };
+        return parseColumnsViewMode(viewLayoutOptions, remainder);
     }
 
     return unknownViewModeError(viewMode);
@@ -48,6 +44,14 @@ function splitViewInstruction(viewMode: string): { mode: string; remainder: stri
         mode: trimmedViewMode.slice(0, firstSpace).toLowerCase(),
         remainder: trimmedViewMode.slice(firstSpace + 1).trim(),
     };
+}
+
+function parseColumnsViewMode(viewLayoutOptions: ViewLayoutOptions, remainder: string): ParseViewLayoutOptionResult {
+    viewLayoutOptions.viewMode = 'columns';
+    // Make a copy of the viewMode string, with initial columns word replaced by 'group'
+    const groupInstruction = 'group ' + remainder;
+    viewLayoutOptions.grouper = parseGrouper(groupInstruction);
+    return { success: true };
 }
 
 function unknownViewModeError(viewMode: string): ParseViewLayoutOptionResult {

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -55,6 +55,7 @@ function parseListViewMode(
     }
 
     viewLayoutOptions.viewMode = 'list';
+    viewLayoutOptions.grouper = null;
     return { success: true };
 }
 

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -10,12 +10,12 @@ export function parseQueryViewMode(
     viewLayoutOptions: ViewLayoutOptions,
     viewMode: string,
 ): ParseViewLayoutOptionResult {
-    if (viewMode === 'list') {
+    if (viewMode.toLowerCase() === 'list') {
         viewLayoutOptions.viewMode = 'list';
         return { success: true };
     }
 
-    if (viewMode === 'columns') {
+    if (viewMode.toLowerCase() === 'columns') {
         viewLayoutOptions.viewMode = 'columns';
         return { success: true };
     }

--- a/src/Layout/ViewLayoutOptions.ts
+++ b/src/Layout/ViewLayoutOptions.ts
@@ -51,10 +51,23 @@ function parseColumnsViewMode(viewLayoutOptions: ViewLayoutOptions, remainder: s
         return missingColumnsGroupingError();
     }
 
-    viewLayoutOptions.viewMode = 'columns';
     // Make a copy of the viewMode string, with initial columns word replaced by 'group'
     const groupInstruction = 'group ' + remainder;
-    viewLayoutOptions.grouper = parseGrouper(groupInstruction);
+    const grouper = parseGrouper(groupInstruction);
+
+    if (grouper === null) {
+        return {
+            success: false,
+            error: `do not understand columns grouping "${remainder}"
+
+Columns view grouping uses the same fields as "group by".
+
+${columnsViewExamples()}`,
+        };
+    }
+
+    viewLayoutOptions.viewMode = 'columns';
+    viewLayoutOptions.grouper = grouper;
     return { success: true };
 }
 

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -376,8 +376,8 @@ ${statement.explainStatement('    ')}
             const tasksSorted = debugSettings.ignoreSortInstructions ? tasks : Sort.by(this.sorting, tasks, searchInfo);
             const tasksSortedLimited = tasksSorted.slice(0, this.limit);
 
-            // If we are in the 'columns' view, use its grouper as our first (ond initially, only)
-            // grouper, so that rendering can later display each top-level group in its own column.
+            // If we are in the 'columns' view, use its grouper as our first grouper
+            // so that rendering can later display each top-level group in its own column.
             const useColumnsGrouper =
                 this.viewLayoutOptions.viewMode === 'columns' && this.viewLayoutOptions.grouper !== null;
             const groupers = useColumnsGrouper ? [this.viewLayoutOptions.grouper!, ...this.grouping] : this.grouping;

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -380,7 +380,7 @@ ${statement.explainStatement('    ')}
             // grouper, so that rendering can later display each top-level group in its own column.
             const useColumnsGrouper =
                 this.viewLayoutOptions.viewMode === 'columns' && this.viewLayoutOptions.grouper !== null;
-            const groupers = useColumnsGrouper ? [this.viewLayoutOptions.grouper!] : this.grouping;
+            const groupers = useColumnsGrouper ? [this.viewLayoutOptions.grouper!, ...this.grouping] : this.grouping;
             const taskGroups = new TaskGroups(groupers, tasksSortedLimited, searchInfo);
 
             if (this._taskGroupLimit !== undefined) {

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -376,7 +376,12 @@ ${statement.explainStatement('    ')}
             const tasksSorted = debugSettings.ignoreSortInstructions ? tasks : Sort.by(this.sorting, tasks, searchInfo);
             const tasksSortedLimited = tasksSorted.slice(0, this.limit);
 
-            const taskGroups = new TaskGroups(this.grouping, tasksSortedLimited, searchInfo);
+            // If we are in the 'columns' view, use its grouper as our first (ond initially, only)
+            // grouper, so that rendering can later display each top-level group in its own column.
+            const useColumnsGrouper =
+                this.viewLayoutOptions.viewMode === 'columns' && this.viewLayoutOptions.grouper !== null;
+            const groupers = useColumnsGrouper ? [this.viewLayoutOptions.grouper!] : this.grouping;
+            const taskGroups = new TaskGroups(groupers, tasksSortedLimited, searchInfo);
 
             if (this._taskGroupLimit !== undefined) {
                 taskGroups.applyTaskLimit(this._taskGroupLimit);

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -2,6 +2,7 @@ import { getSettings } from '../Config/Settings';
 import type { IQuery } from '../IQuery';
 import { QueryLayoutOptions, parseQueryShowHideOptions } from '../Layout/QueryLayoutOptions';
 import { TaskLayoutOptions, parseTaskShowHideOptions } from '../Layout/TaskLayoutOptions';
+import { ViewLayoutOptions, parseQueryViewMode } from '../Layout/ViewLayoutOptions';
 import { errorMessageForException } from '../lib/ExceptionTools';
 import { logging } from '../lib/logging';
 import { expandPlaceholders } from '../Scripting/ExpandPlaceholders';
@@ -38,6 +39,7 @@ export class Query implements IQuery {
 
     private readonly _taskLayoutOptions: TaskLayoutOptions = new TaskLayoutOptions();
     private readonly _queryLayoutOptions: QueryLayoutOptions = new QueryLayoutOptions();
+    private readonly _viewLayoutOptions: ViewLayoutOptions = new ViewLayoutOptions();
     public readonly layoutStatements: Statement[] = [];
 
     private readonly _filters: Filter[] = [];
@@ -46,6 +48,7 @@ export class Query implements IQuery {
     private readonly _grouping: Grouper[] = [];
     private _ignoreGlobalQuery: boolean = false;
 
+    private readonly viewModeRegexp = /^view +(.*)/i;
     private readonly hideOptionsRegexp = /^(hide|show) +(.*)/i;
     private readonly shortModeRegexp = /^short/i;
     private readonly fullModeRegexp = /^full/i;
@@ -143,6 +146,9 @@ export class Query implements IQuery {
             case this.parseSortBy(line, statement):
                 break;
             case this.parseGroupBy(line, statement):
+                break;
+            case this.viewModeRegexp.test(line):
+                this.parseViewMode(statement);
                 break;
             case this.hideOptionsRegexp.test(line):
                 this.parseHideOptions(statement);
@@ -293,6 +299,10 @@ ${source}`;
         return this._taskLayoutOptions;
     }
 
+    get viewLayoutOptions(): ViewLayoutOptions {
+        return this._viewLayoutOptions;
+    }
+
     public get queryLayoutOptions(): QueryLayoutOptions {
         return this._queryLayoutOptions;
     }
@@ -382,6 +392,23 @@ ${statement.explainStatement('    ')}
             }
             return QueryResult.fromError(message);
         }
+    }
+
+    private parseViewMode(statement: Statement): void {
+        const line = statement.anyPlaceholdersExpanded;
+        const viewModeMatch = line.match(this.viewModeRegexp);
+        if (viewModeMatch === null) {
+            return;
+        }
+
+        const result = parseQueryViewMode(this._viewLayoutOptions, viewModeMatch[1].trim());
+
+        if (result.success) {
+            this.saveLayoutStatement(statement);
+            return;
+        }
+
+        this.setError(result.error, statement);
     }
 
     private parseHideOptions(statement: Statement): void {

--- a/src/Renderer/QueryResultsRendererBase.ts
+++ b/src/Renderer/QueryResultsRendererBase.ts
@@ -34,7 +34,12 @@ export abstract class QueryResultsRendererBase {
         // console messages in large vaults, if Obsidian was opened with any
         // notes with tasks code blocks in Reading or Live Preview mode.
         const query = this.query;
-        const error = query.error;
+
+        let error = query.error;
+        if (query.viewLayoutOptions.viewMode === 'columns') {
+            error = '"view columns" is not yet supported.';
+        }
+
         if (state === State.Warm && error === undefined) {
             await this.renderQuerySearchResults(queryResult);
         } else if (error) {

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -1,4 +1,8 @@
-import { ViewLayoutOptions, parseQueryViewMode } from '../../src/Layout/ViewLayoutOptions';
+import {
+    type ParseViewLayoutOptionResult,
+    ViewLayoutOptions,
+    parseQueryViewMode,
+} from '../../src/Layout/ViewLayoutOptions';
 
 describe('storing view mode', () => {
     it('should default to list view', () => {
@@ -19,7 +23,7 @@ describe('parsing view mode', () => {
         options.viewMode = 'columns';
 
         const result = parseQueryViewMode(options, 'list');
-        expect(result).toEqual(true);
+        expect(result.success).toEqual(true);
         expect(options.viewMode).toEqual('list');
     });
 
@@ -28,20 +32,37 @@ describe('parsing view mode', () => {
 
         const result = parseQueryViewMode(options, 'columns');
 
-        expect(result).toEqual(true);
+        expect(result.success).toEqual(true);
         expect(options.viewMode).toEqual('columns');
     });
 
-    it('should report if unknown view mode supplied', () => {
+    it('should report available options for unknown mode', () => {
         const options = new ViewLayoutOptions();
         const initialMode = 'columns';
         options.viewMode = initialMode;
 
-        const result = parseQueryViewMode(options, 'invalid');
+        const result: ParseViewLayoutOptionResult = parseQueryViewMode(options, 'invalid');
 
         // Make sure the mode is not changed when there is an error:
         expect(options.viewMode).toEqual(initialMode);
 
-        expect(result).toEqual(false);
+        expect(result.success).toEqual(false);
+
+        if (!result.success) {
+            // Ensure that the error message contains the supplied option:
+            expect(result.error).toContain('invalid');
+
+            // Inspect the full error message:
+            expect(result.error).toMatchInlineSnapshot(`
+                "do not understand view mode "invalid"
+
+                The available view modes are:
+                    list
+                    columns
+
+                For example:
+                    view list"
+            `);
+        }
     });
 });

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -65,6 +65,16 @@ describe('parsing view mode', () => {
         },
     );
 
+    it('should not allow extra instructions for list mode', () => {
+        const options = new ViewLayoutOptions();
+        options.viewMode = 'columns';
+
+        const result = parseQueryViewMode(options, 'list by priority');
+
+        expect(result.success).toEqual(false);
+        expect(options.viewMode).toEqual('columns');
+    });
+
     it('should report invalid columns grouping', () => {
         const options = new ViewLayoutOptions();
         const result = parseQueryViewMode(options, 'columns by nonsense');

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -39,16 +39,19 @@ describe('parsing view mode', () => {
         expect(options.viewMode).toEqual('columns');
     });
 
-    it('should parse columns mode grouped by priority', () => {
-        const options = new ViewLayoutOptions();
+    it.each(['columns by priority', 'COLUMNS BY PRIORITY'])(
+        'should parse columns grouped by priority: "%s"',
+        (mode) => {
+            const options = new ViewLayoutOptions();
 
-        const result = parseQueryViewMode(options, 'columns by priority');
+            const result = parseQueryViewMode(options, mode);
 
-        expect(result).toEqual({ success: true });
-        expect(options.viewMode).toEqual('columns');
-        expect(options.grouper).not.toBeNull();
-        expect(options.grouper?.property).toEqual('priority');
-    });
+            expect(result).toEqual({ success: true });
+            expect(options.viewMode).toEqual('columns');
+            expect(options.grouper).not.toBeNull();
+            expect(options.grouper?.property).toEqual('priority');
+        },
+    );
 
     it('should report available options for unknown mode', () => {
         const options = new ViewLayoutOptions();

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -27,7 +27,7 @@ describe('parsing view mode', () => {
         expect(options.viewMode).toEqual('list');
     });
 
-    it('should parse columns mode grouped by priority', () => {
+    it('should parse columns mode', () => {
         const options = new ViewLayoutOptions();
 
         const result = parseQueryViewMode(options, 'columns');

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -4,6 +4,12 @@ import {
     parseQueryViewMode,
 } from '../../src/Layout/ViewLayoutOptions';
 import { PriorityField } from '../../src/Query/Filter/PriorityField';
+import { EnableJsInTasksQueries } from '../../src/Config/EnableJsInTasksQueries';
+import { JsInTasksQueriesDisabledError } from '../../src/Scripting/JsInTasksQueriesDisabledError';
+
+afterEach(() => {
+    EnableJsInTasksQueries.getInstance().set(true);
+});
 
 describe('storing view mode', () => {
     it('should default to list view', () => {
@@ -76,6 +82,17 @@ describe('parsing view mode', () => {
         expect(options.viewMode).toEqual('columns');
         expect(options.grouper).not.toBeNull();
         expect(options.grouper?.property).toEqual('function');
+    });
+
+    it('should not support columns grouped by function when JS execution is disabled', () => {
+        EnableJsInTasksQueries.getInstance().set(false);
+
+        const options = new ViewLayoutOptions();
+
+        // Test that the following line throws JsInTasksQueriesDisabledError
+        expect(() => parseQueryViewMode(options, 'columns by function task.status.symbol')).toThrow(
+            JsInTasksQueriesDisabledError,
+        );
     });
 
     it('should not allow extra instructions for list mode', () => {

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -3,6 +3,7 @@ import {
     ViewLayoutOptions,
     parseQueryViewMode,
 } from '../../src/Layout/ViewLayoutOptions';
+import { PriorityField } from '../../src/Query/Filter/PriorityField';
 
 describe('storing view mode', () => {
     it('should default to list view', () => {
@@ -23,6 +24,7 @@ describe('parsing view mode', () => {
     it.each(['list', 'LIST'])('should parse "%s" mode', (mode) => {
         const options = new ViewLayoutOptions();
         options.viewMode = 'columns';
+        options.grouper = new PriorityField().createNormalGrouper();
 
         const result = parseQueryViewMode(options, mode);
         expect(result.success).toEqual(true);
@@ -68,11 +70,13 @@ describe('parsing view mode', () => {
     it('should not allow extra instructions for list mode', () => {
         const options = new ViewLayoutOptions();
         options.viewMode = 'columns';
+        options.grouper = new PriorityField().createNormalGrouper();
 
         const result = parseQueryViewMode(options, 'list by priority');
 
         expect(result.success).toEqual(false);
         expect(options.viewMode).toEqual('columns');
+        expect(options.grouper).not.toBeNull();
     });
 
     it('should report invalid columns grouping', () => {

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -39,7 +39,7 @@ describe('parsing view mode', () => {
         expect(options.viewMode).toEqual('columns');
     });
 
-    it.failing('should parse columns mode grouped by priority', () => {
+    it('should parse columns mode grouped by priority', () => {
         const options = new ViewLayoutOptions();
 
         const result = parseQueryViewMode(options, 'columns by priority');

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -67,6 +67,17 @@ describe('parsing view mode', () => {
         },
     );
 
+    it('should parse columns mode grouped by function', () => {
+        const options = new ViewLayoutOptions();
+
+        const result = parseQueryViewMode(options, 'columns by function task.status.symbol');
+
+        expect(result).toEqual({ success: true });
+        expect(options.viewMode).toEqual('columns');
+        expect(options.grouper).not.toBeNull();
+        expect(options.grouper?.property).toEqual('function');
+    });
+
     it('should not allow extra instructions for list mode', () => {
         const options = new ViewLayoutOptions();
         options.viewMode = 'columns';

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -65,6 +65,28 @@ describe('parsing view mode', () => {
         },
     );
 
+    it('should report invalid columns grouping', () => {
+        const options = new ViewLayoutOptions();
+        const result = parseQueryViewMode(options, 'columns by nonsense');
+
+        expect(result.success).toEqual(false);
+        expect(options.viewMode).toEqual('list');
+        expect(options.grouper).toBeNull();
+
+        if (!result.success) {
+            expect(result.error).toMatchInlineSnapshot(`
+                "do not understand columns grouping "by nonsense"
+
+                Columns view grouping uses the same fields as "group by".
+
+                For example:
+                    view columns by priority
+                    view columns by root
+                    view columns by status.type reverse"
+            `);
+        }
+    });
+
     it('should report available options for unknown mode', () => {
         const options = new ViewLayoutOptions();
         const initialMode = 'columns';

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -1,0 +1,14 @@
+import { ViewLayoutOptions } from '../../src/Layout/ViewLayoutOptions';
+
+describe('storing view mode', () => {
+    it('should default to list view', () => {
+        const options = new ViewLayoutOptions();
+        expect(options.viewMode).toEqual('list');
+    });
+
+    it('should support columns view', () => {
+        const options = new ViewLayoutOptions();
+        options.viewMode = 'columns';
+        expect(options.viewMode).toEqual('columns');
+    });
+});

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -8,12 +8,14 @@ describe('storing view mode', () => {
     it('should default to list view', () => {
         const options = new ViewLayoutOptions();
         expect(options.viewMode).toEqual('list');
+        expect(options.grouper).toBeNull();
     });
 
     it('should support columns view', () => {
         const options = new ViewLayoutOptions();
         options.viewMode = 'columns';
         expect(options.viewMode).toEqual('columns');
+        expect(options.grouper).toBeNull();
     });
 });
 
@@ -25,6 +27,7 @@ describe('parsing view mode', () => {
         const result = parseQueryViewMode(options, mode);
         expect(result.success).toEqual(true);
         expect(options.viewMode).toEqual('list');
+        expect(options.grouper).toBeNull();
     });
 
     it.each(['columns', 'COLUMNS'])('should parse "%s" mode', (mode) => {
@@ -34,6 +37,17 @@ describe('parsing view mode', () => {
 
         expect(result.success).toEqual(true);
         expect(options.viewMode).toEqual('columns');
+    });
+
+    it.failing('should parse columns mode grouped by priority', () => {
+        const options = new ViewLayoutOptions();
+
+        const result = parseQueryViewMode(options, 'columns by priority');
+
+        expect(result).toEqual({ success: true });
+        expect(options.viewMode).toEqual('columns');
+        expect(options.grouper).not.toBeNull();
+        expect(options.grouper?.property).toEqual('priority');
     });
 
     it('should report available options for unknown mode', () => {

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -30,13 +30,25 @@ describe('parsing view mode', () => {
         expect(options.grouper).toBeNull();
     });
 
-    it.each(['columns', 'COLUMNS'])('should parse "%s" mode', (mode) => {
+    it('should report an error for columns mode without a grouping expression', () => {
         const options = new ViewLayoutOptions();
 
-        const result = parseQueryViewMode(options, mode);
+        const result = parseQueryViewMode(options, 'columns');
 
-        expect(result.success).toEqual(true);
-        expect(options.viewMode).toEqual('columns');
+        expect(result.success).toEqual(false);
+        expect(options.viewMode).toEqual('list');
+        expect(options.grouper).toBeNull();
+
+        if (!result.success) {
+            expect(result.error).toMatchInlineSnapshot(`
+                "columns view requires a grouping expression
+
+                For example:
+                    view columns by priority
+                    view columns by root
+                    view columns by status.type reverse"
+            `);
+        }
     });
 
     it.each(['columns by priority', 'COLUMNS BY PRIORITY'])(

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -18,19 +18,19 @@ describe('storing view mode', () => {
 });
 
 describe('parsing view mode', () => {
-    it('should parse list mode', () => {
+    it.each(['list', 'LIST'])('should parse "%s" mode', (mode) => {
         const options = new ViewLayoutOptions();
         options.viewMode = 'columns';
 
-        const result = parseQueryViewMode(options, 'list');
+        const result = parseQueryViewMode(options, mode);
         expect(result.success).toEqual(true);
         expect(options.viewMode).toEqual('list');
     });
 
-    it('should parse columns mode', () => {
+    it.each(['columns', 'COLUMNS'])('should parse "%s" mode', (mode) => {
         const options = new ViewLayoutOptions();
 
-        const result = parseQueryViewMode(options, 'columns');
+        const result = parseQueryViewMode(options, mode);
 
         expect(result.success).toEqual(true);
         expect(options.viewMode).toEqual('columns');

--- a/tests/Layout/ViewLayoutOptions.test.ts
+++ b/tests/Layout/ViewLayoutOptions.test.ts
@@ -1,4 +1,4 @@
-import { ViewLayoutOptions } from '../../src/Layout/ViewLayoutOptions';
+import { ViewLayoutOptions, parseQueryViewMode } from '../../src/Layout/ViewLayoutOptions';
 
 describe('storing view mode', () => {
     it('should default to list view', () => {
@@ -10,5 +10,38 @@ describe('storing view mode', () => {
         const options = new ViewLayoutOptions();
         options.viewMode = 'columns';
         expect(options.viewMode).toEqual('columns');
+    });
+});
+
+describe('parsing view mode', () => {
+    it('should parse list mode', () => {
+        const options = new ViewLayoutOptions();
+        options.viewMode = 'columns';
+
+        const result = parseQueryViewMode(options, 'list');
+        expect(result).toEqual(true);
+        expect(options.viewMode).toEqual('list');
+    });
+
+    it('should parse columns mode grouped by priority', () => {
+        const options = new ViewLayoutOptions();
+
+        const result = parseQueryViewMode(options, 'columns');
+
+        expect(result).toEqual(true);
+        expect(options.viewMode).toEqual('columns');
+    });
+
+    it('should report if unknown view mode supplied', () => {
+        const options = new ViewLayoutOptions();
+        const initialMode = 'columns';
+        options.viewMode = initialMode;
+
+        const result = parseQueryViewMode(options, 'invalid');
+
+        // Make sure the mode is not changed when there is an error:
+        expect(options.viewMode).toEqual(initialMode);
+
+        expect(result).toEqual(false);
     });
 });

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -350,6 +350,14 @@ describe('explain layout instructions', () => {
         expect(explainLayout('full mode')).toEqual('full mode\n');
     });
 
+    it('should explain view list', () => {
+        expect(explainLayout('view list')).toEqual('view list\n');
+    });
+
+    it('should explain view columns by priority', () => {
+        expect(explainLayout('view columns by priority')).toEqual('view columns by priority\n');
+    });
+
     it('should NOT explain explain', () => {
         // Intentionally do not explain the 'explain' instruction, as it just clutters up the documentation.
         expect(explainLayout('explain')).toEqual('');

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -543,7 +543,6 @@ description includes \
             'show toolbar',
             'show tree',
             'show urgency',
-            'view columns',
             'view columns by function task.status.symbol',
             'view columns by priority',
             'view list',

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -1902,6 +1902,31 @@ Problem line: "view nonsense"`);
 `;
             searchTasksAndTestResultsAsMarkdown(tasksAsMarkdown, source, expectedResultsAsMarkdown);
         });
+
+        it('should prepend the "view columns" grouper to any user-supplied groups', () => {
+            // Arrange
+            const source = `
+                view columns by status.name
+                group by priority
+                `;
+
+            // In column view, the view's grouper ('by priority', here) is injected before
+            // all the user-supplied groups.
+            const expectedResultsAsMarkdown = `
+#### Done
+
+##### %%4%%Low priority
+
+- [x] Task 2 - Done   priority 🔽
+
+#### Todo
+
+##### %%1%%High priority
+
+- [ ] Task 1 - Todo - high priority ⏫
+`;
+            searchTasksAndTestResultsAsMarkdown(tasksAsMarkdown, source, expectedResultsAsMarkdown);
+        });
     });
 
     describe('error handling', () => {

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -1575,6 +1575,30 @@ describe('Query', () => {
             expect(query.viewLayoutOptions.viewMode).toEqual('list');
         });
 
+        it('should reject columns view without a grouping expression', () => {
+            const query = new Query('view columns');
+
+            expect(query.viewLayoutOptions.viewMode).toEqual('list');
+            expect(query.viewLayoutOptions.grouper).toBeNull();
+            expect(query.error).toEqual(`columns view requires a grouping expression
+
+For example:
+    view columns by priority
+    view columns by root
+    view columns by status.type reverse
+Problem line: "view columns"`);
+        });
+
+        it('should allow columns view to be grouped by priority', () => {
+            const query = new Query('view columns by priority');
+
+            expect(query.error).toBeUndefined();
+            expect(query.viewLayoutOptions.viewMode).toEqual('columns');
+            expect(query.viewLayoutOptions.grouper).not.toBeNull();
+            expect(query.viewLayoutOptions.grouper?.property).toEqual('priority');
+            expect(query.grouping).toHaveLength(0);
+        });
+
         it('should give a meaningful error message for unknown view mode', () => {
             const query = new Query('view nonsense');
             expect(query.viewLayoutOptions.viewMode).toEqual('list');

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -543,6 +543,8 @@ description includes \
             'show toolbar',
             'show tree',
             'show urgency',
+            'view columns',
+            'view list',
         ];
         test.concurrent.each<string>(filters)('recognises %j', (filter) => {
             // Arrange
@@ -1563,6 +1565,27 @@ describe('Query', () => {
         it('should hide "tree" by default', () => {
             const query = new Query('');
             expect(query.queryLayoutOptions.hideTree).toEqual(true);
+        });
+    });
+
+    describe('view mode', () => {
+        it('should default to "list" view', () => {
+            const query = new Query('');
+            expect(query.viewLayoutOptions.viewMode).toEqual('list');
+        });
+
+        it('should give a meaningful error message for unknown view mode', () => {
+            const query = new Query('view nonsense');
+            expect(query.viewLayoutOptions.viewMode).toEqual('list');
+            expect(query.error).toEqual(`do not understand view mode "nonsense"
+
+The available view modes are:
+    list
+    columns
+
+For example:
+    view list
+Problem line: "view nonsense"`);
         });
     });
 

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -544,6 +544,8 @@ description includes \
             'show tree',
             'show urgency',
             'view columns',
+            'view columns by function task.status.symbol',
+            'view columns by priority',
             'view list',
         ];
         test.concurrent.each<string>(filters)('recognises %j', (filter) => {

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -1000,6 +1000,37 @@ filter by function \\
     });
 });
 
+/**
+ * Applies a query to a collection of tasks represented in Markdown format and verifies the results
+ * against a given expected output rendered in Markdown.
+ *
+ * It runs the search a second time, checking the query works when it's in all-capitals.
+ *
+ * @param tasksAsMarkdown - The tasks represented in Markdown format.
+ * @param source - The query string to apply to the tasks.
+ * @param expectedResultsAsMarkdown - The expected results, in Markdown format, to compare against.
+ */
+function searchTasksAndTestResultsAsMarkdown(
+    tasksAsMarkdown: string,
+    source: string,
+    expectedResultsAsMarkdown: string,
+) {
+    // Arrange
+    const sourceUpper = source.toUpperCase();
+    const query = new Query(source);
+    const queryUpper = new Query(sourceUpper);
+
+    const tasks = createTasksFromMarkdown(tasksAsMarkdown, 'some_markdown_file', 'Some Heading');
+
+    // Act
+    const queryResult = query.applyQueryToTasks(tasks);
+    const queryUpperResult = queryUpper.applyQueryToTasks(tasks);
+
+    // Assert
+    expect(queryResult.asMarkdown()).toEqual(expectedResultsAsMarkdown);
+    expect(queryUpperResult.asMarkdown()).toEqual(expectedResultsAsMarkdown);
+}
+
 describe('Query', () => {
     describe('filtering', () => {
         it('filters paths case insensitive', () => {
@@ -1844,6 +1875,32 @@ Problem line: "view nonsense"`);
 
             expect(queryResult.totalTasksCountBeforeLimit).toEqual(6);
             expect(queryUpperResult.totalTasksCountBeforeLimit).toEqual(6);
+        });
+    });
+
+    describe('grouping instructions in conjunction with columns view', () => {
+        const tasksAsMarkdown = `
+- [ ] Task 1 - Todo - high priority ⏫
+- [x] Task 2 - Done   priority 🔽
+            `;
+
+        it('should apply the "view columns" grouper automatically', () => {
+            const source = `
+                view columns by priority
+                `;
+
+            // In column view, the view's grouper ('by priority', here) is injected as
+            // the first (ond only) grouper in the search.
+            const expectedResultsAsMarkdown = `
+#### %%1%%High priority
+
+- [ ] Task 1 - Todo - high priority ⏫
+
+#### %%4%%Low priority
+
+- [x] Task 2 - Done   priority 🔽
+`;
+            searchTasksAndTestResultsAsMarkdown(tasksAsMarkdown, source, expectedResultsAsMarkdown);
         });
     });
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

This adds two new instructions:

~~~
view list
view columns by ...
~~~

1. `view list` is the current results rendering, and so effectively "works".
2. `view columns by priority` rendering will be added later, once @ilandikov and I have taught Tasks to display query results in columns.

For now, searches that use `view columns` will show an error message.

## Motivation and Context

To enable us to start working on a Columns/Kanban view

See https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/472

- https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/472

## How has this been tested?

1. With tests
2. In an experimental branch on my fork, in which I did an initial implementation of the rendering, as a spike.

## Screenshots (if appropriate)

The error message that is shown if columns view is requested:

<img width="999" height="204" alt="image" src="https://github.com/user-attachments/assets/573a5f7f-9d5b-42e5-9efd-f7e93780a0cd" />


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
