### PR TITLE
fix: prevent edit modal button tap from being lost

### DIFF
--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -337,7 +337,7 @@ Availability of access keys:
     </section>
 
     <section class="tasks-modal-button-section">
-        <button disabled={!formIsValid} type="submit" class="mod-cta">Apply </button>
-        <button type="button" on:click={_onClose}>Cancel</button>
+        <button disabled={!formIsValid} type="submit" class="mod-cta" on:mousedown|preventDefault>Apply </button>
+        <button type="button" on:mousedown|preventDefault on:click={_onClose}>Cancel</button>
     </section>
 </form>

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -315,6 +315,20 @@ describe('Task editing', () => {
         GlobalFilter.getInstance().reset();
     });
 
+    it('should prevent button mousedown from blurring the focused field', () => {
+        const task = taskFromLine({ line: '- [ ] task', path: '' });
+        const { result } = renderAndCheckModal(task, () => {});
+
+        const apply = getAndCheckApplyButton(result);
+        const cancel = result.getByText('Cancel') as HTMLButtonElement;
+
+        const applyMouseDown = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+        const cancelMouseDown = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+
+        expect(apply.dispatchEvent(applyMouseDown)).toBe(false);
+        expect(cancel.dispatchEvent(cancelMouseDown)).toBe(false);
+    });
+
     async function testDescriptionEdit(taskDescription: string, newDescription: string, expectedDescription: string) {
         const line = convertDescriptionToTaskLine(taskDescription);
         const editedTask = await editTaskLine(line, newDescription);


### PR DESCRIPTION
# Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
Changes visible to users:
- [ ] **New feature** (prefix: feat - non-breaking change which adds functionality)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
  - **WARNING: If the link is absent, the PR may be closed without review**, due to the workload that such reviews usually require.
- [ ] **Breaking change** (prefix: feat!! or fix!! - fix or feature that would cause existing functionality to not work as expected)
  - Issue/discussion: <!-- Link to the issue or discussion where this has been agreed with a maintainer -->
- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
    - Issue/discussion: https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3975
- [ ] **Translation** (prefix: i18n - additions or improvements to the translations - see [Support a new language](https://publish.obsidian.md/tasks-contributing/Translation/Support+a+new+language))
- [ ] **Documentation** (prefix: docs - improvements to any documentation content **for users**)
- [ ] **Sample vault** (prefix: vault - improvements to the [Tasks-Demo sample vault](https://github.com/obsidian-tasks-group/obsidian-tasks/tree/main/resources/sample_vaults/Tasks-Demo))
- [ ] **Contributing Guidelines** (prefix: contrib - any improvements to documentation content **for contributors** - see [Contributing to Tasks](https://publish.obsidian.md/tasks-contributing/))
Internal changes:
- [ ] **Refactor** (prefix: refactor - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: test - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: chore - examples include GitHub Actions, issue templates)
## Description
Prevent the Task edit modal's Apply and Cancel buttons from losing the first tap on iOS when a text field is
  focused.
<!--- Describe your changes in detail -->
## Motivation and Context
On iOS, tapping Apply or Cancel while the keyboard is open first blurs the focused input. The modal layout then
  changes and the button moves away from the tap location, making the user tap twice.

  This fixes issue #3975.
## How has this been tested?
 - `yarn test tests/ui/EditTask.test.ts --runInBand` — 128 tests passed
  - `yarn lint:no-fix`
  - Prettier check passed
  - `git diff --check`

  Added a regression test confirming that both modal buttons prevent the `mousedown` event from blurring the
  focused field.

## Screenshots (if appropriate)
Not applicable 

## Checklist
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code changes are on a branch, and not on the main branch.
- [ ] My code follows the code style of this project and passes yarn run lint.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/
  About+Testing).
## Terms
<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->
- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)