### PR TITLE
fix: 'view columns' would crash if any column names were empty

### DIFF
--- a/src/Renderer/HtmlColumnQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlColumnQueryResultsRenderer.ts
@@ -25,7 +25,7 @@ export class HtmlColumnQueryResultsRenderer extends HtmlQueryResultsRenderer {
                 continue;
             }
 
-            if (group.groupHeadings[0].nestingLevel === 0) {
+            if (group.groupHeadings.length == 0 || group.groupHeadings[0].nestingLevel === 0) {
                 const columnContainer = createAndAppendElement('div', columnsContainer);
                 columnContainer.classList.add('tasks-columns-column');
                 this.columnContainers.push(columnContainer);

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_a_custom_tag_column_for_task_with_a_tag.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_a_custom_tag_column_for_task_with_a_tag.approved.html
@@ -1,0 +1,29 @@
+<!--
+- [ ] my description #tag
+-->
+
+<div>
+  <div class="tasks-columns">
+    <div class="tasks-columns-column tasks-columns-column-cannot-drop">
+      <h4 class="tasks-group-heading">For test purposes: #tag</h4>
+      <ul
+        class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
+        <li
+          class="tasks-columns-column-card task-list-item plugin-tasks-list-item"
+          draggable="true"
+          data-task-priority="normal"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>my description #tag</span></span>
+          </span>
+          <span class="task-extras"></span>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div class="task-count">1 task</div>
+</div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_a_default_heading_for_a_column_whose_name_is_the_empty_string.approved.html
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.columns_rendering_renders_a_default_heading_for_a_column_whose_name_is_the_empty_string.approved.html
@@ -1,0 +1,28 @@
+<!--
+- [ ] my description
+-->
+
+<div>
+  <div class="tasks-columns">
+    <div class="tasks-columns-column tasks-columns-column-cannot-drop">
+      <ul
+        class="contains-task-list plugin-tasks-query-result tasks-layout-hide-urgency tasks-layout-hide-backlinks tasks-layout-hide-edit-button">
+        <li
+          class="tasks-columns-column-card task-list-item plugin-tasks-list-item"
+          draggable="true"
+          data-task-priority="normal"
+          data-task=""
+          data-line="0"
+          data-task-status-name="Todo"
+          data-task-status-type="TODO">
+          <input class="task-list-item-checkbox" type="checkbox" data-line="0" />
+          <span class="tasks-list-text">
+            <span class="task-description"><span>my description</span></span>
+          </span>
+          <span class="task-extras"></span>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div class="task-count">1 task</div>
+</div>

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -38,6 +38,11 @@ function makeColumnRenderer(source: string, allTasks: Task[]) {
     return { query, renderer };
 }
 
+async function verifyHtmlFromColumnRenderer(source: string, tasks: Task[]) {
+    const { query, renderer } = makeColumnRenderer(source, tasks);
+    await verifyHtmlFromRenderer(renderer, State.Warm, query, tasks);
+}
+
 describe('columns rendering', () => {
     const commonInstructions = '\nhide backlink\nhide edit button';
     const due_columns = 'view columns by due' + commonInstructions;
@@ -57,8 +62,7 @@ describe('columns rendering', () => {
     it('renders no search results', async () => {
         const tasks = noTasks;
         const source = due_columns;
-        const { query, renderer } = makeColumnRenderer(source, tasks);
-        await verifyHtmlFromRenderer(renderer, State.Warm, query, tasks);
+        await verifyHtmlFromColumnRenderer(source, tasks);
     });
 
     it('renders no due date column', async () => {

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -55,8 +55,10 @@ describe('columns rendering', () => {
     ];
 
     it('renders no search results', async () => {
-        const { query, renderer } = makeColumnRenderer(due_columns, noTasks);
-        await verifyHtmlFromRenderer(renderer, State.Warm, query, noTasks);
+        const tasks = noTasks;
+        const source = due_columns;
+        const { query, renderer } = makeColumnRenderer(source, tasks);
+        await verifyHtmlFromRenderer(renderer, State.Warm, query, tasks);
     });
 
     it('renders no due date column', async () => {

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -39,8 +39,9 @@ function makeColumnRenderer(source: string, allTasks: Task[]) {
 }
 
 describe('columns rendering', () => {
-    const due_columns = 'view columns by due\nhide backlink\nhide edit button';
-    const priority_columns = 'view columns by priority\nhide backlink\nhide edit button';
+    const commonInstructions = '\nhide backlink\nhide edit button';
+    const due_columns = 'view columns by due' + commonInstructions;
+    const priority_columns = 'view columns by priority' + commonInstructions;
 
     const noTasks: Task[] = [];
     const emptyTask = [new TaskBuilder().build()];

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -60,9 +60,7 @@ describe('columns rendering', () => {
     ];
 
     it('renders no search results', async () => {
-        const tasks = noTasks;
-        const source = due_columns;
-        await verifyHtmlFromColumnRenderer(source, tasks);
+        await verifyHtmlFromColumnRenderer(due_columns, noTasks);
     });
 
     it('renders no due date column', async () => {

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -47,9 +47,12 @@ describe('columns rendering', () => {
     const commonInstructions = '\nhide backlink\nhide edit button';
     const due_columns = 'view columns by due' + commonInstructions;
     const priority_columns = 'view columns by priority' + commonInstructions;
+    const tag_function_columns = 'view columns by function task.tags' + commonInstructions;
+    const empty_string_columns = 'view columns by function ""' + commonInstructions;
 
     const noTasks: Task[] = [];
     const emptyTask = [new TaskBuilder().build()];
+    const taskWithTag = [new TaskBuilder().tags(['#tag']).build()];
 
     const withDue = [new TaskBuilder().dueDate('2026-07-13').build()];
     const withDueAndScheduled = [new TaskBuilder().dueDate('2026-06-23').scheduledDate('2025-12-01').build()];
@@ -81,5 +84,16 @@ describe('columns rendering', () => {
 
     it('renders one column with two headings', async () => {
         await verifyHtmlFromColumnRenderer(due_columns + '\ngroup by priority', twoPriorities);
+    });
+
+    it('renders a custom tag column for task with a tag', async () => {
+        await verifyHtmlFromColumnRenderer(tag_function_columns, taskWithTag);
+    });
+
+    it.failing('renders a default heading for a column whose name is the empty string', async () => {
+        // This gives a traceback, and the error is:
+        //      Cannot read properties of undefined (reading 'nestingLevel')
+        //      TypeError: Cannot read properties of undefined (reading 'nestingLevel')
+        await verifyHtmlFromColumnRenderer(empty_string_columns, emptyTask);
     });
 });

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -66,27 +66,22 @@ describe('columns rendering', () => {
     });
 
     it('renders no due date column', async () => {
-        const { query, renderer } = makeColumnRenderer(due_columns, emptyTask);
-        await verifyHtmlFromRenderer(renderer, State.Warm, query, emptyTask);
+        await verifyHtmlFromColumnRenderer(due_columns, emptyTask);
     });
 
     it('renders due date column', async () => {
-        const { query, renderer } = makeColumnRenderer(due_columns, withDue);
-        await verifyHtmlFromRenderer(renderer, State.Warm, query, withDue);
+        await verifyHtmlFromColumnRenderer(due_columns, withDue);
     });
 
     it('renders due date column and scheduled date groups', async () => {
-        const { query, renderer } = makeColumnRenderer(due_columns + '\ngroup by scheduled', withDueAndScheduled);
-        await verifyHtmlFromRenderer(renderer, State.Warm, query, withDueAndScheduled);
+        await verifyHtmlFromColumnRenderer(due_columns + '\ngroup by scheduled', withDueAndScheduled);
     });
 
     it('renders two priority columns', async () => {
-        const { query, renderer } = makeColumnRenderer(priority_columns, twoPriorities);
-        await verifyHtmlFromRenderer(renderer, State.Warm, query, twoPriorities);
+        await verifyHtmlFromColumnRenderer(priority_columns, twoPriorities);
     });
 
     it('renders one column with two headings', async () => {
-        const { query, renderer } = makeColumnRenderer(due_columns + '\ngroup by priority', twoPriorities);
-        await verifyHtmlFromRenderer(renderer, State.Warm, query, twoPriorities);
+        await verifyHtmlFromColumnRenderer(due_columns + '\ngroup by priority', twoPriorities);
     });
 });

--- a/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
+++ b/tests/Renderer/HtmlColumnQueryResultsRenderer.test.ts
@@ -90,10 +90,7 @@ describe('columns rendering', () => {
         await verifyHtmlFromColumnRenderer(tag_function_columns, taskWithTag);
     });
 
-    it.failing('renders a default heading for a column whose name is the empty string', async () => {
-        // This gives a traceback, and the error is:
-        //      Cannot read properties of undefined (reading 'nestingLevel')
-        //      TypeError: Cannot read properties of undefined (reading 'nestingLevel')
+    it('renders a default heading for a column whose name is the empty string', async () => {
         await verifyHtmlFromColumnRenderer(empty_string_columns, emptyTask);
     });
 });


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3985

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Unreported bug in unreleased code: Stop Tasks crashing if any column name was the empty text.

## Motivation and Context

Fixes #3985, which tripped me up in my own vault.


## How has this been tested?

- Exploratory testing
- Adding a new failing tests

## Screenshots (if appropriate)

This is what the sample markdown in #3985 looked like before this fix:

<img width="1527" height="481" alt="image" src="https://github.com/user-attachments/assets/23d67d5a-22db-4c86-9c92-05f41cc29998" />


And this is what the sample markdown in #3985 looks like now:

<img width="1531" height="419" alt="image" src="https://github.com/user-attachments/assets/d26a1488-07ed-4801-9f93-993a2cd2d6e8" />



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
