### PR TITLE
feat: Make 'done' & 'not done' explain the status types they find

### DIFF
--- a/docs/Queries/Explaining Queries.md
+++ b/docs/Queries/Explaining Queries.md
@@ -103,7 +103,8 @@ the results begin with the following, on `2022-10-21`:
 ```text
 Explanation of this Tasks code block query:
 
-  not done
+  not done =>
+    status type is TODO or IN_PROGRESS or ON_HOLD
 
   (due before tomorrow) AND (is recurring) =>
     AND (All of):
@@ -200,7 +201,8 @@ Explanation of the global query:
 
 Explanation of this Tasks code block query:
 
-  not done
+  not done =>
+    status type is TODO or IN_PROGRESS or ON_HOLD
 
   due next week =>
     due date is between:
@@ -252,7 +254,8 @@ Explanation of the Query File Defaults (from properties/frontmatter in the query
   folder includes {{query.file.folder}} =>
   folder includes Test Data/
 
-  not done
+  not done =>
+    status type is TODO or IN_PROGRESS or ON_HOLD
 
   short mode
 

--- a/src/Query/Filter/FilterInstruction.ts
+++ b/src/Query/Filter/FilterInstruction.ts
@@ -16,15 +16,18 @@ import { FilterOrErrorMessage } from './FilterOrErrorMessage';
 export class FilterInstruction {
     private readonly _instruction: string;
     private readonly _filter: FilterFunction;
+    private readonly _explanation: string | undefined;
 
     /**
      * Constructor:
      * @param instruction - Full text of the instruction for the filter: must be matched exactly, ignoring capitalisation.
      * @param filter
+     * @param explanation - an optional explaination line. If not supplied, the supplied instruction line will be used.
      */
-    constructor(instruction: string, filter: FilterFunction) {
+    constructor(instruction: string, filter: FilterFunction, explanation?: string) {
         this._instruction = instruction;
         this._filter = filter;
+        this._explanation = explanation;
     }
 
     public canCreateFilterForLine(line: string): boolean {
@@ -33,7 +36,9 @@ export class FilterInstruction {
 
     public createFilterOrErrorMessage(line: string): FilterOrErrorMessage {
         if (this.canCreateFilterForLine(line)) {
-            return FilterOrErrorMessage.fromFilter(new Filter(line, this._filter, new Explanation(line)));
+            return FilterOrErrorMessage.fromFilter(
+                new Filter(line, this._filter, new Explanation(this._explanation || line)),
+            );
         }
 
         return FilterOrErrorMessage.fromError(line, `do not understand filter: ${line}`);

--- a/src/Query/Filter/FilterInstructions.ts
+++ b/src/Query/Filter/FilterInstructions.ts
@@ -14,8 +14,8 @@ import type { FilterFunction } from './Filter';
 export class FilterInstructions {
     private readonly _filters: FilterInstruction[] = [];
 
-    public add(instruction: string, filter: FilterFunction) {
-        this._filters.push(new FilterInstruction(instruction, filter));
+    public add(instruction: string, filter: FilterFunction, explanation?: string) {
+        this._filters.push(new FilterInstruction(instruction, filter, explanation));
     }
 
     public canCreateFilterForLine(line: string): boolean {

--- a/src/Query/Filter/StatusField.ts
+++ b/src/Query/Filter/StatusField.ts
@@ -20,7 +20,7 @@ export class StatusField extends FilterInstructionsBasedField {
         //   StatusType.IN_PROGRESS
         //   StatusType.ON_HOLD
         //   StatusType.EMPTY (but it's an implementation detail, never shown to users)
-        this._filters.add('done', (task: Task) => task.isDone);
+        this._filters.add('done', (task: Task) => task.isDone, 'status type is DONE or CANCELLED or NON_TASK');
         this._filters.add('not done', (task: Task) => !task.isDone);
     }
 

--- a/src/Query/Filter/StatusField.ts
+++ b/src/Query/Filter/StatusField.ts
@@ -21,7 +21,7 @@ export class StatusField extends FilterInstructionsBasedField {
         //   StatusType.ON_HOLD
         //   StatusType.EMPTY (but it's an implementation detail, never shown to users)
         this._filters.add('done', (task: Task) => task.isDone, 'status type is DONE or CANCELLED or NON_TASK');
-        this._filters.add('not done', (task: Task) => !task.isDone);
+        this._filters.add('not done', (task: Task) => !task.isDone, 'status type is TODO or IN_PROGRESS or ON_HOLD');
     }
 
     public fieldName(): string {

--- a/src/Query/Filter/StatusField.ts
+++ b/src/Query/Filter/StatusField.ts
@@ -12,14 +12,14 @@ export class StatusField extends FilterInstructionsBasedField {
         // instructions to be done.
         // In later versions:
         // treated as done:
-        //   StatusType.DONE counts as done
-        //   StatusType.CANCELLED counts as done
-        //   StatusType.NON_TASK counts as done
+        //   StatusType.DONE
+        //   StatusType.CANCELLED
+        //   StatusType.NON_TASK
         // treated as not done:
-        //   StatusType.TODO counts as not done
-        //   StatusType.IN_PROGRESS counts as not done
-        //   StatusType.ON_HOLD counts as not done
-        //   StatusType.EMPTY counts as not done (but it's an implementation detail, never shown to users)
+        //   StatusType.TODO
+        //   StatusType.IN_PROGRESS
+        //   StatusType.ON_HOLD
+        //   StatusType.EMPTY (but it's an implementation detail, never shown to users)
         this._filters.add('done', (task: Task) => task.isDone);
         this._filters.add('not done', (task: Task) => !task.isDone);
     }

--- a/src/Query/Filter/StatusField.ts
+++ b/src/Query/Filter/StatusField.ts
@@ -11,12 +11,15 @@ export class StatusField extends FilterInstructionsBasedField {
         // with any status character except space were considered by the status filter
         // instructions to be done.
         // In later versions:
+        // treated as done:
         //   StatusType.DONE counts as done
         //   StatusType.CANCELLED counts as done
+        //   StatusType.NON_TASK counts as done
+        // treated as not done:
         //   StatusType.TODO counts as not done
         //   StatusType.IN_PROGRESS counts as not done
         //   StatusType.ON_HOLD counts as not done
-        //   StatusType.NON_TASK counts as done
+        //   StatusType.EMPTY counts as not done (but it's an implementation detail, never shown to users)
         this._filters.add('done', (task: Task) => task.isDone);
         this._filters.add('not done', (task: Task) => !task.isDone);
     }

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_boolean_combinations.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_boolean_combinations.approved.explanation.text
@@ -1,6 +1,7 @@
 Explanation of this Tasks code block query:
 
-  not done
+  not done =>
+    status type is TODO or IN_PROGRESS or ON_HOLD
 
   (due before tomorrow) AND (is recurring) =>
     AND (All of):

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_explains_task_block_with_global_query_active.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_explains_task_block_with_global_query_active.approved.explanation.text
@@ -6,7 +6,8 @@ Explanation of the global query:
 
 Explanation of this Tasks code block query:
 
-  not done
+  not done =>
+    status type is TODO or IN_PROGRESS or ON_HOLD
 
   due next week =>
     due date is between:

--- a/tests/Query/Explain/DocsSamplesForExplain.test.explain_query_file_defaults_explanation.approved.explanation.text
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.explain_query_file_defaults_explanation.approved.explanation.text
@@ -3,7 +3,8 @@ Explanation of the Query File Defaults (from properties/frontmatter in the query
   folder includes {{query.file.folder}} =>
   folder includes Test Data/
 
-  not done
+  not done =>
+    status type is TODO or IN_PROGRESS or ON_HOLD
 
   short mode
 

--- a/tests/Query/Explain/Explainer.test.ts
+++ b/tests/Query/Explain/Explainer.test.ts
@@ -83,7 +83,8 @@ ignore global query
             filter by function task.path === '{{query.file.path}}' =>
             filter by function task.path === 'sample.md'
 
-            not done
+            not done =>
+              status type is TODO or IN_PROGRESS or ON_HOLD
 
             (has start date) AND (description includes some) =>
               AND (All of):
@@ -138,7 +139,8 @@ ignore global query
               filter by function task.path === '{{query.file.path}}' =>
               filter by function task.path === 'sample.md'
 
-              not done
+              not done =>
+                status type is TODO or IN_PROGRESS or ON_HOLD
 
               (has start date) AND (description includes some) =>
                 AND (All of):

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
@@ -9,7 +9,8 @@ Input:
 Result:
   (not done) AND (is recurring) =>
     AND (All of):
-      not done
+      not done =>
+        status type is TODO or IN_PROGRESS or ON_HOLD
       is recurring
 
 
@@ -22,7 +23,8 @@ Input:
 Result:
   ((not done)) AND ((is recurring)) =>
     AND (All of):
-      not done
+      not done =>
+        status type is TODO or IN_PROGRESS or ON_HOLD
       is recurring
 
 
@@ -35,7 +37,8 @@ Input:
 Result:
   (not done) OR (is recurring) =>
     OR (At least one of):
-      not done
+      not done =>
+        status type is TODO or IN_PROGRESS or ON_HOLD
       is recurring
 
 
@@ -48,7 +51,8 @@ Input:
 Result:
   (not done) XOR (is recurring) =>
     XOR (Exactly one of):
-      not done
+      not done =>
+        status type is TODO or IN_PROGRESS or ON_HOLD
       is recurring
 
 
@@ -61,7 +65,8 @@ Input:
 Result:
   (not done) AND NOT (is recurring) =>
     AND (All of):
-      not done
+      not done =>
+        status type is TODO or IN_PROGRESS or ON_HOLD
       NOT:
         is recurring
 
@@ -75,7 +80,8 @@ Input:
 Result:
   (not done) OR NOT (is recurring) =>
     OR (At least one of):
-      not done
+      not done =>
+        status type is TODO or IN_PROGRESS or ON_HOLD
       NOT:
         is recurring
 
@@ -89,7 +95,8 @@ Input:
 Result:
   NOT (not done) =>
     NOT:
-      not done
+      not done =>
+        status type is TODO or IN_PROGRESS or ON_HOLD
 
 
 --------------------------------------------------------
@@ -2245,9 +2252,11 @@ Input:
 Result:
   (not done) OR NOT (not done) =>
     OR (At least one of):
-      not done
+      not done =>
+        status type is TODO or IN_PROGRESS or ON_HOLD
       NOT:
-        not done
+        not done =>
+          status type is TODO or IN_PROGRESS or ON_HOLD
 
 
 --------------------------------------------------------

--- a/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
+++ b/tests/Query/Filter/BooleanField.test.boolean_query_-_exhaustive_tests_explain.approved.txt
@@ -1334,9 +1334,11 @@ Input:
 Result:
   (done) OR NOT (done) =>
     OR (At least one of):
-      done
+      done =>
+        status type is DONE or CANCELLED or NON_TASK
       NOT:
-        done
+        done =>
+          status type is DONE or CANCELLED or NON_TASK
 
 
 --------------------------------------------------------

--- a/tests/Query/Filter/FilterInstruction.test.ts
+++ b/tests/Query/Filter/FilterInstruction.test.ts
@@ -22,4 +22,13 @@ describe('FilterInstruction', () => {
         const filterOrErrorMessage = filterInstruction.createFilterOrErrorMessage(line);
         expect(filterOrErrorMessage).toHaveExplanation(line);
     });
+
+    it('explanation can be made more specific', () => {
+        const line = 'do something';
+        const explanation = 'please do something';
+        const filterInstruction = new FilterInstruction(line, filter, explanation);
+
+        const filterOrErrorMessage = filterInstruction.createFilterOrErrorMessage(line);
+        expect(filterOrErrorMessage).toHaveExplanation(explanation);
+    });
 });

--- a/tests/Query/Filter/FilterInstructions.test.ts
+++ b/tests/Query/Filter/FilterInstructions.test.ts
@@ -17,4 +17,12 @@ describe('FilterInstructions', () => {
         const invalidFilterOrError = instructions.createFilterOrErrorMessage('goodbye');
         expect(invalidFilterOrError).not.toBeValid();
     });
+
+    it('should be able to add a specific explanation', () => {
+        const instructions = new FilterInstructions();
+        instructions.add('simple instruction', (_task: Task) => true, 'here is some detailed explanation');
+
+        const filterOrErrorMessage = instructions.createFilterOrErrorMessage('simple instruction');
+        expect(filterOrErrorMessage).toHaveExplanation('here is some detailed explanation');
+    });
 });

--- a/tests/Query/Filter/FilterInstructions.test.ts
+++ b/tests/Query/Filter/FilterInstructions.test.ts
@@ -1,0 +1,20 @@
+import { FilterInstructions } from '../../../src/Query/Filter/FilterInstructions';
+import type { Task } from '../../../src/Task/Task';
+
+describe('FilterInstructions', () => {
+    it('should be able to add a valid instruction', () => {
+        const instructions = new FilterInstructions();
+        instructions.add('hello', (_task: Task) => true);
+
+        const validFilterOrError = instructions.createFilterOrErrorMessage('hello');
+        expect(validFilterOrError).toBeValid();
+    });
+
+    it('should be able to add an invalid instruction', () => {
+        const instructions = new FilterInstructions();
+        instructions.add('hello', (_task: Task) => true);
+
+        const invalidFilterOrError = instructions.createFilterOrErrorMessage('goodbye');
+        expect(invalidFilterOrError).not.toBeValid();
+    });
+});

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -70,12 +70,12 @@ describe('explaining status', () => {
 
     it('should explain "not done"', () => {
         const filter = new StatusField().createFilterOrErrorMessage('not done');
-        expect(filter).toHaveExplanation('not done');
+        expect(filter).toHaveExplanation('status type is TODO or IN_PROGRESS or ON_HOLD');
     });
 
     it('should honour original case, when explaining simple filters', () => {
         const filter = new StatusField().createFilterOrErrorMessage('NOT done');
-        expect(filter).toHaveExplanation('NOT done');
+        expect(filter).toHaveExplanation('status type is TODO or IN_PROGRESS or ON_HOLD');
     });
 });
 

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -60,6 +60,18 @@ describe('status', () => {
         expect(filter).toMatchTaskWithStatus(new StatusConfiguration('!', 'Todo', 'x', true, StatusType.TODO)); // 'not done' type.
         expect(filter).not.toMatchTaskWithStatus(new StatusConfiguration('^', 'Non', 'x', true, StatusType.NON_TASK));
     });
+});
+
+describe('explaining status', () => {
+    it('should explain "done"', () => {
+        const filter = new StatusField().createFilterOrErrorMessage('done');
+        expect(filter).toHaveExplanation('done');
+    });
+
+    it('should explain "not done"', () => {
+        const filter = new StatusField().createFilterOrErrorMessage('not done');
+        expect(filter).toHaveExplanation('not done');
+    });
 
     it('should honour original case, when explaining simple filters', () => {
         const filter = new StatusField().createFilterOrErrorMessage('NOT done');

--- a/tests/Query/Filter/StatusField.test.ts
+++ b/tests/Query/Filter/StatusField.test.ts
@@ -65,7 +65,7 @@ describe('status', () => {
 describe('explaining status', () => {
     it('should explain "done"', () => {
         const filter = new StatusField().createFilterOrErrorMessage('done');
-        expect(filter).toHaveExplanation('done');
+        expect(filter).toHaveExplanation('status type is DONE or CANCELLED or NON_TASK');
     });
 
     it('should explain "not done"', () => {

--- a/tests/Query/Presets/Presets.test.ts
+++ b/tests/Query/Presets/Presets.test.ts
@@ -63,7 +63,8 @@ describe('include tests', () => {
             expectFiltersToBe(query, ['not done']);
             expect(query.explainQuery()).toMatchInlineSnapshot(`
                 "{{preset.not_done}} =>
-                not done
+                not done =>
+                  status type is TODO or IN_PROGRESS or ON_HOLD
                 "
             `);
         });
@@ -74,7 +75,8 @@ describe('include tests', () => {
             expectFiltersToBe(query, ['not done']);
             expect(query.explainQuery()).toMatchInlineSnapshot(`
                 "preset not_done =>
-                not done
+                not done =>
+                  status type is TODO or IN_PROGRESS or ON_HOLD
                 "
             `);
         });
@@ -88,7 +90,8 @@ describe('include tests', () => {
                 not_done
                  =>
                 preset not_done =>
-                not done
+                not done =>
+                  status type is TODO or IN_PROGRESS or ON_HOLD
                 "
             `);
         });
@@ -297,7 +300,8 @@ return "Hello World";`;
                 "( {{preset.filter1}} ) AND ( {{preset.filter2}} ) =>
                 ( not done ) AND ( due 2025-05-01 ) =>
                   AND (All of):
-                    not done
+                    not done =>
+                      status type is TODO or IN_PROGRESS or ON_HOLD
                     due 2025-05-01 =>
                       due date is on 2025-05-01 (Thursday 1st May 2025)
                 "
@@ -357,7 +361,8 @@ describe('include - explain output', () => {
                       start date is before 2025-04-28 (Monday 28th April 2025) OR no start date
 
                 {{preset.out}}: statement 2 after expansion of placeholder =>
-                not done
+                not done =>
+                  status type is TODO or IN_PROGRESS or ON_HOLD
                 "
             `);
         });
@@ -378,7 +383,8 @@ describe('include - explain output', () => {
                       start date is before 2025-04-28 (Monday 28th April 2025) OR no start date
 
                 preset out =>
-                not done
+                not done =>
+                  status type is TODO or IN_PROGRESS or ON_HOLD
                 "
             `);
         });

--- a/tests/Query/QueryRendererHelper.test.ts
+++ b/tests/Query/QueryRendererHelper.test.ts
@@ -69,7 +69,8 @@ describe('explain', () => {
 
             Explanation of the Query File Defaults (from properties/frontmatter in the query's file):
 
-              not done
+              not done =>
+                status type is TODO or IN_PROGRESS or ON_HOLD
 
               show toolbar
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: #2109 
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Make `done` and `not done` explain the status types they search for.

## Motivation and Context

Fixes #2109.

Thanks to @Divergent-Code for prompting me to look at this.

## How has this been tested?

- Adding new tests
- Updating existing tests
- Manual exploratory testing - see screenshots below...

## Screenshots (if appropriate)

<details><summary>Details of how the test vault was set up in order to create the screenshots below</summary>

I set up the test vault with these statuses:

<img width="593" height="440" alt="image" src="https://github.com/user-attachments/assets/116b4a4e-855c-4ce0-a138-9eeed3c7e9f2" />

The Tasks settings file is [data.json](https://github.com/user-attachments/files/31024771/data.json).

And then I created this note, with some common instructions in `TQ_extra_instructions `, and one of each status type:

~~~
---
TQ_extra_instructions: |-
  ignore global query
  preset this_file
  explain
  group by status
  group by status.type
  hide backlink
---

# issue 2109 - Make done and not done explain what status types they search for

## Tasks

- [ ] #task Test Task 1 todo #chores 📅 2023-04-01
- [/] #task Test Task 2 in progress #chores 📅 2023-04-01
- [~] #task Test Task 3 on hold #chores 📅 2023-04-01
- [n] #task Test Task 4 non-task #chores 📅 2023-04-02
- [x] #task Test Task 5 done #chores 📅 2023-04-01 ✅ 2026-08-13
- [-] #task Test Task 6 cancelled #chores 📅 2023-04-01 ❌ 2026-08-13

## Search 1 - not done

```tasks
not done
```

## Search 2 - done

```tasks
done
```

## Search 3 - done or not done

```tasks
(DONE) OR (NOT DONE)
```
~~~

</details> 



**Confirmation that the explanation of `not done` matches the statuses used by the `not done` filter and `group by status`:**

<img width="806" height="1029" alt="image" src="https://github.com/user-attachments/assets/50204cf6-6d80-4124-aac6-4ece662235c7" />

**Confirmation that the explanation of `done` matches the statuses used by the `done` filter and `group by status`:**

<img width="810" height="1034" alt="image" src="https://github.com/user-attachments/assets/a5963c26-5acf-436d-b3b9-6b22366e4b28" />

**Confirmation that the original capitalisation of `done` and `not done` instructions is retained in the explanation:**

<img width="730" height="574" alt="image" src="https://github.com/user-attachments/assets/71d4aee1-8bee-4d2e-b1fd-48098d3f5cb3" />



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
