### PR TITLE
refactor: improvements to markdown-hard-break code

### DIFF
--- a/src/Commands/ChangeStatusCommands.ts
+++ b/src/Commands/ChangeStatusCommands.ts
@@ -23,7 +23,7 @@ export const setStatusOnLine = (line: string, path: string, newStatus: Status): 
     });
 
     if (task !== null) {
-        const lines = task.handleNewStatusWithRecurrenceInUsersOrder(newStatus).map((t) => t.toFileLineString(true));
+        const lines = task.handleNewStatusWithRecurrenceInUsersOrder(newStatus).map((t) => t.toFileLineString());
         const newLineNumber = lines.length > 0 ? lines.length - 1 : 0;
         return { text: lines.join('\n'), moveTo: { line: newLineNumber } };
     }

--- a/src/Commands/ToggleDone.ts
+++ b/src/Commands/ToggleDone.ts
@@ -17,7 +17,7 @@ export const toggleLine = (line: string, path: string): EditorInsertion => {
         fallbackDate: null, // We don't need this to toggle it here in the editor.
     });
     if (task !== null) {
-        const lines = task.toggleWithRecurrenceInUsersOrder().map((t) => t.toFileLineString(true));
+        const lines = task.toggleWithRecurrenceInUsersOrder().map((t) => t.toFileLineString());
         const newLineNumber = lines.length > 0 ? lines.length - 1 : 0;
         return { text: lines.join('\n'), moveTo: { line: newLineNumber } };
     } else {

--- a/src/Obsidian/File.ts
+++ b/src/Obsidian/File.ts
@@ -169,7 +169,7 @@ Recommendations:
         // Finally, we can insert 1 or more lines over the original task line:
         const updatedFileLines = [
             ...fileLines.slice(0, taskLineNumber),
-            ...newTasks.map((task: ListItem) => task.toFileLineString(true)),
+            ...newTasks.map((task: ListItem) => task.toFileLineString()),
             ...fileLines.slice(taskLineNumber + 1), // Only supports single-line tasks.
         ];
 

--- a/src/Obsidian/LivePreviewExtension.ts
+++ b/src/Obsidian/LivePreviewExtension.ts
@@ -108,7 +108,7 @@ class LivePreviewExtension implements PluginValue {
 
         // Clicked on a task's checkbox. Toggle the task and set it.
         const toggled = task.toggleWithRecurrenceInUsersOrder();
-        const toggledString = toggled.map((t) => t.toFileLineString(true)).join(state.lineBreak);
+        const toggledString = toggled.map((t) => t.toFileLineString()).join(state.lineBreak);
 
         let to = line.to;
 

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -280,6 +280,12 @@ export class ListItem {
         return `${this.indentation}${this.listMarker} ${statusCharacterToString}${this.description}${this.markdownHardBreak}`;
     }
 
+    /**
+     * Processes the given Markdown string to determine the appropriate hard break representation.
+     *
+     * @param originalMarkdown - The input Markdown string to analyse for trailing spaces.
+     * @return A string containing the trailing spaces if two or more are present; otherwise, an empty string.
+     */
     private getMarkdownHardBreak(originalMarkdown: string): string {
         let trailingSpaces = 0;
         for (let index = originalMarkdown.length - 1; index >= 0; index--) {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -23,6 +23,7 @@ export class ListItem {
     public readonly indentation: string;
     public readonly listMarker: string;
     public readonly description: string;
+    public readonly markdownHardBreak: string;
     public readonly statusCharacter: string | null;
 
     public readonly taskLocation: TaskLocation;
@@ -48,6 +49,7 @@ export class ListItem {
         this.listMarker = listMarker;
         this.statusCharacter = statusCharacter;
         this.description = description;
+        this.markdownHardBreak = this.getMarkdownHardBreak(true, originalMarkdown);
         this.originalMarkdown = originalMarkdown;
 
         this.parent = parent;

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -275,11 +275,9 @@ export class ListItem {
         });
     }
 
-    public toFileLineString(preserveTrailingWhitespace = false): string {
+    public toFileLineString(_preserveTrailingWhitespace = false): string {
         const statusCharacterToString = this.statusCharacter ? `[${this.statusCharacter}] ` : '';
-        return `${this.indentation}${this.listMarker} ${statusCharacterToString}${
-            this.description
-        }${this.getMarkdownHardBreak(preserveTrailingWhitespace, this.originalMarkdown)}`;
+        return `${this.indentation}${this.listMarker} ${statusCharacterToString}${this.description}${this.markdownHardBreak}`;
     }
 
     protected getMarkdownHardBreak(preserveTrailingWhitespace: boolean, originalMarkdown: string): string {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -287,6 +287,10 @@ export class ListItem {
      * @return A string containing the trailing spaces if two or more are present; otherwise, an empty string.
      */
     private getMarkdownHardBreak(originalMarkdown: string): string {
+        if (!originalMarkdown.endsWith('  ')) {
+            return '';
+        }
+
         let trailingSpaces = 0;
         for (let index = originalMarkdown.length - 1; index >= 0; index--) {
             if (originalMarkdown[index] !== ' ') {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -280,7 +280,7 @@ export class ListItem {
         return `${this.indentation}${this.listMarker} ${statusCharacterToString}${this.description}${this.markdownHardBreak}`;
     }
 
-    protected getMarkdownHardBreak(originalMarkdown: string): string {
+    private getMarkdownHardBreak(originalMarkdown: string): string {
         let trailingSpaces = 0;
         for (let index = originalMarkdown.length - 1; index >= 0; index--) {
             if (originalMarkdown[index] !== ' ') {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -275,7 +275,7 @@ export class ListItem {
         });
     }
 
-    public toFileLineString(_preserveTrailingWhitespace = false): string {
+    public toFileLineString(): string {
         const statusCharacterToString = this.statusCharacter ? `[${this.statusCharacter}] ` : '';
         return `${this.indentation}${this.listMarker} ${statusCharacterToString}${this.description}${this.markdownHardBreak}`;
     }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -49,7 +49,13 @@ export class ListItem {
         this.listMarker = listMarker;
         this.statusCharacter = statusCharacter;
         this.description = description;
+
+        // If there are 2 or more spaces at the end of the line, we retain them so that when
+        // the ListItem or Task is updated and written out, we keep the original formatting.
+        // There is intentionally no way to update this value once the task line has been read
+        // in from Markdown.
         this.markdownHardBreak = this.getMarkdownHardBreak(originalMarkdown);
+
         this.originalMarkdown = originalMarkdown;
 
         this.parent = parent;

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -280,11 +280,7 @@ export class ListItem {
         return `${this.indentation}${this.listMarker} ${statusCharacterToString}${this.description}${this.markdownHardBreak}`;
     }
 
-    protected getMarkdownHardBreak(preserveTrailingWhitespace: boolean, originalMarkdown: string): string {
-        if (!preserveTrailingWhitespace) {
-            return '';
-        }
-
+    protected getMarkdownHardBreak(_preserveTrailingWhitespace: boolean, originalMarkdown: string): string {
         let trailingSpaces = 0;
         for (let index = originalMarkdown.length - 1; index >= 0; index--) {
             if (originalMarkdown[index] !== ' ') {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -49,7 +49,7 @@ export class ListItem {
         this.listMarker = listMarker;
         this.statusCharacter = statusCharacter;
         this.description = description;
-        this.markdownHardBreak = this.getMarkdownHardBreak(true, originalMarkdown);
+        this.markdownHardBreak = this.getMarkdownHardBreak(originalMarkdown);
         this.originalMarkdown = originalMarkdown;
 
         this.parent = parent;
@@ -280,7 +280,7 @@ export class ListItem {
         return `${this.indentation}${this.listMarker} ${statusCharacterToString}${this.description}${this.markdownHardBreak}`;
     }
 
-    protected getMarkdownHardBreak(_preserveTrailingWhitespace: boolean, originalMarkdown: string): string {
+    protected getMarkdownHardBreak(originalMarkdown: string): string {
         let trailingSpaces = 0;
         for (let index = originalMarkdown.length - 1; index >= 0; index--) {
             if (originalMarkdown[index] !== ' ') {

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -291,14 +291,11 @@ export class ListItem {
             return '';
         }
 
-        let trailingSpaces = 0;
-        for (let index = originalMarkdown.length - 1; index >= 0; index--) {
-            if (originalMarkdown[index] !== ' ') {
-                break;
-            }
-            trailingSpaces++;
+        let markdownHardBreak = '  ';
+        while (originalMarkdown.endsWith(markdownHardBreak + ' ')) {
+            markdownHardBreak += ' ';
         }
 
-        return trailingSpaces >= 2 ? ' '.repeat(trailingSpaces) : '';
+        return markdownHardBreak;
     }
 }

--- a/src/Task/ListItem.ts
+++ b/src/Task/ListItem.ts
@@ -277,17 +277,17 @@ export class ListItem {
         const statusCharacterToString = this.statusCharacter ? `[${this.statusCharacter}] ` : '';
         return `${this.indentation}${this.listMarker} ${statusCharacterToString}${
             this.description
-        }${this.getMarkdownHardBreak(preserveTrailingWhitespace)}`;
+        }${this.getMarkdownHardBreak(preserveTrailingWhitespace, this.originalMarkdown)}`;
     }
 
-    protected getMarkdownHardBreak(preserveTrailingWhitespace: boolean): string {
+    protected getMarkdownHardBreak(preserveTrailingWhitespace: boolean, originalMarkdown: string): string {
         if (!preserveTrailingWhitespace) {
             return '';
         }
 
         let trailingSpaces = 0;
-        for (let index = this.originalMarkdown.length - 1; index >= 0; index--) {
-            if (this.originalMarkdown[index] !== ' ') {
+        for (let index = originalMarkdown.length - 1; index >= 0; index--) {
+            if (originalMarkdown[index] !== ' ') {
                 break;
             }
             trailingSpaces++;

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -324,7 +324,7 @@ export class Task extends ListItem {
      * @note Output depends on {@link Settings.taskFormat}
      * @return {*}  {string}
      */
-    public toFileLineString(_preserveTrailingWhitespace = false): string {
+    public toFileLineString(): string {
         // Preserve Markdown hard-break spaces from the original line when a task
         // edit is being written back. A single trailing space is formatting noise,
         // but two or more trailing spaces are meaningful.

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -330,7 +330,7 @@ export class Task extends ListItem {
         // but two or more trailing spaces are meaningful.
         return `${this.indentation}${this.listMarker} [${
             this.status.symbol
-        }] ${this.toString()}${this.getMarkdownHardBreak(preserveTrailingWhitespace)}`;
+        }] ${this.toString()}${this.getMarkdownHardBreak(preserveTrailingWhitespace, this.originalMarkdown)}`;
     }
 
     /**

--- a/src/Task/Task.ts
+++ b/src/Task/Task.ts
@@ -324,13 +324,13 @@ export class Task extends ListItem {
      * @note Output depends on {@link Settings.taskFormat}
      * @return {*}  {string}
      */
-    public toFileLineString(preserveTrailingWhitespace = false): string {
+    public toFileLineString(_preserveTrailingWhitespace = false): string {
         // Preserve Markdown hard-break spaces from the original line when a task
         // edit is being written back. A single trailing space is formatting noise,
         // but two or more trailing spaces are meaningful.
-        return `${this.indentation}${this.listMarker} [${
-            this.status.symbol
-        }] ${this.toString()}${this.getMarkdownHardBreak(preserveTrailingWhitespace, this.originalMarkdown)}`;
+        return `${this.indentation}${this.listMarker} [${this.status.symbol}] ${this.toString()}${
+            this.markdownHardBreak
+        }`;
     }
 
     /**

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -138,7 +138,7 @@ describe('ToggleDone', () => {
     });
 
     describe('trailing spaces', () => {
-        it('should discard single trailing space when completing a task', () => {
+        it('should discard single trailing space when toggling a task', () => {
             const incomplete = '- [ ] foo';
             const complete = '- [x] foo ✅ 2022-09-04';
 
@@ -146,7 +146,7 @@ describe('ToggleDone', () => {
             expect(toggleLine(complete + ' ', 'x.md').text).toStrictEqual(incomplete);
         });
 
-        it('should preserve Markdown hard-break of 2 spaces when completing a task', () => {
+        it('should preserve Markdown hard-break of 2 spaces when toggling a task', () => {
             const hardBreak = '  ';
             const incomplete = `- [ ] foo${hardBreak}`;
             const complete = `- [x] foo ✅ 2022-09-04${hardBreak}`;
@@ -155,7 +155,7 @@ describe('ToggleDone', () => {
             expect(toggleLine(complete, 'x.md').text).toStrictEqual(incomplete);
         });
 
-        it('should preserve Markdown hard-break of 3 spaces when completing a task', () => {
+        it('should preserve Markdown hard-break of 3 spaces when toggling a task', () => {
             const hardBreak = '   ';
             const incomplete = `- [ ] foo${hardBreak}`;
             const complete = `- [x] foo ✅ 2022-09-04${hardBreak}`;

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -137,13 +137,15 @@ describe('ToggleDone', () => {
         testToggleLine('- [ ] I have a |proper description', '- [x] I have a |proper description');
     });
 
-    it('should preserve Markdown hard-break spaces when completing a task', () => {
-        const hardBreak = '  ';
-        const incomplete = `- [ ] foo${hardBreak}`;
-        const complete = `- [x] foo ✅ 2022-09-04${hardBreak}`;
+    describe('trailing spaces', () => {
+        it('should preserve Markdown hard-break spaces when completing a task', () => {
+            const hardBreak = '  ';
+            const incomplete = `- [ ] foo${hardBreak}`;
+            const complete = `- [x] foo ✅ 2022-09-04${hardBreak}`;
 
-        expect(toggleLine(incomplete, 'x.md').text).toStrictEqual(complete);
-        expect(toggleLine(complete, 'x.md').text).toStrictEqual(incomplete);
+            expect(toggleLine(incomplete, 'x.md').text).toStrictEqual(complete);
+            expect(toggleLine(complete, 'x.md').text).toStrictEqual(incomplete);
+        });
     });
 
     it('should un-complete a completed task', () => {

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -138,8 +138,25 @@ describe('ToggleDone', () => {
     });
 
     describe('trailing spaces', () => {
-        it('should preserve Markdown hard-break spaces when completing a task', () => {
+        it('should discard single trailing space when completing a task', () => {
+            const incomplete = '- [ ] foo';
+            const complete = '- [x] foo ✅ 2022-09-04';
+
+            expect(toggleLine(incomplete + ' ', 'x.md').text).toStrictEqual(complete);
+            expect(toggleLine(complete + ' ', 'x.md').text).toStrictEqual(incomplete);
+        });
+
+        it('should preserve Markdown hard-break of 2 spaces when completing a task', () => {
             const hardBreak = '  ';
+            const incomplete = `- [ ] foo${hardBreak}`;
+            const complete = `- [x] foo ✅ 2022-09-04${hardBreak}`;
+
+            expect(toggleLine(incomplete, 'x.md').text).toStrictEqual(complete);
+            expect(toggleLine(complete, 'x.md').text).toStrictEqual(incomplete);
+        });
+
+        it('should preserve Markdown hard-break of 3 spaces when completing a task', () => {
+            const hardBreak = '   ';
             const incomplete = `- [ ] foo${hardBreak}`;
             const complete = `- [x] foo ✅ 2022-09-04${hardBreak}`;
 

--- a/tests/Query/Sort/Sort.test.ts
+++ b/tests/Query/Sort/Sort.test.ts
@@ -8,7 +8,7 @@ window.moment = moment;
 import { verify } from 'approvals/lib/Providers/Jest/JestApprovals';
 import type { Comparator } from '../../../src/Query/Sort/Sorter';
 import { Sorter } from '../../../src/Query/Sort/Sorter';
-import { Task } from '../../../src/Task/Task';
+import type { Task } from '../../../src/Task/Task';
 import { StatusField } from '../../../src/Query/Filter/StatusField';
 import { DueDateField } from '../../../src/Query/Filter/DueDateField';
 import { PathField } from '../../../src/Query/Filter/PathField';
@@ -200,8 +200,7 @@ describe('Sort', () => {
                     const line = `- [ ] ${description}`;
                     const task = fromLine({ line: line + dateFields });
                     const urgencyDescription = ` urgency = ${task.urgency.toFixed(5)}`;
-                    const description2 = `${description}${urgencyDescription}`;
-                    const task2 = new Task({ ...task, description: description2 });
+                    const task2 = fromLine({ line: line + urgencyDescription + dateFields });
                     tasks.push(task2);
                 }
             }

--- a/tests/Query/Sort/Sort.test.ts
+++ b/tests/Query/Sort/Sort.test.ts
@@ -199,7 +199,8 @@ describe('Sort', () => {
 
                     const line = `- [ ] ${description}`;
                     const task = fromLine({ line: line + dateFields });
-                    const description2 = `${description} urgency = ${task.urgency.toFixed(5)}`;
+                    const urgencyDescription = ` urgency = ${task.urgency.toFixed(5)}`;
+                    const description2 = `${description}${urgencyDescription}`;
                     const task2 = new Task({ ...task, description: description2 });
                     tasks.push(task2);
                 }

--- a/tests/Query/Sort/Sort.test.ts
+++ b/tests/Query/Sort/Sort.test.ts
@@ -199,8 +199,10 @@ describe('Sort', () => {
 
                     const line = `- [ ] ${description}`;
                     const task = fromLine({ line: line + dateFields });
+
                     const urgencyDescription = ` urgency = ${task.urgency.toFixed(5)}`;
                     const task2 = fromLine({ line: line + urgencyDescription + dateFields });
+
                     tasks.push(task2);
                 }
             }

--- a/tests/Query/Sort/Sort.test.ts
+++ b/tests/Query/Sort/Sort.test.ts
@@ -200,6 +200,9 @@ describe('Sort', () => {
                     const line = `- [ ] ${description}`;
                     const task = fromLine({ line: line + dateFields });
 
+                    // Re-read the updated line from Markdown instead of using spread-with-override.
+                    // This avoids preserving trailing spaces from `task` when creating `task2`.
+                    // It matters for the test case where `start`, `scheduled`, and `due` are all null.
                     const urgencyDescription = ` urgency = ${task.urgency.toFixed(5)}`;
                     const task2 = fromLine({ line: line + urgencyDescription + dateFields });
 

--- a/tests/Query/Sort/Sort.test.ts
+++ b/tests/Query/Sort/Sort.test.ts
@@ -191,7 +191,7 @@ describe('Sort', () => {
                     const description = `Start: ${pad(start[0]!)} Scheduled: ${pad(scheduled[0]!)} Due: ${pad(
                         due[0]!,
                     )}`;
-                    let line = `- [ ] ${description}`;
+                    const line = `- [ ] ${description}`;
                     let dateFields = '';
                     dateFields += addDateIfSet('🛫', start[1]);
                     dateFields += addDateIfSet('⏳', scheduled[1]);

--- a/tests/Query/Sort/Sort.test.ts
+++ b/tests/Query/Sort/Sort.test.ts
@@ -191,11 +191,13 @@ describe('Sort', () => {
                     const description = `Start: ${pad(start[0]!)} Scheduled: ${pad(scheduled[0]!)} Due: ${pad(
                         due[0]!,
                     )}`;
-                    const line = `- [ ] ${description}`;
+
                     let dateFields = '';
                     dateFields += addDateIfSet('🛫', start[1]);
                     dateFields += addDateIfSet('⏳', scheduled[1]);
                     dateFields += addDateIfSet('📅', due[1]);
+
+                    const line = `- [ ] ${description}`;
                     const task = fromLine({ line: line + dateFields });
                     const description2 = `${description} urgency = ${task.urgency.toFixed(5)}`;
                     const task2 = new Task({ ...task, description: description2 });

--- a/tests/Query/Sort/Sort.test.ts
+++ b/tests/Query/Sort/Sort.test.ts
@@ -192,10 +192,11 @@ describe('Sort', () => {
                         due[0]!,
                     )}`;
                     let line = `- [ ] ${description}`;
-                    line += addDateIfSet('🛫', start[1]);
-                    line += addDateIfSet('⏳', scheduled[1]);
-                    line += addDateIfSet('📅', due[1]);
-                    const task = fromLine({ line });
+                    let dateFields = '';
+                    dateFields += addDateIfSet('🛫', start[1]);
+                    dateFields += addDateIfSet('⏳', scheduled[1]);
+                    dateFields += addDateIfSet('📅', due[1]);
+                    const task = fromLine({ line: line + dateFields });
                     const description2 = `${description} urgency = ${task.urgency.toFixed(5)}`;
                     const task2 = new Task({ ...task, description: description2 });
                     tasks.push(task2);

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -219,21 +219,21 @@ describe('list item writing', () => {
             const suffix = ' ';
             const item = ListItem.fromListItemLine(expected + suffix, null, taskLocation)!;
 
-            expect(item.toFileLineString(true)).toEqual(expected);
+            expect(item.toFileLineString()).toEqual(expected);
         });
 
         it('should preserve Markdown hard-break of 2 spaces when completing a task', () => {
             const line = '- 2 trailing spaces  ';
             const item = ListItem.fromListItemLine(line, null, taskLocation)!;
 
-            expect(item.toFileLineString(true)).toEqual(line);
+            expect(item.toFileLineString()).toEqual(line);
         });
 
         it('should preserve Markdown hard-break of 3 spaces when completing a task', () => {
             const line = '- 3 trailing spaces   ';
             const item = ListItem.fromListItemLine(line, null, taskLocation)!;
 
-            expect(item.toFileLineString(true)).toEqual(line);
+            expect(item.toFileLineString()).toEqual(line);
         });
     });
 });

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -188,6 +188,30 @@ describe('list item writing', () => {
 
         expect(item.toFileLineString()).toEqual('* star');
     });
+
+    describe('trailing spaces', () => {
+        it('should discard single trailing space when completing a task', () => {
+            const expected = '- foo';
+            const suffix = ' ';
+            const item = ListItem.fromListItemLine(expected + suffix, null, taskLocation)!;
+
+            expect(item.toFileLineString(true)).toEqual(expected);
+        });
+
+        it('should preserve Markdown hard-break of 2 spaces when completing a task', () => {
+            const line = '- 2 trailing spaces  ';
+            const item = ListItem.fromListItemLine(line, null, taskLocation)!;
+
+            expect(item.toFileLineString(true)).toEqual(line);
+        });
+
+        it('should preserve Markdown hard-break of 3 spaces when completing a task', () => {
+            const line = '- 3 trailing spaces   ';
+            const item = ListItem.fromListItemLine(line, null, taskLocation)!;
+
+            expect(item.toFileLineString(true)).toEqual(line);
+        });
+    });
 });
 
 describe('related items', () => {

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -162,6 +162,30 @@ describe('list item parsing', () => {
 
         expect(item).toBeNull();
     });
+
+    describe('trailing spaces - for hard breaks in markdown', () => {
+        it('should discard single trailing space when completing a task', () => {
+            const expected = '- foo';
+            const suffix = ' ';
+            const item = ListItem.fromListItemLine(expected + suffix, null, taskLocation)!;
+
+            expect(item.markdownHardBreak).toEqual('');
+        });
+
+        it('should preserve Markdown hard-break of 2 spaces when completing a task', () => {
+            const line = '- 2 trailing spaces  ';
+            const item = ListItem.fromListItemLine(line, null, taskLocation)!;
+
+            expect(item.markdownHardBreak).toEqual('  ');
+        });
+
+        it('should preserve Markdown hard-break of 3 spaces when completing a task', () => {
+            const line = '- 3 trailing spaces   ';
+            const item = ListItem.fromListItemLine(line, null, taskLocation)!;
+
+            expect(item.markdownHardBreak).toEqual('   ');
+        });
+    });
 });
 
 describe('list item writing', () => {

--- a/tests/Task/ListItem.test.ts
+++ b/tests/Task/ListItem.test.ts
@@ -164,7 +164,7 @@ describe('list item parsing', () => {
     });
 
     describe('trailing spaces - for hard breaks in markdown', () => {
-        it('should discard single trailing space when completing a task', () => {
+        it('should discard single trailing space when parsing a list item', () => {
             const expected = '- foo';
             const suffix = ' ';
             const item = ListItem.fromListItemLine(expected + suffix, null, taskLocation)!;
@@ -172,14 +172,14 @@ describe('list item parsing', () => {
             expect(item.markdownHardBreak).toEqual('');
         });
 
-        it('should preserve Markdown hard-break of 2 spaces when completing a task', () => {
+        it('should preserve Markdown hard-break of 2 spaces when parsing a list item', () => {
             const line = '- 2 trailing spaces  ';
             const item = ListItem.fromListItemLine(line, null, taskLocation)!;
 
             expect(item.markdownHardBreak).toEqual('  ');
         });
 
-        it('should preserve Markdown hard-break of 3 spaces when completing a task', () => {
+        it('should preserve Markdown hard-break of 3 spaces when parsing a list item', () => {
             const line = '- 3 trailing spaces   ';
             const item = ListItem.fromListItemLine(line, null, taskLocation)!;
 
@@ -214,7 +214,7 @@ describe('list item writing', () => {
     });
 
     describe('trailing spaces', () => {
-        it('should discard single trailing space when completing a task', () => {
+        it('should discard single trailing space when writing a list item', () => {
             const expected = '- foo';
             const suffix = ' ';
             const item = ListItem.fromListItemLine(expected + suffix, null, taskLocation)!;
@@ -222,14 +222,14 @@ describe('list item writing', () => {
             expect(item.toFileLineString()).toEqual(expected);
         });
 
-        it('should preserve Markdown hard-break of 2 spaces when completing a task', () => {
+        it('should preserve Markdown hard-break of 2 spaces when writing a list item', () => {
             const line = '- 2 trailing spaces  ';
             const item = ListItem.fromListItemLine(line, null, taskLocation)!;
 
             expect(item.toFileLineString()).toEqual(line);
         });
 
-        it('should preserve Markdown hard-break of 3 spaces when completing a task', () => {
+        it('should preserve Markdown hard-break of 3 spaces when writing a list item', () => {
             const line = '- 3 trailing spaces   ';
             const item = ListItem.fromListItemLine(line, null, taskLocation)!;
 

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -35,7 +35,7 @@ describe('TaskBuilder', () => {
 
             expect(task.markdownHardBreak).toStrictEqual(expectedMarkdownHardBreak);
             expect(task.originalMarkdown).toEqual('- [ ] hello' + inputSuffix);
-            expect(task.toFileLineString(true)).toStrictEqual('- [ ] hello' + expectedMarkdownHardBreak);
+            expect(task.toFileLineString()).toStrictEqual('- [ ] hello' + expectedMarkdownHardBreak);
         });
     });
 

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -81,7 +81,7 @@ describe('TaskBuilder', () => {
     it('createFullyPopulatedTask() should populate every field', () => {
         const task: Task = TaskBuilder.createFullyPopulatedTask();
 
-        expect(getNullOrUnsetFields(task)).toEqual(['children', 'parent']);
+        expect(getNullOrUnsetFields(task)).toEqual(['children', 'markdownHardBreak', 'parent']);
         expect(getNullOrUnsetFields(task.taskLocation)).toEqual([]);
 
         expect(task.originalMarkdown).toEqual(

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -34,7 +34,7 @@ describe('TaskBuilder', () => {
             const task = taskBuilder.markdownHardBreak(inputSuffix).build();
 
             expect(task.markdownHardBreak).toStrictEqual(expectedMarkdownHardBreak);
-            expect(task.originalMarkdown).toEqual('- [ ] hello' + inputSuffix);
+            expect(task.originalMarkdown).toStrictEqual('- [ ] hello' + inputSuffix);
             expect(task.toFileLineString()).toStrictEqual('- [ ] hello' + expectedMarkdownHardBreak);
         });
     });

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -21,6 +21,24 @@ describe('TaskBuilder', () => {
         expect(task.toFileLineString()).toStrictEqual('- [ ] hello #tag1 #tag2');
     });
 
+    describe('trailing spaces (markdownHardBreak)', () => {
+        const taskBuilder = new TaskBuilder().description('hello');
+
+        it.each([
+            ['should handle  0 trailing spaces', '', ''],
+            ['should discard 1 trailing space ', ' ', ''],
+            ['should retain  2 trailing spaces', '  ', '  '],
+            ['should retain  3 trailing spaces', '   ', '   '],
+            ['should retain  4 trailing spaces', '    ', '    '],
+        ])('%s', (_, inputSuffix: string, expectedMarkdownHardBreak: string) => {
+            const task = taskBuilder.markdownHardBreak(inputSuffix).build();
+
+            expect(task.markdownHardBreak).toStrictEqual(expectedMarkdownHardBreak);
+            expect(task.originalMarkdown).toEqual('- [ ] hello' + inputSuffix);
+            expect(task.toFileLineString(true)).toStrictEqual('- [ ] hello' + expectedMarkdownHardBreak);
+        });
+    });
+
     it('should populate originalMarkdown', () => {
         const builder = new TaskBuilder();
         const task = builder.description('hello').build();

--- a/tests/TestingTools/TaskBuilder.test.ts
+++ b/tests/TestingTools/TaskBuilder.test.ts
@@ -26,7 +26,7 @@ describe('TaskBuilder', () => {
 
         it.each([
             ['should handle  0 trailing spaces', '', ''],
-            ['should discard 1 trailing space ', ' ', ''],
+            ['should discard 1 trailing space ', ' ', ''], // if only 1 trailing space, it should be discarded
             ['should retain  2 trailing spaces', '  ', '  '],
             ['should retain  3 trailing spaces', '   ', '   '],
             ['should retain  4 trailing spaces', '    ', '    '],

--- a/tests/TestingTools/TaskBuilder.ts
+++ b/tests/TestingTools/TaskBuilder.ts
@@ -33,6 +33,7 @@ export class TaskBuilder {
 
     private _status: Status = Status.TODO;
     private _description: string = 'my description';
+    private _markdownHardBreak: string = '';
     private _path: string = '';
     private _indentation: string = '';
     private _listMarker: string = '-';
@@ -109,7 +110,7 @@ export class TaskBuilder {
             originalMarkdown: '',
             scheduledDateIsInferred: this._scheduledDateIsInferred,
         });
-        const markdown = task.toFileLineString();
+        const markdown = task.toFileLineString() + this._markdownHardBreak;
         return new Task({
             ...task,
             originalMarkdown: markdown,
@@ -192,6 +193,16 @@ export class TaskBuilder {
      */
     public description(description: string): this {
         this._description = description;
+        return this;
+    }
+
+    /**
+     * Set the markdownHardBreak - empty by default, and can be 2 or more spaces at the end of the task line to force a line-break.
+     *
+     * @param markdownHardBreak - markdownHardBreak, for appending at the end of the task line
+     */
+    public markdownHardBreak(markdownHardBreak: string): this {
+        this._markdownHardBreak = markdownHardBreak;
         return this;
     }
 

--- a/tests/ui/EditTask.test.Exhaustive_editing_Edit_and_save_All_inputs.approved.txt
+++ b/tests/ui/EditTask.test.Exhaustive_editing_Edit_and_save_All_inputs.approved.txt
@@ -10,6 +10,14 @@ KEY: (globalFilter, set created date)
     '- [ ] plain text, not a list item'
 
 ('', false)
+    'plain text, not a list item, had 1 trailing space, should end up with none ' =>
+    '- [ ] plain text, not a list item, had 1 trailing space, should end up with none'
+
+('', false)
+    'plain text, not a list item, should retain its 2 trailing spaces  ' =>
+    '- [ ] plain text, not a list item, should retain its 2 trailing spaces'
+
+('', false)
     '-' =>
     '- [ ] simulate user typing text in to empty description field'
 
@@ -30,8 +38,24 @@ KEY: (globalFilter, set created date)
     '- [ ] list item, but no checkbox'
 
 ('', false)
+    '- list item, but no checkbox, had 1 trailing space, should end up with none ' =>
+    '- [ ] list item, but no checkbox, had 1 trailing space, should end up with none'
+
+('', false)
+    '- list item, but no checkbox, should retain its 2 trailing spaces  ' =>
+    '- [ ] list item, but no checkbox, should retain its 2 trailing spaces'
+
+('', false)
     '- [ ] checkbox with initial description' =>
     '- [ ] checkbox with initial description'
+
+('', false)
+    '- [ ] checkbox with initial description, had 1 trailing space, should end up with none ' =>
+    '- [ ] checkbox with initial description, had 1 trailing space, should end up with none'
+
+('', false)
+    '- [ ] checkbox with initial description, should retain its 2 trailing spaces  ' =>
+    '- [ ] checkbox with initial description, should retain its 2 trailing spaces  '
 
 ('', false)
     '- [ ] checkbox with initial description and created date ➕ 2023-01-01' =>
@@ -54,6 +78,14 @@ KEY: (globalFilter, set created date)
     '- [ ] plain text, not a list item ➕ 2023-07-18'
 
 ('', true)
+    'plain text, not a list item, had 1 trailing space, should end up with none ' =>
+    '- [ ] plain text, not a list item, had 1 trailing space, should end up with none ➕ 2023-07-18'
+
+('', true)
+    'plain text, not a list item, should retain its 2 trailing spaces  ' =>
+    '- [ ] plain text, not a list item, should retain its 2 trailing spaces ➕ 2023-07-18'
+
+('', true)
     '-' =>
     '- [ ] simulate user typing text in to empty description field ➕ 2023-07-18'
 
@@ -74,8 +106,24 @@ KEY: (globalFilter, set created date)
     '- [ ] list item, but no checkbox ➕ 2023-07-18'
 
 ('', true)
+    '- list item, but no checkbox, had 1 trailing space, should end up with none ' =>
+    '- [ ] list item, but no checkbox, had 1 trailing space, should end up with none ➕ 2023-07-18'
+
+('', true)
+    '- list item, but no checkbox, should retain its 2 trailing spaces  ' =>
+    '- [ ] list item, but no checkbox, should retain its 2 trailing spaces ➕ 2023-07-18'
+
+('', true)
     '- [ ] checkbox with initial description' =>
     '- [ ] checkbox with initial description'
+
+('', true)
+    '- [ ] checkbox with initial description, had 1 trailing space, should end up with none ' =>
+    '- [ ] checkbox with initial description, had 1 trailing space, should end up with none'
+
+('', true)
+    '- [ ] checkbox with initial description, should retain its 2 trailing spaces  ' =>
+    '- [ ] checkbox with initial description, should retain its 2 trailing spaces  '
 
 ('', true)
     '- [ ] checkbox with initial description and created date ➕ 2023-01-01' =>
@@ -98,6 +146,14 @@ KEY: (globalFilter, set created date)
     '- [ ] #task plain text, not a list item'
 
 ('#task', false)
+    'plain text, not a list item, had 1 trailing space, should end up with none ' =>
+    '- [ ] #task plain text, not a list item, had 1 trailing space, should end up with none'
+
+('#task', false)
+    'plain text, not a list item, should retain its 2 trailing spaces  ' =>
+    '- [ ] #task plain text, not a list item, should retain its 2 trailing spaces'
+
+('#task', false)
     '-' =>
     '- [ ] #task simulate user typing text in to empty description field'
 
@@ -118,8 +174,24 @@ KEY: (globalFilter, set created date)
     '- [ ] #task list item, but no checkbox'
 
 ('#task', false)
+    '- list item, but no checkbox, had 1 trailing space, should end up with none ' =>
+    '- [ ] #task list item, but no checkbox, had 1 trailing space, should end up with none'
+
+('#task', false)
+    '- list item, but no checkbox, should retain its 2 trailing spaces  ' =>
+    '- [ ] #task list item, but no checkbox, should retain its 2 trailing spaces'
+
+('#task', false)
     '- [ ] checkbox with initial description' =>
     '- [ ] #task checkbox with initial description'
+
+('#task', false)
+    '- [ ] checkbox with initial description, had 1 trailing space, should end up with none ' =>
+    '- [ ] #task checkbox with initial description, had 1 trailing space, should end up with none'
+
+('#task', false)
+    '- [ ] checkbox with initial description, should retain its 2 trailing spaces  ' =>
+    '- [ ] #task checkbox with initial description, should retain its 2 trailing spaces  '
 
 ('#task', false)
     '- [ ] checkbox with initial description and created date ➕ 2023-01-01' =>
@@ -142,6 +214,14 @@ KEY: (globalFilter, set created date)
     '- [ ] #task plain text, not a list item ➕ 2023-07-18'
 
 ('#task', true)
+    'plain text, not a list item, had 1 trailing space, should end up with none ' =>
+    '- [ ] #task plain text, not a list item, had 1 trailing space, should end up with none ➕ 2023-07-18'
+
+('#task', true)
+    'plain text, not a list item, should retain its 2 trailing spaces  ' =>
+    '- [ ] #task plain text, not a list item, should retain its 2 trailing spaces ➕ 2023-07-18'
+
+('#task', true)
     '-' =>
     '- [ ] #task simulate user typing text in to empty description field ➕ 2023-07-18'
 
@@ -162,8 +242,24 @@ KEY: (globalFilter, set created date)
     '- [ ] #task list item, but no checkbox ➕ 2023-07-18'
 
 ('#task', true)
+    '- list item, but no checkbox, had 1 trailing space, should end up with none ' =>
+    '- [ ] #task list item, but no checkbox, had 1 trailing space, should end up with none ➕ 2023-07-18'
+
+('#task', true)
+    '- list item, but no checkbox, should retain its 2 trailing spaces  ' =>
+    '- [ ] #task list item, but no checkbox, should retain its 2 trailing spaces ➕ 2023-07-18'
+
+('#task', true)
     '- [ ] checkbox with initial description' =>
     '- [ ] #task checkbox with initial description ➕ 2023-07-18'
+
+('#task', true)
+    '- [ ] checkbox with initial description, had 1 trailing space, should end up with none ' =>
+    '- [ ] #task checkbox with initial description, had 1 trailing space, should end up with none ➕ 2023-07-18'
+
+('#task', true)
+    '- [ ] checkbox with initial description, should retain its 2 trailing spaces  ' =>
+    '- [ ] #task checkbox with initial description, should retain its 2 trailing spaces ➕ 2023-07-18  '
 
 ('#task', true)
     '- [ ] checkbox with initial description and created date ➕ 2023-01-01' =>

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -657,12 +657,18 @@ describe('Exhaustive editing', () => {
         const initialTaskLineValues = [
             '',
             'plain text, not a list item',
+            'plain text, not a list item, had 1 trailing space, should end up with none ',
+            'plain text, not a list item, should retain its 2 trailing spaces  ', // TODO does not retain trailing spaces
             '-',
             '- ',
             '- [ ]',
             '- [ ] ',
             '- list item, but no checkbox',
+            '- list item, but no checkbox, had 1 trailing space, should end up with none ',
+            '- list item, but no checkbox, should retain its 2 trailing spaces  ', // TODO does not retain trailing spaces
             '- [ ] checkbox with initial description',
+            '- [ ] checkbox with initial description, had 1 trailing space, should end up with none ',
+            '- [ ] checkbox with initial description, should retain its 2 trailing spaces  ',
             '- [ ] checkbox with initial description and created date ➕ 2023-01-01',
             '- [ ] #task checkbox with global filter string and initial description',
             '- [ ] checkbox with initial description ending with task tag at end #task',

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -241,6 +241,22 @@ describe('Task rendering', () => {
         );
     });
 
+    it('should strip 1 trailing space from description', () => {
+        testDescriptionRender(
+            // force line break
+            'started with 1 trailing space ',
+            'started with 1 trailing space',
+        );
+    });
+
+    it('should strip 2 trailing spaces from description', () => {
+        testDescriptionRender(
+            // force line break
+            'started with 2 trailing spaces  ',
+            'started with 2 trailing spaces',
+        );
+    });
+
     const fullyPopulatedLine = TaskBuilder.createFullyPopulatedTask().toFileLineString();
 
     it('should display valid created date', () => {

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -173,6 +173,7 @@ describe('EditableTask tests', () => {
               "id": "abcdef",
               "indentation": "  ",
               "listMarker": "-",
+              "markdownHardBreak": "",
               "onCompletion": "",
               "originalMarkdown": "  - [ ] Do exercises #todo #health 🆔 abcdef ⛔ 123456,abc123 🔼 🔁 every day when done 🏁 delete ➕ 2023-07-01 🛫 2023-07-02 ⏳ 2023-07-03 📅 2023-07-04 ❌ 2023-07-06 ✅ 2023-07-05 ^dcf64c",
               "parent": null,


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Related:

- https://github.com/obsidian-tasks-group/obsidian-tasks/pull/3970
- https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3729

This is a series of refactorings and test additions to address my code-review feedback in comment https://github.com/obsidian-tasks-group/obsidian-tasks/pull/3970#discussion_r3723367297.

Main changes:

- Added `ListItem.markdownHardBreak`, to retain the required number of characters from the initial line
- `ListItem.toFileLineString()` and `Task.toFileLineString()`
    - These now always preserve any 2 or more trailing spaces from the line they were read from.
    - This removes the recently-added `boolean` parameter
- `ListItem.getMarkdownHardBreak()`
    - Refactored for readability
- `Sort.test.ts`
    - Reworked to avoid accidentally-added whitespace due to spread-with-override carrying over indentation characters from an un-related task line
- `TaskBuilder`
    - Now supports and uses `markdownHardBreak`.
    - In practice, this is only used within the tests I added for the new capability.
    - I thought it was going to be needed, but it turned out not be necessary for new tests.
    - I opted to keep it anyway.

In addition to the comments I made in that comment, it also adds some tests of how the Edit Task Modal handles various inputs with trailing spaces. It shows that:

- trailing spaces on existing task lines are handled well.
- trailing spaces on list item lines, and plain test lines, are discarded.

I will leave those cases for now. If a user really cares enough to log an issue, they can be looked at, but I doubt it will affect many people, and I've already spent the better part of a day now, in this area.

## Motivation and Context

Improve safety, readability and code coverage.

## How has this been tested?

By running existing tests and adding new ones.


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
