### PR TITLE
fix: Allow users to interact with Obsidian whilst Tasks is loading

### DIFF
--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -21,6 +21,8 @@ import { GlobalFilter } from '../Config/GlobalFilter';
 import type { TasksEvents } from './TasksEvents';
 import { FileParser } from './FileParser';
 
+const MAX_CONCURRENT_FILE_READS = 4;
+
 export enum State {
     Cold = 'Cold',
     Initializing = 'Initializing',
@@ -250,11 +252,7 @@ export class Cache {
             this.state = State.Initializing;
             this.logger.debug('Cache.loadVault(): state = Initializing');
 
-            await Promise.all(
-                this.vault.getMarkdownFiles().map((file: TFile) => {
-                    return this.indexFile(file);
-                }),
-            );
+            await this.indexFiles(this.vault.getMarkdownFiles());
             this.state = State.Warm;
             // TODO Why is this displayed twice:
             this.logger.debug('Cache.loadVault(): state = Warm');
@@ -267,6 +265,20 @@ export class Cache {
             // Notify that the cache is now warm:
             this.notifySubscribers();
         });
+    }
+
+    private async indexFiles(files: TFile[]): Promise<void> {
+        let nextFileIndex = 0;
+        const indexNextFile = async () => {
+            while (nextFileIndex < files.length) {
+                const file = files[nextFileIndex];
+                nextFileIndex++;
+                await this.indexFile(file);
+            }
+        };
+
+        const workerCount = Math.min(MAX_CONCURRENT_FILE_READS, files.length);
+        await Promise.all(Array.from({ length: workerCount }, () => indexNextFile()));
     }
 
     private async indexFile(file: TFile): Promise<void> {
@@ -291,9 +303,19 @@ export class Cache {
         // Still continue to notify watchers of removal.
 
         let newTasks: Task[] = [];
-        if (listItems !== undefined) {
-            // Only read the file and process for tasks if there are list items.
-            const fileContent = await this.vault.cachedRead(file);
+        const hasTaskListItem = listItems?.some((listItem) => listItem.task !== undefined) ?? false;
+        if (listItems !== undefined && hasTaskListItem) {
+            // Only read the file and process for tasks if there are task list items.
+            let fileContent: string;
+            try {
+                fileContent = await this.vault.cachedRead(file);
+            } catch (error) {
+                this.logger.error(
+                    `Cache.indexFile: unable to read ${file.path}; keeping its previously cached tasks`,
+                    error,
+                );
+                return;
+            }
             newTasks = this.getTasksFromFileContent(
                 new TasksFile(file.path, fileCache),
                 fileContent,

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -273,7 +273,8 @@ export class Cache {
             while (nextFileIndex < files.length) {
                 const file = files[nextFileIndex];
                 nextFileIndex++;
-                await this.indexFile(file);
+                // loadVault() notifies subscribers once, after every worker finishes and the cache is warm.
+                await this.indexFile(file, false);
             }
         };
 
@@ -281,7 +282,7 @@ export class Cache {
         await Promise.all(Array.from({ length: workerCount }, () => indexNextFile()));
     }
 
-    private async indexFile(file: TFile): Promise<void> {
+    private async indexFile(file: TFile, notifyOnChange = true): Promise<void> {
         const fileCache = this.metadataCache.getFileCache(file);
         if (fileCache === null || fileCache === undefined) {
             return;
@@ -310,6 +311,8 @@ export class Cache {
             try {
                 fileContent = await this.vault.cachedRead(file);
             } catch (error) {
+                // A failed read is not evidence that the tasks were deleted. Keep the last successfully read tasks;
+                // task edits read and validate the current file contents before writing any changes.
                 this.logger.error(
                     `Cache.indexFile: unable to read ${file.path}; keeping its previously cached tasks`,
                     error,
@@ -355,8 +358,10 @@ export class Cache {
         this.tasks.push(...newTasks);
         this.logger.debug('Cache.indexFile: ' + file.path + `: read ${newTasks.length} task(s)`);
 
-        // All updated, inform our subscribers.
-        this.notifySubscribers();
+        if (notifyOnChange) {
+            // All updated, inform our subscribers.
+            this.notifySubscribers();
+        }
     }
 
     private getTasksFromFileContent(

--- a/tests/Obsidian/CacheLoading.test.ts
+++ b/tests/Obsidian/CacheLoading.test.ts
@@ -6,37 +6,28 @@ import type { CachedMetadata, EventRef, MetadataCache, TFile, Vault, Workspace }
 import { Cache, State } from '../../src/Obsidian/Cache';
 import type { TasksEvents } from '../../src/Obsidian/TasksEvents';
 import type { Logger } from '../../src/lib/logging';
+import { createTFile } from '../__mocks__/obsidian';
 import { MockDataLoader } from '../TestingTools/MockDataLoader';
 
 jest.mock('obsidian');
-jest.mock('../../src/lib/PerformanceTracker', () => ({
-    PerformanceTracker: class {
-        public start(): void {}
-        public finish(): void {}
-    },
-}));
 
 window.moment = moment;
 
 const eventReference = {} as EventRef;
 const taskData = MockDataLoader.get('one_task');
 
-function createFile(path: string): TFile {
-    const name = path.split('/').pop() ?? path;
-    const extension = name.includes('.') ? name.split('.').pop() ?? '' : '';
-    const basename = extension === '' ? name : name.slice(0, -(extension.length + 1));
-
-    return {
-        vault: {} as Vault,
-        path,
-        name,
-        parent: null,
-        stat: { ctime: 0, mtime: 0, size: 0 },
-        basename,
-        extension,
-    };
-}
-
+/**
+ * Creates a test environment for exercising Cache loading behaviour.
+ *
+ * The returned helpers allow tests to manually run the callbacks registered with
+ * the mocked Obsidian workspace and Tasks events, so cache loading and vault
+ * reload behaviour can be tested deterministically.
+ *
+ * @param files - Markdown files returned by the mocked vault.
+ * @param cachedRead - Mock implementation used when the cache reads file contents.
+ * @param getFileCache - Optional mock implementation for Obsidian metadata lookup.
+ * @returns The Cache under test and helpers for triggering registered lifecycle callbacks.
+ */
 function createCacheEnvironment({
     files,
     cachedRead,
@@ -48,10 +39,16 @@ function createCacheEnvironment({
 }) {
     let layoutReadyCallback: (() => Promise<void>) | undefined;
     let reloadVaultCallback: (() => Promise<void>) | undefined;
+    let changedCallback: ((file: TFile) => Promise<void>) | undefined;
     const metadataCache = {
         getFileCache: jest.fn(getFileCache),
         offref: jest.fn(),
-        on: jest.fn(() => eventReference),
+        on: jest.fn((event: string, callback: (file: TFile) => Promise<void>) => {
+            if (event === 'changed') {
+                changedCallback = callback;
+            }
+            return eventReference;
+        }),
     } as unknown as MetadataCache;
     const vault = {
         cachedRead,
@@ -75,14 +72,16 @@ function createCacheEnvironment({
     } as unknown as TasksEvents;
 
     const cache = new Cache({ metadataCache, vault, workspace, events });
-    cache.logger = {
+    const logger = {
         debug: jest.fn(),
         error: jest.fn(),
         info: jest.fn(),
-    } as unknown as Logger;
+    };
+    cache.logger = logger as unknown as Logger;
 
     return {
         cache,
+        logger,
         runLayoutReady: async () => {
             expect(layoutReadyCallback).toBeDefined();
             await layoutReadyCallback?.();
@@ -91,17 +90,22 @@ function createCacheEnvironment({
             expect(reloadVaultCallback).toBeDefined();
             await reloadVaultCallback?.();
         },
+        runFileChanged: async (file: TFile) => {
+            expect(changedCallback).toBeDefined();
+            await changedCallback?.(file);
+        },
     };
 }
 
 describe('Cache loading', () => {
     it('should limit how many files are indexed concurrently', async () => {
-        const files = Array.from({ length: 12 }, (_value, index) => createFile(`${index}.md`));
+        const files = Array.from({ length: 12 }, (_value, index) => createTFile(`${index}.md`));
         let activeReads = 0;
         let maximumActiveReads = 0;
         const cachedRead = jest.fn<Promise<string>, [TFile]>(async () => {
             activeReads++;
             maximumActiveReads = Math.max(maximumActiveReads, activeReads);
+            // Keep the fake read pending for one event-loop turn so the worker reads overlap.
             await new Promise((resolve) => setTimeout(resolve, 0));
             activeReads--;
             return taskData.fileContents;
@@ -110,13 +114,51 @@ describe('Cache loading', () => {
 
         await runLayoutReady();
 
-        expect(maximumActiveReads).toBeLessThanOrEqual(4);
+        expect(maximumActiveReads).toBe(4);
         expect(cache.getState()).toBe(State.Warm);
     });
 
+    it('should notify subscribers once after the bulk load completes', async () => {
+        const files = [createTFile('one.md'), createTFile('two.md'), createTFile('three.md')];
+        const cachedRead = jest.fn<Promise<string>, [TFile]>(async () => taskData.fileContents);
+        const { cache, logger, runLayoutReady } = createCacheEnvironment({ files, cachedRead });
+        const statesWhenSubscribersWereNotified: State[] = [];
+        logger.debug.mockImplementation((message) => {
+            if (message === 'Cache.notifySubscribers()') {
+                statesWhenSubscribersWereNotified.push(cache.getState());
+            }
+        });
+
+        await runLayoutReady();
+
+        expect(statesWhenSubscribersWereNotified).toEqual([State.Warm]);
+        expect(cache.getState()).toBe(State.Warm);
+    });
+
+    it('should continue notifying subscribers when an individual file changes', async () => {
+        const file = createTFile('changed.md');
+        const changedFileContents = taskData.fileContents.replace('the only task', 'the next task');
+        const cachedRead = jest
+            .fn<Promise<string>, [TFile]>()
+            .mockResolvedValueOnce(taskData.fileContents)
+            .mockResolvedValue(changedFileContents);
+        const { logger, runFileChanged, runLayoutReady } = createCacheEnvironment({ files: [file], cachedRead });
+
+        await runLayoutReady();
+        logger.debug.mockClear();
+        await runFileChanged(file);
+
+        const notificationCalls = logger.debug.mock.calls.filter(
+            ([message]) => message === 'Cache.notifySubscribers()',
+        );
+        expect(notificationCalls).toHaveLength(1);
+    });
+
     it('should not read a file whose metadata contains only plain list items', async () => {
-        const file = createFile('plain-list.md');
+        const file = createTFile('plain-list.md');
         const cachedRead = jest.fn<Promise<string>, [TFile]>(async () => '- a plain list item');
+        // Keep the Markdown fixture unchanged, but make its cached metadata describe plain list items instead of
+        // checkbox items. cachedRead() must not be called, so the intentional mismatch cannot affect the result.
         const plainListMetadata: CachedMetadata = {
             listItems: taskData.cachedMetadata.listItems?.map((item) => ({ ...item, task: undefined })),
         };
@@ -132,8 +174,8 @@ describe('Cache loading', () => {
     });
 
     it('should keep loading when one file read fails', async () => {
-        const unavailableFile = createFile('unavailable.md');
-        const readableFile = createFile('readable.md');
+        const unavailableFile = createTFile('unavailable.md');
+        const readableFile = createTFile('readable.md');
         const readError = new Error('ETIMEDOUT: connection timed out, read');
         const cachedRead = jest.fn<Promise<string>, [TFile]>(async (file) => {
             if (file === unavailableFile) {
@@ -155,7 +197,7 @@ describe('Cache loading', () => {
     });
 
     it('should preserve previously cached tasks when a later read fails', async () => {
-        const file = createFile('temporarily-unavailable.md');
+        const file = createTFile('temporarily-unavailable.md');
         const readError = new Error('EIO: input/output error, read');
         let shouldReadFail = false;
         const cachedRead = jest.fn<Promise<string>, [TFile]>(async () => {

--- a/tests/Obsidian/CacheLoading.test.ts
+++ b/tests/Obsidian/CacheLoading.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment jsdom
+ */
+import moment from 'moment/moment';
+import type { CachedMetadata, EventRef, MetadataCache, TFile, Vault, Workspace } from 'obsidian';
+import { Cache, State } from '../../src/Obsidian/Cache';
+import type { TasksEvents } from '../../src/Obsidian/TasksEvents';
+import type { Logger } from '../../src/lib/logging';
+import { MockDataLoader } from '../TestingTools/MockDataLoader';
+
+jest.mock('obsidian');
+jest.mock('../../src/lib/PerformanceTracker', () => ({
+    PerformanceTracker: class {
+        public start(): void {}
+        public finish(): void {}
+    },
+}));
+
+window.moment = moment;
+
+const eventReference = {} as EventRef;
+const taskData = MockDataLoader.get('one_task');
+
+function createFile(path: string): TFile {
+    const name = path.split('/').pop() ?? path;
+    const extension = name.includes('.') ? name.split('.').pop() ?? '' : '';
+    const basename = extension === '' ? name : name.slice(0, -(extension.length + 1));
+
+    return {
+        vault: {} as Vault,
+        path,
+        name,
+        parent: null,
+        stat: { ctime: 0, mtime: 0, size: 0 },
+        basename,
+        extension,
+    };
+}
+
+function createCacheEnvironment({
+    files,
+    cachedRead,
+    getFileCache = () => taskData.cachedMetadata,
+}: {
+    files: TFile[];
+    cachedRead: jest.Mock<Promise<string>, [TFile]>;
+    getFileCache?: (file: TFile) => CachedMetadata | null;
+}) {
+    let layoutReadyCallback: (() => Promise<void>) | undefined;
+    const metadataCache = {
+        getFileCache: jest.fn(getFileCache),
+        offref: jest.fn(),
+        on: jest.fn(() => eventReference),
+    } as unknown as MetadataCache;
+    const vault = {
+        cachedRead,
+        getMarkdownFiles: jest.fn(() => files),
+        offref: jest.fn(),
+        on: jest.fn(() => eventReference),
+    } as unknown as Vault;
+    const workspace = {
+        onLayoutReady: jest.fn((callback: () => Promise<void>) => {
+            layoutReadyCallback = callback;
+        }),
+    } as unknown as Workspace;
+    const events = {
+        off: jest.fn(),
+        onReloadVault: jest.fn(() => eventReference),
+        onRequestCacheUpdate: jest.fn(() => eventReference),
+        triggerCacheUpdate: jest.fn(),
+    } as unknown as TasksEvents;
+
+    const cache = new Cache({ metadataCache, vault, workspace, events });
+    cache.logger = {
+        debug: jest.fn(),
+        error: jest.fn(),
+        info: jest.fn(),
+    } as unknown as Logger;
+
+    return {
+        cache,
+        runLayoutReady: async () => {
+            expect(layoutReadyCallback).toBeDefined();
+            await layoutReadyCallback?.();
+        },
+    };
+}
+
+describe('Cache loading', () => {
+    it.failing('should limit how many files are indexed concurrently', async () => {
+        const files = Array.from({ length: 12 }, (_value, index) => createFile(`${index}.md`));
+        let activeReads = 0;
+        let maximumActiveReads = 0;
+        const cachedRead = jest.fn<Promise<string>, [TFile]>(async () => {
+            activeReads++;
+            maximumActiveReads = Math.max(maximumActiveReads, activeReads);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            activeReads--;
+            return taskData.fileContents;
+        });
+        const { cache, runLayoutReady } = createCacheEnvironment({ files, cachedRead });
+
+        await runLayoutReady();
+
+        expect(maximumActiveReads).toBeLessThanOrEqual(4);
+        expect(cache.getState()).toBe(State.Warm);
+    });
+
+    it.failing('should not read a file whose metadata contains only plain list items', async () => {
+        const file = createFile('plain-list.md');
+        const cachedRead = jest.fn<Promise<string>, [TFile]>(async () => '- a plain list item');
+        const plainListMetadata: CachedMetadata = {
+            listItems: taskData.cachedMetadata.listItems?.map((item) => ({ ...item, task: undefined })),
+        };
+        const { runLayoutReady } = createCacheEnvironment({
+            files: [file],
+            cachedRead,
+            getFileCache: () => plainListMetadata,
+        });
+
+        await runLayoutReady();
+
+        expect(cachedRead).not.toHaveBeenCalled();
+    });
+
+    it.failing('should keep loading when one file read fails', async () => {
+        const unavailableFile = createFile('unavailable.md');
+        const readableFile = createFile('readable.md');
+        const readError = new Error('ETIMEDOUT: connection timed out, read');
+        const cachedRead = jest.fn<Promise<string>, [TFile]>(async (file) => {
+            if (file === unavailableFile) {
+                throw readError;
+            }
+            return taskData.fileContents;
+        });
+        const { cache, runLayoutReady } = createCacheEnvironment({
+            files: [unavailableFile, readableFile],
+            cachedRead,
+        });
+
+        await expect(runLayoutReady()).resolves.toBeUndefined();
+
+        expect(cache.getState()).toBe(State.Warm);
+        expect(cache.getTasks()).toHaveLength(1);
+        expect(cache.getTasks()[0].path).toBe(readableFile.path);
+        expect(cache.logger.error).toHaveBeenCalledWith(expect.stringContaining(unavailableFile.path), readError);
+    });
+});

--- a/tests/Obsidian/CacheLoading.test.ts
+++ b/tests/Obsidian/CacheLoading.test.ts
@@ -47,6 +47,7 @@ function createCacheEnvironment({
     getFileCache?: (file: TFile) => CachedMetadata | null;
 }) {
     let layoutReadyCallback: (() => Promise<void>) | undefined;
+    let reloadVaultCallback: (() => Promise<void>) | undefined;
     const metadataCache = {
         getFileCache: jest.fn(getFileCache),
         offref: jest.fn(),
@@ -65,7 +66,10 @@ function createCacheEnvironment({
     } as unknown as Workspace;
     const events = {
         off: jest.fn(),
-        onReloadVault: jest.fn(() => eventReference),
+        onReloadVault: jest.fn((callback: () => Promise<void>) => {
+            reloadVaultCallback = callback;
+            return eventReference;
+        }),
         onRequestCacheUpdate: jest.fn(() => eventReference),
         triggerCacheUpdate: jest.fn(),
     } as unknown as TasksEvents;
@@ -83,11 +87,15 @@ function createCacheEnvironment({
             expect(layoutReadyCallback).toBeDefined();
             await layoutReadyCallback?.();
         },
+        runReloadVault: async () => {
+            expect(reloadVaultCallback).toBeDefined();
+            await reloadVaultCallback?.();
+        },
     };
 }
 
 describe('Cache loading', () => {
-    it.failing('should limit how many files are indexed concurrently', async () => {
+    it('should limit how many files are indexed concurrently', async () => {
         const files = Array.from({ length: 12 }, (_value, index) => createFile(`${index}.md`));
         let activeReads = 0;
         let maximumActiveReads = 0;
@@ -106,7 +114,7 @@ describe('Cache loading', () => {
         expect(cache.getState()).toBe(State.Warm);
     });
 
-    it.failing('should not read a file whose metadata contains only plain list items', async () => {
+    it('should not read a file whose metadata contains only plain list items', async () => {
         const file = createFile('plain-list.md');
         const cachedRead = jest.fn<Promise<string>, [TFile]>(async () => '- a plain list item');
         const plainListMetadata: CachedMetadata = {
@@ -123,7 +131,7 @@ describe('Cache loading', () => {
         expect(cachedRead).not.toHaveBeenCalled();
     });
 
-    it.failing('should keep loading when one file read fails', async () => {
+    it('should keep loading when one file read fails', async () => {
         const unavailableFile = createFile('unavailable.md');
         const readableFile = createFile('readable.md');
         const readError = new Error('ETIMEDOUT: connection timed out, read');
@@ -144,5 +152,29 @@ describe('Cache loading', () => {
         expect(cache.getTasks()).toHaveLength(1);
         expect(cache.getTasks()[0].path).toBe(readableFile.path);
         expect(cache.logger.error).toHaveBeenCalledWith(expect.stringContaining(unavailableFile.path), readError);
+    });
+
+    it('should preserve previously cached tasks when a later read fails', async () => {
+        const file = createFile('temporarily-unavailable.md');
+        const readError = new Error('EIO: input/output error, read');
+        let shouldReadFail = false;
+        const cachedRead = jest.fn<Promise<string>, [TFile]>(async () => {
+            if (shouldReadFail) {
+                throw readError;
+            }
+            return taskData.fileContents;
+        });
+        const { cache, runLayoutReady, runReloadVault } = createCacheEnvironment({ files: [file], cachedRead });
+
+        await runLayoutReady();
+        const previouslyCachedTasks = cache.getTasks();
+        expect(previouslyCachedTasks).toHaveLength(1);
+
+        shouldReadFail = true;
+        await expect(runReloadVault()).resolves.toBeUndefined();
+
+        expect(cache.getState()).toBe(State.Warm);
+        expect(cache.getTasks()).toEqual(previouslyCachedTasks);
+        expect(cache.logger.error).toHaveBeenCalledWith(expect.stringContaining(file.path), readError);
     });
 });

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -1,4 +1,4 @@
-import type { App, CachedMetadata, Debouncer, Reference } from 'obsidian';
+import type { App, CachedMetadata, Debouncer, Reference, TFile, Vault } from 'obsidian';
 import type { SimulatedFile } from '../Obsidian/SimulatedFile';
 import { MockDataLoader } from '../TestingTools/MockDataLoader';
 
@@ -10,6 +10,27 @@ export {};
  * not a lot to mock in particular.
  */
 export const mockApp = {} as unknown as App;
+
+/**
+ * Creates a minimal Obsidian TFile for tests that only need file metadata.
+ *
+ * @param path - Vault-relative path to the file.
+ */
+export function createTFile(path: string): TFile {
+    const name = path.split('/').pop() ?? path;
+    const extension = name.includes('.') ? name.split('.').pop() ?? '' : '';
+    const basename = extension === '' ? name : name.slice(0, -(extension.length + 1));
+
+    return {
+        vault: {} as Vault,
+        path,
+        name,
+        parent: null,
+        stat: { ctime: 0, mtime: 0, size: 0 },
+        basename,
+        extension,
+    };
+}
 
 export class MenuItem {
     public title: string | DocumentFragment = '';


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3492

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

This changes the initial Tasks vault scan to:

- index files through a small worker pool instead of starting every file operation at once;
- avoid reading files whose metadata contains no checkbox list items;
- isolate an individual `cachedRead()` failure so the rest of the vault can finish loading; and
- preserve previously cached tasks when a later read of that file fails.

The implementation deliberately does not add a fixed read timeout. A `Promise.race()` timeout would not cancel Obsidian's underlying file read, so timed-out reads could remain active and legitimately slow cloud files could be omitted.

## Motivation and Context

`Cache.loadVault()` currently uses an unbounded `Promise.all()` across every Markdown file. In a large cloud-backed vault, that can create enough filesystem contention to interfere with Obsidian loading the note selected by the user. A single rejected read also rejects the whole initial cache build, preventing it from reaching the warm state.

This addresses #3492. The investigation and planned exploratory test scenarios are documented there.

## How has this been tested?

- Added startup-level regression tests using a real `Cache` driven through its `workspace.onLayoutReady()` callback.
- Verified that simultaneous reads stay within the configured bound.
- Verified that plain-list-only files are not read.
- Verified that one failed read does not prevent another file from being indexed or the cache from becoming warm.
- Verified that previously cached tasks survive a later read failure.
- Ran `yarn test` successfully.
- Ran lint, TypeScript, and Svelte checks successfully.
- Built the production plugin successfully with `yarn build`.

An earlier sequential prototype was manually tested in the reported iCloud-backed vault and allowed repeated note switching while the Tasks cache was still loading. This bounded-worker implementation is awaiting the additional cross-session exploratory testing discussed in #3492.

## Screenshots (if appropriate)

Not applicable.

## Checklist

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage.

## Terms

- [x] My contribution follows this project's contributing guide.
- [x] I agree to follow this project's Code of Conduct.
