### PR TITLE
chore: Make the 'circular-deps.txt' content stable

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Identify circular dependencies
         run: |
           yarn run circular-deps-text || echo continuing after error message
+          git diff circular-deps.txt  || echo continuing after error message
           yarn run circular-deps-image
 
       - name: Archive circular dependencies results

--- a/circular-deps.txt
+++ b/circular-deps.txt
@@ -1,25 +1,22 @@
-Processed 212 files (673ms) (2 warnings)
-
-1) Config/Settings.ts > Config/DismissibleNotices.ts
-2) Config/Settings.ts > Suggestor/Suggestor.ts
-3) Config/Settings.ts > Suggestor/Suggestor.ts > Suggestor/index.ts
-4) Config/Settings.ts > Suggestor/Suggestor.ts > Task/Occurrence.ts
-5) Config/Settings.ts > Suggestor/Suggestor.ts > Task/Task.ts
-6) Config/Settings.ts > Suggestor/Suggestor.ts > Task/Task.ts > DateTime/DateFallback.ts
-7) Task/Task.ts > DateTime/DateFallback.ts
-8) Scripting/TasksFile.ts > Task/Link.ts
-9) Task/Task.ts > Task/ListItem.ts
-10) Task/Task.ts > Task/OnCompletion.ts
-11) Task/Task.ts > Task/Urgency.ts
-12) TaskSerializer/DefaultTaskSerializer.ts > TaskSerializer/index.ts
-13) Api/index.ts > main.ts
-14) Query/FilterParser.ts > Query/Filter/BooleanField.ts
-15) Query/Query.ts > Query/Explain/Explainer.ts
-16) main.ts > Commands/index.ts
-17) Obsidian/Cache.ts > Obsidian/FileParser.ts
-18) Obsidian/TasksEvents.ts > Obsidian/Cache.ts
-19) main.ts > Config/SettingsTab.ts > Config/PresetsSettingsUI.ts
-20) main.ts > Config/SettingsTab.ts
-21) Renderer/QueryResultsRenderer.ts > Renderer/HtmlColumnQueryResultsRenderer.ts > Renderer/HtmlQueryResultsRenderer.ts
-22) main.ts > Renderer/QueryRenderer.ts
-
+Config/Settings.ts > Config/DismissibleNotices.ts
+Config/Settings.ts > Suggestor/Suggestor.ts
+Config/Settings.ts > Suggestor/Suggestor.ts > Suggestor/index.ts
+Config/Settings.ts > Suggestor/Suggestor.ts > Task/Occurrence.ts
+Config/Settings.ts > Suggestor/Suggestor.ts > Task/Task.ts
+Config/Settings.ts > Suggestor/Suggestor.ts > Task/Task.ts > DateTime/DateFallback.ts
+Task/Task.ts > DateTime/DateFallback.ts
+Scripting/TasksFile.ts > Task/Link.ts
+Task/Task.ts > Task/ListItem.ts
+Task/Task.ts > Task/OnCompletion.ts
+Task/Task.ts > Task/Urgency.ts
+TaskSerializer/DefaultTaskSerializer.ts > TaskSerializer/index.ts
+Api/index.ts > main.ts
+Query/FilterParser.ts > Query/Filter/BooleanField.ts
+Query/Query.ts > Query/Explain/Explainer.ts
+main.ts > Commands/index.ts
+Obsidian/Cache.ts > Obsidian/FileParser.ts
+Obsidian/TasksEvents.ts > Obsidian/Cache.ts
+main.ts > Config/SettingsTab.ts > Config/PresetsSettingsUI.ts
+main.ts > Config/SettingsTab.ts
+Renderer/QueryResultsRenderer.ts > Renderer/HtmlColumnQueryResultsRenderer.ts > Renderer/HtmlQueryResultsRenderer.ts
+main.ts > Renderer/QueryRenderer.ts

--- a/circular-deps.txt
+++ b/circular-deps.txt
@@ -1,3 +1,5 @@
+Current circular dependencies:
+
 Config/Settings.ts > Config/DismissibleNotices.ts
 Config/Settings.ts > Suggestor/Suggestor.ts
 Config/Settings.ts > Suggestor/Suggestor.ts > Suggestor/index.ts

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,7 +98,7 @@ const typescriptCommonRules = {
 
 export default defineConfig([
     {
-        ignores: ['**/main.js'],
+        ignores: ['**/main.js', 'scripts/**'],
     },
     js.configs.recommended,
     prettierConfig,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "deploy:local": "node ./scripts/Test-TasksInLocalObsidian.mjs",
     "deploy:local:pwsh": "pwsh -ExecutionPolicy Unrestricted -NoProfile -File ./scripts/Test-TasksInLocalObsidian.ps1",
     "extract-i18n": "npx i18next-parser && node ./scripts/normalizeI18nLocales.mjs",
-    "circular-deps-text": "madge --circular --extensions ts ./src > circular-deps.txt",
+    "circular-deps-text": "node ./scripts/circular-deps-text.mjs > circular-deps.txt",
     "circular-deps-image": "madge --circular --extensions ts ./src --image circular-deps.png",
     "code-docs": "typedoc \"src/**/*\""
   },

--- a/scripts/circular-deps-text.mjs
+++ b/scripts/circular-deps-text.mjs
@@ -39,13 +39,16 @@ const result = spawnSync(
 
 const stdout = result.stdout ?? '';
 
-const stableOutput = stdout
-    .split(/\r?\n/)
-    .slice(1)
-    .map((line) => line.replace(/^\d+\)\s+/, ''))
-    .join('\n')
-    .replace(/^\s*\n/, '')
-    .trimEnd() + '\n';
+const stableOutput =
+    'Current circular dependencies:\n\n' +
+    stdout
+        .split(/\r?\n/)
+        .slice(1)
+        .map((line) => line.replace(/^\d+\)\s+/, ''))
+        .join('\n')
+        .replace(/^\s*\n/, '')
+        .trimEnd() +
+    '\n';
 
 process.stdout.write(stableOutput);
 

--- a/scripts/circular-deps-text.mjs
+++ b/scripts/circular-deps-text.mjs
@@ -1,0 +1,56 @@
+// Runs madge on src/ and normalises its circular-dependency output for stable comparisons.
+// Removes volatile header and numbering, then writes the cleaned result to stdout.
+
+// Output like this:
+//
+// ---
+// Processed 212 files (673ms) (2 warnings)
+//
+// 1) Config/Settings.ts > Config/DismissibleNotices.ts
+// 2) Config/Settings.ts > Suggestor/Suggestor.ts
+// 3) Config/Settings.ts > Suggestor/Suggestor.ts > Suggestor/index.ts
+// 4) Config/Settings.ts > Suggestor/Suggestor.ts > Task/Occurrence.ts
+// ---
+//
+// Becomes this, which is more friendly to git histories and would eventually
+// allow GitHub actions to report unexpected changes in circular dependencies.
+//
+// ---
+// Config/Settings.ts > Config/DismissibleNotices.ts
+// Config/Settings.ts > Suggestor/Suggestor.ts
+// Config/Settings.ts > Suggestor/Suggestor.ts > Suggestor/index.ts
+// Config/Settings.ts > Suggestor/Suggestor.ts > Task/Occurrence.ts
+// ---
+
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const madgeCliPath = require.resolve('madge/bin/cli.js');
+
+const result = spawnSync(
+    process.execPath,
+    [madgeCliPath, '--circular', '--extensions', 'ts', './src'],
+    {
+        encoding: 'utf8',
+        stdio: ['inherit', 'pipe', 'inherit'],
+    },
+);
+
+const stdout = result.stdout ?? '';
+
+const stableOutput = stdout
+    .split(/\r?\n/)
+    .slice(1)
+    .map((line) => line.replace(/^\d+\)\s+/, ''))
+    .join('\n')
+    .replace(/^\s*\n/, '')
+    .trimEnd() + '\n';
+
+process.stdout.write(stableOutput);
+
+if (result.error) {
+    throw result.error;
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

There shouldn't be any circular dependencies between files in `src/`.

But since there are, I am using a tool `madge` to track them in a text file, `circular-deps.txt`.

The raw madge output is not stable, and therefore not friendly to git histories.



This PR creates a new script, `scripts/circular-deps-text.mjs`, that invokes `madge` and writes out stable output.

For example, output like this:

~~~
Processed 212 files (673ms) (2 warnings)

1) Config/Settings.ts > Config/DismissibleNotices.ts
2) Config/Settings.ts > Suggestor/Suggestor.ts
3) Config/Settings.ts > Suggestor/Suggestor.ts > Suggestor/index.ts
4) Config/Settings.ts > Suggestor/Suggestor.ts > Task/Occurrence.ts
~~~

Becomes this, which is more friendly to git histories and would eventually
allow GitHub actions to report unexpected changes in circular dependencies.

~~~
Config/Settings.ts > Config/DismissibleNotices.ts
Config/Settings.ts > Suggestor/Suggestor.ts
Config/Settings.ts > Suggestor/Suggestor.ts > Suggestor/index.ts
Config/Settings.ts > Suggestor/Suggestor.ts > Task/Occurrence.ts
~~~

## Motivation and Context

1. I want to be able to run `madge` in GitHub Actions and detect whether the content actually changed. Because the raw output contains two unstable values (number of files and elapsed time) it always differs.
2. I want any real diffs to be easily readable, that is,  to stop having diffs like this, where maybe only 3 Iines changed, but almost every line in the file shows as a diff:

<img width="1719" height="571" alt="image" src="https://github.com/user-attachments/assets/eeec531e-2339-4cd7-b122-46835a5a2ba9" />


## How has this been tested?

By running the new script repeatedly locally until I was happy with it.

## Screenshots (if appropriate)

See diff above.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
