### PR TITLE
fix: unregister EditorSuggestor Tab handler

### DIFF
--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -23,6 +23,7 @@ function showError(message: string) {
 export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
     private settings: Settings;
     private plugin: TasksPlugin;
+    private popupIsOpen = false;
 
     constructor(app: App, settings: Settings, plugin: TasksPlugin) {
         super(app);
@@ -31,9 +32,9 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
 
         // EditorSuggestor swallows tabs while the suggestor popup is open
         // This is a hack to support indenting while popup is open
-        app.scope.register([], 'Tab', () => {
+        const tabHandler = app.scope.register([], 'Tab', () => {
             const editor = this.context?.editor;
-            if (editor) {
+            if (editor && this.popupIsOpen) {
                 editor.exec('indentMore');
                 // Returning false triggers preventDefault
                 // Should prevent double indent if tabs start to get passed through
@@ -41,9 +42,12 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
             }
             return true;
         });
+        plugin.register(() => app.scope.unregister(tabHandler));
     }
 
     onTrigger(cursor: EditorPosition, editor: Editor, _file: TFile): EditorSuggestTriggerInfo | null {
+        this.popupIsOpen = false;
+
         if (!this.settings.autoSuggestInEditor) return null;
 
         if (_file === undefined) {
@@ -60,6 +64,7 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
 
         if (this.grabSuggestions(editor, _file, line).length === 0) return null;
 
+        this.popupIsOpen = true;
         return {
             start: { line: cursor.line, ch: 0 },
             end: {
@@ -68,6 +73,11 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
             },
             query: line,
         };
+    }
+
+    close(): void {
+        this.popupIsOpen = false;
+        super.close();
     }
 
     getSuggestions(context: EditorSuggestContext): SuggestInfoWithContext[] {


### PR DESCRIPTION
# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
  - **WARNING: If the link is absent, the PR may be closed without review**, due to the workload that such reviews usually require.
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3940
- [ ] **Translation** (prefix: `i18n` - additions or improvements to the translations - see [Support a new language](https://publish.obsidian.md/tasks-contributing/Translation/Support+a+new+language))
- [ ] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: `vault` - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: `contrib` - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))

Internal changes:
- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description
<!--- Remember to provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
Fix the EditorSuggestor Tab handler so it is unregistered when the Tasks plugin unloads. The handler now only indents the editor while the suggestion popup is open, preventing stale handlers from intercepting Tab after plugin reloads.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3940.

Previously, reloading or disabling the plugin could leave registered Tab handlers behind. These stale handlers could indent unrelated editor content.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- `yarn build`
- `yarn run lint`
- Full Jest test suite:
  - 170 test suites passed
  - 4,877 tests passed
  - 260 snapshots passed
- Svelte and TypeScript checks passed

## Screenshots (if appropriate)
Not applicable.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms
<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->
- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)