### PR TITLE
fix: preserve hard-break spaces when toggling tasks

### DIFF
--- a/src/Commands/ChangeStatusCommands.ts
+++ b/src/Commands/ChangeStatusCommands.ts
@@ -23,7 +23,7 @@ export const setStatusOnLine = (line: string, path: string, newStatus: Status): 
     });
 
     if (task !== null) {
-        const lines = task.handleNewStatusWithRecurrenceInUsersOrder(newStatus).map((t) => t.toFileLineString());
+        const lines = task.handleNewStatusWithRecurrenceInUsersOrder(newStatus).map((t) => t.toFileLineString(true));
         const newLineNumber = lines.length > 0 ? lines.length - 1 : 0;
         return { text: lines.join('\n'), moveTo: { line: newLineNumber } };
     }

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -17,7 +17,7 @@ export const toggleLine = (line: string, path: string): EditorInsertion => {
         fallbackDate: null, // We don't need this to toggle it here in the editor.
     });
     if (task !== null) {
-        const lines = task.toggleWithRecurrenceInUsersOrder().map((t) => t.toFileLineString());
+        const lines = task.toggleWithRecurrenceInUsersOrder().map((t) => t.toFileLineString(true));
         const newLineNumber = lines.length > 0 ? lines.length - 1 : 0;
         return { text: lines.join('\n'), moveTo: { line: newLineNumber } };
     } else {

--- a/src/Obsidian/File.ts
+++ b/src/Obsidian/File.ts
@@ -169,7 +169,7 @@ Recommendations:
         // Finally, we can insert 1 or more lines over the original task line:
         const updatedFileLines = [
             ...fileLines.slice(0, taskLineNumber),
-            ...newTasks.map((task: ListItem) => task.toFileLineString()),
+            ...newTasks.map((task: ListItem) => task.toFileLineString(true)),
             ...fileLines.slice(taskLineNumber + 1), // Only supports single-line tasks.
         ];
 

--- a/src/Obsidian/LivePreviewExtension.ts
+++ b/src/Obsidian/LivePreviewExtension.ts
@@ -108,7 +108,7 @@ class LivePreviewExtension implements PluginValue {
 
         // Clicked on a task's checkbox. Toggle the task and set it.
         const toggled = task.toggleWithRecurrenceInUsersOrder();
-        const toggledString = toggled.map((t) => t.toFileLineString()).join(state.lineBreak);
+        const toggledString = toggled.map((t) => t.toFileLineString(true)).join(state.lineBreak);
 
         let to = line.to;
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -264,8 +264,9 @@ export class ListItem {
         });
     }
 
-    public toFileLineString(): string {
+    public toFileLineString(preserveTrailingWhitespace = false): string {
         const statusCharacterToString = this.statusCharacter ? `[${this.statusCharacter}] ` : '';
-        return `${this.indentation}${this.listMarker} ${statusCharacterToString}${this.description}`;
+        const markdownHardBreak = preserveTrailingWhitespace ? this.originalMarkdown.match(/ {2,}$/u)?.[0] ?? '' : '';
+        return `${this.indentation}${this.listMarker} ${statusCharacterToString}${this.description}${markdownHardBreak}`;
     }
 }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -266,7 +266,12 @@ export class ListItem {
 
     public toFileLineString(preserveTrailingWhitespace = false): string {
         const statusCharacterToString = this.statusCharacter ? `[${this.statusCharacter}] ` : '';
-        const markdownHardBreak = preserveTrailingWhitespace ? this.originalMarkdown.match(/ {2,}$/u)?.[0] ?? '' : '';
-        return `${this.indentation}${this.listMarker} ${statusCharacterToString}${this.description}${markdownHardBreak}`;
+        return `${this.indentation}${this.listMarker} ${statusCharacterToString}${
+            this.description
+        }${this.getMarkdownHardBreak(preserveTrailingWhitespace)}`;
+    }
+
+    protected getMarkdownHardBreak(preserveTrailingWhitespace: boolean): string {
+        return preserveTrailingWhitespace ? this.originalMarkdown.match(/ {2,}$/u)?.[0] ?? '' : '';
     }
 }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -272,6 +272,18 @@ export class ListItem {
     }
 
     protected getMarkdownHardBreak(preserveTrailingWhitespace: boolean): string {
-        return preserveTrailingWhitespace ? this.originalMarkdown.match(/ {2,}$/u)?.[0] ?? '' : '';
+        if (!preserveTrailingWhitespace) {
+            return '';
+        }
+
+        let trailingSpaces = 0;
+        for (let index = this.originalMarkdown.length - 1; index >= 0; index--) {
+            if (this.originalMarkdown[index] !== ' ') {
+                break;
+            }
+            trailingSpaces++;
+        }
+
+        return trailingSpaces >= 2 ? ' '.repeat(trailingSpaces) : '';
     }
 }

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -326,8 +326,9 @@ export class Task extends ListItem {
         // Preserve Markdown hard-break spaces from the original line when a task
         // edit is being written back. A single trailing space is formatting noise,
         // but two or more trailing spaces are meaningful.
-        const markdownHardBreak = preserveTrailingWhitespace ? this.originalMarkdown.match(/ {2,}$/u)?.[0] ?? '' : '';
-        return `${this.indentation}${this.listMarker} [${this.status.symbol}] ${this.toString()}${markdownHardBreak}`;
+        return `${this.indentation}${this.listMarker} [${
+            this.status.symbol
+        }] ${this.toString()}${this.getMarkdownHardBreak(preserveTrailingWhitespace)}`;
     }
 
     /**

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -322,8 +322,12 @@ export class Task extends ListItem {
      * @note Output depends on {@link Settings.taskFormat}
      * @return {*}  {string}
      */
-    public toFileLineString(): string {
-        return `${this.indentation}${this.listMarker} [${this.status.symbol}] ${this.toString()}`;
+    public toFileLineString(preserveTrailingWhitespace = false): string {
+        // Preserve Markdown hard-break spaces from the original line when a task
+        // edit is being written back. A single trailing space is formatting noise,
+        // but two or more trailing spaces are meaningful.
+        const markdownHardBreak = preserveTrailingWhitespace ? this.originalMarkdown.match(/ {2,}$/u)?.[0] ?? '' : '';
+        return `${this.indentation}${this.listMarker} [${this.status.symbol}] ${this.toString()}${markdownHardBreak}`;
     }
 
     /**

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -137,6 +137,15 @@ describe('ToggleDone', () => {
         testToggleLine('- [ ] I have a |proper description', '- [x] I have a |proper description');
     });
 
+    it('should preserve Markdown hard-break spaces when completing a task', () => {
+        const hardBreak = '  ';
+        const incomplete = `- [ ] foo${hardBreak}`;
+        const complete = `- [x] foo ✅ 2022-09-04${hardBreak}`;
+
+        expect(toggleLine(incomplete, 'x.md').text).toStrictEqual(complete);
+        expect(toggleLine(complete, 'x.md').text).toStrictEqual(incomplete);
+    });
+
     it('should un-complete a completed task', () => {
         testToggleLine('|- [x]  ✅ 2022-09-04', '|- [ ] ');
         testToggleLine('1. [x]  ✅ 2022-09-04|', '1. [ ] |');


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3729

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Preserve Markdown hard-break spaces when changing a task’s status.

  When a task is followed by a continuation line and uses two trailing spaces for a Markdown line break, toggling
  the task no longer removes those spaces.

## Motivation and Context

 Fixes #3729.

  Previously, changing a task from incomplete to complete—or back—could remove meaningful trailing whitespace and
  break the intended Markdown hard line break.

## How has this been tested?

- Added regression tests covering Markdown hard line breaks.
- Focused test suite passed (15 tests).
- Full Jest suite passed (170 suites, 4,878 tests).
- `yarn build` passed.
- `yarn lint` passed (two pre-existing warnings).
- Verified manually in Obsidian Desktop using the Tasks-Demo vault.

## Screenshots (if appropriate)

 Not applicable. This is a Markdown serialization bug with no new UI.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
