### PR TITLE
fix: avoid extra space when toggling tasks with tag-only descriptions

### DIFF
--- a/src/TaskSerializer/DefaultTaskSerializer.ts
+++ b/src/TaskSerializer/DefaultTaskSerializer.ts
@@ -383,7 +383,12 @@ export class DefaultTaskSerializer implements TaskSerializer {
         // components but now we want them back.
         // The goal is for a task of them form 'Do something #tag1 (due) tomorrow #tag2 (start) today'
         // to actually have the description 'Do something #tag1 #tag2'
-        if (trailingTags.length > 0) state.line += ' ' + trailingTags;
+        if (trailingTags.length > 0) {
+            if (state.line.length > 0) {
+                state.line += ' ';
+            }
+            state.line += trailingTags;
+        }
 
         // NEW_TASK_FIELD_EDIT_REQUIRED
         return {

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -137,6 +137,32 @@ describe('ToggleDone', () => {
         testToggleLine('- [ ] I have a |proper description', '- [x] I have a |proper description');
     });
 
+    describe('tag-only descriptions', () => {
+        it.failing('should not add a space when completing a task without a global filter', () => {
+            testToggleLine('- [ ] #tag|', '- [x] #tag| ✅ 2022-09-04');
+        });
+
+        it.failing('should not add a space when un-completing a task without a global filter', () => {
+            testToggleLine('- [x] #tag ✅ 2022-09-04|', '- [ ] #tag|');
+        });
+
+        it.failing('should not add a space when completing a task that matches the global filter', () => {
+            GlobalFilter.getInstance().set('#task');
+            testToggleLine('- [ ] #task|', '- [x] #task| ✅ 2022-09-04');
+        });
+
+        it.failing('should not add a space when un-completing a task that matches the global filter', () => {
+            GlobalFilter.getInstance().set('#task');
+            testToggleLine('- [x] #task ✅ 2022-09-04|', '- [ ] #task|');
+        });
+
+        it('should preserve spacing when a task does not match the global filter', () => {
+            GlobalFilter.getInstance().set('#task');
+            testToggleLine('- [ ] #other|', '- [x] #other|');
+            testToggleLine('- [x] #other|', '- [ ] #other|');
+        });
+    });
+
     describe('trailing spaces', () => {
         it('should discard single trailing space when toggling a task', () => {
             const incomplete = '- [ ] foo';

--- a/tests/Commands/ToggleDone.test.ts
+++ b/tests/Commands/ToggleDone.test.ts
@@ -130,7 +130,7 @@ describe('ToggleDone', () => {
         testToggleLine('1. [ ] |', '1. [x] |');
 
         // Done date is added if task does not match global filter
-        testToggleLine('- [ ] #task|', '- [x]  #tas|k ✅ 2022-09-04'); // Extra space added before #; cursor moves left
+        testToggleLine('- [ ] #task|', '- [x] #task| ✅ 2022-09-04');
         testToggleLine('* [ ] #task description|', '* [x] #task description| ✅ 2022-09-04');
 
         // Issue #449 - cursor jumped 13 characters to the right on completion
@@ -138,20 +138,20 @@ describe('ToggleDone', () => {
     });
 
     describe('tag-only descriptions', () => {
-        it.failing('should not add a space when completing a task without a global filter', () => {
+        it('should not add a space when completing a task without a global filter', () => {
             testToggleLine('- [ ] #tag|', '- [x] #tag| ✅ 2022-09-04');
         });
 
-        it.failing('should not add a space when un-completing a task without a global filter', () => {
+        it('should not add a space when un-completing a task without a global filter', () => {
             testToggleLine('- [x] #tag ✅ 2022-09-04|', '- [ ] #tag|');
         });
 
-        it.failing('should not add a space when completing a task that matches the global filter', () => {
+        it('should not add a space when completing a task that matches the global filter', () => {
             GlobalFilter.getInstance().set('#task');
             testToggleLine('- [ ] #task|', '- [x] #task| ✅ 2022-09-04');
         });
 
-        it.failing('should not add a space when un-completing a task that matches the global filter', () => {
+        it('should not add a space when un-completing a task that matches the global filter', () => {
             GlobalFilter.getInstance().set('#task');
             testToggleLine('- [x] #task ✅ 2022-09-04|', '- [ ] #task|');
         });
@@ -205,7 +205,7 @@ describe('ToggleDone', () => {
         testToggleLine('+ [x]  ✅ 2022-09-04|', '+ [ ] ✅ 2022-09-04|');
 
         // Done date is added if task matches the global filter
-        testToggleLine('|- [x] #task ✅ 2022-09-04', '|- [ ]  #task'); // Extra space added before #
+        testToggleLine('|- [x] #task ✅ 2022-09-04', '|- [ ] #task');
         testToggleLine('1. [x] #task description ✅ 2022-09-04|', '1. [ ] #task description|');
 
         // Issue #449 - cursor jumped 13 characters to the left on un-completion

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -223,8 +223,8 @@ describe('DataviewTaskSerializer', () => {
             });
         });
 
-        it('should parse tags', () => {
-            const description = ' #hello #world #task';
+        it.failing('should parse a description containing only tags without adding whitespace', () => {
+            const description = '#hello #world #task';
             const taskDetails = deserialize(description);
             expect(taskDetails).toMatchTaskDetails({ tags: ['#hello', '#world', '#task'], description });
         });

--- a/tests/TaskSerializer/DataviewTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DataviewTaskSerializer.test.ts
@@ -223,7 +223,7 @@ describe('DataviewTaskSerializer', () => {
             });
         });
 
-        it.failing('should parse a description containing only tags without adding whitespace', () => {
+        it('should parse a description containing only tags without adding whitespace', () => {
             const description = '#hello #world #task';
             const taskDetails = deserialize(description);
             expect(taskDetails).toMatchTaskDetails({ tags: ['#hello', '#world', '#task'], description });

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -263,8 +263,8 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
             });
         });
 
-        it('should parse tags', () => {
-            const description = ' #hello #world #task';
+        it.failing('should parse a description containing only tags without adding whitespace', () => {
+            const description = '#hello #world #task';
             const taskDetails = deserialize(description);
             expect(taskDetails).toMatchTaskDetails({ tags: ['#hello', '#world', '#task'], description });
         });

--- a/tests/TaskSerializer/DefaultTaskSerializer.test.ts
+++ b/tests/TaskSerializer/DefaultTaskSerializer.test.ts
@@ -263,7 +263,7 @@ describe.each(symbolMap)("DefaultTaskSerializer with '$taskFormat' symbols", ({ 
             });
         });
 
-        it.failing('should parse a description containing only tags without adding whitespace', () => {
+        it('should parse a description containing only tags without adding whitespace', () => {
             const description = '#hello #world #task';
             const taskDetails = deserialize(description);
             expect(taskDetails).toMatchTaskDetails({ tags: ['#hello', '#world', '#task'], description });


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)
- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3772
- [ ] **Translation** (prefix: `i18n` - additions or improvements to the translations)
- [ ] **Documentation** (prefix: `docs` - improvements to documentation content for users)
- [ ] **Sample vault** (prefix: `vault` - improvements to the Tasks-Demo sample vault)
- [ ] **Contributing Guidelines** (prefix: `contrib` - improvements to documentation for contributors)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking internal restructuring)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - GitHub Actions, issue templates, and similar changes)

## Description

Avoid adding an extra space before tags when changing the status of a task whose description contains only tags.

The default task serializer temporarily removes trailing tags while parsing metadata. When the remaining description was empty, it restored those tags with an unconditional leading space. The serializer now inserts that separator only when preceding description text exists.

Regression coverage includes completing and un-completing tag-only tasks, matching and non-matching global filters, cursor positions, and both the default and Dataview task formats.

## Motivation and Context

Fixes #3772.

Tag-only tasks such as `- [ ] #task` previously gained a second space before the tag when their status changed.

## How has this been tested?

- Focused Jest suites: 3 suites, 152 tests, and 2 snapshots passed.
- Full Jest suite: 170 suites, 4,922 tests, and 260 snapshots passed.
- `yarn build` passed.
- `yarn lint` passed with two pre-existing `no-require-imports` warnings.
- `yarn lint:markdown` passed.
- Exploratory setup used Obsidian 1.13.4 on an Android 15 Pixel 6 emulator. The basic checkbox round-trip retained one space before the tag; Tasks-specific completion-date handling was not conclusively verified there, so the Android run is not being counted as regression validation.

## Screenshots (if appropriate)

 The defect is an extra character in the serialized Markdown and is covered by exact string assertions.

<img width="414" height="392" alt="2026-08-07_14-05-38_grim" src="https://github.com/user-attachments/assets/62992ae8-b584-4c46-a48c-15be6fed42a5" />
<img width="527" height="1039" alt="2026-08-07_14-08-15_grim" src="https://github.com/user-attachments/assets/5b9e0aac-7a82-4334-8d90-8b9c7b9ff9c7" />


## Checklist

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage.

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
