### PR TITLE
feat: Update SettingsTab to use Obsidian 1.13's `getSettingDefinitions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "madge": "^8.0.0",
     "markdownlint-cli2": "^0.22.1",
     "moment": "^2.29.4",
-    "obsidian": "1.8.7",
+    "obsidian": "1.13.1",
     "obsidian-typings": "^2.11.1",
     "prettier": "^2.8.8",
     "prettier-plugin-svelte": "^2.10.1",

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -1,4 +1,4 @@
-import { Modal, Notice, Setting, TextComponent } from 'obsidian';
+import { ButtonComponent, Modal, Notice, Setting, TextComponent } from 'obsidian';
 import type { Plugin } from 'obsidian';
 import { StatusConfiguration, StatusType } from '../Statuses/StatusConfiguration';
 import { StatusValidator } from '../Statuses/StatusValidator';
@@ -19,6 +19,11 @@ export class CustomStatusModal extends Modal {
     private isCoreStatus: boolean;
     constructor(public plugin: Plugin, statusType: StatusConfiguration, isCoreStatus: boolean) {
         super(plugin.app);
+        this.setTitle(
+            isCoreStatus
+                ? i18n.t('modals.customStatusModal.title.editCoreStatus')
+                : i18n.t('modals.customStatusModal.title.editCustomStatus'),
+        );
         this.statusSymbol = statusType.symbol;
         this.statusName = statusType.name;
         this.statusNextSymbol = statusType.nextStatusSymbol;
@@ -131,33 +136,24 @@ export class CustomStatusModal extends Modal {
                 });
         }
 
-        const footerEl = contentEl.createDiv();
-        const footerButtons = new Setting(footerEl);
-        footerButtons.addButton((b) => {
-            b.setTooltip('Save')
-                .setIcon('checkmark')
-                .onClick(async () => {
-                    const errors = validator.validate(this.statusConfiguration());
-                    if (errors.length > 0) {
-                        const message =
-                            errors.join('\n') + '\n\n' + i18n.t('modals.customStatusModal.fixErrorsBeforeSaving');
-                        // console.debug(message);
-                        new Notice(message);
-                        return;
-                    }
-                    this.saved = true;
-                    this.close();
-                });
-            return b;
-        });
-        footerButtons.addExtraButton((b) => {
-            b.setIcon('cross')
-                .setTooltip('Cancel')
-                .onClick(() => {
-                    this.saved = false;
-                    this.close();
-                });
-            return b;
+        const buttonContainerEl = contentEl.createDiv({ cls: 'modal-button-container' });
+        new ButtonComponent(buttonContainerEl)
+            .setButtonText(i18n.t('common.save'))
+            .setCta()
+            .onClick(() => {
+                const errors = validator.validate(this.statusConfiguration());
+                if (errors.length > 0) {
+                    const message =
+                        errors.join('\n') + '\n\n' + i18n.t('modals.customStatusModal.fixErrorsBeforeSaving');
+                    new Notice(message);
+                    return;
+                }
+                this.saved = true;
+                this.close();
+            });
+        new ButtonComponent(buttonContainerEl).setButtonText(i18n.t('common.cancel')).onClick(() => {
+            this.saved = false;
+            this.close();
         });
     }
 

--- a/src/Config/CustomStatusModal.ts
+++ b/src/Config/CustomStatusModal.ts
@@ -137,6 +137,10 @@ export class CustomStatusModal extends Modal {
         }
 
         const buttonContainerEl = contentEl.createDiv({ cls: 'modal-button-container' });
+        new ButtonComponent(buttonContainerEl).setButtonText(i18n.t('common.cancel')).onClick(() => {
+            this.saved = false;
+            this.close();
+        });
         new ButtonComponent(buttonContainerEl)
             .setButtonText(i18n.t('common.save'))
             .setCta()
@@ -151,10 +155,6 @@ export class CustomStatusModal extends Modal {
                 this.saved = true;
                 this.close();
             });
-        new ButtonComponent(buttonContainerEl).setButtonText(i18n.t('common.cancel')).onClick(() => {
-            this.saved = false;
-            this.close();
-        });
     }
 
     // updateTitle(admonitionPreview: HTMLElement, title: string) {

--- a/src/Config/GlobalQueryModal.ts
+++ b/src/Config/GlobalQueryModal.ts
@@ -12,7 +12,7 @@ export class GlobalQueryModal extends Modal {
 
     constructor(app: App, initial: string, private readonly onSave: (value: string) => void) {
         super(app);
-        this.modalEl.addClass('mod-lg');
+        this.modalEl.addClass('mod-lg', 'tasks-global-query-modal');
         this.setTitle(i18n.t('settings.globalQuery.heading'));
 
         this.contentEl.createEl('p', {

--- a/src/Config/GlobalQueryModal.ts
+++ b/src/Config/GlobalQueryModal.ts
@@ -1,0 +1,48 @@
+import { type App, ButtonComponent, Modal, TextAreaComponent } from 'obsidian';
+import { i18n } from '../i18n/i18n';
+
+/**
+ * Modal for editing the Global query in a full-width, multi-line textarea.
+ * Uses `mod-lg` so the modal expands to full height on mobile. The longer
+ * descriptive copy lives here (rather than inline on the settings row) so the
+ * settings row itself can stay compact.
+ */
+export class GlobalQueryModal extends Modal {
+    private readonly textarea: TextAreaComponent;
+
+    constructor(app: App, initial: string, private readonly onSave: (value: string) => void) {
+        super(app);
+        this.modalEl.addClass('mod-lg');
+        this.setTitle(i18n.t('settings.globalQuery.heading'));
+
+        this.contentEl.createEl('p', {
+            cls: 'setting-item-description',
+            text: i18n.t('settings.globalQuery.query.description'),
+        });
+        const docsParaEl = this.contentEl.createEl('p', { cls: 'setting-item-description' });
+        docsParaEl.createEl('a', {
+            text: i18n.t('settings.seeTheDocumentation'),
+            href: 'https://publish.obsidian.md/tasks/Queries/Global+Query',
+        });
+        docsParaEl.appendText('.');
+
+        this.textarea = new TextAreaComponent(this.contentEl)
+            .setPlaceholder('# ' + i18n.t('settings.globalQuery.query.placeholder'))
+            .setValue(initial);
+        this.textarea.inputEl.addClass('tasks-global-query-textarea');
+
+        const buttonContainerEl = this.contentEl.createDiv({ cls: 'modal-button-container' });
+        new ButtonComponent(buttonContainerEl)
+            .setButtonText(i18n.t('common.save'))
+            .setCta()
+            .onClick(() => {
+                this.onSave(this.textarea.getValue());
+                this.close();
+            });
+        new ButtonComponent(buttonContainerEl).setButtonText(i18n.t('common.cancel')).onClick(() => this.close());
+    }
+
+    onOpen(): void {
+        this.textarea.inputEl.focus();
+    }
+}

--- a/src/Config/GlobalQueryModal.ts
+++ b/src/Config/GlobalQueryModal.ts
@@ -32,6 +32,7 @@ export class GlobalQueryModal extends Modal {
         this.textarea.inputEl.addClass('tasks-global-query-textarea');
 
         const buttonContainerEl = this.contentEl.createDiv({ cls: 'modal-button-container' });
+        new ButtonComponent(buttonContainerEl).setButtonText(i18n.t('common.cancel')).onClick(() => this.close());
         new ButtonComponent(buttonContainerEl)
             .setButtonText(i18n.t('common.save'))
             .setCta()
@@ -39,7 +40,6 @@ export class GlobalQueryModal extends Modal {
                 this.onSave(this.textarea.getValue());
                 this.close();
             });
-        new ButtonComponent(buttonContainerEl).setButtonText(i18n.t('common.cancel')).onClick(() => this.close());
     }
 
     onOpen(): void {

--- a/src/Config/PresetsSettingsUI.scss
+++ b/src/Config/PresetsSettingsUI.scss
@@ -2,6 +2,17 @@
 /* Presets section                               */
 /* ---------------------------------------------- */
 
+// Declarative settings (Obsidian 1.13.0+): the preset row shows a short
+// preview of the query — whitespace preserved, clamped to 3 lines.
+.tasks-presets-value-preview {
+    white-space: pre-wrap;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    overflow: hidden;
+}
+
 .tasks-settings {
     // Main wrapper for presets section
     .tasks-presets-wrapper {

--- a/src/Config/PresetsSettingsUI.scss
+++ b/src/Config/PresetsSettingsUI.scss
@@ -2,6 +2,23 @@
 /* Presets section                               */
 /* ---------------------------------------------- */
 
+// Edit-preset modal: a wide form sheet, with each field's control
+// below its label and filling the modal's width.
+.modal.tasks-edit-preset-modal {
+    --dialog-width: 700px;
+    --dialog-max-width: 90vw;
+
+    .form-field input,
+    .form-field textarea {
+        width: 100%;
+    }
+
+    .form-field textarea {
+        font-family: var(--font-monospace);
+        resize: vertical;
+    }
+}
+
 // Declarative settings (Obsidian 1.13.0+): the preset row shows a short
 // preview of the query — whitespace preserved, clamped to 3 lines.
 .tasks-presets-value-preview {

--- a/src/Config/PresetsSettingsUI.ts
+++ b/src/Config/PresetsSettingsUI.ts
@@ -1,4 +1,14 @@
-import { Setting, TextAreaComponent } from 'obsidian';
+import {
+    type App,
+    ButtonComponent,
+    Modal,
+    Setting,
+    type SettingDefinition,
+    type SettingDefinitionItem,
+    TextAreaComponent,
+    TextComponent,
+    displayTooltip,
+} from 'obsidian';
 import type TasksPlugin from '../main';
 import type { TasksEvents } from '../Obsidian/TasksEvents';
 import { PresetsSettingsService, type RenamesInProgress } from '../Query/Presets/PresetsSettingsService';
@@ -27,6 +37,81 @@ export class PresetsSettingsUI {
     constructor(plugin: TasksPlugin, events: TasksEvents) {
         this.plugin = plugin;
         this.events = events;
+    }
+
+    /**
+     * Returns declarative setting definitions for the Presets sub-page.
+     * Used by the Obsidian 1.13.0+ getSettingDefinitions() path; older
+     * versions render via {@link renderPresetsSettings} instead.
+     *
+     * @param refresh Callback the host invokes to rebuild the page after a
+     *                structural change (add/rename/delete).
+     */
+    public getPresetsDefinitions(refresh: () => void): SettingDefinitionItem[] {
+        const presets = getSettings().presets;
+
+        const openEditForm = (key: string | null) => {
+            const initial = key === null ? { name: '', value: '' } : { name: key, value: presets[key] ?? '' };
+            new EditPresetModal(this.plugin.app, getSettings().presets, key, initial, (name, value) => {
+                let next = getSettings().presets;
+                if (key !== null && key !== name) {
+                    const renamed = this.presetsSettingsService.renamePreset(next, key, name);
+                    if (!renamed) {
+                        return;
+                    }
+                    next = renamed;
+                }
+                next = this.presetsSettingsService.updatePresetValue(next, name, value);
+                this.savePresetsSettings(next, getSettings(), refresh);
+            }).open();
+        };
+
+        const presetRow = (key: string): SettingDefinition => ({
+            name: key,
+            desc: presets[key] ?? '',
+            searchable: false,
+            render: (setting) => {
+                setting.addExtraButton((btn) =>
+                    btn
+                        .setIcon('lucide-pencil')
+                        .setTooltip(i18n.t('common.edit'))
+                        .onClick(() => openEditForm(key)),
+                );
+            },
+        });
+
+        return [
+            {
+                type: 'list',
+                emptyState: i18n.t('settings.presets.emptyState'),
+                addItem: {
+                    name: i18n.t('settings.presets.buttons.addNewPreset'),
+                    action: () => openEditForm(null),
+                },
+                onReorder: (oldIndex, newIndex) => {
+                    const currentKeys = Object.keys(getSettings().presets);
+                    const key = currentKeys[oldIndex];
+                    if (!key) {
+                        return;
+                    }
+                    const updated = this.presetsSettingsService.reorderPreset(getSettings().presets, key, newIndex);
+                    if (updated) {
+                        // The list has already moved the row, so no refresh is needed.
+                        this.savePresetsSettings(updated, getSettings(), null);
+                    }
+                },
+                onDelete: (index) => {
+                    const currentKeys = Object.keys(getSettings().presets);
+                    const key = currentKeys[index];
+                    if (!key) {
+                        return;
+                    }
+                    const updated = this.presetsSettingsService.deletePreset(getSettings().presets, key);
+                    this.savePresetsSettings(updated, getSettings(), refresh);
+                },
+                items: Object.keys(presets).map(presetRow),
+            },
+        ];
     }
 
     /**
@@ -393,5 +478,92 @@ export class PresetsSettingsUI {
         }
 
         this.events.triggerReloadOpenSearchResults();
+    }
+}
+
+/**
+ * Modal for creating or editing a preset. Collects a name and a query in a form
+ * and persists via the callback when the user clicks Save.
+ *
+ * Pass `editingKey === null` to create a new preset; pass a key to edit that
+ * preset (renames are allowed as long as the new name isn't a duplicate).
+ */
+class EditPresetModal extends Modal {
+    private readonly nameInput: TextComponent;
+    private readonly valueInput: TextAreaComponent;
+
+    constructor(
+        app: App,
+        private readonly existing: Readonly<PresetsMap>,
+        private readonly editingKey: string | null,
+        initial: { name: string; value: string },
+        private readonly onSave: (name: string, value: string) => void,
+    ) {
+        super(app);
+        this.modalEl.addClass('mod-lg');
+        this.setTitle(
+            editingKey === null
+                ? i18n.t('settings.presets.buttons.addNewPreset')
+                : i18n.t('modals.editPresetModal.title'),
+        );
+
+        let nameRef!: TextComponent;
+        let valueRef!: TextAreaComponent;
+
+        new Setting(this.contentEl).setName(i18n.t('modals.editPresetModal.name.name')).addText((text) => {
+            text.setPlaceholder(i18n.t('modals.editPresetModal.name.placeholder')).setValue(initial.name);
+            nameRef = text;
+        });
+
+        new Setting(this.contentEl)
+            .setName(i18n.t('modals.editPresetModal.query.name'))
+            .setDesc(i18n.t('modals.editPresetModal.query.description'))
+            .addTextArea((text) => {
+                text.setPlaceholder(i18n.t('modals.editPresetModal.query.placeholder')).setValue(initial.value);
+                text.inputEl.rows = 6;
+                valueRef = text;
+            });
+
+        this.nameInput = nameRef;
+        this.valueInput = valueRef;
+
+        this.nameInput.inputEl.addEventListener('keydown', (evt) => {
+            if (!evt.isComposing && evt.key === 'Enter') {
+                evt.preventDefault();
+                this.submit();
+            }
+        });
+
+        const buttonContainerEl = this.contentEl.createDiv({ cls: 'modal-button-container' });
+        new ButtonComponent(buttonContainerEl)
+            .setButtonText(i18n.t('common.save'))
+            .setCta()
+            .onClick(() => this.submit());
+        new ButtonComponent(buttonContainerEl).setButtonText(i18n.t('common.cancel')).onClick(() => this.close());
+    }
+
+    onOpen(): void {
+        this.nameInput.inputEl.focus();
+        this.nameInput.inputEl.select();
+    }
+
+    private submit(): void {
+        const name = this.nameInput.getValue().trim();
+        if (!name) {
+            displayTooltip(this.nameInput.inputEl, i18n.t('modals.editPresetModal.name.required'), {
+                classes: ['mod-error'],
+            });
+            return;
+        }
+        const isRenamingToExisting =
+            name !== this.editingKey && Object.prototype.hasOwnProperty.call(this.existing, name);
+        if (isRenamingToExisting) {
+            displayTooltip(this.nameInput.inputEl, i18n.t('modals.editPresetModal.name.duplicate'), {
+                classes: ['mod-error'],
+            });
+            return;
+        }
+        this.onSave(name, this.valueInput.getValue());
+        this.close();
     }
 }

--- a/src/Config/PresetsSettingsUI.ts
+++ b/src/Config/PresetsSettingsUI.ts
@@ -50,43 +50,13 @@ export class PresetsSettingsUI {
     public getPresetsDefinitions(refresh: () => void): SettingDefinitionItem[] {
         const presets = getSettings().presets;
 
-        const openEditForm = (key: string | null) => {
-            const initial = key === null ? { name: '', value: '' } : { name: key, value: presets[key] ?? '' };
-            new EditPresetModal(this.plugin.app, getSettings().presets, key, initial, (name, value) => {
-                let next = getSettings().presets;
-                if (key !== null && key !== name) {
-                    const renamed = this.presetsSettingsService.renamePreset(next, key, name);
-                    if (!renamed) {
-                        return;
-                    }
-                    next = renamed;
-                }
-                next = this.presetsSettingsService.updatePresetValue(next, name, value);
-                this.savePresetsSettings(next, getSettings(), refresh);
-            }).open();
-        };
-
-        const presetRow = (key: string): SettingDefinition => ({
-            name: key,
-            desc: presets[key] ?? '',
-            searchable: false,
-            render: (setting) => {
-                setting.addExtraButton((btn) =>
-                    btn
-                        .setIcon('lucide-pencil')
-                        .setTooltip(i18n.t('common.edit'))
-                        .onClick(() => openEditForm(key)),
-                );
-            },
-        });
-
         return [
             {
                 type: 'list',
                 emptyState: i18n.t('settings.presets.emptyState'),
                 addItem: {
                     name: i18n.t('settings.presets.buttons.addNewPreset'),
-                    action: () => openEditForm(null),
+                    action: () => this.openEditPresetForm(null, refresh),
                 },
                 onReorder: (oldIndex, newIndex) => {
                     const currentKeys = Object.keys(getSettings().presets);
@@ -109,9 +79,46 @@ export class PresetsSettingsUI {
                     const updated = this.presetsSettingsService.deletePreset(getSettings().presets, key);
                     this.savePresetsSettings(updated, getSettings(), refresh);
                 },
-                items: Object.keys(presets).map(presetRow),
+                items: Object.keys(presets).map((key) => this.presetRow(key, presets[key] ?? '', refresh)),
             },
         ];
+    }
+
+    private presetRow(key: string, value: string, refresh: () => void): SettingDefinition {
+        return {
+            name: key,
+            desc: value,
+            searchable: false,
+            render: (setting) => {
+                setting.addExtraButton((btn) =>
+                    btn
+                        .setIcon('lucide-pencil')
+                        .setTooltip(i18n.t('common.edit'))
+                        .onClick(() => this.openEditPresetForm(key, refresh)),
+                );
+            },
+        };
+    }
+
+    /**
+     * Open the modal that creates a preset (`key === null`) or edits the
+     * preset named `key`, persisting the result when the user saves.
+     */
+    private openEditPresetForm(key: string | null, refresh: () => void): void {
+        const presets = getSettings().presets;
+        const initial = key === null ? { name: '', value: '' } : { name: key, value: presets[key] ?? '' };
+        new EditPresetModal(this.plugin.app, presets, key, initial, (name, value) => {
+            let next = getSettings().presets;
+            if (key !== null && key !== name) {
+                const renamed = this.presetsSettingsService.renamePreset(next, key, name);
+                if (!renamed) {
+                    return;
+                }
+                next = renamed;
+            }
+            next = this.presetsSettingsService.updatePresetValue(next, name, value);
+            this.savePresetsSettings(next, getSettings(), refresh);
+        }).open();
     }
 
     /**

--- a/src/Config/PresetsSettingsUI.ts
+++ b/src/Config/PresetsSettingsUI.ts
@@ -507,32 +507,28 @@ class EditPresetModal extends Modal {
         private readonly onSave: (name: string, value: string) => void,
     ) {
         super(app);
-        this.modalEl.addClass('mod-lg');
+        this.modalEl.addClass('mod-lg', 'tasks-edit-preset-modal');
         this.setTitle(
             editingKey === null
                 ? i18n.t('settings.presets.buttons.addNewPreset')
                 : i18n.t('modals.editPresetModal.title'),
         );
 
-        let nameRef!: TextComponent;
-        let valueRef!: TextAreaComponent;
+        // Form layout: each field is a label above a full-width control,
+        // reusing Obsidian's own 'form-field' styling.
+        const nameFieldEl = this.contentEl.createEl('p', { cls: 'form-field' });
+        nameFieldEl.createEl('label', { text: i18n.t('modals.editPresetModal.name.name') });
+        this.nameInput = new TextComponent(nameFieldEl)
+            .setPlaceholder(i18n.t('modals.editPresetModal.name.placeholder'))
+            .setValue(initial.name);
 
-        new Setting(this.contentEl).setName(i18n.t('modals.editPresetModal.name.name')).addText((text) => {
-            text.setPlaceholder(i18n.t('modals.editPresetModal.name.placeholder')).setValue(initial.name);
-            nameRef = text;
-        });
-
-        new Setting(this.contentEl)
-            .setName(i18n.t('modals.editPresetModal.query.name'))
-            .setDesc(i18n.t('modals.editPresetModal.query.description'))
-            .addTextArea((text) => {
-                text.setPlaceholder(i18n.t('modals.editPresetModal.query.placeholder')).setValue(initial.value);
-                text.inputEl.rows = 6;
-                valueRef = text;
-            });
-
-        this.nameInput = nameRef;
-        this.valueInput = valueRef;
+        const queryFieldEl = this.contentEl.createEl('p', { cls: 'form-field' });
+        queryFieldEl.createEl('label', { text: i18n.t('modals.editPresetModal.query.name') });
+        queryFieldEl.createDiv({ cls: 'form-field-help', text: i18n.t('modals.editPresetModal.query.description') });
+        this.valueInput = new TextAreaComponent(queryFieldEl)
+            .setPlaceholder(i18n.t('modals.editPresetModal.query.placeholder'))
+            .setValue(initial.value);
+        this.valueInput.inputEl.rows = 12;
 
         this.nameInput.inputEl.addEventListener('keydown', (evt) => {
             if (!evt.isComposing && evt.key === 'Enter') {
@@ -542,11 +538,11 @@ class EditPresetModal extends Modal {
         });
 
         const buttonContainerEl = this.contentEl.createDiv({ cls: 'modal-button-container' });
+        new ButtonComponent(buttonContainerEl).setButtonText(i18n.t('common.cancel')).onClick(() => this.close());
         new ButtonComponent(buttonContainerEl)
             .setButtonText(i18n.t('common.save'))
             .setCta()
             .onClick(() => this.submit());
-        new ButtonComponent(buttonContainerEl).setButtonText(i18n.t('common.cancel')).onClick(() => this.close());
     }
 
     onOpen(): void {

--- a/src/Config/PresetsSettingsUI.ts
+++ b/src/Config/PresetsSettingsUI.ts
@@ -88,7 +88,6 @@ export class PresetsSettingsUI {
         return {
             name: key,
             desc: value,
-            searchable: false,
             render: (setting) => {
                 setting.addExtraButton((btn) =>
                     btn

--- a/src/Config/PresetsSettingsUI.ts
+++ b/src/Config/PresetsSettingsUI.ts
@@ -89,6 +89,7 @@ export class PresetsSettingsUI {
             name: key,
             desc: value,
             render: (setting) => {
+                setting.descEl.addClass('tasks-presets-value-preview');
                 setting.addExtraButton((btn) =>
                     btn
                         .setIcon('lucide-pencil')

--- a/src/Config/SettingsTab.scss
+++ b/src/Config/SettingsTab.scss
@@ -86,3 +86,28 @@
 .tasks-settings .tasks-setting-multiline-text-textarea {
     min-width: -webkit-fill-available;
 }
+
+/* The status symbol renders as a `<code>` element styled to match Obsidian's
+ * inline-code chrome — `var(--code-*)` tokens pick up the theme. */
+.tasks-status-symbol {
+    color: var(--code-normal);
+    font-family: var(--font-monospace);
+    background-color: var(--background-modifier-hover);
+    border-radius: var(--code-radius);
+    font-size: var(--code-size);
+    padding: 0.15em 0.3em;
+    border: var(--code-border-width) solid var(--code-border-color);
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    margin-inline-end: 0.5em;
+}
+
+/* Global Query modal: full-width, multi-line textarea. */
+textarea.tasks-global-query-textarea {
+    display: block;
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 16em;
+    font-family: var(--font-monospace);
+    resize: vertical;
+}

--- a/src/Config/SettingsTab.scss
+++ b/src/Config/SettingsTab.scss
@@ -102,6 +102,12 @@
     margin-inline-end: 0.5em;
 }
 
+/* Global Query modal: wider than the default dialog, to give the query room. */
+.modal.tasks-global-query-modal {
+    --dialog-width: 800px;
+    --dialog-max-width: 90vw;
+}
+
 /* Global Query modal: full-width, multi-line textarea. */
 textarea.tasks-global-query-textarea {
     display: block;

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -439,6 +439,9 @@ export class SettingsTab extends PluginSettingTab {
             });
 
             let decided = false;
+            // Cancel first: on desktop, DOM order decides and the primary action
+            // belongs on the right. Mobile reorders Cancel with CSS regardless.
+            modal.addCancelButton();
             modal.addButton((btn) => {
                 enableBtn = btn;
                 btn.setButtonText(i18n.t('settings.searches.enableCustomSearches.confirm.enable'))
@@ -453,7 +456,6 @@ export class SettingsTab extends PluginSettingTab {
                         return undefined;
                     });
             });
-            modal.addCancelButton();
 
             const originalOnClose = modal.onClose.bind(modal);
             modal.onClose = () => {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -7,6 +7,7 @@ import {
     Setting,
     type SettingDefinition,
     type SettingDefinitionItem,
+    type ToggleComponent,
     debounce,
     requireApiVersion,
     sanitizeHTMLToDom,
@@ -154,7 +155,7 @@ export class SettingsTab extends PluginSettingTab {
                 btn
                     .setIcon('book-open')
                     .setTooltip(i18n.t('settings.seeTheDocumentation'))
-                    .onClick(() => window.open(docsUrl, '_blank')),
+                    .onClick(() => window.open(docsUrl, '_blank', 'noopener')),
             );
             inner(setting);
         };
@@ -170,24 +171,27 @@ export class SettingsTab extends PluginSettingTab {
      */
     private withReload(inner: (setting: Setting, markChanged: () => void) => void) {
         return (setting: Setting) => {
-            let reloadBtnEl: HTMLButtonElement | null = null;
+            let reloadBtnAdded = false;
             const markChanged = () => {
-                if (reloadBtnEl) {
-                    return;
+                if (!reloadBtnAdded) {
+                    reloadBtnAdded = true;
+                    this.addReloadButton(setting);
                 }
-                setting.addButton((btn) => {
-                    btn.setButtonText(i18n.t('common.reload'))
-                        .setCta()
-                        .onClick(() => window.location.reload());
-                    // Place the Reload button before the row's control, matching
-                    // Obsidian's own "Relaunch" placement on restart-required
-                    // settings.
-                    setting.controlEl.prepend(btn.buttonEl);
-                    reloadBtnEl = btn.buttonEl;
-                });
             };
             inner(setting, markChanged);
         };
+    }
+
+    private addReloadButton(setting: Setting): void {
+        setting.addButton((btn) => {
+            btn.setButtonText(i18n.t('common.reload'))
+                .setCta()
+                .onClick(() => window.location.reload());
+            // Place the Reload button before the row's control, matching
+            // Obsidian's own "Relaunch" placement on restart-required
+            // settings.
+            setting.controlEl.prepend(btn.buttonEl);
+        });
     }
 
     public getSettingDefinitions(): SettingDefinitionItem[] {
@@ -292,19 +296,21 @@ export class SettingsTab extends PluginSettingTab {
                             btn
                                 .setIcon('pencil')
                                 .setTooltip(i18n.t('common.edit'))
-                                .onClick(() => {
-                                    new GlobalQueryModal(this.app, getSettings().globalQuery, async (value) => {
-                                        updateSettings({ globalQuery: value });
-                                        GlobalQuery.getInstance().set(value);
-                                        await this.plugin.saveSettings();
-                                        this.events.triggerReloadOpenSearchResults();
-                                    }).open();
-                                }),
+                                .onClick(() => this.openGlobalQueryModal()),
                         );
                     }, 'https://publish.obsidian.md/tasks/Queries/Global+Query'),
                 },
             ],
         };
+    }
+
+    private openGlobalQueryModal(): void {
+        new GlobalQueryModal(this.app, getSettings().globalQuery, async (value) => {
+            updateSettings({ globalQuery: value });
+            GlobalQuery.getInstance().set(value);
+            await this.plugin.saveSettings();
+            this.events.triggerReloadOpenSearchResults();
+        }).open();
     }
 
     // ---- Searches & search results ---------------------------------------
@@ -323,28 +329,7 @@ export class SettingsTab extends PluginSettingTab {
                             groupByFunction: '<code>group by function</code>',
                         }),
                     ),
-                    render: (setting) => {
-                        setting.addToggle((toggle) => {
-                            toggle.setValue(EnableJsInTasksQueries.getInstance().get()).onChange((value) => {
-                                if (!value) {
-                                    // Turning OFF: no confirmation needed.
-                                    EnableJsInTasksQueries.getInstance().set(false);
-                                    this.events.triggerReloadOpenSearchResults();
-                                    return;
-                                }
-                                // Turning ON: require explicit acknowledgement.
-                                this.confirmEnableCustomSearches((confirmed) => {
-                                    if (confirmed) {
-                                        EnableJsInTasksQueries.getInstance().set(true);
-                                        this.events.triggerReloadOpenSearchResults();
-                                    } else {
-                                        // Revert the toggle UI back to off.
-                                        toggle.setValue(false);
-                                    }
-                                });
-                            });
-                        });
-                    },
+                    render: (setting) => this.renderEnableCustomSearchesToggle(setting),
                 },
                 {
                     name: i18n.t('settings.searchResults.taskCountLocation.name'),
@@ -368,6 +353,31 @@ export class SettingsTab extends PluginSettingTab {
                 },
             ],
         };
+    }
+
+    private renderEnableCustomSearchesToggle(setting: Setting): void {
+        setting.addToggle((toggle) => {
+            toggle.setValue(EnableJsInTasksQueries.getInstance().get()).onChange((value) => {
+                if (!value) {
+                    // Turning OFF: no confirmation needed.
+                    EnableJsInTasksQueries.getInstance().set(false);
+                    this.events.triggerReloadOpenSearchResults();
+                    return;
+                }
+                // Turning ON: require explicit acknowledgement.
+                this.confirmEnableCustomSearches((confirmed) => this.applyCustomSearchesChoice(toggle, confirmed));
+            });
+        });
+    }
+
+    private applyCustomSearchesChoice(toggle: ToggleComponent, confirmed: boolean): void {
+        if (confirmed) {
+            EnableJsInTasksQueries.getInstance().set(true);
+            this.events.triggerReloadOpenSearchResults();
+        } else {
+            // Revert the toggle UI back to off.
+            toggle.setValue(false);
+        }
     }
 
     /**
@@ -516,31 +526,17 @@ export class SettingsTab extends PluginSettingTab {
                                 .setIcon('book-open')
                                 .setTooltip(i18n.t('settings.seeTheDocumentation'))
                                 .onClick(() =>
-                                    window.open('https://publish.obsidian.md/tasks/Getting+Started/Statuses', '_blank'),
+                                    window.open(
+                                        'https://publish.obsidian.md/tasks/Getting+Started/Statuses',
+                                        '_blank',
+                                        'noopener',
+                                    ),
                                 ),
                         (btn) => {
                             btn.setIcon('lucide-palette').setTooltip(
                                 i18n.t('settings.statuses.buttons.importFromTheme'),
                             );
-                            btn.extraSettingsEl.addEventListener('click', (evt) => {
-                                const menu = new Menu();
-                                for (const { name, collection } of getThemeCollections()) {
-                                    menu.addItem((item) =>
-                                        item
-                                            .setTitle(
-                                                i18n.t('settings.statuses.collections.buttons.importCollection.name', {
-                                                    themeName: name,
-                                                    numberOfStatuses: collection.length,
-                                                }),
-                                            )
-                                            .onClick(() => {
-                                                const { statusSettings: current } = getSettings();
-                                                addCustomStatesToSettings(collection, current, this);
-                                            }),
-                                    );
-                                }
-                                menu.showAtMouseEvent(evt);
-                            });
+                            btn.extraSettingsEl.addEventListener('click', (evt) => this.showImportFromThemeMenu(evt));
                         },
                     ],
                     onDelete: (index) => {
@@ -600,6 +596,30 @@ export class SettingsTab extends PluginSettingTab {
     }
 
     /**
+     * Show a menu of the theme status collections; choosing one imports its
+     * statuses into the custom statuses list.
+     */
+    private showImportFromThemeMenu(evt: MouseEvent): void {
+        const menu = new Menu();
+        for (const { name, collection } of getThemeCollections()) {
+            menu.addItem((item) =>
+                item
+                    .setTitle(
+                        i18n.t('settings.statuses.collections.buttons.importCollection.name', {
+                            themeName: name,
+                            numberOfStatuses: collection.length,
+                        }),
+                    )
+                    .onClick(() => {
+                        const { statusSettings: current } = getSettings();
+                        addCustomStatesToSettings(collection, current, this);
+                    }),
+            );
+        }
+        menu.showAtMouseEvent(evt);
+    }
+
+    /**
      * Builds one list row for a single status. The row's `name` is the
      * status's friendly name, with the symbol prepended as a `<code>` chip; a
      * pencil extraButton opens the existing edit modal. Deletion is wired by
@@ -616,23 +636,28 @@ export class SettingsTab extends PluginSettingTab {
                 setting.addExtraButton((btn) => {
                     btn.setIcon('pencil')
                         .setTooltip(i18n.t('common.edit'))
-                        .onClick(() => {
-                            const modal = new CustomStatusModal(this.plugin, status, isCoreStatus);
-                            modal.onClose = () => {
-                                if (!modal.saved) {
-                                    return;
-                                }
-                                const { statusSettings: current } = getSettings();
-                                const list = isCoreStatus ? current.coreStatuses : current.customStatuses;
-                                if (StatusSettings.replaceStatus(list, status, modal.statusConfiguration())) {
-                                    updateAndSaveStatusSettings(current, this);
-                                }
-                            };
-                            modal.open();
-                        });
+                        .onClick(() => this.openEditStatusModal(status, isCoreStatus));
                 });
             },
         };
+    }
+
+    /**
+     * Open the edit modal for a status, and persist the edit when it is saved.
+     */
+    private openEditStatusModal(status: StatusConfiguration, isCoreStatus: boolean): void {
+        const modal = new CustomStatusModal(this.plugin, status, isCoreStatus);
+        modal.onClose = () => {
+            if (!modal.saved) {
+                return;
+            }
+            const { statusSettings: current } = getSettings();
+            const list = isCoreStatus ? current.coreStatuses : current.customStatuses;
+            if (StatusSettings.replaceStatus(list, status, modal.statusConfiguration())) {
+                updateAndSaveStatusSettings(current, this);
+            }
+        };
+        modal.open();
     }
 
     private async createStatusRegistryReport(): Promise<void> {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -1,8 +1,9 @@
 import {
-    type ButtonComponent,
+    ButtonComponent,
     type ConfirmationButton,
     ConfirmationModal,
     Menu,
+    Modal,
     Notice,
     PluginSettingTab,
     Setting,
@@ -512,6 +513,20 @@ export class SettingsTab extends PluginSettingTab {
                 {
                     type: 'list',
                     heading: i18n.t('settings.statuses.coreStatuses.heading'),
+                    extraButtons: [
+                        (btn) =>
+                            btn
+                                .setIcon('info')
+                                .setTooltip(i18n.t('common.moreInfo'))
+                                .onClick(() =>
+                                    this.showInfoModal(
+                                        i18n.t('settings.statuses.coreStatuses.heading'),
+                                        `<p>${i18n.t('settings.statuses.coreStatuses.description.line1')}</p>` +
+                                            `<p>${i18n.t('settings.statuses.coreStatuses.description.line2')}</p>`,
+                                        'https://publish.obsidian.md/tasks/Getting+Started/Statuses',
+                                    ),
+                                ),
+                    ],
                     items: [
                         ...statusSettings.coreStatuses.map((status) => statusRow(status, true)),
                         {
@@ -546,21 +561,17 @@ export class SettingsTab extends PluginSettingTab {
                     extraButtons: [
                         (btn) =>
                             btn
-                                .setIcon('book-open')
-                                .setTooltip(i18n.t('settings.seeTheDocumentation'))
+                                .setIcon('info')
+                                .setTooltip(i18n.t('common.moreInfo'))
                                 .onClick(() =>
-                                    window.open(
+                                    this.showInfoModal(
+                                        i18n.t('settings.statuses.customStatuses.heading'),
+                                        `<p>${i18n.t('settings.statuses.customStatuses.description.line1')}</p>` +
+                                            `<p>${i18n.t('settings.statuses.customStatuses.description.line2')}</p>` +
+                                            `<p>${i18n.t('settings.statuses.customStatuses.description.line3')}</p>`,
                                         'https://publish.obsidian.md/tasks/Getting+Started/Statuses',
-                                        '_blank',
-                                        'noopener',
                                     ),
                                 ),
-                        (btn) => {
-                            btn.setIcon('lucide-palette').setTooltip(
-                                i18n.t('settings.statuses.buttons.importFromTheme'),
-                            );
-                            btn.extraSettingsEl.addEventListener('click', (evt) => this.showImportFromThemeMenu(evt));
-                        },
                     ],
                     onDelete: (index) => {
                         const { statusSettings: current } = getSettings();
@@ -586,43 +597,54 @@ export class SettingsTab extends PluginSettingTab {
                     items: statusSettings.customStatuses.map((status) => statusRow(status, false)),
                 },
                 {
-                    name: i18n.t('settings.statuses.customStatuses.buttons.addAllUnknown.name'),
-                    desc: i18n.t('settings.statuses.customStatuses.buttons.addAllUnknown.description'),
-                    searchable: false,
-                    action: () => {
-                        const { statusSettings: current } = getSettings();
-                        const tasks = this.plugin.getTasks();
-                        const unknownStatuses = StatusRegistry.getInstance().findUnknownStatuses(
-                            tasks.map((task) => task.status),
-                        );
-                        if (unknownStatuses.length === 0) {
-                            return;
-                        }
-                        unknownStatuses.forEach((s) => {
-                            StatusSettings.addStatus(current.customStatuses, s);
-                        });
-                        updateAndSaveStatusSettings(current, this);
-                    },
-                },
-                {
-                    name: i18n.t('settings.statuses.customStatuses.buttons.resetCustomStatuses.name'),
-                    desc: i18n.t('settings.statuses.customStatuses.buttons.resetCustomStatuses.description'),
-                    searchable: false,
-                    action: () => {
-                        const { statusSettings: current } = getSettings();
-                        StatusSettings.resetAllCustomStatuses(current);
-                        updateAndSaveStatusSettings(current, this);
-                    },
+                    type: 'list',
+                    items: [
+                        {
+                            name: i18n.t('settings.statuses.buttons.importFromTheme.name'),
+                            desc: i18n.t('settings.statuses.buttons.importFromTheme.description'),
+                            searchable: false,
+                            action: (el) => this.showImportFromThemeMenu(el),
+                        },
+                        {
+                            name: i18n.t('settings.statuses.customStatuses.buttons.addAllUnknown.name'),
+                            desc: i18n.t('settings.statuses.customStatuses.buttons.addAllUnknown.description'),
+                            searchable: false,
+                            action: () => {
+                                const { statusSettings: current } = getSettings();
+                                const tasks = this.plugin.getTasks();
+                                const unknownStatuses = StatusRegistry.getInstance().findUnknownStatuses(
+                                    tasks.map((task) => task.status),
+                                );
+                                if (unknownStatuses.length === 0) {
+                                    return;
+                                }
+                                unknownStatuses.forEach((s) => {
+                                    StatusSettings.addStatus(current.customStatuses, s);
+                                });
+                                updateAndSaveStatusSettings(current, this);
+                            },
+                        },
+                        {
+                            name: i18n.t('settings.statuses.customStatuses.buttons.resetCustomStatuses.name'),
+                            desc: i18n.t('settings.statuses.customStatuses.buttons.resetCustomStatuses.description'),
+                            searchable: false,
+                            action: () => {
+                                const { statusSettings: current } = getSettings();
+                                StatusSettings.resetAllCustomStatuses(current);
+                                updateAndSaveStatusSettings(current, this);
+                            },
+                        },
+                    ],
                 },
             ],
         };
     }
 
     /**
-     * Show a menu of the theme status collections; choosing one imports its
-     * statuses into the custom statuses list.
+     * Show a menu of the theme status collections, anchored below `anchorEl`;
+     * choosing one imports its statuses into the custom statuses list.
      */
-    private showImportFromThemeMenu(evt: MouseEvent): void {
+    private showImportFromThemeMenu(anchorEl: HTMLElement): void {
         const menu = new Menu();
         for (const { name, collection } of getThemeCollections()) {
             menu.addItem((item) =>
@@ -639,7 +661,29 @@ export class SettingsTab extends PluginSettingTab {
                     }),
             );
         }
-        menu.showAtMouseEvent(evt);
+        const rect = anchorEl.getBoundingClientRect();
+        menu.showAtPosition({ x: rect.left, y: rect.bottom });
+    }
+
+    /**
+     * Show a small modal with descriptive text about a section, opened from an
+     * info button in the section's header. The footer offers the section's
+     * documentation, and an Okay button to dismiss.
+     */
+    private showInfoModal(title: string, html: string, docsUrl: string): void {
+        const modal = new Modal(this.app);
+        modal.setTitle(title);
+        modal.contentEl.append(SettingsTab.createFragmentWithHTML(html));
+
+        const buttonContainerEl = modal.contentEl.createDiv({ cls: 'modal-button-container' });
+        new ButtonComponent(buttonContainerEl)
+            .setButtonText(i18n.t('settings.seeTheDocumentation'))
+            .onClick(() => window.open(docsUrl, '_blank', 'noopener'));
+        new ButtonComponent(buttonContainerEl)
+            .setButtonText(i18n.t('common.okay'))
+            .setCta()
+            .onClick(() => modal.close());
+        modal.open();
     }
 
     /**

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -1,4 +1,5 @@
 import {
+    type ButtonComponent,
     type ConfirmationButton,
     ConfirmationModal,
     Menu,
@@ -23,6 +24,7 @@ import type { TasksEvents } from '../Obsidian/TasksEvents';
 import * as Themes from './Themes';
 import {
     type HeadingState,
+    type Settings,
     TASK_FORMATS,
     getSettings,
     isFeatureEnabled,
@@ -59,6 +61,17 @@ interface HeadingConfiguration {
 }
 
 /**
+ * A snapshot of the settings when the plugin loaded.
+ * {@link SettingsTab.withReload} compares current values against these.
+ */
+let settingsAtPluginLoad: Settings | null = null;
+
+function getSettingsAtPluginLoad(): Settings {
+    settingsAtPluginLoad ??= JSON.parse(JSON.stringify(getSettings()));
+    return settingsAtPluginLoad as Settings;
+}
+
+/**
  * The plugin's settings tab, with two implementations of the UI:
  *
  * - {@link getSettingDefinitions} — the declarative API, used by Obsidian 1.13.0 and later.
@@ -86,6 +99,9 @@ export class SettingsTab extends PluginSettingTab {
         this.plugin = plugin;
         this.presetsSettingsUI = new PresetsSettingsUI(plugin, events);
         this.events = events;
+
+        // Record the setting values now, before the user can change them.
+        getSettingsAtPluginLoad();
     }
 
     private static readonly createFragmentWithHTML = (html: string) => sanitizeHTMLToDom(html);
@@ -115,10 +131,8 @@ export class SettingsTab extends PluginSettingTab {
     // -----------------------------------------------------------------------
     // Declarative settings API (Obsidian 1.13.0+)
     //
-    // The plugin keeps its data in a module-level object accessed via
-    // getSettings/updateSettings, not on this.plugin.settings. Override the
-    // default control-binding hooks so declarative `control` definitions read
-    // and write through those helpers.
+    // Settings live in a module-level store (getSettings/updateSettings), not
+    // on this.plugin.settings, so override the control-binding hooks.
     // -----------------------------------------------------------------------
 
     public getControlValue(key: string): unknown {
@@ -162,36 +176,45 @@ export class SettingsTab extends PluginSettingTab {
     }
 
     /**
-     * Wrap a render callback with a "Reload" button that appears after the
-     * underlying control changes. Use for settings whose effect only takes
-     * after the host window reloads (`settings.changeRequiresRestart`).
+     * Wrap a render callback with a "Reload" button for a setting whose effect
+     * only takes after the host window reloads (`settings.changeRequiresRestart`).
      *
-     * The inner callback receives a `markChanged()` it must call from its own
-     * onChange handler to reveal the reload button.
+     * The button is shown whenever the setting's current value differs from
+     * the value in use since the plugin loaded, so it survives tab rebuilds and
+     * closing/reopening the settings, and it disappears again if the value is
+     * changed back.
+     *
+     * The inner callback receives a `refreshReloadButton()` it must call from
+     * its own onChange handler, after persisting the new value.
      */
-    private withReload(inner: (setting: Setting, markChanged: () => void) => void) {
+    private withReload(key: keyof Settings, inner: (setting: Setting, refreshReloadButton: () => void) => void) {
         return (setting: Setting) => {
-            let reloadBtnAdded = false;
-            const markChanged = () => {
-                if (!reloadBtnAdded) {
-                    reloadBtnAdded = true;
-                    this.addReloadButton(setting);
+            let reloadBtn: ButtonComponent | null = null;
+            const refreshReloadButton = () => {
+                const needsReload =
+                    JSON.stringify(getSettings()[key]) !== JSON.stringify(getSettingsAtPluginLoad()[key]);
+                if (needsReload && reloadBtn === null) {
+                    reloadBtn = this.addReloadButton(setting);
                 }
+                reloadBtn?.buttonEl.toggle(needsReload);
             };
-            inner(setting, markChanged);
+            inner(setting, refreshReloadButton);
+            // Show the button now if a reload is already pending.
+            refreshReloadButton();
         };
     }
 
-    private addReloadButton(setting: Setting): void {
+    private addReloadButton(setting: Setting): ButtonComponent {
+        let button!: ButtonComponent;
         setting.addButton((btn) => {
+            button = btn;
             btn.setButtonText(i18n.t('common.reload'))
                 .setCta()
                 .onClick(() => window.location.reload());
-            // Place the Reload button before the row's control, matching
-            // Obsidian's own "Relaunch" placement on restart-required
-            // settings.
+            // Put the button before the control, to match Obsidian's own 'Relaunch' buttons.
             setting.controlEl.prepend(btn.buttonEl);
         });
+        return button;
     }
 
     public getSettingDefinitions(): SettingDefinitionItem[] {
@@ -218,7 +241,7 @@ export class SettingsTab extends PluginSettingTab {
                     `<p>${i18n.t('settings.format.description.line2')}</p>`,
             ),
             render: this.withDocs(
-                this.withReload((setting, markChanged) => {
+                this.withReload('taskFormat', (setting, refreshReloadButton) => {
                     setting.addDropdown((dropdown) => {
                         for (const key of Object.keys(TASK_FORMATS) as (keyof TASK_FORMATS)[]) {
                             dropdown.addOption(key, TASK_FORMATS[key].getDisplayName());
@@ -226,7 +249,7 @@ export class SettingsTab extends PluginSettingTab {
                         dropdown.setValue(getSettings().taskFormat).onChange(async (value) => {
                             updateSettings({ taskFormat: value as keyof TASK_FORMATS });
                             await this.plugin.saveSettings();
-                            markChanged();
+                            refreshReloadButton();
                         });
                     });
                 }),
@@ -277,13 +300,13 @@ export class SettingsTab extends PluginSettingTab {
                     name: i18n.t('settings.globalFilter.removeFilter.name'),
                     desc: i18n.t('settings.globalFilter.removeFilter.description'),
                     visible: () => getSettings().globalFilter.length > 0,
-                    render: this.withReload((setting, markChanged) => {
+                    render: this.withReload('removeGlobalFilter', (setting, refreshReloadButton) => {
                         setting.addToggle((toggle) => {
                             toggle.setValue(getSettings().removeGlobalFilter).onChange(async (value) => {
                                 updateSettings({ removeGlobalFilter: value });
                                 GlobalFilter.getInstance().setRemoveGlobalFilter(value);
                                 await this.plugin.saveSettings();
-                                markChanged();
+                                refreshReloadButton();
                             });
                         });
                     }),
@@ -472,9 +495,7 @@ export class SettingsTab extends PluginSettingTab {
     private statusesPage(): SettingDefinitionItem {
         const { statusSettings } = getSettings();
 
-        // Built alongside the row definitions, so the custom-statuses search
-        // can filter on the underlying status (symbol, name and type), not
-        // just the definition's display name.
+        // Lets the custom-statuses search filter on the status symbol, name and type.
         const rowStatuses = new WeakMap<SettingDefinition, StatusConfiguration>();
         const statusRow = (status: StatusConfiguration, isCoreStatus: boolean): SettingDefinition => {
             const row = this.statusRow(status, isCoreStatus);
@@ -735,7 +756,7 @@ export class SettingsTab extends PluginSettingTab {
                             `${i18n.t('settings.datesFromFileNames.scheduledDate.toggle.description.line4')}</p>`,
                     ),
                     render: this.withDocs(
-                        this.withReload((setting, markChanged) => {
+                        this.withReload('useFilenameAsScheduledDate', (setting, refreshReloadButton) => {
                             setting.addToggle((toggle) => {
                                 toggle.setValue(getSettings().useFilenameAsScheduledDate).onChange(async (value) => {
                                     updateSettings({ useFilenameAsScheduledDate: value });
@@ -744,7 +765,7 @@ export class SettingsTab extends PluginSettingTab {
                                     if (requireApiVersion('1.13.0')) {
                                         this.refreshDomState();
                                     }
-                                    markChanged();
+                                    refreshReloadButton();
                                 });
                             });
                         }),
@@ -756,7 +777,7 @@ export class SettingsTab extends PluginSettingTab {
                     desc: i18n.t('settings.datesFromFileNames.scheduledDate.extraFormat.description.line1'),
                     visible: () => getSettings().useFilenameAsScheduledDate,
                     render: this.withDocs(
-                        this.withReload((setting, markChanged) => {
+                        this.withReload('filenameAsScheduledDateFormat', (setting, refreshReloadButton) => {
                             setting.addText((text) => {
                                 text.setPlaceholder(
                                     i18n.t('settings.datesFromFileNames.scheduledDate.extraFormat.placeholder'),
@@ -765,7 +786,7 @@ export class SettingsTab extends PluginSettingTab {
                                     .onChange(async (value) => {
                                         updateSettings({ filenameAsScheduledDateFormat: value });
                                         await this.plugin.saveSettings();
-                                        markChanged();
+                                        refreshReloadButton();
                                     });
                             });
                         }),
@@ -776,7 +797,7 @@ export class SettingsTab extends PluginSettingTab {
                     name: i18n.t('settings.datesFromFileNames.scheduledDate.folders.name'),
                     desc: i18n.t('settings.datesFromFileNames.scheduledDate.folders.description'),
                     visible: () => getSettings().useFilenameAsScheduledDate,
-                    render: this.withReload((setting, markChanged) => {
+                    render: this.withReload('filenameAsDateFolders', (setting, refreshReloadButton) => {
                         setting.addText((input) => {
                             input
                                 .setValue(SettingsTab.renderFolderArray(getSettings().filenameAsDateFolders))
@@ -784,7 +805,7 @@ export class SettingsTab extends PluginSettingTab {
                                     const folders = SettingsTab.parseCommaSeparatedFolders(value);
                                     updateSettings({ filenameAsDateFolders: folders });
                                     await this.plugin.saveSettings();
-                                    markChanged();
+                                    refreshReloadButton();
                                 });
                         });
                     }),
@@ -834,7 +855,7 @@ export class SettingsTab extends PluginSettingTab {
                     name: i18n.t('settings.autoSuggest.toggle.name'),
                     desc: i18n.t('settings.autoSuggest.toggle.description'),
                     render: this.withDocs(
-                        this.withReload((setting, markChanged) => {
+                        this.withReload('autoSuggestInEditor', (setting, refreshReloadButton) => {
                             setting.addToggle((toggle) => {
                                 toggle.setValue(getSettings().autoSuggestInEditor).onChange(async (value) => {
                                     updateSettings({ autoSuggestInEditor: value });
@@ -843,7 +864,7 @@ export class SettingsTab extends PluginSettingTab {
                                     if (requireApiVersion('1.13.0')) {
                                         this.refreshDomState();
                                     }
-                                    markChanged();
+                                    refreshReloadButton();
                                 });
                             });
                         }),
@@ -854,7 +875,7 @@ export class SettingsTab extends PluginSettingTab {
                     name: i18n.t('settings.autoSuggest.minLength.name'),
                     desc: i18n.t('settings.autoSuggest.minLength.description'),
                     visible: () => getSettings().autoSuggestInEditor,
-                    render: this.withReload((setting, markChanged) => {
+                    render: this.withReload('autoSuggestMinMatch', (setting, refreshReloadButton) => {
                         setting.addSlider((slider) => {
                             slider
                                 .setLimits(0, 3, 1)
@@ -862,7 +883,7 @@ export class SettingsTab extends PluginSettingTab {
                                 .onChange(async (value) => {
                                     updateSettings({ autoSuggestMinMatch: value });
                                     await this.plugin.saveSettings();
-                                    markChanged();
+                                    refreshReloadButton();
                                 });
                         });
                     }),
@@ -871,7 +892,7 @@ export class SettingsTab extends PluginSettingTab {
                     name: i18n.t('settings.autoSuggest.maxSuggestions.name'),
                     desc: i18n.t('settings.autoSuggest.maxSuggestions.description'),
                     visible: () => getSettings().autoSuggestInEditor,
-                    render: this.withReload((setting, markChanged) => {
+                    render: this.withReload('autoSuggestMaxItems', (setting, refreshReloadButton) => {
                         setting.addSlider((slider) => {
                             slider
                                 .setLimits(3, 20, 1)
@@ -879,7 +900,7 @@ export class SettingsTab extends PluginSettingTab {
                                 .onChange(async (value) => {
                                     updateSettings({ autoSuggestMaxItems: value });
                                     await this.plugin.saveSettings();
-                                    markChanged();
+                                    refreshReloadButton();
                                 });
                         });
                     }),

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -268,6 +268,9 @@ export class SettingsTab extends PluginSettingTab {
             items: [
                 {
                     name: i18n.t('settings.globalFilter.filter.name'),
+                    // Group headings are not searchable, so the first row in
+                    // the group carries the heading as a search alias.
+                    aliases: [i18n.t('settings.globalDefaults.heading')],
                     desc: SettingsTab.createFragmentWithHTML(
                         `<p><b>${i18n.t('settings.globalFilter.filter.description.line1')}</b></p>` +
                             `<p>${i18n.t('settings.globalFilter.filter.description.line2')}</p>` +
@@ -533,7 +536,9 @@ export class SettingsTab extends PluginSettingTab {
                         {
                             name: i18n.t('settings.statuses.coreStatuses.buttons.checkStatuses.name'),
                             desc: i18n.t('settings.statuses.coreStatuses.buttons.checkStatuses.tooltip'),
-                            searchable: false,
+                            // List headings are not searchable, so this
+                            // always-present row carries the heading as an alias.
+                            aliases: [i18n.t('settings.statuses.coreStatuses.heading')],
                             action: async () => {
                                 await this.createStatusRegistryReport();
                             },
@@ -628,7 +633,7 @@ export class SettingsTab extends PluginSettingTab {
                         {
                             name: i18n.t('settings.statuses.customStatuses.buttons.resetCustomStatuses.name'),
                             desc: i18n.t('settings.statuses.customStatuses.buttons.resetCustomStatuses.description'),
-                            searchable: false,
+                            aliases: [i18n.t('settings.statuses.customStatuses.heading')],
                             action: () => {
                                 const { statusSettings: current } = getSettings();
                                 StatusSettings.resetAllCustomStatuses(current);
@@ -804,6 +809,7 @@ export class SettingsTab extends PluginSettingTab {
             items: [
                 {
                     name: i18n.t('settings.dates.createdDate.name'),
+                    aliases: [i18n.t('settings.dates.heading')],
                     desc: i18n.t('settings.dates.createdDate.description'),
                     render: this.renderToggleWithDocs(
                         'setCreatedDate',
@@ -839,6 +845,7 @@ export class SettingsTab extends PluginSettingTab {
             items: [
                 {
                     name: i18n.t('settings.datesFromFileNames.scheduledDate.toggle.name'),
+                    aliases: [i18n.t('settings.datesFromFileNames.heading')],
                     desc: SettingsTab.createFragmentWithHTML(
                         `<p>${i18n.t('settings.datesFromFileNames.scheduledDate.toggle.description.line1')} ` +
                             `${i18n.t('settings.datesFromFileNames.scheduledDate.toggle.description.line2')}</p>` +
@@ -913,6 +920,7 @@ export class SettingsTab extends PluginSettingTab {
             items: [
                 {
                     name: i18n.t('settings.recurringTasks.nextLine.name'),
+                    aliases: [i18n.t('settings.recurringTasks.heading')],
                     desc: i18n.t('settings.recurringTasks.nextLine.description'),
                     render: this.renderToggleWithDocs(
                         'recurrenceOnNextLine',
@@ -943,6 +951,7 @@ export class SettingsTab extends PluginSettingTab {
             items: [
                 {
                     name: i18n.t('settings.autoSuggest.toggle.name'),
+                    aliases: [i18n.t('settings.taskEntry.heading')],
                     desc: i18n.t('settings.autoSuggest.toggle.description'),
                     render: this.withDocs(
                         this.withReload('autoSuggestInEditor', (setting, refreshReloadButton) => {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -509,6 +509,7 @@ export class SettingsTab extends PluginSettingTab {
         return {
             type: 'page',
             name: i18n.t('settings.statuses.heading'),
+            status: () => (this.statusesChangedSinceLoad() ? 'warning' : null),
             items: [
                 {
                     type: 'list',
@@ -641,6 +642,43 @@ export class SettingsTab extends PluginSettingTab {
     }
 
     /**
+     * Status edits only fully take effect after a reload, so a Notice prompts
+     * for a reload whenever the statuses differ from those in use.
+     */
+    private statusesChangedSinceLoad(): boolean {
+        return (
+            JSON.stringify(getSettings().statusSettings) !== JSON.stringify(getSettingsAtPluginLoad().statusSettings)
+        );
+    }
+
+    private reloadNotice: Notice | null = null;
+
+    /**
+     * Show a Notice with a Reload button after a status edit. The one Notice
+     * is reused, so editing several statuses does not stack notices; it hides
+     * again if the statuses return to the values in use.
+     */
+    public refreshStatusesReloadNotice(): void {
+        if (!this.statusesChangedSinceLoad()) {
+            this.reloadNotice?.hide();
+            this.reloadNotice = null;
+            return;
+        }
+        if (this.reloadNotice !== null && this.reloadNotice.messageEl.isConnected) {
+            return;
+        }
+
+        const notice = new Notice(i18n.t('settings.statuses.reloadRequired'), 0);
+        const buttonContainerEl = notice.containerEl.createDiv('notice-button-container');
+        const ctaEl = buttonContainerEl.createDiv({ cls: 'notice-cta', text: i18n.t('common.reload') });
+        ctaEl.addEventListener('click', () => {
+            notice.hide();
+            window.location.reload();
+        });
+        this.reloadNotice = notice;
+    }
+
+    /**
      * Show a menu of the theme status collections, anchored below `anchorEl`;
      * choosing one imports its statuses into the custom statuses list.
      */
@@ -678,11 +716,9 @@ export class SettingsTab extends PluginSettingTab {
         const buttonContainerEl = modal.contentEl.createDiv({ cls: 'modal-button-container' });
         new ButtonComponent(buttonContainerEl)
             .setButtonText(i18n.t('settings.seeTheDocumentation'))
+            .setClass('mod-secondary')
             .onClick(() => window.open(docsUrl, '_blank', 'noopener'));
-        new ButtonComponent(buttonContainerEl)
-            .setButtonText(i18n.t('common.okay'))
-            .setCta()
-            .onClick(() => modal.close());
+        new ButtonComponent(buttonContainerEl).setButtonText(i18n.t('common.okay')).onClick(() => modal.close());
         modal.open();
     }
 
@@ -1908,6 +1944,7 @@ function updateAndSaveStatusSettings(statusTypes: StatusSettings, settings: Sett
     StatusSettings.applyToStatusRegistry(statusTypes, StatusRegistry.getInstance());
 
     settings.saveSettingsAndRebuildSettingsTab();
+    settings.refreshStatusesReloadNotice();
 }
 
 function makeMultilineTextSetting(setting: Setting) {

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -1,4 +1,16 @@
-import { Notice, PluginSettingTab, Setting, debounce, sanitizeHTMLToDom } from 'obsidian';
+import {
+    type ConfirmationButton,
+    ConfirmationModal,
+    Menu,
+    Notice,
+    PluginSettingTab,
+    Setting,
+    type SettingDefinition,
+    type SettingDefinitionItem,
+    debounce,
+    requireApiVersion,
+    sanitizeHTMLToDom,
+} from 'obsidian';
 import { StatusConfiguration, StatusType } from '../Statuses/StatusConfiguration';
 import type TasksPlugin from '../main';
 import { StatusRegistry } from '../Statuses/StatusRegistry';
@@ -21,6 +33,7 @@ import { StatusSettings } from './StatusSettings';
 
 import { CustomStatusModal } from './CustomStatusModal';
 import { GlobalQuery } from './GlobalQuery';
+import { GlobalQueryModal } from './GlobalQueryModal';
 import { PresetsSettingsUI } from './PresetsSettingsUI';
 import { EnableJsInTasksQueries } from './EnableJsInTasksQueries';
 
@@ -44,6 +57,15 @@ interface HeadingConfiguration {
     settings: SettingConfiguration[];
 }
 
+/**
+ * The plugin's settings tab, with two implementations of the UI:
+ *
+ * - {@link getSettingDefinitions} — the declarative API, used by Obsidian 1.13.0 and later.
+ * - {@link display} — the imperative fallback, used by older Obsidian versions.
+ *
+ * Obsidian picks the right path per host, so BOTH implementations must be
+ * updated whenever a setting is added, removed or changed.
+ */
 export class SettingsTab extends PluginSettingTab {
     // If the UI needs a more complex setting you can create a
     // custom function and specify it from the json file. It will
@@ -69,15 +91,784 @@ export class SettingsTab extends PluginSettingTab {
 
     public saveSettingsAndRebuildSettingsTab(): void {
         void this.plugin.saveSettings();
+        this.rebuildSettingsTab();
+    }
 
+    private rebuildSettingsTab(): void {
         // Rebuilding the settings tab resets it to the top, so restore how far down it was.
         const previousDistanceFromTop = this.containerEl.scrollTop;
 
-        this.display();
+        if (requireApiVersion('1.13.0')) {
+            // Obsidian 1.13.0+ renders this tab from getSettingDefinitions(),
+            // so rebuild it declaratively. display() would render nothing here.
+            this.update();
+        } else {
+            this.display();
+        }
 
         requestAnimationFrame(() => {
             this.containerEl.scrollTo({ top: previousDistanceFromTop });
         });
+    }
+
+    // -----------------------------------------------------------------------
+    // Declarative settings API (Obsidian 1.13.0+)
+    //
+    // The plugin keeps its data in a module-level object accessed via
+    // getSettings/updateSettings, not on this.plugin.settings. Override the
+    // default control-binding hooks so declarative `control` definitions read
+    // and write through those helpers.
+    // -----------------------------------------------------------------------
+
+    public getControlValue(key: string): unknown {
+        return (getSettings() as unknown as Record<string, unknown>)[key];
+    }
+
+    public async setControlValue(key: string, value: unknown): Promise<void> {
+        updateSettings({ [key]: value });
+        await this.plugin.saveSettings();
+    }
+
+    /**
+     * Convenience: build a `render` callback that adds a toggle plus a docs
+     * extraButton. Reads/writes via the same getControlValue/setControlValue
+     * bridge as a `control` definition.
+     */
+    private renderToggleWithDocs(key: keyof ReturnType<typeof getSettings>, docsUrl: string) {
+        return this.withDocs((setting: Setting) => {
+            setting.addToggle((toggle) => {
+                toggle.setValue(this.getControlValue(key) as boolean).onChange(async (value) => {
+                    await this.setControlValue(key, value);
+                });
+            });
+        }, docsUrl);
+    }
+
+    /**
+     * Convenience: build a `render` callback that adds a docs extraButton onto
+     * an existing render callback.
+     */
+    private withDocs(inner: (setting: Setting) => void, docsUrl: string) {
+        return (setting: Setting) => {
+            setting.addExtraButton((btn) =>
+                btn
+                    .setIcon('book-open')
+                    .setTooltip(i18n.t('settings.seeTheDocumentation'))
+                    .onClick(() => window.open(docsUrl, '_blank')),
+            );
+            inner(setting);
+        };
+    }
+
+    /**
+     * Wrap a render callback with a "Reload" button that appears after the
+     * underlying control changes. Use for settings whose effect only takes
+     * after the host window reloads (`settings.changeRequiresRestart`).
+     *
+     * The inner callback receives a `markChanged()` it must call from its own
+     * onChange handler to reveal the reload button.
+     */
+    private withReload(inner: (setting: Setting, markChanged: () => void) => void) {
+        return (setting: Setting) => {
+            let reloadBtnEl: HTMLButtonElement | null = null;
+            const markChanged = () => {
+                if (reloadBtnEl) {
+                    return;
+                }
+                setting.addButton((btn) => {
+                    btn.setButtonText(i18n.t('common.reload'))
+                        .setCta()
+                        .onClick(() => window.location.reload());
+                    // Place the Reload button before the row's control, matching
+                    // Obsidian's own "Relaunch" placement on restart-required
+                    // settings.
+                    setting.controlEl.prepend(btn.buttonEl);
+                    reloadBtnEl = btn.buttonEl;
+                });
+            };
+            inner(setting, markChanged);
+        };
+    }
+
+    public getSettingDefinitions(): SettingDefinitionItem[] {
+        return [
+            this.taskFormatDefinition(),
+            this.globalDefaultsGroup(),
+            this.searchesGroup(),
+            this.presetsPage(),
+            this.statusesPage(),
+            this.datesGroup(),
+            this.datesFromFilenamesGroup(),
+            this.recurringTasksGroup(),
+            this.taskEntryGroup(),
+        ];
+    }
+
+    // ---- Task format (general, no heading) --------------------------------
+
+    private taskFormatDefinition(): SettingDefinitionItem {
+        return {
+            name: i18n.t('settings.format.name'),
+            desc: SettingsTab.createFragmentWithHTML(
+                `<p>${i18n.t('settings.format.description.line1')}</p>` +
+                    `<p>${i18n.t('settings.format.description.line2')}</p>`,
+            ),
+            render: this.withDocs(
+                this.withReload((setting, markChanged) => {
+                    setting.addDropdown((dropdown) => {
+                        for (const key of Object.keys(TASK_FORMATS) as (keyof TASK_FORMATS)[]) {
+                            dropdown.addOption(key, TASK_FORMATS[key].getDisplayName());
+                        }
+                        dropdown.setValue(getSettings().taskFormat).onChange(async (value) => {
+                            updateSettings({ taskFormat: value as keyof TASK_FORMATS });
+                            await this.plugin.saveSettings();
+                            markChanged();
+                        });
+                    });
+                }),
+                'https://publish.obsidian.md/tasks/Reference/Task+Formats/About+Task+Formats',
+            ),
+        };
+    }
+
+    // ---- Global defaults (filter + query) ---------------------------------
+
+    private globalDefaultsGroup(): SettingDefinitionItem {
+        return {
+            type: 'group',
+            heading: i18n.t('settings.globalDefaults.heading'),
+            items: [
+                {
+                    name: i18n.t('settings.globalFilter.filter.name'),
+                    desc: SettingsTab.createFragmentWithHTML(
+                        `<p><b>${i18n.t('settings.globalFilter.filter.description.line1')}</b></p>` +
+                            `<p>${i18n.t('settings.globalFilter.filter.description.line2')}</p>` +
+                            `<p>${i18n.t('settings.globalFilter.filter.description.line3')} ` +
+                            `${i18n.t('settings.globalFilter.filter.description.line4')}</p>`,
+                    ),
+                    render: this.withDocs((setting) => {
+                        setting.addText((text) => {
+                            text.setPlaceholder(i18n.t('settings.globalFilter.filter.placeholder'))
+                                .setValue(GlobalFilter.getInstance().get())
+                                .onChange(
+                                    debounce(
+                                        async (value) => {
+                                            updateSettings({ globalFilter: value });
+                                            GlobalFilter.getInstance().set(value);
+                                            await this.plugin.saveSettings();
+                                            // Re-evaluate the 'visible' predicate of the remove-filter row.
+                                            if (requireApiVersion('1.13.0')) {
+                                                this.refreshDomState();
+                                            }
+                                            this.events.triggerReloadVault();
+                                        },
+                                        500,
+                                        true,
+                                    ),
+                                );
+                        });
+                    }, 'https://publish.obsidian.md/tasks/Getting+Started/Global+Filter'),
+                },
+                {
+                    name: i18n.t('settings.globalFilter.removeFilter.name'),
+                    desc: i18n.t('settings.globalFilter.removeFilter.description'),
+                    visible: () => getSettings().globalFilter.length > 0,
+                    render: this.withReload((setting, markChanged) => {
+                        setting.addToggle((toggle) => {
+                            toggle.setValue(getSettings().removeGlobalFilter).onChange(async (value) => {
+                                updateSettings({ removeGlobalFilter: value });
+                                GlobalFilter.getInstance().setRemoveGlobalFilter(value);
+                                await this.plugin.saveSettings();
+                                markChanged();
+                            });
+                        });
+                    }),
+                },
+                {
+                    name: i18n.t('settings.globalQuery.heading'),
+                    desc: i18n.t('settings.globalQuery.query.shortDescription'),
+                    render: this.withDocs((setting) => {
+                        setting.addExtraButton((btn) =>
+                            btn
+                                .setIcon('pencil')
+                                .setTooltip(i18n.t('common.edit'))
+                                .onClick(() => {
+                                    new GlobalQueryModal(this.app, getSettings().globalQuery, async (value) => {
+                                        updateSettings({ globalQuery: value });
+                                        GlobalQuery.getInstance().set(value);
+                                        await this.plugin.saveSettings();
+                                        this.events.triggerReloadOpenSearchResults();
+                                    }).open();
+                                }),
+                        );
+                    }, 'https://publish.obsidian.md/tasks/Queries/Global+Query'),
+                },
+            ],
+        };
+    }
+
+    // ---- Searches & search results ---------------------------------------
+
+    private searchesGroup(): SettingDefinitionItem {
+        return {
+            type: 'group',
+            heading: i18n.t('settings.searches.heading'),
+            items: [
+                {
+                    name: i18n.t('settings.searches.enableCustomSearches.name'),
+                    desc: SettingsTab.createFragmentWithHTML(
+                        i18n.t('settings.searches.enableCustomSearches.description.line1', {
+                            filterByFunction: '<code>filter by function</code>',
+                            sortByFunction: '<code>sort by function</code>',
+                            groupByFunction: '<code>group by function</code>',
+                        }),
+                    ),
+                    render: (setting) => {
+                        setting.addToggle((toggle) => {
+                            toggle.setValue(EnableJsInTasksQueries.getInstance().get()).onChange((value) => {
+                                if (!value) {
+                                    // Turning OFF: no confirmation needed.
+                                    EnableJsInTasksQueries.getInstance().set(false);
+                                    this.events.triggerReloadOpenSearchResults();
+                                    return;
+                                }
+                                // Turning ON: require explicit acknowledgement.
+                                this.confirmEnableCustomSearches((confirmed) => {
+                                    if (confirmed) {
+                                        EnableJsInTasksQueries.getInstance().set(true);
+                                        this.events.triggerReloadOpenSearchResults();
+                                    } else {
+                                        // Revert the toggle UI back to off.
+                                        toggle.setValue(false);
+                                    }
+                                });
+                            });
+                        });
+                    },
+                },
+                {
+                    name: i18n.t('settings.searchResults.taskCountLocation.name'),
+                    desc: i18n.t('settings.searchResults.taskCountLocation.description'),
+                    render: (setting) => {
+                        setting.addDropdown((dropdown) => {
+                            dropdown.addOption('top', i18n.t('settings.searchResults.taskCountLocation.options.top'));
+                            dropdown.addOption(
+                                'bottom',
+                                i18n.t('settings.searchResults.taskCountLocation.options.bottom'),
+                            );
+                            dropdown.setValue(getSettings().searchResults.taskCountLocation).onChange(async (value) => {
+                                updateSettings({
+                                    searchResults: { taskCountLocation: value as 'top' | 'bottom' },
+                                });
+                                await this.plugin.saveSettings();
+                                this.events.triggerReloadOpenSearchResults();
+                            });
+                        });
+                    },
+                },
+            ],
+        };
+    }
+
+    /**
+     * Show a {@link ConfirmationModal} explaining the risks of enabling custom
+     * searches (which let queries execute arbitrary JavaScript). The user must
+     * tick a checkbox before the Enable button is available. Calls back with
+     * `true` if the user enabled, `false` if they cancelled or closed.
+     */
+    private confirmEnableCustomSearches(callback: (confirmed: boolean) => void): void {
+        // The version check is always true in practice: this method is only
+        // called from the declarative settings path, which requires 1.13.0+.
+        if (requireApiVersion('1.13.0')) {
+            const modal = new ConfirmationModal(this.app);
+            modal.setTitle(i18n.t('settings.searches.enableCustomSearches.name'));
+
+            modal.contentEl.createEl('p', {
+                cls: 'setting-item-description',
+                text: i18n.t('settings.searches.enableCustomSearches.description.line2'),
+            });
+            const warningEl = modal.contentEl.createEl('p', { cls: 'setting-item-description mod-warning' });
+            warningEl.createEl('b', {
+                text: i18n.t('settings.searches.enableCustomSearches.description.line3'),
+            });
+            modal.contentEl.createEl('p', {
+                cls: 'setting-item-description',
+                text: i18n.t('settings.searches.enableCustomSearches.description.line4'),
+            });
+
+            let acknowledged = false;
+            let enableBtn: ConfirmationButton | null = null;
+            modal.addCheckbox(i18n.t('settings.searches.enableCustomSearches.confirm.acknowledge'), (value) => {
+                acknowledged = value;
+                if (enableBtn) {
+                    enableBtn.setDisabled(!acknowledged);
+                }
+            });
+
+            let decided = false;
+            modal.addButton((btn) => {
+                enableBtn = btn;
+                btn.setButtonText(i18n.t('settings.searches.enableCustomSearches.confirm.enable'))
+                    .setCta()
+                    .setDisabled(true)
+                    .onClick(() => {
+                        if (!acknowledged) {
+                            return true; // keep the modal open
+                        }
+                        decided = true;
+                        callback(true);
+                        return undefined;
+                    });
+            });
+            modal.addCancelButton();
+
+            const originalOnClose = modal.onClose.bind(modal);
+            modal.onClose = () => {
+                originalOnClose();
+                if (!decided) {
+                    callback(false);
+                }
+            };
+            modal.open();
+        } else {
+            callback(false);
+        }
+    }
+
+    // ---- Presets (sub-page) ----------------------------------------------
+
+    private presetsPage(): SettingDefinitionItem {
+        return {
+            type: 'page',
+            name: i18n.t('settings.presets.name'),
+            desc: SettingsTab.createFragmentWithHTML(
+                '<p>' +
+                    i18n.t('settings.presets.line1', {
+                        name: '<code>name</code>',
+                        instruction1: '<code>preset name</code>',
+                        instruction2: '<code>{{preset.name}}</code>',
+                    }) +
+                    '</p><p>' +
+                    i18n.t('settings.presets.line2') +
+                    '</p>' +
+                    this.seeTheDocumentation('https://publish.obsidian.md/tasks/Queries/Presets'),
+            ),
+            items: this.presetsSettingsUI.getPresetsDefinitions(() => this.rebuildSettingsTab()),
+        };
+    }
+
+    // ---- Statuses (sub-page) ---------------------------------------------
+
+    private statusesPage(): SettingDefinitionItem {
+        const { statusSettings } = getSettings();
+
+        // Built alongside the row definitions, so the custom-statuses search
+        // can filter on the underlying status (symbol, name and type), not
+        // just the definition's display name.
+        const rowStatuses = new WeakMap<SettingDefinition, StatusConfiguration>();
+        const statusRow = (status: StatusConfiguration, isCoreStatus: boolean): SettingDefinition => {
+            const row = this.statusRow(status, isCoreStatus);
+            rowStatuses.set(row, status);
+            return row;
+        };
+
+        return {
+            type: 'page',
+            name: i18n.t('settings.statuses.heading'),
+            items: [
+                {
+                    type: 'list',
+                    heading: i18n.t('settings.statuses.coreStatuses.heading'),
+                    items: [
+                        ...statusSettings.coreStatuses.map((status) => statusRow(status, true)),
+                        {
+                            name: i18n.t('settings.statuses.coreStatuses.buttons.checkStatuses.name'),
+                            desc: i18n.t('settings.statuses.coreStatuses.buttons.checkStatuses.tooltip'),
+                            searchable: false,
+                            action: async () => {
+                                await this.createStatusRegistryReport();
+                            },
+                        },
+                    ],
+                },
+                {
+                    type: 'list',
+                    heading: i18n.t('settings.statuses.customStatuses.heading'),
+                    emptyState: i18n.t('settings.statuses.customStatuses.emptyState'),
+                    search: {
+                        placeholder: i18n.t('settings.statuses.filter.placeholder'),
+                        match: (def, query) => {
+                            const status = rowStatuses.get(def);
+                            if (!status) {
+                                return true;
+                            }
+                            const q = query.toLowerCase();
+                            return (
+                                status.name.toLowerCase().includes(q) ||
+                                status.symbol.toLowerCase().includes(q) ||
+                                humanizeStatusType(status.type).toLowerCase().includes(q)
+                            );
+                        },
+                    },
+                    extraButtons: [
+                        (btn) =>
+                            btn
+                                .setIcon('book-open')
+                                .setTooltip(i18n.t('settings.seeTheDocumentation'))
+                                .onClick(() =>
+                                    window.open('https://publish.obsidian.md/tasks/Getting+Started/Statuses', '_blank'),
+                                ),
+                        (btn) => {
+                            btn.setIcon('lucide-palette').setTooltip(
+                                i18n.t('settings.statuses.buttons.importFromTheme'),
+                            );
+                            btn.extraSettingsEl.addEventListener('click', (evt) => {
+                                const menu = new Menu();
+                                for (const { name, collection } of getThemeCollections()) {
+                                    menu.addItem((item) =>
+                                        item
+                                            .setTitle(
+                                                i18n.t('settings.statuses.collections.buttons.importCollection.name', {
+                                                    themeName: name,
+                                                    numberOfStatuses: collection.length,
+                                                }),
+                                            )
+                                            .onClick(() => {
+                                                const { statusSettings: current } = getSettings();
+                                                addCustomStatesToSettings(collection, current, this);
+                                            }),
+                                    );
+                                }
+                                menu.showAtMouseEvent(evt);
+                            });
+                        },
+                    ],
+                    onDelete: (index) => {
+                        const { statusSettings: current } = getSettings();
+                        current.customStatuses.splice(index, 1);
+                        updateAndSaveStatusSettings(current, this);
+                    },
+                    addItem: {
+                        name: i18n.t('settings.statuses.buttons.addStatus'),
+                        action: () => {
+                            const draft = new StatusConfiguration('', '', '', false, StatusType.TODO);
+                            const modal = new CustomStatusModal(this.plugin, draft, false);
+                            modal.onClose = () => {
+                                if (!modal.saved) {
+                                    return;
+                                }
+                                const { statusSettings: current } = getSettings();
+                                StatusSettings.addStatus(current.customStatuses, modal.statusConfiguration());
+                                updateAndSaveStatusSettings(current, this);
+                            };
+                            modal.open();
+                        },
+                    },
+                    items: statusSettings.customStatuses.map((status) => statusRow(status, false)),
+                },
+                {
+                    name: i18n.t('settings.statuses.customStatuses.buttons.addAllUnknown.name'),
+                    desc: i18n.t('settings.statuses.customStatuses.buttons.addAllUnknown.description'),
+                    searchable: false,
+                    action: () => {
+                        const { statusSettings: current } = getSettings();
+                        const tasks = this.plugin.getTasks();
+                        const unknownStatuses = StatusRegistry.getInstance().findUnknownStatuses(
+                            tasks.map((task) => task.status),
+                        );
+                        if (unknownStatuses.length === 0) {
+                            return;
+                        }
+                        unknownStatuses.forEach((s) => {
+                            StatusSettings.addStatus(current.customStatuses, s);
+                        });
+                        updateAndSaveStatusSettings(current, this);
+                    },
+                },
+                {
+                    name: i18n.t('settings.statuses.customStatuses.buttons.resetCustomStatuses.name'),
+                    desc: i18n.t('settings.statuses.customStatuses.buttons.resetCustomStatuses.description'),
+                    searchable: false,
+                    action: () => {
+                        const { statusSettings: current } = getSettings();
+                        StatusSettings.resetAllCustomStatuses(current);
+                        updateAndSaveStatusSettings(current, this);
+                    },
+                },
+            ],
+        };
+    }
+
+    /**
+     * Builds one list row for a single status. The row's `name` is the
+     * status's friendly name, with the symbol prepended as a `<code>` chip; a
+     * pencil extraButton opens the existing edit modal. Deletion is wired by
+     * the list's `onDelete`, so no per-row delete button is needed.
+     */
+    private statusRow(status: StatusConfiguration, isCoreStatus: boolean): SettingDefinition {
+        const symbol = status.symbol || ' ';
+        return {
+            name: status.name || i18n.t('settings.statuses.unnamed'),
+            render: (setting) => {
+                // Prepend the symbol to the left of the row's name — reads as
+                // the list marker for the friendly name beside it (`- [/] In progress`).
+                setting.nameEl.prepend(createEl('code', { cls: 'tasks-status-symbol', text: `- [${symbol}]` }));
+                setting.addExtraButton((btn) => {
+                    btn.setIcon('pencil')
+                        .setTooltip(i18n.t('common.edit'))
+                        .onClick(() => {
+                            const modal = new CustomStatusModal(this.plugin, status, isCoreStatus);
+                            modal.onClose = () => {
+                                if (!modal.saved) {
+                                    return;
+                                }
+                                const { statusSettings: current } = getSettings();
+                                const list = isCoreStatus ? current.coreStatuses : current.customStatuses;
+                                if (StatusSettings.replaceStatus(list, status, modal.statusConfiguration())) {
+                                    updateAndSaveStatusSettings(current, this);
+                                }
+                            };
+                            modal.open();
+                        });
+                });
+            },
+        };
+    }
+
+    private async createStatusRegistryReport(): Promise<void> {
+        const { statusSettings } = getSettings();
+        const buttonName = i18n.t('settings.statuses.coreStatuses.buttons.checkStatuses.name');
+
+        // Generate a new file unique file name, in the root of the vault
+        const now = window.moment();
+        const formattedDateTime = now.format('YYYY-MM-DD HH-mm-ss');
+        const filename = `Tasks Plugin - ${buttonName} ${formattedDateTime}.md`;
+
+        // Create the report
+        const version = this.plugin.manifest.version;
+        const fileContent = createStatusRegistryReport(
+            statusSettings,
+            StatusRegistry.getInstance(),
+            buttonName,
+            version,
+        );
+
+        // Save the file, and open it
+        const file = await this.app.vault.create(filename, fileContent);
+        const leaf = this.app.workspace.getLeaf(true);
+        await leaf.openFile(file);
+    }
+
+    // ---- Dates ------------------------------------------------------------
+
+    private datesGroup(): SettingDefinitionItem {
+        return {
+            type: 'group',
+            heading: i18n.t('settings.dates.heading'),
+            items: [
+                {
+                    name: i18n.t('settings.dates.createdDate.name'),
+                    desc: i18n.t('settings.dates.createdDate.description'),
+                    render: this.renderToggleWithDocs(
+                        'setCreatedDate',
+                        'https://publish.obsidian.md/tasks/Getting+Started/Dates#Created+date',
+                    ),
+                },
+                {
+                    name: i18n.t('settings.dates.doneDate.name'),
+                    desc: i18n.t('settings.dates.doneDate.description'),
+                    render: this.renderToggleWithDocs(
+                        'setDoneDate',
+                        'https://publish.obsidian.md/tasks/Getting+Started/Dates#Done+date',
+                    ),
+                },
+                {
+                    name: i18n.t('settings.dates.cancelledDate.name'),
+                    desc: i18n.t('settings.dates.cancelledDate.description'),
+                    render: this.renderToggleWithDocs(
+                        'setCancelledDate',
+                        'https://publish.obsidian.md/tasks/Getting+Started/Dates#Cancelled+date',
+                    ),
+                },
+            ],
+        };
+    }
+
+    // ---- Dates from file names -------------------------------------------
+
+    private datesFromFilenamesGroup(): SettingDefinitionItem {
+        return {
+            type: 'group',
+            heading: i18n.t('settings.datesFromFileNames.heading'),
+            items: [
+                {
+                    name: i18n.t('settings.datesFromFileNames.scheduledDate.toggle.name'),
+                    desc: SettingsTab.createFragmentWithHTML(
+                        `<p>${i18n.t('settings.datesFromFileNames.scheduledDate.toggle.description.line1')} ` +
+                            `${i18n.t('settings.datesFromFileNames.scheduledDate.toggle.description.line2')}</p>` +
+                            `<p>${i18n.t('settings.datesFromFileNames.scheduledDate.toggle.description.line3')} ` +
+                            `${i18n.t('settings.datesFromFileNames.scheduledDate.toggle.description.line4')}</p>`,
+                    ),
+                    render: this.withDocs(
+                        this.withReload((setting, markChanged) => {
+                            setting.addToggle((toggle) => {
+                                toggle.setValue(getSettings().useFilenameAsScheduledDate).onChange(async (value) => {
+                                    updateSettings({ useFilenameAsScheduledDate: value });
+                                    await this.plugin.saveSettings();
+                                    // Re-evaluate the 'visible' predicates of the dependent rows.
+                                    if (requireApiVersion('1.13.0')) {
+                                        this.refreshDomState();
+                                    }
+                                    markChanged();
+                                });
+                            });
+                        }),
+                        'https://publish.obsidian.md/tasks/Getting+Started/Use+Filename+as+Default+Date',
+                    ),
+                },
+                {
+                    name: i18n.t('settings.datesFromFileNames.scheduledDate.extraFormat.name'),
+                    desc: i18n.t('settings.datesFromFileNames.scheduledDate.extraFormat.description.line1'),
+                    visible: () => getSettings().useFilenameAsScheduledDate,
+                    render: this.withDocs(
+                        this.withReload((setting, markChanged) => {
+                            setting.addText((text) => {
+                                text.setPlaceholder(
+                                    i18n.t('settings.datesFromFileNames.scheduledDate.extraFormat.placeholder'),
+                                )
+                                    .setValue(getSettings().filenameAsScheduledDateFormat)
+                                    .onChange(async (value) => {
+                                        updateSettings({ filenameAsScheduledDateFormat: value });
+                                        await this.plugin.saveSettings();
+                                        markChanged();
+                                    });
+                            });
+                        }),
+                        'https://momentjs.com/docs/#/displaying/format/',
+                    ),
+                },
+                {
+                    name: i18n.t('settings.datesFromFileNames.scheduledDate.folders.name'),
+                    desc: i18n.t('settings.datesFromFileNames.scheduledDate.folders.description'),
+                    visible: () => getSettings().useFilenameAsScheduledDate,
+                    render: this.withReload((setting, markChanged) => {
+                        setting.addText((input) => {
+                            input
+                                .setValue(SettingsTab.renderFolderArray(getSettings().filenameAsDateFolders))
+                                .onChange(async (value) => {
+                                    const folders = SettingsTab.parseCommaSeparatedFolders(value);
+                                    updateSettings({ filenameAsDateFolders: folders });
+                                    await this.plugin.saveSettings();
+                                    markChanged();
+                                });
+                        });
+                    }),
+                },
+            ],
+        };
+    }
+
+    // ---- Recurring tasks --------------------------------------------------
+
+    private recurringTasksGroup(): SettingDefinitionItem {
+        return {
+            type: 'group',
+            heading: i18n.t('settings.recurringTasks.heading'),
+            items: [
+                {
+                    name: i18n.t('settings.recurringTasks.nextLine.name'),
+                    desc: i18n.t('settings.recurringTasks.nextLine.description'),
+                    render: this.renderToggleWithDocs(
+                        'recurrenceOnNextLine',
+                        'https://publish.obsidian.md/tasks/Getting+Started/Recurring+Tasks',
+                    ),
+                },
+                {
+                    name: i18n.t('settings.recurringTasks.removeScheduledDate.name'),
+                    desc: SettingsTab.createFragmentWithHTML(
+                        `<p>${i18n.t('settings.recurringTasks.removeScheduledDate.description.line1')}</p>` +
+                            `<p>${i18n.t('settings.recurringTasks.removeScheduledDate.description.line2')}</p>`,
+                    ),
+                    render: this.renderToggleWithDocs(
+                        'removeScheduledDateOnRecurrence',
+                        'https://publish.obsidian.md/tasks/Getting+Started/Recurring+Tasks',
+                    ),
+                },
+            ],
+        };
+    }
+
+    // ---- Task entry (auto-suggest + dialog access keys) -------------------
+
+    private taskEntryGroup(): SettingDefinitionItem {
+        return {
+            type: 'group',
+            heading: i18n.t('settings.taskEntry.heading'),
+            items: [
+                {
+                    name: i18n.t('settings.autoSuggest.toggle.name'),
+                    desc: i18n.t('settings.autoSuggest.toggle.description'),
+                    render: this.withDocs(
+                        this.withReload((setting, markChanged) => {
+                            setting.addToggle((toggle) => {
+                                toggle.setValue(getSettings().autoSuggestInEditor).onChange(async (value) => {
+                                    updateSettings({ autoSuggestInEditor: value });
+                                    await this.plugin.saveSettings();
+                                    // Re-evaluate the 'visible' predicates of the dependent rows.
+                                    if (requireApiVersion('1.13.0')) {
+                                        this.refreshDomState();
+                                    }
+                                    markChanged();
+                                });
+                            });
+                        }),
+                        'https://publish.obsidian.md/tasks/Getting+Started/Auto-Suggest',
+                    ),
+                },
+                {
+                    name: i18n.t('settings.autoSuggest.minLength.name'),
+                    desc: i18n.t('settings.autoSuggest.minLength.description'),
+                    visible: () => getSettings().autoSuggestInEditor,
+                    render: this.withReload((setting, markChanged) => {
+                        setting.addSlider((slider) => {
+                            slider
+                                .setLimits(0, 3, 1)
+                                .setValue(getSettings().autoSuggestMinMatch)
+                                .onChange(async (value) => {
+                                    updateSettings({ autoSuggestMinMatch: value });
+                                    await this.plugin.saveSettings();
+                                    markChanged();
+                                });
+                        });
+                    }),
+                },
+                {
+                    name: i18n.t('settings.autoSuggest.maxSuggestions.name'),
+                    desc: i18n.t('settings.autoSuggest.maxSuggestions.description'),
+                    visible: () => getSettings().autoSuggestInEditor,
+                    render: this.withReload((setting, markChanged) => {
+                        setting.addSlider((slider) => {
+                            slider
+                                .setLimits(3, 20, 1)
+                                .setValue(getSettings().autoSuggestMaxItems)
+                                .onChange(async (value) => {
+                                    updateSettings({ autoSuggestMaxItems: value });
+                                    await this.plugin.saveSettings();
+                                    markChanged();
+                                });
+                        });
+                    }),
+                },
+                {
+                    name: i18n.t('settings.dialogs.accessKeys.name'),
+                    desc: i18n.t('settings.dialogs.accessKeys.description'),
+                    render: this.renderToggleWithDocs(
+                        'provideAccessKeys',
+                        'https://publish.obsidian.md/tasks/Getting+Started/Create+or+edit+Task#Keyboard+shortcuts',
+                    ),
+                },
+            ],
+        };
     }
 
     public display(): void {
@@ -836,20 +1627,7 @@ export class SettingsTab extends PluginSettingTab {
         setting.infoEl.remove();
 
         /* -------------------- Add all Status types supported by ... buttons -------------------- */
-        type NamedTheme = [string, StatusCollection];
-        const themes: NamedTheme[] = [
-            // Light and Dark themes - alphabetical order
-            [i18n.t('settings.statuses.collections.anuppuccinTheme'), Themes.anuppuccinSupportedStatuses()],
-            [i18n.t('settings.statuses.collections.auraTheme'), Themes.auraSupportedStatuses()],
-            [i18n.t('settings.statuses.collections.borderTheme'), Themes.borderSupportedStatuses()],
-            [i18n.t('settings.statuses.collections.ebullientworksTheme'), Themes.ebullientworksSupportedStatuses()],
-            [i18n.t('settings.statuses.collections.itsThemeAndSlrvbCheckboxes'), Themes.itsSupportedStatuses()],
-            [i18n.t('settings.statuses.collections.minimalTheme'), Themes.minimalSupportedStatuses()],
-            [i18n.t('settings.statuses.collections.thingsTheme'), Themes.thingsSupportedStatuses()],
-            // Dark only themes - alphabetical order
-            [i18n.t('settings.statuses.collections.lytModeTheme'), Themes.lytModeSupportedStatuses()],
-        ];
-        for (const [name, collection] of themes) {
+        for (const { name, collection } of getThemeCollections()) {
             const addStatusesSupportedByThisTheme = new Setting(containerEl).addButton((button) => {
                 const label = i18n.t('settings.statuses.collections.buttons.addCollection.name', {
                     themeName: name,
@@ -896,6 +1674,58 @@ export class SettingsTab extends PluginSettingTab {
         });
         clearCustomStatuses.infoEl.remove();
     }
+}
+
+/**
+ * Human-readable label for a {@link StatusType}. The enum values are
+ * SCREAMING_SNAKE_CASE for storage; we surface friendlier titles in the UI.
+ */
+export function humanizeStatusType(type: StatusType): string {
+    switch (type) {
+        case StatusType.TODO:
+            return i18n.t('settings.statuses.types.todo');
+        case StatusType.IN_PROGRESS:
+            return i18n.t('settings.statuses.types.inProgress');
+        case StatusType.ON_HOLD:
+            return i18n.t('settings.statuses.types.onHold');
+        case StatusType.DONE:
+            return i18n.t('settings.statuses.types.done');
+        case StatusType.CANCELLED:
+            return i18n.t('settings.statuses.types.cancelled');
+        case StatusType.NON_TASK:
+            return i18n.t('settings.statuses.types.nonTask');
+        case StatusType.EMPTY:
+            return i18n.t('settings.statuses.types.empty');
+    }
+}
+
+/**
+ * Returns the named theme collections used to seed common status sets.
+ * Shared between the imperative `display()` path and the declarative
+ * statuses page's "Import from theme" menu.
+ */
+function getThemeCollections(): { name: string; collection: StatusCollection }[] {
+    return [
+        // Light and Dark themes - alphabetical order
+        {
+            name: i18n.t('settings.statuses.collections.anuppuccinTheme'),
+            collection: Themes.anuppuccinSupportedStatuses(),
+        },
+        { name: i18n.t('settings.statuses.collections.auraTheme'), collection: Themes.auraSupportedStatuses() },
+        { name: i18n.t('settings.statuses.collections.borderTheme'), collection: Themes.borderSupportedStatuses() },
+        {
+            name: i18n.t('settings.statuses.collections.ebullientworksTheme'),
+            collection: Themes.ebullientworksSupportedStatuses(),
+        },
+        {
+            name: i18n.t('settings.statuses.collections.itsThemeAndSlrvbCheckboxes'),
+            collection: Themes.itsSupportedStatuses(),
+        },
+        { name: i18n.t('settings.statuses.collections.minimalTheme'), collection: Themes.minimalSupportedStatuses() },
+        { name: i18n.t('settings.statuses.collections.thingsTheme'), collection: Themes.thingsSupportedStatuses() },
+        // Dark only themes - alphabetical order
+        { name: i18n.t('settings.statuses.collections.lytModeTheme'), collection: Themes.lytModeSupportedStatuses() },
+    ];
 }
 
 /**

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -724,18 +724,26 @@ export class SettingsTab extends PluginSettingTab {
 
     /**
      * Builds one list row for a single status. The row's `name` is the
-     * status's friendly name, with the symbol prepended as a `<code>` chip; a
+     * status's friendly name, with the symbol and its toggle transition
+     * prepended as a `<code>` chip, and the status type shown as a flair; a
      * pencil extraButton opens the existing edit modal. Deletion is wired by
      * the list's `onDelete`, so no per-row delete button is needed.
      */
     private statusRow(status: StatusConfiguration, isCoreStatus: boolean): SettingDefinition {
         const symbol = status.symbol || ' ';
+        const nextSymbol = status.nextStatusSymbol || ' ';
         return {
             name: status.name || i18n.t('settings.statuses.unnamed'),
             render: (setting) => {
-                // Prepend the symbol to the left of the row's name — reads as
-                // the list marker for the friendly name beside it (`- [/] In progress`).
-                setting.nameEl.prepend(createEl('code', { cls: 'tasks-status-symbol', text: `- [${symbol}]` }));
+                // Prepend the symbol and transition to the left of the row's
+                // name — reads as the list marker for the friendly name beside
+                // it (`- [/] → [x] In progress`).
+                setting.nameEl.createEl('code', {
+                    cls: 'tasks-status-symbol',
+                    text: `- [${symbol}] → [${nextSymbol}]`,
+                    prepend: true,
+                });
+                setting.controlEl.createSpan({ cls: 'flair', text: humanizeStatusType(status.type) });
                 setting.addExtraButton((btn) => {
                     btn.setIcon('pencil')
                         .setTooltip(i18n.t('common.edit'))

--- a/src/i18n/locales/be.json
+++ b/src/i18n/locales/be.json
@@ -1,7 +1,6 @@
 {
   "common": {
     "cancel": "",
-    "delete": "",
     "edit": "",
     "reload": "",
     "save": ""

--- a/src/i18n/locales/be.json
+++ b/src/i18n/locales/be.json
@@ -347,6 +347,7 @@
         "placeholder": ""
       },
       "heading": "Статусы задач",
+      "reloadRequired": "",
       "types": {
         "cancelled": "",
         "done": "",

--- a/src/i18n/locales/be.json
+++ b/src/i18n/locales/be.json
@@ -1,4 +1,11 @@
 {
+  "common": {
+    "cancel": "",
+    "delete": "",
+    "edit": "",
+    "reload": "",
+    "save": ""
+  },
   "main": {
     "loadingPlugin": "Загрузка плагіна: {{name}} v{{version}}",
     "unloadingPlugin": "Выгрузка плагіна: {{name}} v{{version}}"
@@ -25,7 +32,25 @@
         "description": "Кіруйце тым, як статус паводзіць сябе пры пошуку і пераключэнні.",
         "name": "Тып статусу задачы"
       },
-      "fixErrorsBeforeSaving": "Выпраўце памылкі перад захаваннем."
+      "fixErrorsBeforeSaving": "Выпраўце памылкі перад захаваннем.",
+      "title": {
+        "editCoreStatus": "",
+        "editCustomStatus": ""
+      }
+    },
+    "editPresetModal": {
+      "name": {
+        "duplicate": "",
+        "name": "",
+        "placeholder": "",
+        "required": ""
+      },
+      "query": {
+        "description": "",
+        "name": "",
+        "placeholder": ""
+      },
+      "title": ""
     }
   },
   "notices": {
@@ -176,6 +201,9 @@
       },
       "name": "Фармат задачы"
     },
+    "globalDefaults": {
+      "heading": ""
+    },
     "globalFilter": {
       "filter": {
         "description": {
@@ -197,13 +225,15 @@
       "heading": "Глабальны запыт",
       "query": {
         "description": "Запыт, які аўтаматычна ўключаецца ў пачатку кожнага блока Tasks у сховішчы. Карысны для дадання фільтраў па змаўчанні або параметраў макета.",
-        "placeholder": "Напрыклад...\npath does not include _templates/\nlimit 300\nshow urgency"
+        "placeholder": "Напрыклад...\npath does not include _templates/\nlimit 300\nshow urgency",
+        "shortDescription": ""
       }
     },
     "presets": {
       "buttons": {
         "addNewPreset": ""
       },
+      "emptyState": "",
       "line1": "",
       "line2": "",
       "name": ""
@@ -235,6 +265,10 @@
     },
     "searches": {
       "enableCustomSearches": {
+        "confirm": {
+          "acknowledge": "",
+          "enable": ""
+        },
         "description": {
           "line1": "",
           "line2": "",
@@ -247,6 +281,10 @@
     },
     "seeTheDocumentation": "Глядзіце дакументацыю",
     "statuses": {
+      "buttons": {
+        "addStatus": "",
+        "importFromTheme": ""
+      },
       "collections": {
         "anuppuccinTheme": "Тэма AnuPpuccin",
         "auraTheme": "Тэма Aura",
@@ -254,6 +292,9 @@
         "buttons": {
           "addCollection": {
             "name": "{{themeName}}: Дадаць {{numberOfStatuses}} падтрымоўваныя статусы"
+          },
+          "importCollection": {
+            "name": ""
           }
         },
         "ebullientworksTheme": "Тэма Ebullientworks",
@@ -278,12 +319,14 @@
       "customStatuses": {
         "buttons": {
           "addAllUnknown": {
+            "description": "",
             "name": "Дадаць усе невядомыя тыпы статусаў"
           },
           "addNewStatus": {
             "name": "Дадаць новы статус задачы"
           },
           "resetCustomStatuses": {
+            "description": "",
             "name": "Скінуць карыстальніцкія тыпы статусаў да значэнняў па змаўчанні"
           }
         },
@@ -293,9 +336,26 @@
           "line3": "<b>Заўвага</b> Любыя статусы з тым жа сімвалам, што і ў папярэдніх статусаў, будуць праігнараваныя. Вы можаце пацвердзіць фактычна загружаныя статусы, запусціўшы каманду «Стварыць або рэдагаваць задачу» і паглядзеўшы на выпадальны спіс Статус.",
           "line4": "Глядзіце дакументацыю, каб пачаць!"
         },
+        "emptyState": "",
         "heading": "Карыстальніцкія статусы"
       },
-      "heading": "Статусы задач"
+      "filter": {
+        "placeholder": ""
+      },
+      "heading": "Статусы задач",
+      "types": {
+        "cancelled": "",
+        "done": "",
+        "empty": "",
+        "inProgress": "",
+        "nonTask": "",
+        "onHold": "",
+        "todo": ""
+      },
+      "unnamed": ""
+    },
+    "taskEntry": {
+      "heading": ""
     }
   }
 }

--- a/src/i18n/locales/be.json
+++ b/src/i18n/locales/be.json
@@ -2,6 +2,8 @@
   "common": {
     "cancel": "",
     "edit": "",
+    "moreInfo": "",
+    "okay": "",
     "reload": "",
     "save": ""
   },
@@ -282,7 +284,10 @@
     "statuses": {
       "buttons": {
         "addStatus": "",
-        "importFromTheme": ""
+        "importFromTheme": {
+          "description": "",
+          "name": ""
+        }
       },
       "collections": {
         "anuppuccinTheme": "Тэма AnuPpuccin",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1,7 +1,6 @@
 {
   "common": {
     "cancel": "",
-    "delete": "",
     "edit": "",
     "reload": "",
     "save": ""

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -347,6 +347,7 @@
         "placeholder": ""
       },
       "heading": "Aufgabenstatus",
+      "reloadRequired": "",
       "types": {
         "cancelled": "",
         "done": "",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2,6 +2,8 @@
   "common": {
     "cancel": "",
     "edit": "",
+    "moreInfo": "",
+    "okay": "",
     "reload": "",
     "save": ""
   },
@@ -282,7 +284,10 @@
     "statuses": {
       "buttons": {
         "addStatus": "",
-        "importFromTheme": ""
+        "importFromTheme": {
+          "description": "",
+          "name": ""
+        }
       },
       "collections": {
         "anuppuccinTheme": "AnuPpuccin Theme",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1,4 +1,11 @@
 {
+  "common": {
+    "cancel": "",
+    "delete": "",
+    "edit": "",
+    "reload": "",
+    "save": ""
+  },
   "main": {
     "loadingPlugin": "Lade Plugin: {{name}} v{{version}}",
     "unloadingPlugin": "Entlade Plugin: {{name}} v{{version}}"
@@ -25,7 +32,25 @@
         "description": "Kontrollieren Sie, wie der Status beim Suchen und Umschalten funktioniert.",
         "name": "Typ des Aufgabenstatus"
       },
-      "fixErrorsBeforeSaving": "Fehler vor dem Speichern beheben."
+      "fixErrorsBeforeSaving": "Fehler vor dem Speichern beheben.",
+      "title": {
+        "editCoreStatus": "",
+        "editCustomStatus": ""
+      }
+    },
+    "editPresetModal": {
+      "name": {
+        "duplicate": "",
+        "name": "",
+        "placeholder": "",
+        "required": ""
+      },
+      "query": {
+        "description": "",
+        "name": "",
+        "placeholder": ""
+      },
+      "title": ""
     }
   },
   "notices": {
@@ -176,6 +201,9 @@
       },
       "name": "Aufgabenformat"
     },
+    "globalDefaults": {
+      "heading": ""
+    },
     "globalFilter": {
       "filter": {
         "description": {
@@ -197,13 +225,15 @@
       "heading": "Globale Abfrage",
       "query": {
         "description": "Fügen Sie automatisch eine Abfrage am Anfang jedes Tasks-Blocks im Tresor hinzu. Nützlich für Standardfilter oder Layout-Optionen.",
-        "placeholder": "Zum Beispiel...\npath does not include _templates/\nlimit 300\nshow urgency"
+        "placeholder": "Zum Beispiel...\npath does not include _templates/\nlimit 300\nshow urgency",
+        "shortDescription": ""
       }
     },
     "presets": {
       "buttons": {
         "addNewPreset": ""
       },
+      "emptyState": "",
       "line1": "",
       "line2": "",
       "name": ""
@@ -235,6 +265,10 @@
     },
     "searches": {
       "enableCustomSearches": {
+        "confirm": {
+          "acknowledge": "",
+          "enable": ""
+        },
         "description": {
           "line1": "",
           "line2": "",
@@ -247,6 +281,10 @@
     },
     "seeTheDocumentation": "Vgl. die Dokumentation",
     "statuses": {
+      "buttons": {
+        "addStatus": "",
+        "importFromTheme": ""
+      },
       "collections": {
         "anuppuccinTheme": "AnuPpuccin Theme",
         "auraTheme": "Aura Theme",
@@ -254,6 +292,9 @@
         "buttons": {
           "addCollection": {
             "name": "{{themeName}}: Füge {{numberOfStatuses}} unterstützte Status hinzu"
+          },
+          "importCollection": {
+            "name": ""
           }
         },
         "ebullientworksTheme": "Ebullientworks Theme",
@@ -278,12 +319,14 @@
       "customStatuses": {
         "buttons": {
           "addAllUnknown": {
+            "description": "",
             "name": "Alle unbekannten Statustypen hinzufügen"
           },
           "addNewStatus": {
             "name": "Neuen Aufgabenstatus hinzufügen"
           },
           "resetCustomStatuses": {
+            "description": "",
             "name": "Benutzerdefinierte Statustypen auf Standard zurücksetzen"
           }
         },
@@ -293,9 +336,26 @@
           "line3": "Hinweis: Status mit dem gleichen Symbol wie ein früherer Status ignorieren wir. Bestätigen Sie die tatsächlich geladenen Status, indem Sie den 'Aufgabe erstellen oder bearbeiten'-Befehl ausführen und das Status-Dropdown anschauen.",
           "line4": "Nutzen Sie die Dokumentation, um loszulegen!"
         },
+        "emptyState": "",
         "heading": "Benutzerdefinierte Status"
       },
-      "heading": "Aufgabenstatus"
+      "filter": {
+        "placeholder": ""
+      },
+      "heading": "Aufgabenstatus",
+      "types": {
+        "cancelled": "",
+        "done": "",
+        "empty": "",
+        "inProgress": "",
+        "nonTask": "",
+        "onHold": "",
+        "todo": ""
+      },
+      "unnamed": ""
+    },
+    "taskEntry": {
+      "heading": ""
     }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2,6 +2,8 @@
   "common": {
     "cancel": "Cancel",
     "edit": "Edit",
+    "moreInfo": "More info",
+    "okay": "Okay",
     "reload": "Reload",
     "save": "Save"
   },
@@ -282,7 +284,10 @@
     "statuses": {
       "buttons": {
         "addStatus": "Add status",
-        "importFromTheme": "Import from theme"
+        "importFromTheme": {
+          "description": "Add the statuses supported by a theme or CSS snippet.",
+          "name": "Import from theme"
+        }
       },
       "collections": {
         "anuppuccinTheme": "AnuPpuccin",
@@ -311,7 +316,7 @@
         },
         "description": {
           "line1": "These are the core statuses that Tasks supports natively, with no need for custom CSS styling or theming.",
-          "line2": "You can add edit and add your own custom statuses in the section below."
+          "line2": "You can add and edit your own custom statuses in the Custom statuses section."
         },
         "heading": "Core statuses"
       },
@@ -331,7 +336,7 @@
         },
         "description": {
           "line1": "You should first <b>select and install a CSS snippet or theme</b> to style custom checkboxes.",
-          "line2": "Then, use the buttons below to set up your custom statuses, to match your chosen CSS checkboxes.",
+          "line2": "Then, set up your custom statuses to match your chosen CSS checkboxes.",
           "line3": "<b>Note</b> Any statuses with the same symbol as any earlier statuses will be ignored. You can confirm the actually loaded statuses by running the 'Create or edit task' command and looking at the Status drop-down.",
           "line4": "See the documentation to get started!"
         },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,4 +1,11 @@
 {
+  "common": {
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "edit": "Edit",
+    "reload": "Reload",
+    "save": "Save"
+  },
   "main": {
     "loadingPlugin": "Loading plugin: {{name}} v{{version}}",
     "unloadingPlugin": "Unloading plugin: {{name}} v{{version}}"
@@ -11,21 +18,39 @@
       },
       "editNextStatusSymbol": {
         "description": "When clicked on this is the symbol that should be used next.",
-        "name": "Task Next Status Symbol"
+        "name": "Next status symbol"
       },
       "editStatusName": {
         "description": "This is the friendly name of the task status.",
-        "name": "Task Status Name"
+        "name": "Name"
       },
       "editStatusSymbol": {
-        "description": "This is the character between the square braces. (It can only be edited for Custom statuses, and not Core statuses.)",
-        "name": "Task Status Symbol"
+        "description": "This is the character between the square braces. (It can only be edited for custom statuses, and not core statuses.)",
+        "name": "Symbol"
       },
       "editStatusType": {
         "description": "Control how the status behaves for searching and toggling.",
-        "name": "Task Status Type"
+        "name": "Type"
       },
-      "fixErrorsBeforeSaving": "Fix errors before saving."
+      "fixErrorsBeforeSaving": "Fix errors before saving.",
+      "title": {
+        "editCoreStatus": "Edit core status",
+        "editCustomStatus": "Edit custom status"
+      }
+    },
+    "editPresetModal": {
+      "name": {
+        "duplicate": "A preset with this name already exists",
+        "name": "Name",
+        "placeholder": "e.g. open tasks",
+        "required": "Required"
+      },
+      "query": {
+        "description": "Optional. You can fill this in later.",
+        "name": "Query",
+        "placeholder": "not done\npath includes Work"
+      },
+      "title": "Edit preset"
     }
   },
   "notices": {
@@ -48,7 +73,7 @@
         "updateReport": {
           "line1": "If you change the Tasks status settings, you can get an updated report by:",
           "line2": "Going to `Settings` -> `Tasks`.",
-          "line3": "Clicking on `Review and check your Statuses`."
+          "line3": "Clicking on `Review and check your statuses`."
         }
       },
       "columnHeadings": {
@@ -172,9 +197,12 @@
       },
       "displayName": {
         "dataview": "Dataview",
-        "tasksEmojiFormat": "Tasks Emoji Format"
+        "tasksEmojiFormat": "Tasks emoji format"
       },
-      "name": "Task Format"
+      "name": "Task format"
+    },
+    "globalDefaults": {
+      "heading": "Global defaults"
     },
     "globalFilter": {
       "filter": {
@@ -194,16 +222,18 @@
       }
     },
     "globalQuery": {
-      "heading": "Global Query",
+      "heading": "Global query",
       "query": {
         "description": "A query that is automatically included at the start of every Tasks block in the vault. Useful for adding default filters, or layout options.",
-        "placeholder": "For example...\npath does not include _templates/\nlimit 300\nshow urgency"
+        "placeholder": "For example...\npath does not include _templates/\nlimit 300\nshow urgency",
+        "shortDescription": "Instructions automatically included at the start of every Tasks block."
       }
     },
     "presets": {
       "buttons": {
         "addNewPreset": "Add new preset"
       },
+      "emptyState": "No presets yet.",
       "line1": "You can define named instructions here, that you can re-use in multiple queries. A preset called '{{name}}' can be used in Tasks queries with either '{{instruction1}}' or '{{instruction2}}'.",
       "line2": "Any open Tasks queries are reloaded automatically when presets are edited.",
       "name": "Presets"
@@ -235,6 +265,10 @@
     },
     "searches": {
       "enableCustomSearches": {
+        "confirm": {
+          "acknowledge": "I understand the risks",
+          "enable": "Enable"
+        },
         "description": {
           "line1": "Enables '{{filterByFunction}}', '{{sortByFunction}}', and '{{groupByFunction}}', which execute JavaScript in Tasks queries.",
           "line2": "Malicious JavaScript in a Tasks query or Markdown file could run inside Obsidian and access or modify your vault contents, local files, or other system resources.",
@@ -247,25 +281,32 @@
     },
     "seeTheDocumentation": "See the documentation",
     "statuses": {
+      "buttons": {
+        "addStatus": "Add status",
+        "importFromTheme": "Import from theme"
+      },
       "collections": {
-        "anuppuccinTheme": "AnuPpuccin Theme",
-        "auraTheme": "Aura Theme",
-        "borderTheme": "Border Theme",
+        "anuppuccinTheme": "AnuPpuccin",
+        "auraTheme": "Aura",
+        "borderTheme": "Border",
         "buttons": {
           "addCollection": {
-            "name": "{{themeName}}: Add {{numberOfStatuses}} supported Statuses"
+            "name": "{{themeName}}: add {{numberOfStatuses}} supported statuses"
+          },
+          "importCollection": {
+            "name": "{{themeName}} ({{numberOfStatuses}} statuses)"
           }
         },
-        "ebullientworksTheme": "Ebullientworks Theme",
-        "itsThemeAndSlrvbCheckboxes": "ITS Theme & SlRvb Checkboxes",
-        "lytModeTheme": "LYT Mode Theme (Dark mode only)",
-        "minimalTheme": "Minimal Theme",
-        "thingsTheme": "Things Theme"
+        "ebullientworksTheme": "Ebullientworks",
+        "itsThemeAndSlrvbCheckboxes": "ITS & SlRvb Checkboxes",
+        "lytModeTheme": "LYT Mode (dark mode only)",
+        "minimalTheme": "Minimal",
+        "thingsTheme": "Things"
       },
       "coreStatuses": {
         "buttons": {
           "checkStatuses": {
-            "name": "Review and check your Statuses",
+            "name": "Review and check your statuses",
             "tooltip": "Create a new file in the root of the vault, containing a Mermaid diagram of the current status settings."
           }
         },
@@ -273,29 +314,48 @@
           "line1": "These are the core statuses that Tasks supports natively, with no need for custom CSS styling or theming.",
           "line2": "You can add edit and add your own custom statuses in the section below."
         },
-        "heading": "Core Statuses"
+        "heading": "Core statuses"
       },
       "customStatuses": {
         "buttons": {
           "addAllUnknown": {
-            "name": "Add All Unknown Status Types"
+            "description": "Add any status symbols found in your vault but not yet configured here.",
+            "name": "Add all unknown status types"
           },
           "addNewStatus": {
-            "name": "Add New Task Status"
+            "name": "Add new task status"
           },
           "resetCustomStatuses": {
-            "name": "Reset Custom Status Types to Defaults"
+            "description": "Discard all custom statuses and restore the defaults.",
+            "name": "Reset custom status types to defaults"
           }
         },
         "description": {
-          "line1": "You should first <b>select and install a CSS Snippet or Theme</b> to style custom checkboxes.",
+          "line1": "You should first <b>select and install a CSS snippet or theme</b> to style custom checkboxes.",
           "line2": "Then, use the buttons below to set up your custom statuses, to match your chosen CSS checkboxes.",
           "line3": "<b>Note</b> Any statuses with the same symbol as any earlier statuses will be ignored. You can confirm the actually loaded statuses by running the 'Create or edit task' command and looking at the Status drop-down.",
           "line4": "See the documentation to get started!"
         },
-        "heading": "Custom Statuses"
+        "emptyState": "No custom statuses yet.",
+        "heading": "Custom statuses"
       },
-      "heading": "Task Statuses"
+      "filter": {
+        "placeholder": "Filter statuses…"
+      },
+      "heading": "Task statuses",
+      "types": {
+        "cancelled": "Cancelled",
+        "done": "Done",
+        "empty": "Empty",
+        "inProgress": "In progress",
+        "nonTask": "Non-task",
+        "onHold": "On hold",
+        "todo": "To do"
+      },
+      "unnamed": "(unnamed)"
+    },
+    "taskEntry": {
+      "heading": "Task entry"
     }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -347,6 +347,7 @@
         "placeholder": "Filter statuses…"
       },
       "heading": "Task statuses",
+      "reloadRequired": "Changes take effect after reload.",
       "types": {
         "cancelled": "Cancelled",
         "done": "Done",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,7 +1,6 @@
 {
   "common": {
     "cancel": "Cancel",
-    "delete": "Delete",
     "edit": "Edit",
     "reload": "Reload",
     "save": "Save"

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1,7 +1,6 @@
 {
   "common": {
     "cancel": "",
-    "delete": "",
     "edit": "",
     "reload": "",
     "save": ""

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1,4 +1,11 @@
 {
+  "common": {
+    "cancel": "",
+    "delete": "",
+    "edit": "",
+    "reload": "",
+    "save": ""
+  },
   "main": {
     "loadingPlugin": "플러그인 로드 중: {{name}} v{{version}}",
     "unloadingPlugin": "플러그인 언로드 중: {{name}} v{{version}}"
@@ -25,7 +32,25 @@
         "description": "검색 및 상태 전환 시 어떻게 동작할지 제어합니다.",
         "name": "상태 유형"
       },
-      "fixErrorsBeforeSaving": "저장하기 전에 오류를 수정하세요."
+      "fixErrorsBeforeSaving": "저장하기 전에 오류를 수정하세요.",
+      "title": {
+        "editCoreStatus": "",
+        "editCustomStatus": ""
+      }
+    },
+    "editPresetModal": {
+      "name": {
+        "duplicate": "",
+        "name": "",
+        "placeholder": "",
+        "required": ""
+      },
+      "query": {
+        "description": "",
+        "name": "",
+        "placeholder": ""
+      },
+      "title": ""
     }
   },
   "notices": {
@@ -176,6 +201,9 @@
       },
       "name": "작업 형식"
     },
+    "globalDefaults": {
+      "heading": ""
+    },
     "globalFilter": {
       "filter": {
         "description": {
@@ -197,13 +225,15 @@
       "heading": "전역 쿼리",
       "query": {
         "description": "보관소의 모든 Tasks 블록 시작에 자동으로 포함되는 쿼리입니다. 기본 필터나 레이아웃 옵션을 추가할 때 유용합니다.",
-        "placeholder": "예시...\npath does not include _templates/\nlimit 300\nshow urgency"
+        "placeholder": "예시...\npath does not include _templates/\nlimit 300\nshow urgency",
+        "shortDescription": ""
       }
     },
     "presets": {
       "buttons": {
         "addNewPreset": "새 프리셋 추가"
       },
+      "emptyState": "",
       "line1": "여기서 이름 있는 지침을 정의해 여러 쿼리에서 재사용할 수 있습니다. '{{name}}' 프리셋은 Tasks 쿼리에서 '{{instruction1}}' 또는 '{{instruction2}}'로 사용할 수 있습니다.",
       "line2": "프리셋을 수정하면 열려 있는 모든 Tasks 쿼리가 자동으로 새로고침됩니다.",
       "name": "프리셋"
@@ -235,6 +265,10 @@
     },
     "searches": {
       "enableCustomSearches": {
+        "confirm": {
+          "acknowledge": "",
+          "enable": ""
+        },
         "description": {
           "line1": "",
           "line2": "",
@@ -247,6 +281,10 @@
     },
     "seeTheDocumentation": "문서 보기",
     "statuses": {
+      "buttons": {
+        "addStatus": "",
+        "importFromTheme": ""
+      },
       "collections": {
         "anuppuccinTheme": "AnuPpuccin 테마",
         "auraTheme": "Aura 테마",
@@ -254,6 +292,9 @@
         "buttons": {
           "addCollection": {
             "name": "{{themeName}}: 지원되는 상태 {{numberOfStatuses}}개 추가"
+          },
+          "importCollection": {
+            "name": ""
           }
         },
         "ebullientworksTheme": "Ebullientworks 테마",
@@ -278,12 +319,14 @@
       "customStatuses": {
         "buttons": {
           "addAllUnknown": {
+            "description": "",
             "name": "알 수 없는 모든 상태 유형 추가"
           },
           "addNewStatus": {
             "name": "새 작업 상태 추가"
           },
           "resetCustomStatuses": {
+            "description": "",
             "name": "사용자 정의 상태를 기본값으로 재설정"
           }
         },
@@ -293,9 +336,26 @@
           "line3": "<b>참고:</b> 이전에 정의된 상태와 기호가 동일한 상태는 무시됩니다. '작업 생성/편집' 명령어의 상태 드롭다운 메뉴에서 실제로 로드된 상태를 확인할 수 있습니다.",
           "line4": "시작하려면 문서를 참고하세요!"
         },
+        "emptyState": "",
         "heading": "사용자 정의 상태"
       },
-      "heading": "작업 상태"
+      "filter": {
+        "placeholder": ""
+      },
+      "heading": "작업 상태",
+      "types": {
+        "cancelled": "",
+        "done": "",
+        "empty": "",
+        "inProgress": "",
+        "nonTask": "",
+        "onHold": "",
+        "todo": ""
+      },
+      "unnamed": ""
+    },
+    "taskEntry": {
+      "heading": ""
     }
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2,6 +2,8 @@
   "common": {
     "cancel": "",
     "edit": "",
+    "moreInfo": "",
+    "okay": "",
     "reload": "",
     "save": ""
   },
@@ -282,7 +284,10 @@
     "statuses": {
       "buttons": {
         "addStatus": "",
-        "importFromTheme": ""
+        "importFromTheme": {
+          "description": "",
+          "name": ""
+        }
       },
       "collections": {
         "anuppuccinTheme": "AnuPpuccin 테마",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -347,6 +347,7 @@
         "placeholder": ""
       },
       "heading": "작업 상태",
+      "reloadRequired": "",
       "types": {
         "cancelled": "",
         "done": "",

--- a/src/i18n/locales/pt_br.json
+++ b/src/i18n/locales/pt_br.json
@@ -1,4 +1,11 @@
 {
+  "common": {
+    "cancel": "",
+    "delete": "",
+    "edit": "",
+    "reload": "",
+    "save": ""
+  },
   "main": {
     "loadingPlugin": "Carregando plugin: {{name}} v{{version}}",
     "unloadingPlugin": "Descarregando plugin: {{name}} v{{version}}"
@@ -25,7 +32,25 @@
         "description": "Controla como o status se comporta em relação a pesquisas e alternância.",
         "name": "Tipo de Status da Tarefa"
       },
-      "fixErrorsBeforeSaving": "Corrija os erros antes de salvar."
+      "fixErrorsBeforeSaving": "Corrija os erros antes de salvar.",
+      "title": {
+        "editCoreStatus": "",
+        "editCustomStatus": ""
+      }
+    },
+    "editPresetModal": {
+      "name": {
+        "duplicate": "",
+        "name": "",
+        "placeholder": "",
+        "required": ""
+      },
+      "query": {
+        "description": "",
+        "name": "",
+        "placeholder": ""
+      },
+      "title": ""
     }
   },
   "notices": {
@@ -176,6 +201,9 @@
       },
       "name": "Formato da Tarefa"
     },
+    "globalDefaults": {
+      "heading": ""
+    },
     "globalFilter": {
       "filter": {
         "description": {
@@ -197,13 +225,15 @@
       "heading": "Consulta Global",
       "query": {
         "description": "Uma consulta que é incluída automaticamente no início de cada bloco do Tasks no cofre. Útil para adicionar filtros padrão ou opções de layout.",
-        "placeholder": "Por exemplo...\npath does not include _templates/\nlimit 300\nshow urgency"
+        "placeholder": "Por exemplo...\npath does not include _templates/\nlimit 300\nshow urgency",
+        "shortDescription": ""
       }
     },
     "presets": {
       "buttons": {
         "addNewPreset": "Adicionar nova predefinição"
       },
+      "emptyState": "",
       "line1": "Você pode definir instruções nomeadas aqui, que podem ser reutilizadas em várias consultas. Uma predefinição chamada '{{name}}' pode ser usada em consultas do Tasks com '{{instruction1}}' ou '{{instruction2}}'.",
       "line2": "Quaisquer consultas do Tasks abertas são recarregadas automaticamente quando as predefinições são editadas.",
       "name": "Predefinições (Presets)"
@@ -235,6 +265,10 @@
     },
     "searches": {
       "enableCustomSearches": {
+        "confirm": {
+          "acknowledge": "",
+          "enable": ""
+        },
         "description": {
           "line1": "",
           "line2": "",
@@ -247,6 +281,10 @@
     },
     "seeTheDocumentation": "Veja a documentação",
     "statuses": {
+      "buttons": {
+        "addStatus": "",
+        "importFromTheme": ""
+      },
       "collections": {
         "anuppuccinTheme": "Tema AnuPpuccin",
         "auraTheme": "Tema Aura",
@@ -254,6 +292,9 @@
         "buttons": {
           "addCollection": {
             "name": "{{themeName}}: Adicionar {{numberOfStatuses}} Status suportados"
+          },
+          "importCollection": {
+            "name": ""
           }
         },
         "ebullientworksTheme": "Tema Ebullientworks",
@@ -278,12 +319,14 @@
       "customStatuses": {
         "buttons": {
           "addAllUnknown": {
+            "description": "",
             "name": "Adicionar Todos os Tipos de Status Desconhecidos"
           },
           "addNewStatus": {
             "name": "Adicionar Novo Status de Tarefa"
           },
           "resetCustomStatuses": {
+            "description": "",
             "name": "Redefinir Tipos de Status Personalizados para os Padrões"
           }
         },
@@ -293,9 +336,26 @@
           "line3": "<b>Nota:</b> Qualquer status com o mesmo símbolo de um status anterior será ignorado. Você pode confirmar os status que foram realmente carregados executando o comando 'Criar ou editar tarefa' e olhando a lista suspensa de Status.",
           "line4": "Veja a documentação para começar!"
         },
+        "emptyState": "",
         "heading": "Status Personalizados"
       },
-      "heading": "Status das Tarefas"
+      "filter": {
+        "placeholder": ""
+      },
+      "heading": "Status das Tarefas",
+      "types": {
+        "cancelled": "",
+        "done": "",
+        "empty": "",
+        "inProgress": "",
+        "nonTask": "",
+        "onHold": "",
+        "todo": ""
+      },
+      "unnamed": ""
+    },
+    "taskEntry": {
+      "heading": ""
     }
   }
 }

--- a/src/i18n/locales/pt_br.json
+++ b/src/i18n/locales/pt_br.json
@@ -1,7 +1,6 @@
 {
   "common": {
     "cancel": "",
-    "delete": "",
     "edit": "",
     "reload": "",
     "save": ""

--- a/src/i18n/locales/pt_br.json
+++ b/src/i18n/locales/pt_br.json
@@ -347,6 +347,7 @@
         "placeholder": ""
       },
       "heading": "Status das Tarefas",
+      "reloadRequired": "",
       "types": {
         "cancelled": "",
         "done": "",

--- a/src/i18n/locales/pt_br.json
+++ b/src/i18n/locales/pt_br.json
@@ -2,6 +2,8 @@
   "common": {
     "cancel": "",
     "edit": "",
+    "moreInfo": "",
+    "okay": "",
     "reload": "",
     "save": ""
   },
@@ -282,7 +284,10 @@
     "statuses": {
       "buttons": {
         "addStatus": "",
-        "importFromTheme": ""
+        "importFromTheme": {
+          "description": "",
+          "name": ""
+        }
       },
       "collections": {
         "anuppuccinTheme": "Tema AnuPpuccin",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1,4 +1,11 @@
 {
+  "common": {
+    "cancel": "",
+    "delete": "",
+    "edit": "",
+    "reload": "",
+    "save": ""
+  },
   "main": {
     "loadingPlugin": "Загрузка плагина: {{name}} v{{version}}",
     "unloadingPlugin": "Выгрузка плагина: {{name}} v{{version}}"
@@ -25,7 +32,25 @@
         "description": "Управление поведением статуса при поиске и переключении.",
         "name": "Тип статуса задачи"
       },
-      "fixErrorsBeforeSaving": "Исправьте ошибки перед сохранением."
+      "fixErrorsBeforeSaving": "Исправьте ошибки перед сохранением.",
+      "title": {
+        "editCoreStatus": "",
+        "editCustomStatus": ""
+      }
+    },
+    "editPresetModal": {
+      "name": {
+        "duplicate": "",
+        "name": "",
+        "placeholder": "",
+        "required": ""
+      },
+      "query": {
+        "description": "",
+        "name": "",
+        "placeholder": ""
+      },
+      "title": ""
     }
   },
   "notices": {
@@ -176,6 +201,9 @@
       },
       "name": "Формат задач"
     },
+    "globalDefaults": {
+      "heading": ""
+    },
     "globalFilter": {
       "filter": {
         "description": {
@@ -197,13 +225,15 @@
       "heading": "Глобальный запрос",
       "query": {
         "description": "Запрос, который автоматически включается в начало каждого блока Tasks в хранилище. Полезно для добавления фильтров по умолчанию или параметров макета.",
-        "placeholder": "Например...\npath does not include _templates/\nlimit 300\nshow urgency"
+        "placeholder": "Например...\npath does not include _templates/\nlimit 300\nshow urgency",
+        "shortDescription": ""
       }
     },
     "presets": {
       "buttons": {
         "addNewPreset": ""
       },
+      "emptyState": "",
       "line1": "",
       "line2": "",
       "name": ""
@@ -235,6 +265,10 @@
     },
     "searches": {
       "enableCustomSearches": {
+        "confirm": {
+          "acknowledge": "",
+          "enable": ""
+        },
         "description": {
           "line1": "",
           "line2": "",
@@ -247,6 +281,10 @@
     },
     "seeTheDocumentation": "Смотрите документацию",
     "statuses": {
+      "buttons": {
+        "addStatus": "",
+        "importFromTheme": ""
+      },
       "collections": {
         "anuppuccinTheme": "Тема AnuPpuccin",
         "auraTheme": "Тема Aura",
@@ -254,6 +292,9 @@
         "buttons": {
           "addCollection": {
             "name": "{{themeName}}: Добавить {{numberOfStatuses}} поддерживаемых статусов"
+          },
+          "importCollection": {
+            "name": ""
           }
         },
         "ebullientworksTheme": "Тема Ebullientworks",
@@ -278,12 +319,14 @@
       "customStatuses": {
         "buttons": {
           "addAllUnknown": {
+            "description": "",
             "name": "Добавить все неизвестные типы статусов"
           },
           "addNewStatus": {
             "name": "Добавить новый статус задачи"
           },
           "resetCustomStatuses": {
+            "description": "",
             "name": "Сбросить пользовательские типы статусов к значениям по умолчанию"
           }
         },
@@ -293,9 +336,26 @@
           "line3": "<b>Примечание.</b> Любые статусы с тем же символом, что и у более ранних статусов, будут игнорироваться. Вы можете подтвердить фактически загруженные статусы, запустив команду 'Создать или редактировать задачу' и посмотрев на раскрывающийся список статусов.",
           "line4": "Смотрите документацию, чтобы начать!"
         },
+        "emptyState": "",
         "heading": "Пользовательские статусы"
       },
-      "heading": "Статусы задач"
+      "filter": {
+        "placeholder": ""
+      },
+      "heading": "Статусы задач",
+      "types": {
+        "cancelled": "",
+        "done": "",
+        "empty": "",
+        "inProgress": "",
+        "nonTask": "",
+        "onHold": "",
+        "todo": ""
+      },
+      "unnamed": ""
+    },
+    "taskEntry": {
+      "heading": ""
     }
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1,7 +1,6 @@
 {
   "common": {
     "cancel": "",
-    "delete": "",
     "edit": "",
     "reload": "",
     "save": ""

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -347,6 +347,7 @@
         "placeholder": ""
       },
       "heading": "Статусы задач",
+      "reloadRequired": "",
       "types": {
         "cancelled": "",
         "done": "",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -2,6 +2,8 @@
   "common": {
     "cancel": "",
     "edit": "",
+    "moreInfo": "",
+    "okay": "",
     "reload": "",
     "save": ""
   },
@@ -282,7 +284,10 @@
     "statuses": {
       "buttons": {
         "addStatus": "",
-        "importFromTheme": ""
+        "importFromTheme": {
+          "description": "",
+          "name": ""
+        }
       },
       "collections": {
         "anuppuccinTheme": "Тема AnuPpuccin",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1,7 +1,6 @@
 {
   "common": {
     "cancel": "",
-    "delete": "",
     "edit": "",
     "reload": "",
     "save": ""

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -2,6 +2,8 @@
   "common": {
     "cancel": "",
     "edit": "",
+    "moreInfo": "",
+    "okay": "",
     "reload": "",
     "save": ""
   },
@@ -282,7 +284,10 @@
     "statuses": {
       "buttons": {
         "addStatus": "",
-        "importFromTheme": ""
+        "importFromTheme": {
+          "description": "",
+          "name": ""
+        }
       },
       "collections": {
         "anuppuccinTheme": "AnuPpuccin Teması",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -347,6 +347,7 @@
         "placeholder": ""
       },
       "heading": "Görev Durumları",
+      "reloadRequired": "",
       "types": {
         "cancelled": "",
         "done": "",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1,4 +1,11 @@
 {
+  "common": {
+    "cancel": "",
+    "delete": "",
+    "edit": "",
+    "reload": "",
+    "save": ""
+  },
   "main": {
     "loadingPlugin": "Eklenti yükleniyor: {{name}} v{{version}}",
     "unloadingPlugin": "Eklenti kaldırılıyor: {{name}} v{{version}}"
@@ -25,7 +32,25 @@
         "description": "Durumun arama ve geçişlerde nasıl davranacağını belirler.",
         "name": "Görev Durum Türü"
       },
-      "fixErrorsBeforeSaving": "Kaydetmeden önce hataları düzeltin."
+      "fixErrorsBeforeSaving": "Kaydetmeden önce hataları düzeltin.",
+      "title": {
+        "editCoreStatus": "",
+        "editCustomStatus": ""
+      }
+    },
+    "editPresetModal": {
+      "name": {
+        "duplicate": "",
+        "name": "",
+        "placeholder": "",
+        "required": ""
+      },
+      "query": {
+        "description": "",
+        "name": "",
+        "placeholder": ""
+      },
+      "title": ""
     }
   },
   "notices": {
@@ -176,6 +201,9 @@
       },
       "name": "Görev Biçimi"
     },
+    "globalDefaults": {
+      "heading": ""
+    },
     "globalFilter": {
       "filter": {
         "description": {
@@ -197,13 +225,15 @@
       "heading": "Genel Sorgu",
       "query": {
         "description": "Kasadaki her Tasks bloğunun başına otomatik olarak eklenen sorgu. Varsayılan filtreler veya düzen seçenekleri eklemek için kullanışlıdır.",
-        "placeholder": "Örneğin...\npath does not include _templates/\nlimit 300\nshow urgency"
+        "placeholder": "Örneğin...\npath does not include _templates/\nlimit 300\nshow urgency",
+        "shortDescription": ""
       }
     },
     "presets": {
       "buttons": {
         "addNewPreset": "Yeni ön ayar ekle"
       },
+      "emptyState": "",
       "line1": "Burada birden fazla sorguda yeniden kullanabileceğiniz adlandırılmış talimatlar tanımlayabilirsiniz. '{{name}}' adlı bir ön ayar, Tasks sorgularında '{{instruction1}}' veya '{{instruction2}}' ile kullanılabilir.",
       "line2": "Ön ayarlar düzenlendiğinde açık Tasks sorguları otomatik olarak yeniden yüklenir.",
       "name": "Ön Ayarlar"
@@ -235,6 +265,10 @@
     },
     "searches": {
       "enableCustomSearches": {
+        "confirm": {
+          "acknowledge": "",
+          "enable": ""
+        },
         "description": {
           "line1": "Tasks sorgularında JavaScript çalıştıran '{{filterByFunction}}', '{{sortByFunction}}' ve '{{groupByFunction}}' özelliklerini etkinleştirir.",
           "line2": "Bir Tasks sorgusunda veya Markdown dosyasında kötü amaçlı JavaScript, Obsidian içinde çalışarak kasa içeriklerinize, yerel dosyalarınıza veya diğer sistem kaynaklarına erişebilir ya da bunları değiştirebilir.",
@@ -247,6 +281,10 @@
     },
     "seeTheDocumentation": "Belgelere bakın",
     "statuses": {
+      "buttons": {
+        "addStatus": "",
+        "importFromTheme": ""
+      },
       "collections": {
         "anuppuccinTheme": "AnuPpuccin Teması",
         "auraTheme": "Aura Teması",
@@ -254,6 +292,9 @@
         "buttons": {
           "addCollection": {
             "name": "{{themeName}}: {{numberOfStatuses}} desteklenen Durumu ekle"
+          },
+          "importCollection": {
+            "name": ""
           }
         },
         "ebullientworksTheme": "Ebullientworks Teması",
@@ -278,12 +319,14 @@
       "customStatuses": {
         "buttons": {
           "addAllUnknown": {
+            "description": "",
             "name": "Tüm Bilinmeyen Durum Türlerini Ekle"
           },
           "addNewStatus": {
             "name": "Yeni Görev Durumu Ekle"
           },
           "resetCustomStatuses": {
+            "description": "",
             "name": "Özel Durum Türlerini Varsayılanlara Sıfırla"
           }
         },
@@ -293,9 +336,26 @@
           "line3": "<b>Not:</b> Daha önce yer alan durumlarla aynı simgeye sahip durumlar yok sayılır. Gerçekte yüklenen durumları 'Görev oluştur veya düzenle' komutunu çalıştırıp Durum açılır menüsüne bakarak doğrulayabilirsiniz.",
           "line4": "Başlamak için belgelere bakın!"
         },
+        "emptyState": "",
         "heading": "Özel Durumlar"
       },
-      "heading": "Görev Durumları"
+      "filter": {
+        "placeholder": ""
+      },
+      "heading": "Görev Durumları",
+      "types": {
+        "cancelled": "",
+        "done": "",
+        "empty": "",
+        "inProgress": "",
+        "nonTask": "",
+        "onHold": "",
+        "todo": ""
+      },
+      "unnamed": ""
+    },
+    "taskEntry": {
+      "heading": ""
     }
   }
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1,7 +1,6 @@
 {
   "common": {
     "cancel": "",
-    "delete": "",
     "edit": "",
     "reload": "",
     "save": ""

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -347,6 +347,7 @@
         "placeholder": ""
       },
       "heading": "Статуси задач",
+      "reloadRequired": "",
       "types": {
         "cancelled": "",
         "done": "",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1,4 +1,11 @@
 {
+  "common": {
+    "cancel": "",
+    "delete": "",
+    "edit": "",
+    "reload": "",
+    "save": ""
+  },
   "main": {
     "loadingPlugin": "Завантаження плагіна: {{name}} v{{version}}",
     "unloadingPlugin": "Вивантаження плагіна: {{name}} v{{version}}"
@@ -25,7 +32,25 @@
         "description": "Керуйте тим, як статус поводиться під час пошуку та перемикання.",
         "name": "Тип статусу задачі"
       },
-      "fixErrorsBeforeSaving": "Виправте помилки перед збереженням."
+      "fixErrorsBeforeSaving": "Виправте помилки перед збереженням.",
+      "title": {
+        "editCoreStatus": "",
+        "editCustomStatus": ""
+      }
+    },
+    "editPresetModal": {
+      "name": {
+        "duplicate": "",
+        "name": "",
+        "placeholder": "",
+        "required": ""
+      },
+      "query": {
+        "description": "",
+        "name": "",
+        "placeholder": ""
+      },
+      "title": ""
     }
   },
   "notices": {
@@ -176,6 +201,9 @@
       },
       "name": "Формат задач"
     },
+    "globalDefaults": {
+      "heading": ""
+    },
     "globalFilter": {
       "filter": {
         "description": {
@@ -197,13 +225,15 @@
       "heading": "Глобальний запит",
       "query": {
         "description": "Запит, який автоматично включається на початку кожного блоку Tasks у сховищі. Корисно для додавання фільтрів за замовчуванням або параметрів макета.",
-        "placeholder": "Наприклад...\npath does not include _templates/\nlimit 300\nshow urgency"
+        "placeholder": "Наприклад...\npath does not include _templates/\nlimit 300\nshow urgency",
+        "shortDescription": ""
       }
     },
     "presets": {
       "buttons": {
         "addNewPreset": ""
       },
+      "emptyState": "",
       "line1": "",
       "line2": "",
       "name": ""
@@ -235,6 +265,10 @@
     },
     "searches": {
       "enableCustomSearches": {
+        "confirm": {
+          "acknowledge": "",
+          "enable": ""
+        },
         "description": {
           "line1": "",
           "line2": "",
@@ -247,6 +281,10 @@
     },
     "seeTheDocumentation": "Переглянути документацію",
     "statuses": {
+      "buttons": {
+        "addStatus": "",
+        "importFromTheme": ""
+      },
       "collections": {
         "anuppuccinTheme": "Тема AnuPpuccin",
         "auraTheme": "Тема Aura",
@@ -254,6 +292,9 @@
         "buttons": {
           "addCollection": {
             "name": "{{themeName}}: Додати {{numberOfStatuses}} підтримуваних статусів"
+          },
+          "importCollection": {
+            "name": ""
           }
         },
         "ebullientworksTheme": "Тема Ebullientworks",
@@ -278,12 +319,14 @@
       "customStatuses": {
         "buttons": {
           "addAllUnknown": {
+            "description": "",
             "name": "Додати всі невідомі типи статусів"
           },
           "addNewStatus": {
             "name": "Додати новий статус задачі"
           },
           "resetCustomStatuses": {
+            "description": "",
             "name": "Скинути користувацькі типи статусів до значень за замовчуванням"
           }
         },
@@ -293,9 +336,26 @@
           "line3": "<b>Примітка</b> Будь-які статуси з тим самим символом, що й попередні статуси, буде проігноровано. Ви можете підтвердити фактично завантажені статуси, виконавши команду «Створити або редагувати задачу» та переглянувши спадне меню «Статус».",
           "line4": "Перегляньте документацію, щоб розпочати!"
         },
+        "emptyState": "",
         "heading": "Користувацькі статуси"
       },
-      "heading": "Статуси задач"
+      "filter": {
+        "placeholder": ""
+      },
+      "heading": "Статуси задач",
+      "types": {
+        "cancelled": "",
+        "done": "",
+        "empty": "",
+        "inProgress": "",
+        "nonTask": "",
+        "onHold": "",
+        "todo": ""
+      },
+      "unnamed": ""
+    },
+    "taskEntry": {
+      "heading": ""
     }
   }
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -2,6 +2,8 @@
   "common": {
     "cancel": "",
     "edit": "",
+    "moreInfo": "",
+    "okay": "",
     "reload": "",
     "save": ""
   },
@@ -282,7 +284,10 @@
     "statuses": {
       "buttons": {
         "addStatus": "",
-        "importFromTheme": ""
+        "importFromTheme": {
+          "description": "",
+          "name": ""
+        }
       },
       "collections": {
         "anuppuccinTheme": "Тема AnuPpuccin",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -1,7 +1,6 @@
 {
   "common": {
     "cancel": "",
-    "delete": "",
     "edit": "",
     "reload": "",
     "save": ""

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -2,6 +2,8 @@
   "common": {
     "cancel": "",
     "edit": "",
+    "moreInfo": "",
+    "okay": "",
     "reload": "",
     "save": ""
   },
@@ -282,7 +284,10 @@
     "statuses": {
       "buttons": {
         "addStatus": "",
-        "importFromTheme": ""
+        "importFromTheme": {
+          "description": "",
+          "name": ""
+        }
       },
       "collections": {
         "anuppuccinTheme": "Theme AnuPpuccin",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -347,6 +347,7 @@
         "placeholder": ""
       },
       "heading": "Trạng thái nhiệm vụ",
+      "reloadRequired": "",
       "types": {
         "cancelled": "",
         "done": "",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -1,4 +1,11 @@
 {
+  "common": {
+    "cancel": "",
+    "delete": "",
+    "edit": "",
+    "reload": "",
+    "save": ""
+  },
   "main": {
     "loadingPlugin": "Đang tải plugin: {{name}} v{{version}}",
     "unloadingPlugin": "Đang gỡ plugin: {{name}} v{{version}}"
@@ -25,7 +32,25 @@
         "description": "Kiểm soát cách trạng thái hoạt động khi tìm kiếm và chuyển trạng thái.",
         "name": "Loại trạng thái nhiệm vụ"
       },
-      "fixErrorsBeforeSaving": "Vui lòng sửa lỗi trước khi lưu."
+      "fixErrorsBeforeSaving": "Vui lòng sửa lỗi trước khi lưu.",
+      "title": {
+        "editCoreStatus": "",
+        "editCustomStatus": ""
+      }
+    },
+    "editPresetModal": {
+      "name": {
+        "duplicate": "",
+        "name": "",
+        "placeholder": "",
+        "required": ""
+      },
+      "query": {
+        "description": "",
+        "name": "",
+        "placeholder": ""
+      },
+      "title": ""
     }
   },
   "notices": {
@@ -176,6 +201,9 @@
       },
       "name": "Định dạng nhiệm vụ"
     },
+    "globalDefaults": {
+      "heading": ""
+    },
     "globalFilter": {
       "filter": {
         "description": {
@@ -197,13 +225,15 @@
       "heading": "Truy vấn toàn cục",
       "query": {
         "description": "Một truy vấn được tự động bao gồm ở đầu mỗi khối Tasks trong vault. Hữu ích để thêm bộ lọc mặc định hoặc tùy chọn bố cục.",
-        "placeholder": "Ví dụ...\npath does not include _templates/\nlimit 300\nshow urgency"
+        "placeholder": "Ví dụ...\npath does not include _templates/\nlimit 300\nshow urgency",
+        "shortDescription": ""
       }
     },
     "presets": {
       "buttons": {
         "addNewPreset": "Thêm preset mới"
       },
+      "emptyState": "",
       "line1": "Bạn có thể định nghĩa các hướng dẫn được đặt tên ở đây, mà bạn có thể sử dụng lại trong nhiều truy vấn. Một preset có tên '{{name}}' có thể được sử dụng trong truy vấn Tasks với '{{instruction1}}' hoặc '{{instruction2}}'.",
       "line2": "Bất kỳ truy vấn Tasks nào đang mở sẽ được tải lại tự động khi các preset được chỉnh sửa.",
       "name": "Preset"
@@ -235,6 +265,10 @@
     },
     "searches": {
       "enableCustomSearches": {
+        "confirm": {
+          "acknowledge": "",
+          "enable": ""
+        },
         "description": {
           "line1": "",
           "line2": "",
@@ -247,6 +281,10 @@
     },
     "seeTheDocumentation": "Xem tài liệu",
     "statuses": {
+      "buttons": {
+        "addStatus": "",
+        "importFromTheme": ""
+      },
       "collections": {
         "anuppuccinTheme": "Theme AnuPpuccin",
         "auraTheme": "Theme Aura",
@@ -254,6 +292,9 @@
         "buttons": {
           "addCollection": {
             "name": "{{themeName}}: Thêm {{numberOfStatuses}} Trạng thái được hỗ trợ"
+          },
+          "importCollection": {
+            "name": ""
           }
         },
         "ebullientworksTheme": "Theme Ebullientworks",
@@ -278,12 +319,14 @@
       "customStatuses": {
         "buttons": {
           "addAllUnknown": {
+            "description": "",
             "name": "Thêm tất cả loại trạng thái không xác định"
           },
           "addNewStatus": {
             "name": "Thêm trạng thái nhiệm vụ mới"
           },
           "resetCustomStatuses": {
+            "description": "",
             "name": "Đặt lại loại trạng thái tùy chỉnh về mặc định"
           }
         },
@@ -293,9 +336,26 @@
           "line3": "<b>Lưu ý</b> Bất kỳ trạng thái nào có cùng ký hiệu với bất kỳ trạng thái trước đó nào sẽ bị bỏ qua. Bạn có thể xác nhận các trạng thái thực sự được tải bằng cách chạy lệnh 'Tạo hoặc chỉnh sửa nhiệm vụ' và xem menu thả xuống Trạng thái.",
           "line4": "Xem tài liệu để bắt đầu!"
         },
+        "emptyState": "",
         "heading": "Trạng thái tùy chỉnh"
       },
-      "heading": "Trạng thái nhiệm vụ"
+      "filter": {
+        "placeholder": ""
+      },
+      "heading": "Trạng thái nhiệm vụ",
+      "types": {
+        "cancelled": "",
+        "done": "",
+        "empty": "",
+        "inProgress": "",
+        "nonTask": "",
+        "onHold": "",
+        "todo": ""
+      },
+      "unnamed": ""
+    },
+    "taskEntry": {
+      "heading": ""
     }
   }
 }

--- a/src/i18n/locales/zh_cn.json
+++ b/src/i18n/locales/zh_cn.json
@@ -1,7 +1,6 @@
 {
   "common": {
     "cancel": "",
-    "delete": "",
     "edit": "",
     "reload": "",
     "save": ""

--- a/src/i18n/locales/zh_cn.json
+++ b/src/i18n/locales/zh_cn.json
@@ -1,4 +1,11 @@
 {
+  "common": {
+    "cancel": "",
+    "delete": "",
+    "edit": "",
+    "reload": "",
+    "save": ""
+  },
   "main": {
     "loadingPlugin": "加载插件: {{name}} v{{version}}",
     "unloadingPlugin": "卸载插件: {{name}} v{{version}}"
@@ -25,7 +32,25 @@
         "description": "控制搜索和切换状态的行为。",
         "name": "任务状态类型"
       },
-      "fixErrorsBeforeSaving": "在保存前修复错误。"
+      "fixErrorsBeforeSaving": "在保存前修复错误。",
+      "title": {
+        "editCoreStatus": "",
+        "editCustomStatus": ""
+      }
+    },
+    "editPresetModal": {
+      "name": {
+        "duplicate": "",
+        "name": "",
+        "placeholder": "",
+        "required": ""
+      },
+      "query": {
+        "description": "",
+        "name": "",
+        "placeholder": ""
+      },
+      "title": ""
     }
   },
   "notices": {
@@ -176,6 +201,9 @@
       },
       "name": "任务格式"
     },
+    "globalDefaults": {
+      "heading": ""
+    },
     "globalFilter": {
       "filter": {
         "description": {
@@ -197,13 +225,15 @@
       "heading": "全局查询",
       "query": {
         "description": "自动包含在库中每个 Tasks 块开头的查询语句.用于添加默认过滤器或布局选项。",
-        "placeholder": "例如...\npath does not include _templates/\nlimit 300\nshow urgency"
+        "placeholder": "例如...\npath does not include _templates/\nlimit 300\nshow urgency",
+        "shortDescription": ""
       }
     },
     "presets": {
       "buttons": {
         "addNewPreset": ""
       },
+      "emptyState": "",
       "line1": "您可以在这里定义命名指令，可以在多个查询中重复使用。一个名为 '{{name}}' 的预设可以在任务查询中使用 '{{instruction1}}' 或 '{{instruction2}}'。",
       "line2": "任何打开的任务查询在预设被编辑时都会自动重新加载。",
       "name": "预设"
@@ -235,6 +265,10 @@
     },
     "searches": {
       "enableCustomSearches": {
+        "confirm": {
+          "acknowledge": "",
+          "enable": ""
+        },
         "description": {
           "line1": "",
           "line2": "",
@@ -247,6 +281,10 @@
     },
     "seeTheDocumentation": "参阅文档",
     "statuses": {
+      "buttons": {
+        "addStatus": "",
+        "importFromTheme": ""
+      },
       "collections": {
         "anuppuccinTheme": "AnuPpuccin 主题",
         "auraTheme": "Aura 主题",
@@ -254,6 +292,9 @@
         "buttons": {
           "addCollection": {
             "name": "{{themeName}}: 添加 {{numberOfStatuses}} 种支持状态"
+          },
+          "importCollection": {
+            "name": ""
           }
         },
         "ebullientworksTheme": "Ebullientworks 主题",
@@ -278,12 +319,14 @@
       "customStatuses": {
         "buttons": {
           "addAllUnknown": {
+            "description": "",
             "name": "添加所有未知状态类型"
           },
           "addNewStatus": {
             "name": "添加新任务状态"
           },
           "resetCustomStatuses": {
+            "description": "",
             "name": "重置自定义状态类型为默认值"
           }
         },
@@ -293,9 +336,26 @@
           "line3": "<b>注意</b>任何与更早的状态具有相同符号的状态都将被忽略.您可以通过运行“Create or edit task”命令并查看“Status”下拉列表来确认实际加载的状态。",
           "line4": "参阅文档！"
         },
+        "emptyState": "",
         "heading": "自定义状态"
       },
-      "heading": "任务状态"
+      "filter": {
+        "placeholder": ""
+      },
+      "heading": "任务状态",
+      "types": {
+        "cancelled": "",
+        "done": "",
+        "empty": "",
+        "inProgress": "",
+        "nonTask": "",
+        "onHold": "",
+        "todo": ""
+      },
+      "unnamed": ""
+    },
+    "taskEntry": {
+      "heading": ""
     }
   }
 }

--- a/src/i18n/locales/zh_cn.json
+++ b/src/i18n/locales/zh_cn.json
@@ -347,6 +347,7 @@
         "placeholder": ""
       },
       "heading": "任务状态",
+      "reloadRequired": "",
       "types": {
         "cancelled": "",
         "done": "",

--- a/src/i18n/locales/zh_cn.json
+++ b/src/i18n/locales/zh_cn.json
@@ -2,6 +2,8 @@
   "common": {
     "cancel": "",
     "edit": "",
+    "moreInfo": "",
+    "okay": "",
     "reload": "",
     "save": ""
   },
@@ -282,7 +284,10 @@
     "statuses": {
       "buttons": {
         "addStatus": "",
-        "importFromTheme": ""
+        "importFromTheme": {
+          "description": "",
+          "name": ""
+        }
       },
       "collections": {
         "anuppuccinTheme": "AnuPpuccin 主题",

--- a/tests/Statuses/StatusRegistryReport.test.StatusRegistryReport_should_create_a_report.approved.md
+++ b/tests/Statuses/StatusRegistryReport.test.StatusRegistryReport_should_create_a_report.approved.md
@@ -1,4 +1,4 @@
-# Review and check your Statuses
+# Review and check your statuses
 
 ## About this file
 
@@ -7,7 +7,7 @@ This file was created by the Obsidian Tasks plugin (version x.y.z) to help visua
 If you change the Tasks status settings, you can get an updated report by:
 
 - Going to `Settings` -> `Tasks`.
-- Clicking on `Review and check your Statuses`.
+- Clicking on `Review and check your statuses`.
 
 You can delete this file any time.
 

--- a/tests/Statuses/StatusRegistryReport.test.ts
+++ b/tests/Statuses/StatusRegistryReport.test.ts
@@ -16,7 +16,7 @@ describe('StatusRegistryReport', function () {
         ];
         const { statusSettings, statusRegistry } = createStatuses(coreStatusesData, customStatusesData);
 
-        const reportName = 'Review and check your Statuses';
+        const reportName = 'Review and check your statuses';
 
         // Act
         const version = 'x.y.z'; // lower-case, as the capitalised version would get edited at the next release.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7117,10 +7117,10 @@ obsidian@1.12.3:
     "@types/codemirror" "5.60.8"
     moment "2.29.4"
 
-obsidian@1.8.7:
-  version "1.8.7"
-  resolved "https://registry.yarnpkg.com/obsidian/-/obsidian-1.8.7.tgz#601e9ea1724289effa4c9bb3b4e20d327263634f"
-  integrity sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==
+obsidian@1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/obsidian/-/obsidian-1.13.1.tgz#3dc280d49e8391a0e2958ca90ee71a6d45fd14d6"
+  integrity sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==
   dependencies:
     "@types/codemirror" "5.60.8"
     moment "2.29.4"


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
  - **WARNING: If the link is absent, the PR may be closed without review**, due to the workload that such reviews usually require.
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
- [ ] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
- [ ] **Translation** (prefix: `i18n` - additions or improvements to the translations - see [Support a new language](https://publish.obsidian.md/tasks-contributing/Translation/Support+a+new+language))
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

<!--- Remember to provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Obsidian 1.13 introduces Setting Definitions for creating settings declaratively. This new API allows settings to be discoverable in settings search, and enables the use of setting pages which reduces the overall visual complexity.

## How has this been tested?

I manually tested each component on macOS. Changes only impact settings so I only ensured that settings are persisted correctly.

Testing environment: macOS 26.3

## Screenshots (if appropriate)

<img width="790" height="874" alt="image" src="https://github.com/user-attachments/assets/5d3343ba-c31b-4692-bf96-14d386e85735" />

<img width="764" height="898" alt="image" src="https://github.com/user-attachments/assets/739e4f4c-9c41-4cda-826b-d0bec6387d1b" />

<img width="742" height="915" alt="image" src="https://github.com/user-attachments/assets/79fef5c3-d21e-4e54-b378-3eb8de7c7dca" />


### Presets Page
<img width="754" height="865" alt="image" src="https://github.com/user-attachments/assets/67614bc8-7328-4921-96e7-19dfafd57407" />


### Task statuses
<img width="749" height="633" alt="image" src="https://github.com/user-attachments/assets/5189cdc1-1361-4709-a629-5f08b76aecf6" />


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
