### PR TITLE
fix: Make user CSS for task background colours work in column views

### DIFF
--- a/src/Renderer/HtmlColumnQueryResultsRenderer.scss
+++ b/src/Renderer/HtmlColumnQueryResultsRenderer.scss
@@ -46,32 +46,12 @@
             // (it would be nice to skip this below the last task in each column or group):
             margin-bottom: 0.5rem;
 
-            // Ensure that the different background colour on cards does not obscure links
-            // and the backlink on tasks:
-            position: relative;
-            isolation: isolate;
+            // Put a border around the task and its checkbox:
+            border: 1px solid var(--background-modifier-border);
+            border-radius: 6px;
 
-            // Create a pseudo element that surrounds both the task description and its checkbox,
-            // so we can draw a border surrounding the whole task including its checkbox:
-            &:before {
-                content: "";
-                position: absolute;
-
-                // The pseudo element starts 3ch before the description, which is the offset
-                // used by Obsidian when positioning checkboxes:
-                top: 0;
-                inset-inline-start: -3ch;
-                width: calc(100% + 3ch);
-                height: 100%;
-
-                // Put a border around the task and its checkbox:
-                border: 1px solid var(--background-modifier-border);
-                border-radius: 6px;
-
-                // Give cards a different background colour:
-                z-index: -1;
-                background: var(--background-primary);
-            }
+            // Give cards a different background colour:
+            background: var(--background-primary);
         }
     }
 }


### PR DESCRIPTION
Implemented by pairing, and detailed discussion, with @ilandikov  - thank you!

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: Not reported - see 3rd screenshot in #3978

## Description

I tried really hard to get the borders around task cards in column views to contain the checkbox.

Doing this required some `&:before` trickery, and it turned out that this broke any user CSS snippets that set the task background colours, in tasks searches that use the new 'view columns by ...' instruction.

After much experimenting, @ilandikov and I have decided that the least-bad option is to:

1. retain the background and border around tasks in columns view, so that they look like cards,
2. give up on any hope of making the checkbox be included inside that border.

The problem is the `-3ch` offset that Obsidian uses to position checkboxes.

## Motivation and Context

See above -  I was regarding this as a show-stopper to enable release of the columns view facility.

## How has this been tested?

In the test vault - see screenshots below.

## Screenshots (if appropriate)

| Before | After |
|--------|--------|
| <img width="495" height="1176" alt="image" src="https://github.com/user-attachments/assets/274afb43-255e-475a-8a4e-ac64b2bd55bd" /> | <img width="498" height="1178" alt="image" src="https://github.com/user-attachments/assets/a3cf5973-dc43-470b-ab99-e43597337059" /> | 

Notice that:

1. The checkbox is now outside the border and background colour on each task
2. And the custom background colour is now successfully displayed in the (lower) columns view, as well as in the (upper) lists view.



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
    - No tests on CSS

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
