### PR TITLE
fix: Stop Apply and Cancel needing two taps on mobile

### DIFF
--- a/src/ui/Dependency.svelte
+++ b/src/ui/Dependency.svelte
@@ -200,7 +200,15 @@
                     >[{task.status.symbol}] {descriptionAdjustedForDependencySearch(task)}</span
                 >
 
-                <button on:click={() => removeTask(task)} type="button" class="task-dependency-delete">
+                <!-- 'mousedown|preventDefault' keeps focus where it is while this button is
+                     tapped, so that the focus-dependent padding in TaskModal.scss does not
+                     move the modal contents mid-tap. See the longer note in EditTask.svelte. -->
+                <button
+                    on:click={() => removeTask(task)}
+                    on:mousedown|preventDefault
+                    type="button"
+                    class="task-dependency-delete"
+                >
                     <svg
                         style="display: block; margin: auto;"
                         xmlns="http://www.w3.org/2000/svg"

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -336,8 +336,24 @@ Availability of access keys:
         {/if}
     </section>
 
+    <!--
+    The 'mousedown|preventDefault' below stops these buttons needing to be tapped
+    twice on mobile.
+
+    While a field has focus, TaskModal.scss adds up to 360px of padding below the
+    modal content, so that the sticky button bar can be scrolled clear of the
+    software keyboard. WebKit does not give a <button> focus when it is tapped, but
+    it does blur the focused text field - so tapping Apply removes that padding
+    mid-tap and moves the button bar by several hundred pixels. The button is then no
+    longer under the finger, and the browser delivers the click to the <form> rather
+    than to the button, making the first tap appear to do nothing.
+
+    Cancelling the default action of 'mousedown' leaves focus where it is, so the
+    padding stays and the buttons do not move while they are being tapped. It does
+    not affect the click itself, nor keyboard activation.
+    -->
     <section class="tasks-modal-button-section">
-        <button disabled={!formIsValid} type="submit" class="mod-cta">Apply </button>
-        <button type="button" on:click={_onClose}>Cancel</button>
+        <button disabled={!formIsValid} type="submit" class="mod-cta" on:mousedown|preventDefault>Apply </button>
+        <button type="button" on:click={_onClose} on:mousedown|preventDefault>Cancel</button>
     </section>
 </form>

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { type RenderResult, fireEvent, render } from '@testing-library/svelte';
+import { type RenderResult, fireEvent, render, waitFor } from '@testing-library/svelte';
 import moment from 'moment';
 import { taskFromLine } from '../../src/Commands/CreateOrEditTaskParser';
 import type { EditModalShowSettings } from '../../src/Config/EditModalShowSettings';
@@ -794,5 +794,51 @@ describe('Hiding modal fields', () => {
         updateSettings({ isShownInEditModal: hideFields('before_this', 'after_this') });
 
         testElementNotRendered('line-after-dependencies');
+    });
+});
+
+describe('Buttons in the modal on mobile', () => {
+    // Regression test for the Apply button needing two taps on mobile.
+    //
+    // '.is-mobile .tasks-edit-modal-container:focus-within .modal-content' adds up to
+    // 360px of padding while a field has focus, to let the sticky button bar scroll
+    // clear of the software keyboard. WebKit does not focus a <button> when it is
+    // tapped, but it does blur the focused text field, so that padding is removed
+    // part-way through the tap and the button bar moves several hundred pixels. By
+    // the time the tap finishes, the button is no longer under the finger and the
+    // click is delivered to the <form> instead - so the first tap appears to do
+    // nothing.
+    //
+    // Preventing the default action of 'mousedown' stops the focus change, so the
+    // field keeps focus, the padding stays, and nothing moves during the tap.
+    //
+    // jsdom has no layout and does not move focus on 'mousedown', so this checks the
+    // one thing it can: that the default action is cancelled.
+    it.each([['Apply'], ['Cancel']])(
+        'should cancel the default focus change when %s is pressed',
+        async (buttonText) => {
+            const task = new TaskBuilder().build();
+            const { result } = renderAndCheckModal(task, () => {});
+
+            const button = result.getByText(buttonText) as HTMLButtonElement;
+
+            // fireEvent resolves to false when a listener called preventDefault().
+            await expect(fireEvent.mouseDown(button)).resolves.toBe(false);
+        },
+    );
+
+    it('should cancel the default focus change when a dependency is removed', async () => {
+        const blockingTask = new TaskBuilder().id('abcdef').description('Wash the bin').build();
+        const task = new TaskBuilder().dependsOn(['abcdef']).description('Take out the trash').build();
+        const { container } = renderAndCheckModal(task, () => {}, [task, blockingTask]);
+
+        // The dependency fields are only rendered once the component has mounted.
+        const deleteButton = await waitFor(() => {
+            const button = container.querySelector<HTMLButtonElement>('.task-dependency-delete');
+            expect(button).not.toBeNull();
+            return button!;
+        });
+
+        await expect(fireEvent.mouseDown(deleteButton)).resolves.toBe(false);
     });
 });


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3975 

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

While a field has focus, TaskModal.scss adds up to 360px of padding below the modal content so the sticky button bar can be scrolled clear of the software keyboard. WebKit does not give a <button> focus when it is tapped, but it does blur the focused text field - so the padding is removed part way through the tap and the button bar moves several hundred pixels. The button is no longer under the finger when the tap finishes, so the browser delivers the click to the <form> rather than to the button, and the first tap appears to do nothing.

Cancel the default action of 'mousedown' on the Apply, Cancel and dependency delete buttons. That leaves focus where it is, so the padding stays and nothing moves while the button is being tapped. It does not affect the click itself, nor keyboard activation.

## Motivation and Context

Fixes #3975 

## How has this been tested?

Unit tests and manual verification

## Screenshots (if appropriate)

https://github.com/user-attachments/assets/8d6e5f84-8c55-44e9-9f6f-87d2ce3ce5c5

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
