### PR TITLE
chore(deps-dev): downgrade @evilmartians/lefthook from 2.1.10 back down to 1.7.2 (#3952)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@codemirror/view": "^6.2.0",
     "@eslint/js": "^8.57.0",
     "@eslint/json": "0.14.0",
-    "@evilmartians/lefthook": "^2.1.10",
+    "@evilmartians/lefthook": "^1.7.2",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/svelte": "^3.2.2",
     "@tsconfig/svelte": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,10 +867,10 @@
     "@eslint/core" "^1.2.1"
     levn "^0.4.1"
 
-"@evilmartians/lefthook@^2.1.10":
-  version "2.1.10"
-  resolved "https://registry.yarnpkg.com/@evilmartians/lefthook/-/lefthook-2.1.10.tgz#3fcedfea7b9955f42b464bb3534df6280cb8bcec"
-  integrity sha512-l5tiHiPQQdFE27g8j8Y1fgvGP9jiIxaxU3Bejq845hJn3M1OT2+QwjB/oqIIb7px2cTxUqFndTCSxK+HPY40rg==
+"@evilmartians/lefthook@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@evilmartians/lefthook/-/lefthook-1.7.2.tgz#5904a6f0f7be9059ec9abdb955cf227e088adc0f"
+  integrity sha512-h3oY73g8kwJ/W3mZdmwXW15htAyKFlUnfMDhS8JAUYzAW3MKqkw3LXCHP3BV06On8/PYUgN1NOJQjYeaEuRUeA==
 
 "@floating-ui/core@^1.7.5":
   version "1.7.5"


### PR DESCRIPTION


# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

This reverts commit 0bf8466573c110fb62cec541899fd4c888d95080 from PR #3886.

The previous change prevented me from committing edits to Markdown on my Mac.

## Motivation and Context

Fixes #3952:

- #3952

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
