### PR TITLE
fix(presets): hide_everything preset now hides the task count (#3899)

### DIFF
--- a/src/Query/Presets/Presets.ts
+++ b/src/Query/Presets/Presets.ts
@@ -11,7 +11,7 @@ export const defaultPresets = {
     hide_query_elements:
         '# Hide toolbar, postpone, edit and backlinks\nhide toolbar\nhide postpone button\nhide edit button\nhide backlinks',
     hide_everything:
-        '# Hide everything except description and any tags\npreset hide_date_fields\npreset hide_non_date_fields\npreset hide_query_elements',
+        '# Hide everything except description and any tags\npreset hide_date_fields\npreset hide_non_date_fields\npreset hide_query_elements\nhide task count',
 };
 
 function summariseInstruction(instructions: string) {

--- a/tests/Query/Presets/DocsForPresets.test.default-presets.approved.md
+++ b/tests/Query/Presets/DocsForPresets.test.default-presets.approved.md
@@ -9,7 +9,7 @@
 | `hide_date_fields` | `# Hide any values for all date fields`<br>`hide due date`<br>`hide scheduled date`<br>`hide start date`<br>`hide created date`<br>`hide done date`<br>`hide cancelled date` |
 | `hide_non_date_fields` | `# Hide all the non-date fields, but not tags`<br>`hide id`<br>`hide depends on`<br>`hide recurrence rule`<br>`hide on completion`<br>`hide priority` |
 | `hide_query_elements` | `# Hide toolbar, postpone, edit and backlinks`<br>`hide toolbar`<br>`hide postpone button`<br>`hide edit button`<br>`hide backlinks` |
-| `hide_everything` | `# Hide everything except description and any tags`<br>`preset hide_date_fields`<br>`preset hide_non_date_fields`<br>`preset hide_query_elements` |
+| `hide_everything` | `# Hide everything except description and any tags`<br>`preset hide_date_fields`<br>`preset hide_non_date_fields`<br>`preset hide_query_elements`<br>`hide task count` |
 
 
 <!-- placeholder to force blank line after included text -->

--- a/tests/Query/Presets/Presets.test.ts
+++ b/tests/Query/Presets/Presets.test.ts
@@ -543,7 +543,8 @@ describe('include settings tests', () => {
               "hide_everything": "# Hide everything except description and any tags
             preset hide_date_fields
             preset hide_non_date_fields
-            preset hide_query_elements",
+            preset hide_query_elements
+            hide task count",
               "hide_non_date_fields": "# Hide all the non-date fields, but not tags
             hide id
             hide depends on


### PR DESCRIPTION
## Repository Understanding

[Obsidian Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) is a widely-used Obsidian community plugin for managing and querying tasks via `tasks` code blocks. It supports **presets** — named bundles of query instructions defined in `src/Query/Presets/Presets.ts`. The `hide_everything` preset is documented as "Hide everything except description and any tags" and composes three sub-presets (`hide_date_fields`, `hide_non_date_fields`, `hide_query_elements`). Layout options such as the task count are toggled by instructions like `hide task count`, mapped in `src/Layout/QueryLayoutOptions.ts` (`['task count', 'hideTaskCount']`).

This fix aligns the `hide_everything` preset with its documented intent (hide everything) and with the project's convention of composing granular `hide *` instructions.

## Problem Statement

**Issue #3899** — the `hide_everything` preset does not hide the task count.

- **Why it matters:** users rely on `preset hide_everything` to produce a minimal rendering (description + tags only). The stray "N tasks" count line contradicts the preset's stated purpose and clutters the output.
- **Who is affected:** anyone using `preset hide_everything` (or building on it) who expects a fully minimal result.
- **Evidence:** issue #3899 includes a clear reproduction (Sandbox Vault → `preset hide_everything` → Reading Mode shows the count) and before/after screenshots. No open PR references it (verified — unclaimed).

## Root Cause Analysis

`defaultPresets.hide_everything` (Presets.ts:13) nested three sub-presets but never included `hide task count`. The task-count line is controlled by the `hideTaskCount` layout option, which is only set when the `hide task count` instruction is present. Because the preset omitted that instruction, the count remained visible.

## Proposed Solution

Add `hide task count` as the final line of the `hide_everything` preset body. This is the minimal, correct change: it reuses the existing, tested `hide task count` instruction rather than introducing new logic. Updated the three test artifacts that snapshot the preset text so the suite stays green:
- `tests/Query/Presets/Presets.test.ts` (hard-coded expected string)
- `tests/Query/Presets/DocsForPresets.test.default-presets.approved.md` (docs snapshot)
- (The help-message approved doc truncates to the first line, so it is unaffected.)

## Alternatives Considered

- **Add `hide group count` too:** broader, but out of scope for #3899 (only the task count is reported). Could be a follow-up if maintainers want it; kept minimal here.
- **Change default `hideTaskCount` behavior globally:** rejected — would change behavior for every other query, violating backward compatibility and the principle of minimal, localized fixes.

## Expected Impact

- **Usability / correctness:** `preset hide_everything` now hides the task count as documented.
- **Maintainability:** uses existing instruction; no new code path.
- **Backward compatibility:** only affects the `hide_everything` preset's output (the intended behavior); no API/break.
- **Testing:** existing preset/docs tests updated to match.

## Risk Assessment

- **Risks:** very low — single-line preset addition + test/snapshot updates.
- **Mitigations:** instruction keyword verified against `QueryLayoutOptions.ts` mapping.
- **Rollback:** `git revert` of the one commit.

## Testing Plan

- Verified the instruction token `hide task count` is valid (mapped to `hideTaskCount` in `QueryLayoutOptions.ts`).
- Updated all three test artifacts that reference the preset string (found via `grep` across `src/` and `tests/` — no other references remain).
- Note: could not run the full jest suite locally (repo uses yarn; `npm install` hit an environment-specific spawn error on this Windows/MSYS host). The change is a string addition to a preset plus matching snapshot updates, so CI on the maintainer's Linux runners will validate it. Recommend the maintainer's CI as the authoritative check.

## Documentation Changes

- The preset's documented behavior is now accurate by construction; the auto-generated docs snapshot (`DocsForPresets.test.default-presets.approved.md`) was updated to reflect the new line. No prose docs change required.

## Pull Request Description

**Summary**
The `hide_everything` preset now also hides the task count, matching its documented "hide everything except description and tags" intent.

**Motivation**
Fixes #3899: queries using `preset hide_everything` still rendered the "N tasks" count line. Adding `hide task count` to the preset body resolves it using the existing instruction.

**Implementation Details**
- `src/Query/Presets/Presets.ts`: appended `hide task count` to `hide_everything`.
- Updated `Presets.test.ts` and the default-presets docs approval snapshot.

**Testing**
- Instruction keyword validated against `QueryLayoutOptions.ts`.
- Affected test/snapshot files updated.

**Breaking Changes**
None.

**Checklist**
- [x] No duplicated functionality
- [x] No unnecessary abstractions
- [x] No dead code
- [x] No breaking API
- [x] No security regressions
- [x] No unnecessary dependencies
- [x] Consistent coding style
- [x] Repository conventions followed
- [x] Tests included (updated)
- [x] Documentation updated (snapshot)
- [x] Backward compatibility maintained
