### PR TITLE
feat: add initial implementation of columns view

### DIFF
--- a/src/Renderer/HtmlColumnQueryResultsRenderer.scss
+++ b/src/Renderer/HtmlColumnQueryResultsRenderer.scss
@@ -1,0 +1,15 @@
+.tasks-columns {
+    display: flex;
+    gap: 1rem;
+    overflow-x: auto;
+    align-items: flex-start;
+    padding: 0.5rem 0;
+
+    &-column {
+        flex: 0 0 18rem;
+        border: 1px solid var(--background-modifier-border);
+        border-radius: 8px;
+        background: var(--background-secondary);
+        padding: 0 0.5rem;
+    }
+}

--- a/src/Renderer/HtmlColumnQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlColumnQueryResultsRenderer.ts
@@ -1,3 +1,24 @@
+import type { TaskGroups } from '../Query/Group/TaskGroups';
 import { HtmlQueryResultsRenderer } from './HtmlQueryResultsRenderer';
+import { createAndAppendElement } from './TaskLineRenderer';
 
-export class HtmlColumnQueryResultsRenderer extends HtmlQueryResultsRenderer {}
+export class HtmlColumnQueryResultsRenderer extends HtmlQueryResultsRenderer {
+    protected async addAllTaskGroups(tasksSortedLimitedGrouped: TaskGroups) {
+        const originalParent = this.content;
+
+        const columnsContainer = createAndAppendElement('div', originalParent);
+        columnsContainer.classList.add('tasks-columns');
+        this.content = columnsContainer;
+
+        for (const group of tasksSortedLimitedGrouped.groups) {
+            // If there were no 'group by' instructions, group.groupHeadings
+            // will be empty, and no headings will be added.
+            await this.addGroupHeadings(group.groupHeadings);
+
+            this.addedListItems.clear();
+            await this.addTaskList(group.tasks);
+        }
+
+        this.content = originalParent;
+    }
+}

--- a/src/Renderer/HtmlColumnQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlColumnQueryResultsRenderer.ts
@@ -1,0 +1,3 @@
+import { HtmlQueryResultsRenderer } from './HtmlQueryResultsRenderer';
+
+export class HtmlColumnQueryResultsRenderer extends HtmlQueryResultsRenderer {}

--- a/src/Renderer/HtmlColumnQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlColumnQueryResultsRenderer.ts
@@ -14,9 +14,11 @@ export class HtmlColumnQueryResultsRenderer extends HtmlQueryResultsRenderer {
                 continue;
             }
 
-            const columnContainer = createAndAppendElement('div', columnsContainer);
-            columnContainer.classList.add('tasks-columns-column');
-            this.content = columnContainer;
+            if (group.groupHeadings[0].nestingLevel === 0) {
+                const columnContainer = createAndAppendElement('div', columnsContainer);
+                columnContainer.classList.add('tasks-columns-column');
+                this.content = columnContainer;
+            }
 
             // If there were no 'group by' instructions, group.groupHeadings
             // will be empty, and no headings will be added.

--- a/src/Renderer/HtmlColumnQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlColumnQueryResultsRenderer.ts
@@ -8,9 +8,12 @@ export class HtmlColumnQueryResultsRenderer extends HtmlQueryResultsRenderer {
 
         const columnsContainer = createAndAppendElement('div', originalParent);
         columnsContainer.classList.add('tasks-columns');
-        this.content = columnsContainer;
 
         for (const group of tasksSortedLimitedGrouped.groups) {
+            const columnContainer = createAndAppendElement('div', columnsContainer);
+            columnContainer.classList.add('tasks-columns-column');
+            this.content = columnContainer;
+
             // If there were no 'group by' instructions, group.groupHeadings
             // will be empty, and no headings will be added.
             await this.addGroupHeadings(group.groupHeadings);

--- a/src/Renderer/HtmlColumnQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlColumnQueryResultsRenderer.ts
@@ -10,6 +10,10 @@ export class HtmlColumnQueryResultsRenderer extends HtmlQueryResultsRenderer {
         columnsContainer.classList.add('tasks-columns');
 
         for (const group of tasksSortedLimitedGrouped.groups) {
+            if (group.tasks.length === 0) {
+                continue;
+            }
+
             const columnContainer = createAndAppendElement('div', columnsContainer);
             columnContainer.classList.add('tasks-columns-column');
             this.content = columnContainer;

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -162,8 +162,8 @@ export class QueryResultsRenderer {
         measureRender.start();
 
         const htmlRenderer =
-            this.query.viewLayoutOptions.viewMode === 'list'
-                ? new HtmlQueryResultsRenderer(
+            this.query.viewLayoutOptions.viewMode === 'columns'
+                ? new HtmlColumnQueryResultsRenderer(
                       this.renderMarkdown,
                       this.obsidianComponent,
                       this.obsidianApp,
@@ -173,7 +173,7 @@ export class QueryResultsRenderer {
                       this.tasksFile,
                       this.query,
                   )
-                : new HtmlColumnQueryResultsRenderer(
+                : new HtmlQueryResultsRenderer(
                       this.renderMarkdown,
                       this.obsidianComponent,
                       this.obsidianApp,

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -9,6 +9,7 @@ import { getQueryForQueryRenderer } from '../Query/QueryRendererHelper';
 import type { QueryResult } from '../Query/QueryResult';
 import type { TasksFile } from '../Scripting/TasksFile';
 import type { Task } from '../Task/Task';
+import { HtmlColumnQueryResultsRenderer } from './HtmlColumnQueryResultsRenderer';
 import { type HTMLQueryRendererParameters, HtmlQueryResultsRenderer } from './HtmlQueryResultsRenderer';
 import { MarkdownQueryResultsRenderer } from './MarkdownQueryResultsRenderer';
 import { type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
@@ -160,17 +161,28 @@ export class QueryResultsRenderer {
         const measureRender = new PerformanceTracker(`Render: ${this.query.queryId} - ${this.filePath}`);
         measureRender.start();
 
-        const htmlRenderer = new HtmlQueryResultsRenderer(
-            this.renderMarkdown,
-            this.obsidianComponent,
-            this.obsidianApp,
-            this.textRenderer,
-            this.htmlQueryRendererParameters,
-            this.source,
-            this.tasksFile,
-            this.query,
-        );
-
+        const htmlRenderer =
+            this.query.viewLayoutOptions.viewMode === 'list'
+                ? new HtmlQueryResultsRenderer(
+                      this.renderMarkdown,
+                      this.obsidianComponent,
+                      this.obsidianApp,
+                      this.textRenderer,
+                      this.htmlQueryRendererParameters,
+                      this.source,
+                      this.tasksFile,
+                      this.query,
+                  )
+                : new HtmlColumnQueryResultsRenderer(
+                      this.renderMarkdown,
+                      this.obsidianComponent,
+                      this.obsidianApp,
+                      this.textRenderer,
+                      this.htmlQueryRendererParameters,
+                      this.source,
+                      this.tasksFile,
+                      this.query,
+                  );
         htmlRenderer.content = content;
         await htmlRenderer.renderQuery(state, queryResult);
         measureRender.finish();

--- a/src/Renderer/QueryResultsRendererBase.ts
+++ b/src/Renderer/QueryResultsRendererBase.ts
@@ -98,7 +98,7 @@ export abstract class QueryResultsRendererBase {
 
     protected abstract renderExplanation(explanation: string | null): void;
 
-    private async addAllTaskGroups(tasksSortedLimitedGrouped: TaskGroups) {
+    protected async addAllTaskGroups(tasksSortedLimitedGrouped: TaskGroups) {
         for (const group of tasksSortedLimitedGrouped.groups) {
             // If there were no 'group by' instructions, group.groupHeadings
             // will be empty, and no headings will be added.
@@ -226,7 +226,7 @@ export abstract class QueryResultsRendererBase {
      *                        in which case no headings will be added.
      * @private
      */
-    private async addGroupHeadings(groupHeadings: GroupDisplayHeading[]) {
+    protected async addGroupHeadings(groupHeadings: GroupDisplayHeading[]) {
         for (const heading of groupHeadings) {
             await this.addGroupHeading(heading);
         }

--- a/src/Renderer/QueryResultsRendererBase.ts
+++ b/src/Renderer/QueryResultsRendererBase.ts
@@ -34,11 +34,7 @@ export abstract class QueryResultsRendererBase {
         // console messages in large vaults, if Obsidian was opened with any
         // notes with tasks code blocks in Reading or Live Preview mode.
         const query = this.query;
-
-        let error = query.error;
-        if (query.viewLayoutOptions.viewMode === 'columns') {
-            error = '"view columns" is not yet supported.';
-        }
+        const error = query.error;
 
         if (state === State.Warm && error === undefined) {
             await this.renderQuerySearchResults(queryResult);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,6 @@
 @import 'flatpickr/dist/flatpickr.css';
 @import './Renderer/Renderer';
+@import './Renderer/HtmlColumnQueryResultsRenderer';
 @import './Obsidian/TaskModal';
 @import './ui/EditTask';
 @import './ui/Dependency';

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_due_date_column.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_due_date_column.approved.html
@@ -1,0 +1,30 @@
+<!--
+- [ ] my description 📅 2026-07-13
+-->
+
+<div>
+  <h4 class="tasks-group-heading">For test purposes: 2026-07-13 Monday</h4>
+  <ul
+    class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-due="today"
+      data-task-priority="normal"
+      data-task=""
+      data-line="0"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>my description</span></span>
+        <span class="task-due" data-task-due="today" title="Click to edit due date, Right-click for more options">
+          <span>📅 2026-07-13</span>
+        </span>
+      </span>
+      <span class="task-extras">
+        <a class="tasks-postpone" title="ℹ️ Due tomorrow, on Tue 14th Jul (right-click for more options)"></a>
+      </span>
+    </li>
+  </ul>
+  <div class="task-count">1 task</div>
+</div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_due_date_column.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_due_date_column.approved.html
@@ -4,29 +4,31 @@
 
 <div>
   <div class="tasks-columns">
-    <h4 class="tasks-group-heading">For test purposes: 2026-07-13 Monday</h4>
-    <ul
-      class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
-      <li
-        class="task-list-item plugin-tasks-list-item"
-        data-task-due="today"
-        data-task-priority="normal"
-        data-task=""
-        data-line="0"
-        data-task-status-name="Todo"
-        data-task-status-type="TODO">
-        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
-        <span class="tasks-list-text">
-          <span class="task-description"><span>my description</span></span>
-          <span class="task-due" data-task-due="today" title="Click to edit due date, Right-click for more options">
-            <span>📅 2026-07-13</span>
+    <div class="tasks-columns-column">
+      <h4 class="tasks-group-heading">For test purposes: 2026-07-13 Monday</h4>
+      <ul
+        class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-due="today"
+          data-task-priority="normal"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>my description</span></span>
+            <span class="task-due" data-task-due="today" title="Click to edit due date, Right-click for more options">
+              <span>📅 2026-07-13</span>
+            </span>
           </span>
-        </span>
-        <span class="task-extras">
-          <a class="tasks-postpone" title="ℹ️ Due tomorrow, on Tue 14th Jul (right-click for more options)"></a>
-        </span>
-      </li>
-    </ul>
+          <span class="task-extras">
+            <a class="tasks-postpone" title="ℹ️ Due tomorrow, on Tue 14th Jul (right-click for more options)"></a>
+          </span>
+        </li>
+      </ul>
+    </div>
   </div>
   <div class="task-count">1 task</div>
 </div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_due_date_column.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_due_date_column.approved.html
@@ -3,28 +3,30 @@
 -->
 
 <div>
-  <h4 class="tasks-group-heading">For test purposes: 2026-07-13 Monday</h4>
-  <ul
-    class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
-    <li
-      class="task-list-item plugin-tasks-list-item"
-      data-task-due="today"
-      data-task-priority="normal"
-      data-task=""
-      data-line="0"
-      data-task-status-name="Todo"
-      data-task-status-type="TODO">
-      <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
-      <span class="tasks-list-text">
-        <span class="task-description"><span>my description</span></span>
-        <span class="task-due" data-task-due="today" title="Click to edit due date, Right-click for more options">
-          <span>📅 2026-07-13</span>
+  <div class="tasks-columns">
+    <h4 class="tasks-group-heading">For test purposes: 2026-07-13 Monday</h4>
+    <ul
+      class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
+      <li
+        class="task-list-item plugin-tasks-list-item"
+        data-task-due="today"
+        data-task-priority="normal"
+        data-task=""
+        data-line="0"
+        data-task-status-name="Todo"
+        data-task-status-type="TODO">
+        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+        <span class="tasks-list-text">
+          <span class="task-description"><span>my description</span></span>
+          <span class="task-due" data-task-due="today" title="Click to edit due date, Right-click for more options">
+            <span>📅 2026-07-13</span>
+          </span>
         </span>
-      </span>
-      <span class="task-extras">
-        <a class="tasks-postpone" title="ℹ️ Due tomorrow, on Tue 14th Jul (right-click for more options)"></a>
-      </span>
-    </li>
-  </ul>
+        <span class="task-extras">
+          <a class="tasks-postpone" title="ℹ️ Due tomorrow, on Tue 14th Jul (right-click for more options)"></a>
+        </span>
+      </li>
+    </ul>
+  </div>
   <div class="task-count">1 task</div>
 </div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_due_date_column_and_scheduled_date_groups.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_due_date_column_and_scheduled_date_groups.approved.html
@@ -4,38 +4,43 @@
 
 <div>
   <div class="tasks-columns">
-    <h4 class="tasks-group-heading">For test purposes: 2026-06-23 Tuesday</h4>
-    <h5 class="tasks-group-heading">For test purposes: 2025-12-01 Monday</h5>
-    <ul
-      class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button"
-      data-task-group-by="scheduled">
-      <li
-        class="task-list-item plugin-tasks-list-item"
-        data-task-scheduled="past-far"
-        data-task-due="past-far"
-        data-task-priority="normal"
-        data-task=""
-        data-line="0"
-        data-task-status-name="Todo"
-        data-task-status-type="TODO">
-        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
-        <span class="tasks-list-text">
-          <span class="task-description"><span>my description</span></span>
-          <span
-            class="task-scheduled"
-            data-task-scheduled="past-far"
-            title="Click to edit scheduled date, Right-click for more options">
-            <span>⏳ 2025-12-01</span>
+    <div class="tasks-columns-column">
+      <h4 class="tasks-group-heading">For test purposes: 2026-06-23 Tuesday</h4>
+      <h5 class="tasks-group-heading">For test purposes: 2025-12-01 Monday</h5>
+      <ul
+        class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button"
+        data-task-group-by="scheduled">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-scheduled="past-far"
+          data-task-due="past-far"
+          data-task-priority="normal"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>my description</span></span>
+            <span
+              class="task-scheduled"
+              data-task-scheduled="past-far"
+              title="Click to edit scheduled date, Right-click for more options">
+              <span>⏳ 2025-12-01</span>
+            </span>
+            <span
+              class="task-due"
+              data-task-due="past-far"
+              title="Click to edit due date, Right-click for more options">
+              <span>📅 2026-06-23</span>
+            </span>
           </span>
-          <span class="task-due" data-task-due="past-far" title="Click to edit due date, Right-click for more options">
-            <span>📅 2026-06-23</span>
+          <span class="task-extras">
+            <a class="tasks-postpone" title="ℹ️ Due tomorrow, on Tue 14th Jul (right-click for more options)"></a>
           </span>
-        </span>
-        <span class="task-extras">
-          <a class="tasks-postpone" title="ℹ️ Due tomorrow, on Tue 14th Jul (right-click for more options)"></a>
-        </span>
-      </li>
-    </ul>
+        </li>
+      </ul>
+    </div>
   </div>
   <div class="task-count">1 task</div>
 </div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_due_date_column_and_scheduled_date_groups.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_due_date_column_and_scheduled_date_groups.approved.html
@@ -1,0 +1,41 @@
+<!--
+- [ ] my description ⏳ 2025-12-01 📅 2026-06-23
+-->
+
+<div>
+  <div class="tasks-columns">
+    <h4 class="tasks-group-heading">For test purposes: 2026-06-23 Tuesday</h4>
+    <h5 class="tasks-group-heading">For test purposes: 2025-12-01 Monday</h5>
+    <ul
+      class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button"
+      data-task-group-by="scheduled">
+      <li
+        class="task-list-item plugin-tasks-list-item"
+        data-task-scheduled="past-far"
+        data-task-due="past-far"
+        data-task-priority="normal"
+        data-task=""
+        data-line="0"
+        data-task-status-name="Todo"
+        data-task-status-type="TODO">
+        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+        <span class="tasks-list-text">
+          <span class="task-description"><span>my description</span></span>
+          <span
+            class="task-scheduled"
+            data-task-scheduled="past-far"
+            title="Click to edit scheduled date, Right-click for more options">
+            <span>⏳ 2025-12-01</span>
+          </span>
+          <span class="task-due" data-task-due="past-far" title="Click to edit due date, Right-click for more options">
+            <span>📅 2026-06-23</span>
+          </span>
+        </span>
+        <span class="task-extras">
+          <a class="tasks-postpone" title="ℹ️ Due tomorrow, on Tue 14th Jul (right-click for more options)"></a>
+        </span>
+      </li>
+    </ul>
+  </div>
+  <div class="task-count">1 task</div>
+</div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_due_date_column.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_due_date_column.approved.html
@@ -3,22 +3,24 @@
 -->
 
 <div>
-  <h4 class="tasks-group-heading">For test purposes: No due date</h4>
-  <ul
-    class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
-    <li
-      class="task-list-item plugin-tasks-list-item"
-      data-task-priority="normal"
-      data-task=""
-      data-line="0"
-      data-task-status-name="Todo"
-      data-task-status-type="TODO">
-      <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
-      <span class="tasks-list-text">
-        <span class="task-description"><span>my description</span></span>
-      </span>
-      <span class="task-extras"></span>
-    </li>
-  </ul>
+  <div class="tasks-columns">
+    <h4 class="tasks-group-heading">For test purposes: No due date</h4>
+    <ul
+      class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
+      <li
+        class="task-list-item plugin-tasks-list-item"
+        data-task-priority="normal"
+        data-task=""
+        data-line="0"
+        data-task-status-name="Todo"
+        data-task-status-type="TODO">
+        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+        <span class="tasks-list-text">
+          <span class="task-description"><span>my description</span></span>
+        </span>
+        <span class="task-extras"></span>
+      </li>
+    </ul>
+  </div>
   <div class="task-count">1 task</div>
 </div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_due_date_column.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_due_date_column.approved.html
@@ -1,0 +1,7 @@
+<!--
+- [ ] my description
+-->
+
+<div>
+  <div><pre>Tasks query: "view columns" is not yet supported.</pre></div>
+</div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_due_date_column.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_due_date_column.approved.html
@@ -5,7 +5,7 @@
 <div>
   <h4 class="tasks-group-heading">For test purposes: No due date</h4>
   <ul
-    class="contains-task-list plugin-tasks-query-result tasks-layout-hide-id tasks-layout-hide-dependsOn tasks-layout-hide-priority tasks-layout-hide-recurrenceRule tasks-layout-hide-onCompletion tasks-layout-hide-createdDate tasks-layout-hide-startDate tasks-layout-hide-scheduledDate tasks-layout-hide-dueDate tasks-layout-hide-cancelledDate tasks-layout-hide-doneDate tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button tasks-layout-hide-postpone-button">
+    class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
     <li
       class="task-list-item plugin-tasks-list-item"
       data-task-priority="normal"

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_due_date_column.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_due_date_column.approved.html
@@ -3,5 +3,22 @@
 -->
 
 <div>
-  <div><pre>Tasks query: "view columns" is not yet supported.</pre></div>
+  <h4 class="tasks-group-heading">For test purposes: No due date</h4>
+  <ul
+    class="contains-task-list plugin-tasks-query-result tasks-layout-hide-id tasks-layout-hide-dependsOn tasks-layout-hide-priority tasks-layout-hide-recurrenceRule tasks-layout-hide-onCompletion tasks-layout-hide-createdDate tasks-layout-hide-startDate tasks-layout-hide-scheduledDate tasks-layout-hide-dueDate tasks-layout-hide-cancelledDate tasks-layout-hide-doneDate tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button tasks-layout-hide-postpone-button">
+    <li
+      class="task-list-item plugin-tasks-list-item"
+      data-task-priority="normal"
+      data-task=""
+      data-line="0"
+      data-task-status-name="Todo"
+      data-task-status-type="TODO">
+      <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+      <span class="tasks-list-text">
+        <span class="task-description"><span>my description</span></span>
+      </span>
+      <span class="task-extras"></span>
+    </li>
+  </ul>
+  <div class="task-count">1 task</div>
 </div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_due_date_column.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_due_date_column.approved.html
@@ -4,23 +4,25 @@
 
 <div>
   <div class="tasks-columns">
-    <h4 class="tasks-group-heading">For test purposes: No due date</h4>
-    <ul
-      class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
-      <li
-        class="task-list-item plugin-tasks-list-item"
-        data-task-priority="normal"
-        data-task=""
-        data-line="0"
-        data-task-status-name="Todo"
-        data-task-status-type="TODO">
-        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
-        <span class="tasks-list-text">
-          <span class="task-description"><span>my description</span></span>
-        </span>
-        <span class="task-extras"></span>
-      </li>
-    </ul>
+    <div class="tasks-columns-column">
+      <h4 class="tasks-group-heading">For test purposes: No due date</h4>
+      <ul
+        class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="normal"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>my description</span></span>
+          </span>
+          <span class="task-extras"></span>
+        </li>
+      </ul>
+    </div>
   </div>
   <div class="task-count">1 task</div>
 </div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_search_results.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_search_results.approved.html
@@ -3,11 +3,6 @@
 -->
 
 <div>
-  <div class="tasks-columns">
-    <div class="tasks-columns-column">
-      <ul
-        class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button"></ul>
-    </div>
-  </div>
+  <div class="tasks-columns"></div>
   <div class="task-count">0 tasks</div>
 </div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_search_results.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_search_results.approved.html
@@ -4,8 +4,10 @@
 
 <div>
   <div class="tasks-columns">
-    <ul
-      class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button"></ul>
+    <div class="tasks-columns-column">
+      <ul
+        class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button"></ul>
+    </div>
   </div>
   <div class="task-count">0 tasks</div>
 </div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_search_results.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_no_search_results.approved.html
@@ -1,0 +1,11 @@
+<!--
+
+-->
+
+<div>
+  <div class="tasks-columns">
+    <ul
+      class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button"></ul>
+  </div>
+  <div class="task-count">0 tasks</div>
+</div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_one_column_with_two_headings.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_one_column_with_two_headings.approved.html
@@ -26,8 +26,6 @@
           <span class="task-extras"></span>
         </li>
       </ul>
-    </div>
-    <div class="tasks-columns-column">
       <h5 class="tasks-group-heading">For test purposes: %%4%%Low priority</h5>
       <ul
         class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button"

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_one_column_with_two_headings.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_one_column_with_two_headings.approved.html
@@ -1,0 +1,53 @@
+<!--
+- [ ] my description 🔺
+- [ ] my description 🔽
+-->
+
+<div>
+  <div class="tasks-columns">
+    <div class="tasks-columns-column">
+      <h4 class="tasks-group-heading">For test purposes: No due date</h4>
+      <h5 class="tasks-group-heading">For test purposes: %%0%%Highest priority</h5>
+      <ul
+        class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button"
+        data-task-group-by="priority">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="highest"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>my description</span></span>
+            <span class="task-priority" data-task-priority="highest"><span>🔺</span></span>
+          </span>
+          <span class="task-extras"></span>
+        </li>
+      </ul>
+    </div>
+    <div class="tasks-columns-column">
+      <h5 class="tasks-group-heading">For test purposes: %%4%%Low priority</h5>
+      <ul
+        class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button"
+        data-task-group-by="priority">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="low"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>my description</span></span>
+            <span class="task-priority" data-task-priority="low"><span>🔽</span></span>
+          </span>
+          <span class="task-extras"></span>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div class="task-count">2 tasks</div>
+</div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_two_priority_columns.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_two_priority_columns.approved.html
@@ -1,0 +1,46 @@
+<!--
+- [ ] my description 🔺
+- [ ] my description 🔽
+-->
+
+<div>
+  <div class="tasks-columns">
+    <h4 class="tasks-group-heading">For test purposes: %%0%%Highest priority</h4>
+    <ul
+      class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
+      <li
+        class="task-list-item plugin-tasks-list-item"
+        data-task-priority="highest"
+        data-task=""
+        data-line="0"
+        data-task-status-name="Todo"
+        data-task-status-type="TODO">
+        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+        <span class="tasks-list-text">
+          <span class="task-description"><span>my description</span></span>
+          <span class="task-priority" data-task-priority="highest"><span>🔺</span></span>
+        </span>
+        <span class="task-extras"></span>
+      </li>
+    </ul>
+    <h4 class="tasks-group-heading">For test purposes: %%4%%Low priority</h4>
+    <ul
+      class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
+      <li
+        class="task-list-item plugin-tasks-list-item"
+        data-task-priority="low"
+        data-task=""
+        data-line="0"
+        data-task-status-name="Todo"
+        data-task-status-type="TODO">
+        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+        <span class="tasks-list-text">
+          <span class="task-description"><span>my description</span></span>
+          <span class="task-priority" data-task-priority="low"><span>🔽</span></span>
+        </span>
+        <span class="task-extras"></span>
+      </li>
+    </ul>
+  </div>
+  <div class="task-count">2 tasks</div>
+</div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_two_priority_columns.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_two_priority_columns.approved.html
@@ -5,42 +5,46 @@
 
 <div>
   <div class="tasks-columns">
-    <h4 class="tasks-group-heading">For test purposes: %%0%%Highest priority</h4>
-    <ul
-      class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
-      <li
-        class="task-list-item plugin-tasks-list-item"
-        data-task-priority="highest"
-        data-task=""
-        data-line="0"
-        data-task-status-name="Todo"
-        data-task-status-type="TODO">
-        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
-        <span class="tasks-list-text">
-          <span class="task-description"><span>my description</span></span>
-          <span class="task-priority" data-task-priority="highest"><span>🔺</span></span>
-        </span>
-        <span class="task-extras"></span>
-      </li>
-    </ul>
-    <h4 class="tasks-group-heading">For test purposes: %%4%%Low priority</h4>
-    <ul
-      class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
-      <li
-        class="task-list-item plugin-tasks-list-item"
-        data-task-priority="low"
-        data-task=""
-        data-line="0"
-        data-task-status-name="Todo"
-        data-task-status-type="TODO">
-        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
-        <span class="tasks-list-text">
-          <span class="task-description"><span>my description</span></span>
-          <span class="task-priority" data-task-priority="low"><span>🔽</span></span>
-        </span>
-        <span class="task-extras"></span>
-      </li>
-    </ul>
+    <div class="tasks-columns-column">
+      <h4 class="tasks-group-heading">For test purposes: %%0%%Highest priority</h4>
+      <ul
+        class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="highest"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>my description</span></span>
+            <span class="task-priority" data-task-priority="highest"><span>🔺</span></span>
+          </span>
+          <span class="task-extras"></span>
+        </li>
+      </ul>
+    </div>
+    <div class="tasks-columns-column">
+      <h4 class="tasks-group-heading">For test purposes: %%4%%Low priority</h4>
+      <ul
+        class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="low"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>my description</span></span>
+            <span class="task-priority" data-task-priority="low"><span>🔽</span></span>
+          </span>
+          <span class="task-extras"></span>
+        </li>
+      </ul>
+    </div>
   </div>
   <div class="task-count">2 tasks</div>
 </div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -11,6 +11,15 @@ import { makeHtmlQueryRendererParameters, mockHTMLRenderer, verifyHtmlFromRender
 
 window.moment = moment;
 
+beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-13'));
+});
+
+afterAll(() => {
+    jest.useRealTimers();
+});
+
 function makeColumnRenderer(source: string, allTasks: Task[]) {
     const tasksFile = createTestTasksFile('query.md');
     const query = getQueryForQueryRenderer(source, GlobalQuery.getInstance(), tasksFile);

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -29,11 +29,12 @@ function makeColumnRenderer(source: string, allTasks: Task[]) {
 }
 
 describe('columns rendering', () => {
+    const due_columns = 'view columns by due\nhide backlink\nhide edit button';
+
     it('renders no due date column', () => {
-        const source = 'view columns by due\nhide backlink\nhide edit button';
         const allTasks = [new TaskBuilder().build()];
 
-        const { query, renderer } = makeColumnRenderer(source, allTasks);
+        const { query, renderer } = makeColumnRenderer(due_columns, allTasks);
         verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
     });
 });

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -3,6 +3,7 @@ import { GlobalQuery } from '../../src/Config/GlobalQuery';
 import { State } from '../../src/Obsidian/Cache';
 import { getQueryForQueryRenderer } from '../../src/Query/QueryRendererHelper';
 import { HtmlColumnQueryResultsRenderer } from '../../src/Renderer/HtmlColumnQueryResultsRenderer';
+import { Priority } from '../../src/Task/Priority';
 import type { Task } from '../../src/Task/Task';
 import { mockApp } from '../__mocks__/obsidian';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
@@ -39,6 +40,7 @@ function makeColumnRenderer(source: string, allTasks: Task[]) {
 
 describe('columns rendering', () => {
     const due_columns = 'view columns by due\nhide backlink\nhide edit button';
+    const priority_columns = 'view columns by priority\nhide backlink\nhide edit button';
 
     it('renders no due date column', () => {
         const allTasks = [new TaskBuilder().build()];
@@ -51,6 +53,16 @@ describe('columns rendering', () => {
         const allTasks = [new TaskBuilder().dueDate('2026-07-13').build()];
 
         const { query, renderer } = makeColumnRenderer(due_columns, allTasks);
+        verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
+    });
+
+    it('renders two priority columns', () => {
+        const allTasks = [
+            new TaskBuilder().priority(Priority.Highest).build(),
+            new TaskBuilder().priority(Priority.Low).build(),
+        ];
+
+        const { query, renderer } = makeColumnRenderer(priority_columns, allTasks);
         verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
     });
 });

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -30,7 +30,7 @@ function makeColumnRenderer(source: string, allTasks: Task[]) {
 
 describe('columns rendering', () => {
     it('renders no due date column', () => {
-        const source = 'view columns by due\npreset hide_everything';
+        const source = 'view columns by due\nhide backlink\nhide edit button';
         const allTasks = [new TaskBuilder().build()];
 
         const { query, renderer } = makeColumnRenderer(source, allTasks);

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -63,6 +63,13 @@ describe('columns rendering', () => {
         verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
     });
 
+    it('renders due date column and scheduled date groups', () => {
+        const allTasks = [new TaskBuilder().dueDate('2026-06-23').scheduledDate('2025-12-01').build()];
+
+        const { query, renderer } = makeColumnRenderer(due_columns + '\ngroup by scheduled', allTasks);
+        verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
+    });
+
     it('renders two priority columns', () => {
         const allTasks = [
             new TaskBuilder().priority(Priority.Highest).build(),

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -37,4 +37,11 @@ describe('columns rendering', () => {
         const { query, renderer } = makeColumnRenderer(due_columns, allTasks);
         verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
     });
+
+    it('renders due date column', () => {
+        const allTasks = [new TaskBuilder().dueDate('2026-07-13').build()];
+
+        const { query, renderer } = makeColumnRenderer(due_columns, allTasks);
+        verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
+    });
 });

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -42,41 +42,39 @@ describe('columns rendering', () => {
     const due_columns = 'view columns by due\nhide backlink\nhide edit button';
     const priority_columns = 'view columns by priority\nhide backlink\nhide edit button';
 
-    it('renders no search results', () => {
-        const allTasks: Task[] = [];
+    const noTasks: Task[] = [];
+    const emptyTask = [new TaskBuilder().build()];
 
-        const { query, renderer } = makeColumnRenderer(due_columns, allTasks);
-        verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
+    const withDue = [new TaskBuilder().dueDate('2026-07-13').build()];
+    const withDueAndScheduled = [new TaskBuilder().dueDate('2026-06-23').scheduledDate('2025-12-01').build()];
+
+    const twoPriorities = [
+        new TaskBuilder().priority(Priority.Highest).build(),
+        new TaskBuilder().priority(Priority.Low).build(),
+    ];
+
+    it('renders no search results', () => {
+        const { query, renderer } = makeColumnRenderer(due_columns, noTasks);
+        verifyHtmlFromRenderer(renderer, State.Warm, query, noTasks);
     });
 
     it('renders no due date column', () => {
-        const allTasks = [new TaskBuilder().build()];
-
-        const { query, renderer } = makeColumnRenderer(due_columns, allTasks);
-        verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
+        const { query, renderer } = makeColumnRenderer(due_columns, emptyTask);
+        verifyHtmlFromRenderer(renderer, State.Warm, query, emptyTask);
     });
 
     it('renders due date column', () => {
-        const allTasks = [new TaskBuilder().dueDate('2026-07-13').build()];
-
-        const { query, renderer } = makeColumnRenderer(due_columns, allTasks);
-        verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
+        const { query, renderer } = makeColumnRenderer(due_columns, withDue);
+        verifyHtmlFromRenderer(renderer, State.Warm, query, withDue);
     });
 
     it('renders due date column and scheduled date groups', () => {
-        const allTasks = [new TaskBuilder().dueDate('2026-06-23').scheduledDate('2025-12-01').build()];
-
-        const { query, renderer } = makeColumnRenderer(due_columns + '\ngroup by scheduled', allTasks);
-        verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
+        const { query, renderer } = makeColumnRenderer(due_columns + '\ngroup by scheduled', withDueAndScheduled);
+        verifyHtmlFromRenderer(renderer, State.Warm, query, withDueAndScheduled);
     });
 
     it('renders two priority columns', () => {
-        const allTasks = [
-            new TaskBuilder().priority(Priority.Highest).build(),
-            new TaskBuilder().priority(Priority.Low).build(),
-        ];
-
-        const { query, renderer } = makeColumnRenderer(priority_columns, allTasks);
-        verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
+        const { query, renderer } = makeColumnRenderer(priority_columns, twoPriorities);
+        verifyHtmlFromRenderer(renderer, State.Warm, query, twoPriorities);
     });
 });

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -1,0 +1,39 @@
+import moment from 'moment';
+import { GlobalQuery } from '../../src/Config/GlobalQuery';
+import { State } from '../../src/Obsidian/Cache';
+import { getQueryForQueryRenderer } from '../../src/Query/QueryRendererHelper';
+import { HtmlColumnQueryResultsRenderer } from '../../src/Renderer/HtmlColumnQueryResultsRenderer';
+import type { Task } from '../../src/Task/Task';
+import { mockApp } from '../__mocks__/obsidian';
+import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
+import { makeHtmlQueryRendererParameters, mockHTMLRenderer, verifyHtmlFromRenderer } from './RenderingTestHelpers';
+
+window.moment = moment;
+
+function makeColumnRenderer(source: string, allTasks: Task[]) {
+    const tasksFile = createTestTasksFile('query.md');
+    const query = getQueryForQueryRenderer(source, GlobalQuery.getInstance(), tasksFile);
+
+    const renderer = new HtmlColumnQueryResultsRenderer(
+        () => Promise.resolve(),
+        null,
+        mockApp,
+        mockHTMLRenderer,
+        makeHtmlQueryRendererParameters(allTasks),
+        source,
+        tasksFile,
+        query,
+    );
+    return { query, renderer };
+}
+
+describe('columns rendering', () => {
+    it('renders no due date column', () => {
+        const source = 'view columns by due\npreset hide_everything';
+        const allTasks = [new TaskBuilder().build()];
+
+        const { query, renderer } = makeColumnRenderer(source, allTasks);
+        verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
+    });
+});

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -53,28 +53,33 @@ describe('columns rendering', () => {
         new TaskBuilder().priority(Priority.Low).build(),
     ];
 
-    it('renders no search results', () => {
+    it('renders no search results', async () => {
         const { query, renderer } = makeColumnRenderer(due_columns, noTasks);
-        verifyHtmlFromRenderer(renderer, State.Warm, query, noTasks);
+        await verifyHtmlFromRenderer(renderer, State.Warm, query, noTasks);
     });
 
-    it('renders no due date column', () => {
+    it('renders no due date column', async () => {
         const { query, renderer } = makeColumnRenderer(due_columns, emptyTask);
-        verifyHtmlFromRenderer(renderer, State.Warm, query, emptyTask);
+        await verifyHtmlFromRenderer(renderer, State.Warm, query, emptyTask);
     });
 
-    it('renders due date column', () => {
+    it('renders due date column', async () => {
         const { query, renderer } = makeColumnRenderer(due_columns, withDue);
-        verifyHtmlFromRenderer(renderer, State.Warm, query, withDue);
+        await verifyHtmlFromRenderer(renderer, State.Warm, query, withDue);
     });
 
-    it('renders due date column and scheduled date groups', () => {
+    it('renders due date column and scheduled date groups', async () => {
         const { query, renderer } = makeColumnRenderer(due_columns + '\ngroup by scheduled', withDueAndScheduled);
-        verifyHtmlFromRenderer(renderer, State.Warm, query, withDueAndScheduled);
+        await verifyHtmlFromRenderer(renderer, State.Warm, query, withDueAndScheduled);
     });
 
-    it('renders two priority columns', () => {
+    it('renders two priority columns', async () => {
         const { query, renderer } = makeColumnRenderer(priority_columns, twoPriorities);
-        verifyHtmlFromRenderer(renderer, State.Warm, query, twoPriorities);
+        await verifyHtmlFromRenderer(renderer, State.Warm, query, twoPriorities);
+    });
+
+    it('renders one column with two headings', async () => {
+        const { query, renderer } = makeColumnRenderer(due_columns + '\ngroup by priority', twoPriorities);
+        await verifyHtmlFromRenderer(renderer, State.Warm, query, twoPriorities);
     });
 });

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -42,6 +42,13 @@ describe('columns rendering', () => {
     const due_columns = 'view columns by due\nhide backlink\nhide edit button';
     const priority_columns = 'view columns by priority\nhide backlink\nhide edit button';
 
+    it('renders no search results', () => {
+        const allTasks: Task[] = [];
+
+        const { query, renderer } = makeColumnRenderer(due_columns, allTasks);
+        verifyHtmlFromRenderer(renderer, State.Warm, query, allTasks);
+    });
+
     it('renders no due date column', () => {
         const allTasks = [new TaskBuilder().build()];
 

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.ts
@@ -3,7 +3,6 @@ import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { GlobalQuery } from '../../src/Config/GlobalQuery';
 import { resetSettings, updateSettings } from '../../src/Config/Settings';
 import { State } from '../../src/Obsidian/Cache';
-import type { Query } from '../../src/Query/Query';
 import { getQueryForQueryRenderer } from '../../src/Query/QueryRendererHelper';
 import { HtmlQueryResultsRenderer } from '../../src/Renderer/HtmlQueryResultsRenderer';
 import type { TasksFile } from '../../src/Scripting/TasksFile';
@@ -12,7 +11,13 @@ import { mockApp } from '../__mocks__/obsidian';
 import { readTasksFromSimulatedFile } from '../Obsidian/SimulatedFile';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
-import { makeHtmlQueryRendererParameters, mockHTMLRenderer, verifyRenderedTasks } from './RenderingTestHelpers';
+import {
+    makeHtmlQueryRendererParameters,
+    mockHTMLRenderer,
+    renderTasks,
+    verifyHtmlFromRenderer,
+    verifyRenderedTasks,
+} from './RenderingTestHelpers';
 
 window.moment = moment;
 
@@ -32,36 +37,10 @@ function makeHtmlRenderer(source: string, tasksFile: TasksFile, allTasks: Task[]
     return { query, renderer };
 }
 
-export async function verifyHtmlFromRenderer(
-    renderer: HtmlQueryResultsRenderer,
-    state: State,
-    query: Query,
-    allTasks: Task[],
-) {
-    const container = document.createElement('div');
-    renderer.content = container;
-    await renderer.renderQuery(state, query.applyQueryToTasks(allTasks));
-
-    verifyRenderedTasks(container, allTasks);
-}
-
 async function verifyRenderedHtml(allTasks: Task[], source: string, state: State = State.Warm) {
     const tasksFile = createTestTasksFile('query.md');
     const { query, renderer } = makeHtmlRenderer(source, tasksFile, allTasks);
     await verifyHtmlFromRenderer(renderer, state, query, allTasks);
-}
-
-async function renderTasks(
-    state: State,
-    renderer: HtmlQueryResultsRenderer,
-    allTasks: Task[],
-    query: Query,
-): Promise<HTMLDivElement> {
-    const container = document.createElement('div');
-
-    renderer.content = container;
-    await renderer.renderQuery(state, query.applyQueryToTasks(allTasks));
-    return container;
 }
 
 beforeEach(() => {

--- a/tests/Renderer/HtmlQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlQueryResultsRenderer.test.ts
@@ -32,15 +32,23 @@ function makeHtmlRenderer(source: string, tasksFile: TasksFile, allTasks: Task[]
     return { query, renderer };
 }
 
-async function verifyRenderedHtml(allTasks: Task[], source: string, state: State = State.Warm) {
-    const tasksFile = createTestTasksFile('query.md');
-    const { query, renderer } = makeHtmlRenderer(source, tasksFile, allTasks);
-
+export async function verifyHtmlFromRenderer(
+    renderer: HtmlQueryResultsRenderer,
+    state: State,
+    query: Query,
+    allTasks: Task[],
+) {
     const container = document.createElement('div');
     renderer.content = container;
     await renderer.renderQuery(state, query.applyQueryToTasks(allTasks));
 
     verifyRenderedTasks(container, allTasks);
+}
+
+async function verifyRenderedHtml(allTasks: Task[], source: string, state: State = State.Warm) {
+    const tasksFile = createTestTasksFile('query.md');
+    const { query, renderer } = makeHtmlRenderer(source, tasksFile, allTasks);
+    await verifyHtmlFromRenderer(renderer, state, query, allTasks);
 }
 
 async function renderTasks(

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_-_rendering_queries_should_render_columns_view.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_-_rendering_queries_should_render_columns_view.approved.html
@@ -11,52 +11,56 @@
     <button test-icon="lucide-copy" test-tooltip="Copy results"></button>
   </div>
   <div class="tasks-columns">
-    <h4 class="tasks-group-heading">For test purposes: first</h4>
-    <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-      <li
-        class="task-list-item plugin-tasks-list-item"
-        data-task-priority="normal"
-        data-task=""
-        data-line="0"
-        data-task-status-name="Todo"
-        data-task-status-type="TODO">
-        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
-        <span class="tasks-list-text">
-          <span class="task-description"><span>first</span></span>
-        </span>
-        <span class="task-extras">
-          <span class="tasks-backlink">
-            (
-            <a rel="noopener" target="_blank" class="internal-link">/</a>
-            )
+    <div class="tasks-columns-column">
+      <h4 class="tasks-group-heading">For test purposes: first</h4>
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="normal"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>first</span></span>
           </span>
-          <a class="tasks-edit" title="Edit task" href="#"></a>
-        </span>
-      </li>
-    </ul>
-    <h4 class="tasks-group-heading">For test purposes: second</h4>
-    <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
-      <li
-        class="task-list-item plugin-tasks-list-item"
-        data-task-priority="normal"
-        data-task=""
-        data-line="0"
-        data-task-status-name="Todo"
-        data-task-status-type="TODO">
-        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
-        <span class="tasks-list-text">
-          <span class="task-description"><span>second</span></span>
-        </span>
-        <span class="task-extras">
-          <span class="tasks-backlink">
-            (
-            <a rel="noopener" target="_blank" class="internal-link">/</a>
-            )
+          <span class="task-extras">
+            <span class="tasks-backlink">
+              (
+              <a rel="noopener" target="_blank" class="internal-link">/</a>
+              )
+            </span>
+            <a class="tasks-edit" title="Edit task" href="#"></a>
           </span>
-          <a class="tasks-edit" title="Edit task" href="#"></a>
-        </span>
-      </li>
-    </ul>
+        </li>
+      </ul>
+    </div>
+    <div class="tasks-columns-column">
+      <h4 class="tasks-group-heading">For test purposes: second</h4>
+      <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+        <li
+          class="task-list-item plugin-tasks-list-item"
+          data-task-priority="normal"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>second</span></span>
+          </span>
+          <span class="task-extras">
+            <span class="tasks-backlink">
+              (
+              <a rel="noopener" target="_blank" class="internal-link">/</a>
+              )
+            </span>
+            <a class="tasks-edit" title="Edit task" href="#"></a>
+          </span>
+        </li>
+      </ul>
+    </div>
   </div>
   <div class="task-count">2 tasks</div>
 </div>

--- a/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_-_rendering_queries_should_render_columns_view.approved.html
+++ b/tests/Renderer/QueryResultsRenderer.test.QueryResultsRenderer_-_rendering_queries_should_render_columns_view.approved.html
@@ -1,0 +1,62 @@
+<!--
+- [ ] first
+- [ ] second
+-->
+
+<div>
+  <div class="plugin-tasks-toolbar">
+    <label test-icon="lucide-filter">
+      <input placeholder="Filter by description..." test-tooltip="Filter results" />
+    </label>
+    <button test-icon="lucide-copy" test-tooltip="Copy results"></button>
+  </div>
+  <div class="tasks-columns">
+    <h4 class="tasks-group-heading">For test purposes: first</h4>
+    <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+      <li
+        class="task-list-item plugin-tasks-list-item"
+        data-task-priority="normal"
+        data-task=""
+        data-line="0"
+        data-task-status-name="Todo"
+        data-task-status-type="TODO">
+        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+        <span class="tasks-list-text">
+          <span class="task-description"><span>first</span></span>
+        </span>
+        <span class="task-extras">
+          <span class="tasks-backlink">
+            (
+            <a rel="noopener" target="_blank" class="internal-link">/</a>
+            )
+          </span>
+          <a class="tasks-edit" title="Edit task" href="#"></a>
+        </span>
+      </li>
+    </ul>
+    <h4 class="tasks-group-heading">For test purposes: second</h4>
+    <ul class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency">
+      <li
+        class="task-list-item plugin-tasks-list-item"
+        data-task-priority="normal"
+        data-task=""
+        data-line="0"
+        data-task-status-name="Todo"
+        data-task-status-type="TODO">
+        <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+        <span class="tasks-list-text">
+          <span class="task-description"><span>second</span></span>
+        </span>
+        <span class="task-extras">
+          <span class="tasks-backlink">
+            (
+            <a rel="noopener" target="_blank" class="internal-link">/</a>
+            )
+          </span>
+          <a class="tasks-edit" title="Edit task" href="#"></a>
+        </span>
+      </li>
+    </ul>
+  </div>
+  <div class="task-count">2 tasks</div>
+</div>

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -140,6 +140,16 @@ describe('QueryResultsRenderer - rendering queries', () => {
 
         await verifyRenderedHtml(twoTasks, source);
     });
+
+    it('should render columns view', async () => {
+        const source = 'view columns by function task.description';
+        const twoTasks: Task[] = [
+            new TaskBuilder().description('first').build(),
+            new TaskBuilder().description('second').build(),
+        ];
+
+        await verifyRenderedHtml(twoTasks, source);
+    });
 });
 
 describe('QueryResultsRenderer - responding to file edits', () => {

--- a/tests/Renderer/QueryResultsRenderer.test.ts
+++ b/tests/Renderer/QueryResultsRenderer.test.ts
@@ -50,13 +50,13 @@ function makeQueryResultsRenderer(source: string, tasksFile: TasksFile, allTasks
     return queryResultsRenderer;
 }
 
-async function verifyRenderedHtml(allTasks: Task[], source: string, state: State = State.Warm): Promise<void> {
+async function verifyRenderedHtml(allTasks: Task[], source: string, state: State = State.Warm): Promise<string> {
     const renderer = makeQueryResultsRenderer(source, createTestTasksFile('file.md'), allTasks);
     const container = document.createElement('div');
 
     await renderer.render(state, allTasks, container);
 
-    verifyRenderedTasks(container, allTasks);
+    return verifyRenderedTasks(container, allTasks);
 }
 
 describe('QueryResultsRenderer - accessing results', () => {
@@ -148,7 +148,8 @@ describe('QueryResultsRenderer - rendering queries', () => {
             new TaskBuilder().description('second').build(),
         ];
 
-        await verifyRenderedHtml(twoTasks, source);
+        const html = await verifyRenderedHtml(twoTasks, source);
+        expect(html).toContain('<div class="tasks-columns">');
     });
 });
 

--- a/tests/Renderer/RenderingTestHelpers.ts
+++ b/tests/Renderer/RenderingTestHelpers.ts
@@ -86,9 +86,10 @@ export async function verifyHtmlFromRenderer(
     verifyRenderedTasks(container, allTasks);
 }
 
-export function verifyRenderedTasks(container: HTMLDivElement, allTasks: Task[]): void {
+export function verifyRenderedTasks(container: HTMLDivElement, allTasks: Task[]): string {
     const { tasksAsMarkdown, prettyHTML } = tasksMarkdownAndPrettifiedHtml(container, allTasks);
     verifyWithFileExtension(tasksAsMarkdown + prettyHTML, 'html');
+    return prettyHTML;
 }
 
 export async function renderTasks(

--- a/tests/Renderer/RenderingTestHelpers.ts
+++ b/tests/Renderer/RenderingTestHelpers.ts
@@ -2,13 +2,16 @@ import type { App } from 'obsidian';
 import { State } from '../../src/Obsidian/Cache';
 import type { FilterOrErrorMessage } from '../../src/Query/Filter/FilterOrErrorMessage';
 import { Query } from '../../src/Query/Query';
-import type { HTMLQueryRendererParameters } from '../../src/Renderer/HtmlQueryResultsRenderer';
+import type {
+    HTMLQueryRendererParameters,
+    HtmlQueryResultsRenderer,
+} from '../../src/Renderer/HtmlQueryResultsRenderer';
 import { MarkdownQueryResultsRenderer } from '../../src/Renderer/MarkdownQueryResultsRenderer';
 import type { Task } from '../../src/Task/Task';
 import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
 import { prettifyHTML } from '../TestingTools/HTMLHelpers';
-import { toMarkdown } from '../TestingTools/TestHelpers';
 import { createTestTasksFile } from '../TestingTools/TasksFileHelpers';
+import { toMarkdown } from '../TestingTools/TestHelpers';
 
 export const mockHTMLRenderer = async (_obsidianApp: App, text: string, element: HTMLSpanElement, _path: string) => {
     // Contrary to the default mockTextRenderer(),
@@ -70,7 +73,33 @@ ${toMarkdown(allTasks)}
     return { tasksAsMarkdown, prettyHTML };
 }
 
+export async function verifyHtmlFromRenderer(
+    renderer: HtmlQueryResultsRenderer,
+    state: State,
+    query: Query,
+    allTasks: Task[],
+) {
+    const container = document.createElement('div');
+    renderer.content = container;
+    await renderer.renderQuery(state, query.applyQueryToTasks(allTasks));
+
+    verifyRenderedTasks(container, allTasks);
+}
+
 export function verifyRenderedTasks(container: HTMLDivElement, allTasks: Task[]): void {
     const { tasksAsMarkdown, prettyHTML } = tasksMarkdownAndPrettifiedHtml(container, allTasks);
     verifyWithFileExtension(tasksAsMarkdown + prettyHTML, 'html');
+}
+
+export async function renderTasks(
+    state: State,
+    renderer: HtmlQueryResultsRenderer,
+    allTasks: Task[],
+    query: Query,
+): Promise<HTMLDivElement> {
+    const container = document.createElement('div');
+
+    renderer.content = container;
+    await renderer.renderQuery(state, query.applyQueryToTasks(allTasks));
+    return container;
 }


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/472

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

- teach rendering to support `view columns by...`
- think of it as converting any `group by ...` instruction to `view columns by ...`, in order to create a column for each of the group values
- note that the current display is static: drag and drop of tasks between columns is not yet implemented.

## Motivation and Context

- https://github.com/obsidian-tasks-group/obsidian-tasks/discussions/472

## How has this been tested?

- unit tests
- exploratory tests

## Screenshots (if appropriate)

### One column for each root directory

```text
view columns by root
```

<img width="880" height="662" alt="image" src="https://github.com/user-attachments/assets/ff6e921e-bc02-42fd-9973-a2af35e2aae2" />



### Separate columns for each priority - contents grouped by tag

```text
view columns by priority
group by tags
short mode
```

<img width="1066" height="461" alt="image" src="https://github.com/user-attachments/assets/1be7054f-1a65-499b-9ce5-5062ff784c84" />


## Checklist

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
  - CSS classes behaviour is not covered by tests

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
