### PR TITLE
fix: stop regex searches freezing Obsidian by catastrophic backtracking

### DIFF
--- a/docs/Queries/Regular Expressions.md
+++ b/docs/Queries/Regular Expressions.md
@@ -150,6 +150,9 @@ Implementation details:
 Please be aware of the following limitations in Tasks' implementation of regular expression searching:
 
 - [Lookahead and Lookbehind](https://www.regular-expressions.info/lookaround.html) searches are untested, and are presumed not to work on Apple mobile devices, or to cause serious performance problems with slow searches.
+- Since Tasks X.Y.Z:
+  - the maximum allowed length of regular expression search strings is now 500 characters.
+  - code has been added to prevent malicious searches (accidental or intentional) from freezing Obsidian by [Catastrophic Backtracking](https://www.regular-expressions.info/catastrophic.html).
 
 ## Regular expression examples
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -166,6 +166,14 @@ MIT License
 
 Copyright (c) 2022 Elias Mangoro
 */
+
+/*
+License safe-regex2 (included library):
+
+MIT License
+
+Copyright (c) 2019-present The Fastify team <https://github.com/fastify/fastify#team>
+*/
 `;
 
 const prod = process.argv[2] === 'production';

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "i18next": "^24.2.1",
     "mustache": "^4.2.0",
     "mustache-validator": "^0.2.0",
-    "rrule": "^2.8.1"
+    "rrule": "^2.8.1",
+    "safe-regex2": "^5.1.1"
   }
 }

--- a/src/Query/Matchers/RegexMatcher.ts
+++ b/src/Query/Matchers/RegexMatcher.ts
@@ -1,3 +1,4 @@
+import { validateRegExpSafety } from '../../lib/RegExpTools';
 import { Explanation } from '../Explain/Explanation';
 import { IStringMatcher } from './IStringMatcher';
 
@@ -36,7 +37,13 @@ export class RegexMatcher extends IStringMatcher {
         const query = regexInput.match(regexPattern);
 
         if (query !== null) {
+            // Validate syntax first so that genuine SyntaxErrors (e.g. unterminated groups)
+            // are reported before the safety check, which can misclassify malformed patterns.
             const regExp = new RegExp(query[1], query[2]);
+            const safetyError = validateRegExpSafety(query[1]);
+            if (safetyError !== null) {
+                throw new SyntaxError(safetyError);
+            }
             return new RegexMatcher(regExp);
         } else {
             return null;
@@ -74,6 +81,9 @@ to find them literally, you must add a \ before them:
 CAUTION! Regular expression (or 'regex') searching is a powerful
 but advanced feature that requires thorough knowledge in order to
 use successfully, and not miss intended search results.
+
+Patterns with nested quantifiers (e.g. (a+)+) are rejected because
+they can cause extreme slowdowns (catastrophic backtracking).
 `;
     }
 

--- a/src/Query/Matchers/RegexMatcher.ts
+++ b/src/Query/Matchers/RegexMatcher.ts
@@ -82,8 +82,8 @@ CAUTION! Regular expression (or 'regex') searching is a powerful
 but advanced feature that requires thorough knowledge in order to
 use successfully, and not miss intended search results.
 
-Patterns with nested quantifiers (e.g. (a+)+) are rejected because
-they can cause extreme slowdowns (catastrophic backtracking).
+Patterns with nested quantifiers (for example (a+)+) are rejected
+because they can cause extreme slowdowns (catastrophic backtracking).
 `;
     }
 

--- a/src/lib/RegExpTools.ts
+++ b/src/lib/RegExpTools.ts
@@ -1,3 +1,31 @@
+import safe from 'safe-regex2';
+
+const MAX_REGEX_PATTERN_LENGTH = 500;
+
+/**
+ * Check whether a regular expression pattern is safe from catastrophic backtracking (ReDoS).
+ *
+ * Uses the {@link https://github.com/fastify/safe-regex2 | safe-regex2} library to detect
+ * patterns with a star height greater than 1 (nested quantifiers such as `(a+)+`),
+ * which can cause exponential matching time against certain inputs.
+ *
+ * Also enforces a maximum pattern length as defense-in-depth.
+ *
+ * @param pattern - The regex source string (without surrounding slashes or flags).
+ * @returns `null` if the pattern is safe, or a string describing the problem if it is unsafe.
+ */
+export function validateRegExpSafety(pattern: string): string | null {
+    if (pattern.length > MAX_REGEX_PATTERN_LENGTH) {
+        return `Regular expression pattern is too long (${pattern.length} characters, maximum ${MAX_REGEX_PATTERN_LENGTH}).`;
+    }
+
+    if (!safe(pattern, { limit: 25 })) {
+        return 'Regular expression may cause performance problems (possible catastrophic backtracking detected).';
+    }
+
+    return null;
+}
+
 /**
  * Escape a string so it can be used as part of a RegExp literally.
  * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping

--- a/src/lib/RegExpTools.ts
+++ b/src/lib/RegExpTools.ts
@@ -20,7 +20,7 @@ export function validateRegExpSafety(pattern: string): string | null {
     }
 
     if (!safe(pattern, { limit: 25 })) {
-        return 'Regular expression may cause performance problems (possible catastrophic backtracking detected).';
+        return `Regular expression /${pattern}/ may cause performance problems (possible catastrophic backtracking detected).`;
     }
 
     return null;

--- a/tests/Query/Filter/TextField.test.ts
+++ b/tests/Query/Filter/TextField.test.ts
@@ -38,8 +38,8 @@ CAUTION! Regular expression (or 'regex') searching is a powerful
 but advanced feature that requires thorough knowledge in order to
 use successfully, and not miss intended search results.
 
-Patterns with nested quantifiers (e.g. (a+)+) are rejected because
-they can cause extreme slowdowns (catastrophic backtracking).
+Patterns with nested quantifiers (for example (a+)+) are rejected
+because they can cause extreme slowdowns (catastrophic backtracking).
 `,
         );
     });

--- a/tests/Query/Filter/TextField.test.ts
+++ b/tests/Query/Filter/TextField.test.ts
@@ -37,6 +37,9 @@ to find them literally, you must add a \ before them:
 CAUTION! Regular expression (or 'regex') searching is a powerful
 but advanced feature that requires thorough knowledge in order to
 use successfully, and not miss intended search results.
+
+Patterns with nested quantifiers (e.g. (a+)+) are rejected because
+they can cause extreme slowdowns (catastrophic backtracking).
 `,
         );
     });
@@ -52,6 +55,32 @@ describe('explains regular sub-string searches', () => {
     it('should explain simple string search, preserving instruction case', () => {
         const field = new DescriptionField().createFilterOrErrorMessage('description INCLUDES hello');
         expect(field).toHaveExplanation('description INCLUDES hello');
+    });
+});
+
+describe('should reject unsafe regular expressions', () => {
+    it('should report catastrophic backtracking pattern', () => {
+        const instruction = 'description regex matches /(a+)+$/';
+        const filterOrError = new DescriptionField().createFilterOrErrorMessage(instruction);
+        expect(filterOrError).not.toBeValid();
+        expect(filterOrError.error).toContain('catastrophic backtracking');
+    });
+
+    it.each([
+        ['description regex matches /(a+)+$/'],
+        ['description regex matches /(x+x+)+y/'],
+        ['description regex matches /(.*)*$/'],
+        ['description regex does not match /(a+)+b/'],
+    ])('should reject unsafe pattern in filter: %s', (instruction: string) => {
+        const filterOrError = new DescriptionField().createFilterOrErrorMessage(instruction);
+        expect(filterOrError).not.toBeValid();
+        expect(filterOrError.error).toContain('catastrophic backtracking');
+    });
+
+    it('should still accept safe regex patterns', () => {
+        const instruction = 'description regex matches /waiting|waits|wartet/i';
+        const filterOrError = new DescriptionField().createFilterOrErrorMessage(instruction);
+        expect(filterOrError).toBeValid();
     });
 });
 

--- a/tests/Query/Matchers/RegexMatcher.test.ts
+++ b/tests/Query/Matchers/RegexMatcher.test.ts
@@ -97,4 +97,41 @@ describe('RegexMatcher ReDoS protection', () => {
             'Regular expression /(a+)+$/ rejected because it may be vulnerable to catastrophic backtracking.',
         );
     });
+
+    it.each([
+        ['/(a+)+$/'],
+        ['/(a+)+b/'],
+        // Note: /(a|a)*$/ is a known false negative in safe-regex2 (not detected)
+        ['/(.*)*$/'],
+        ['/(a+){10}/'],
+        ['/(x+x+)+y/'],
+    ])('should reject unsafe pattern: %s', (pattern: string) => {
+        const t = () => {
+            RegexMatcher.validateAndConstruct(pattern);
+        };
+        // TODO it.each() does not support .failing
+        //      Remove the '.not' once the check is implemented.
+        expect(t).not.toThrow(Error);
+        expect(t).not.toThrowError('catastrophic backtracking');
+    });
+
+    it.each([
+        ['/hello world/i'],
+        [String.raw`/\d\d:\d\d/`],
+        ['/(beep|boop)*/'],
+        ['/waiting|waits|wartet/i'],
+        ['/^Log/i'],
+    ])('should accept safe pattern: %s', (pattern: string) => {
+        const matcher = RegexMatcher.validateAndConstruct(pattern);
+        expect(matcher).not.toBeNull();
+    });
+
+    it.failing('should reject patterns exceeding the maximum length', () => {
+        const longPattern = '/' + 'a'.repeat(501) + '/';
+        const t = () => {
+            RegexMatcher.validateAndConstruct(longPattern);
+        };
+        expect(t).toThrow(Error);
+        expect(t).toThrowError('too long');
+    });
 });

--- a/tests/Query/Matchers/RegexMatcher.test.ts
+++ b/tests/Query/Matchers/RegexMatcher.test.ts
@@ -87,14 +87,14 @@ describe('RegexMatcher flags', () => {
 });
 
 describe('RegexMatcher ReDoS protection', () => {
-    it.failing('should reject regex vulnerable to catastrophic backtracking (ReDoS)', () => {
+    it('should reject regex vulnerable to catastrophic backtracking (ReDoS)', () => {
         // Issue #3944
         const t = () => {
             RegexMatcher.validateAndConstruct('/(a+)+$/');
         };
         expect(t).toThrow(SyntaxError);
         expect(t).toThrowError(
-            'Regular expression /(a+)+$/ rejected because it may be vulnerable to catastrophic backtracking.',
+            'Regular expression may cause performance problems (possible catastrophic backtracking detected',
         );
     });
 
@@ -109,10 +109,8 @@ describe('RegexMatcher ReDoS protection', () => {
         const t = () => {
             RegexMatcher.validateAndConstruct(pattern);
         };
-        // TODO it.each() does not support .failing
-        //      Remove the '.not' once the check is implemented.
-        expect(t).not.toThrow(Error);
-        expect(t).not.toThrowError('catastrophic backtracking');
+        expect(t).toThrow(Error);
+        expect(t).toThrowError('catastrophic backtracking');
     });
 
     it.each([
@@ -126,7 +124,7 @@ describe('RegexMatcher ReDoS protection', () => {
         expect(matcher).not.toBeNull();
     });
 
-    it.failing('should reject patterns exceeding the maximum length', () => {
+    it('should reject patterns exceeding the maximum length', () => {
         const longPattern = '/' + 'a'.repeat(501) + '/';
         const t = () => {
             RegexMatcher.validateAndConstruct(longPattern);

--- a/tests/Query/Matchers/RegexMatcher.test.ts
+++ b/tests/Query/Matchers/RegexMatcher.test.ts
@@ -85,3 +85,16 @@ describe('RegexMatcher flags', () => {
         expect(t).toThrowError("Invalid flags supplied to RegExp constructor 'ii'");
     });
 });
+
+describe('RegexMatcher ReDoS protection', () => {
+    it.failing('should reject regex vulnerable to catastrophic backtracking (ReDoS)', () => {
+        // Issue #3944
+        const t = () => {
+            RegexMatcher.validateAndConstruct('/(a+)+$/');
+        };
+        expect(t).toThrow(SyntaxError);
+        expect(t).toThrowError(
+            'Regular expression /(a+)+$/ rejected because it may be vulnerable to catastrophic backtracking.',
+        );
+    });
+});

--- a/tests/Query/Matchers/RegexMatcher.test.ts
+++ b/tests/Query/Matchers/RegexMatcher.test.ts
@@ -94,7 +94,7 @@ describe('RegexMatcher ReDoS protection', () => {
         };
         expect(t).toThrow(SyntaxError);
         expect(t).toThrowError(
-            'Regular expression may cause performance problems (possible catastrophic backtracking detected',
+            'Regular expression /(a+)+$/ may cause performance problems (possible catastrophic backtracking detected)',
         );
     });
 

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -669,8 +669,8 @@ CAUTION! Regular expression (or 'regex') searching is a powerful
 but advanced feature that requires thorough knowledge in order to
 use successfully, and not miss intended search results.
 
-Patterns with nested quantifiers (e.g. (a+)+) are rejected because
-they can cause extreme slowdowns (catastrophic backtracking).
+Patterns with nested quantifiers (for example (a+)+) are rejected
+because they can cause extreme slowdowns (catastrophic backtracking).
 
 Problem line: "${source}"`,
             );

--- a/tests/Query/Query.test.ts
+++ b/tests/Query/Query.test.ts
@@ -669,6 +669,9 @@ CAUTION! Regular expression (or 'regex') searching is a powerful
 but advanced feature that requires thorough knowledge in order to
 use successfully, and not miss intended search results.
 
+Patterns with nested quantifiers (e.g. (a+)+) are rejected because
+they can cause extreme slowdowns (catastrophic backtracking).
+
 Problem line: "${source}"`,
             );
         });

--- a/tests/lib/RegExpTools.test.ts
+++ b/tests/lib/RegExpTools.test.ts
@@ -1,4 +1,4 @@
-import { checkRegExpsIdentical } from '../../src/lib/RegExpTools';
+import { checkRegExpsIdentical, validateRegExpSafety } from '../../src/lib/RegExpTools';
 
 describe('regular expression equality', () => {
     it('should recognise identical regular expressions', () => {
@@ -17,5 +17,45 @@ describe('regular expression equality', () => {
             checkRegExpsIdentical(/ABC/, /ABC/g);
         };
         expect(t).toThrow(Error);
+    });
+});
+
+describe('validateRegExpSafety', () => {
+    it.each([
+        ['hello world'],
+        [String.raw`\d\d:\d\d`],
+        ['(beep|boop)*'],
+        [String.raw`\blocation\s*:[^:\n]+\b(Oakland|San Francisco)\b`],
+        ['^Log'],
+        ['waiting|waits|wartet'],
+        [String.raw`#tag\/subtag[0-9]\/subsubtag[0-9]`],
+        [String.raw`[⏫🔼🔽📅⏳🛫🔁]`],
+    ])('should accept safe pattern: %s', (pattern: string) => {
+        expect(validateRegExpSafety(pattern)).toBeNull();
+    });
+
+    it.each([
+        ['(a+)+$', 'catastrophic backtracking'],
+        ['(a+)+b', 'catastrophic backtracking'],
+        // Note: (a|a)*$ is a known false negative in safe-regex2 (not detected)
+        ['(.*)*', 'catastrophic backtracking'],
+        ['(a+){10}', 'catastrophic backtracking'],
+        ['(x+x+)+y', 'catastrophic backtracking'],
+    ])('should reject unsafe pattern: %s (%s)', (pattern: string, _reason: string) => {
+        const result = validateRegExpSafety(pattern);
+        expect(result).not.toBeNull();
+        expect(result).toContain('catastrophic backtracking');
+    });
+
+    it('should reject patterns exceeding the maximum length', () => {
+        const longPattern = 'a'.repeat(501);
+        const result = validateRegExpSafety(longPattern);
+        expect(result).not.toBeNull();
+        expect(result).toContain('too long');
+    });
+
+    it('should accept patterns at exactly the maximum length', () => {
+        const pattern = 'a'.repeat(500);
+        expect(validateRegExpSafety(pattern)).toBeNull();
     });
 });

--- a/tests/lib/RegExpTools.test.ts
+++ b/tests/lib/RegExpTools.test.ts
@@ -47,6 +47,15 @@ describe('validateRegExpSafety', () => {
         expect(result).toContain('catastrophic backtracking');
     });
 
+    it.failing('should reject unsafe pattern, but safe-regex2 does not detect it ', () => {
+        // If this starts passing after a future update to safe-regex2:
+        // 1. Activate this pattern in the 'known false negative' comment above
+        // 2. Delete this test.
+        const result = validateRegExpSafety('(a|a)*$');
+        expect(result).not.toBeNull();
+        expect(result).toContain('catastrophic backtracking');
+    });
+
     it('should reject patterns exceeding the maximum length', () => {
         const longPattern = 'a'.repeat(501);
         const result = validateRegExpSafety(longPattern);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7864,6 +7864,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+ret@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.5.0.tgz#30a4d38a7e704bd96dc5ffcbe7ce2a9274c41c95"
+  integrity sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -7993,6 +7998,13 @@ safe-regex-test@^1.1.0:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-regex "^1.2.1"
+
+safe-regex2@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-regex2/-/safe-regex2-5.1.1.tgz#a5f3a6e35b8d84d0f41fa22efd5b6d30b367bbc7"
+  integrity sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==
+  dependencies:
+    ret "~0.5.0"
 
 safe-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
# Types of changes


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3944

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Fix #3944:  Regex "regex matches" filter is vulnerable to catastrophic backtracking (ReDoS), can freeze Obsidian

**Credit: almost all this code was written by @saberzero1, to whom, huge thanks.**

I took his code and divided it in to smaller commits (with initial failing test), refined the error message during exploratory testing, and added the new dependency to released plugin.


Note, from the tests, which patterns this is known to detect, and one (commented-out) that it does not:

```ts
        ['(a+)+$', 'catastrophic backtracking'],
        ['(a+)+b', 'catastrophic backtracking'],
        // Note: (a|a)*$ is a known false negative in safe-regex2 (not detected)
        ['(.*)*', 'catastrophic backtracking'],
        ['(a+){10}', 'catastrophic backtracking'],
        ['(x+x+)+y', 'catastrophic backtracking'],
```

## Motivation and Context

Fixes #3944.

The example in the 'Steps to reproduce' of the bug report now gives this output:

```text
Error: Parsing regular expression.
The error message was:
    "SyntaxError: Regular expression /(a+)+$/ may cause performance problems (possible catastrophic backtracking detected)."

See https://publish.obsidian.md/tasks/Queries/Regular+Expressions

Regular expressions must look like this:
    /pattern/
or this:
    /pattern/flags

Where:
- pattern: The 'regular expression' pattern to search for.
- flags:   Optional characters that modify the search.
           i => make the search case-insensitive
           u => add Unicode support

Examples:  /^Log/
           /^Log/i
           /File Name\.md/
           /waiting|waits|waited/i
           /\d\d:\d\d/

The following characters have special meaning in the pattern:
to find them literally, you must add a \ before them:
    [\^$.|?*+()

CAUTION! Regular expression (or 'regex') searching is a powerful
but advanced feature that requires thorough knowledge in order to
use successfully, and not miss intended search results.

Patterns with nested quantifiers (for example (a+)+) are rejected
because they can cause extreme slowdowns (catastrophic backtracking).

Problem line: "description regex matches /(a+)+$/"
```

## How has this been tested?

- New automated tests, including an initial failing test to verify the initial behaviour
- Exploratory testing
- Confirmed that the pattern in the original bug report is found.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
