### PR TITLE
Fix warnings from stale non-list cache entries

### DIFF
--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -5,6 +5,7 @@ import type { TasksFile } from '../Scripting/TasksFile';
 import { Lazy } from '../lib/Lazy';
 import { DateFallback } from '../DateTime/DateFallback';
 import { ListItem } from '../Task/ListItem';
+import { TaskRegularExpressions } from '../Task/TaskRegularExpressions';
 import { TaskLocation } from '../Task/TaskLocation';
 import { Cache } from './Cache';
 
@@ -123,6 +124,15 @@ export class FileParser {
         sectionIndex: number,
     ) {
         if (listItem.task === undefined) {
+            // CachedMetadata can temporarily contain stale listItems entries
+            // that point at headings, prose or blank lines. Do not send those
+            // lines through ListItem parsing, where they produce a misleading
+            // warning. This uses Tasks' existing marker grammar so supported
+            // bullet, numbered and blockquote list styles remain unchanged.
+            if (!TaskRegularExpressions.listItemRegex.test(line)) {
+                this.logger.debug(`${this.filePath}: line ${lineNumber} - ignoring non-list listItems cache entry.`);
+                return sectionIndex;
+            }
             this.createListItem(listItem, line, lineNumber, taskLocation);
             return sectionIndex;
         }

--- a/tests/Obsidian/FileParser.test.ts
+++ b/tests/Obsidian/FileParser.test.ts
@@ -1,7 +1,53 @@
+import type { CachedMetadata, ListItemCache } from 'obsidian';
+import { FileParser } from '../../src/Obsidian/FileParser';
+import type { TasksFile } from '../../src/Scripting/TasksFile';
+import { logging } from '../../src/lib/logging';
 import { MockDataLoader } from '../TestingTools/MockDataLoader';
 import { readTasksFromSimulatedFile } from './SimulatedFile';
 
 describe('FileParser', () => {
+    it('ignores stale non-list cache entries without changing supported list parsing', () => {
+        const lines = [
+            '# Heading',
+            'Prose line',
+            '',
+            '- parent list item',
+            '  - [ ] child task',
+            '+ plus list item',
+            '* star list item',
+            '> - quoted list item',
+            '1. numbered list item',
+            '1) alternate numbered list item',
+        ];
+        const position = (line: number) => ({
+            start: { line, col: 0, offset: 0 },
+            end: { line, col: lines[line].length, offset: lines[line].length },
+        });
+        const listItems: ListItemCache[] = lines.map((_line, line) => ({
+            parent: line === 4 ? 3 : -1,
+            position: position(line),
+        }));
+        listItems[4].task = ' ';
+        const cachedMetadata: CachedMetadata = {
+            listItems,
+            sections: [
+                { type: 'paragraph', position: { start: position(0).start, end: position(lines.length - 1).end } },
+            ],
+        };
+        const logger = logging.getLogger('FileParser.test');
+        const warn = jest.spyOn(logger, 'warn');
+        const debug = jest.spyOn(logger, 'debug');
+        const tasksFile = { path: 'stale-cache.md', cachedMetadata } as TasksFile;
+        const parser = new FileParser(tasksFile, lines.join('\n'), listItems, logger, jest.fn());
+
+        const tasks = parser.parseFileContent();
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(debug).toHaveBeenCalledTimes(3);
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0].parent?.description).toEqual('parent list item');
+    });
+
     it('should set all non-TasksFile data in TaskLocation', () => {
         // This test exists to detect accidental changes to the task-reading code.
         // I found that intentionally breaking the setting of _sectionIndex was


### PR DESCRIPTION
## Summary

- ignore `CachedMetadata.listItems` entries that point at headings, prose or blank lines
- reuse Tasks' existing list-marker grammar so bullet, numbered and blockquote lists keep their current behavior
- add a regression test that also preserves parent-list relationships for child tasks

This also suppresses the warning for footnote cache entries described in #3538; Tasks continues to ignore those unsupported list contexts.

Fixes #3538

## Testing

- `jest --ci` (165 suites, 4,793 tests)
- `yarn lint:no-fix` (0 errors; two pre-existing test warnings)
- `tsc --noEmit`
- `svelte-check` (0 errors, 0 warnings)