### PR TITLE
refactor: Addressed some 'no-explicit-any' eslint warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -130,6 +130,7 @@ export default defineConfig([
             '@typescript-eslint/no-misused-promises': 0,
             '@typescript-eslint/no-namespace': 0,
             '@typescript-eslint/no-redundant-type-constituents': 0,
+            '@typescript-eslint/no-require-imports': 0,
             '@typescript-eslint/no-restricted-imports':0,
             '@typescript-eslint/no-unnecessary-type-assertion': 0,
             '@typescript-eslint/no-unsafe-argument': 0,

--- a/lint.txt
+++ b/lint.txt
@@ -19,10 +19,6 @@ Prefer explicitly defining any function parameters and return type              
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/DateTime/TasksDate.ts
   125:32  warning  Expected an error object to be thrown  @typescript-eslint/only-throw-error
 
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/IQuery.ts
-   93:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
-  103:37  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
-
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Obsidian/Cache.ts
   240:64  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
   371:28  warning  Unexpected any. Specify a different type                                @typescript-eslint/no-explicit-any
@@ -32,10 +28,6 @@ Prefer explicitly defining any function parameters and return type              
   155:9   warning  Use 'window.setTimeout()' instead of 'setTimeout()' for popout window compatibility  obsidianmd/prefer-window-timers
   155:20  warning  Promise returned in function argument where a void return was expected               @typescript-eslint/no-misused-promises
   245:38  warning  '_' is assigned a value but never used                                               @typescript-eslint/no-unused-vars
-
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Obsidian/FileParser.ts
-  16:41  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
-  28:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Obsidian/LivePreviewExtension.ts
   152:13  warning  Use 'window.setTimeout()' instead of 'setTimeout()' for popout window compatibility  obsidianmd/prefer-window-timers
@@ -50,28 +42,16 @@ Prefer explicitly defining any function parameters and return type              
   193:62  warning  'token' will use Object's default stringification format ('[object Object]') when stringified                                                                            @typescript-eslint/no-base-to-string
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Query/Filter/FunctionField.ts
-   89:23  warning  Unsafe assignment of an `any` value                                            @typescript-eslint/no-unsafe-assignment
-   90:23  warning  Unsafe assignment of an `any` value                                            @typescript-eslint/no-unsafe-assignment
-  102:41  warning  Unexpected any. Specify a different type                                       @typescript-eslint/no-explicit-any
-  116:9   warning  Unsafe return of a value of type `any`                                         @typescript-eslint/no-unsafe-return
-  131:40  warning  Unexpected any. Specify a different type                                       @typescript-eslint/no-explicit-any
-  131:53  warning  Unexpected any. Specify a different type                                       @typescript-eslint/no-explicit-any
   176:57  warning  Unexpected any. Specify a different type                                       @typescript-eslint/no-explicit-any
   176:70  warning  Unexpected any. Specify a different type                                       @typescript-eslint/no-explicit-any
   185:34  warning  Unsafe argument of type `any` assigned to a parameter of type `Moment | null`  @typescript-eslint/no-unsafe-argument
   185:42  warning  Unsafe argument of type `any` assigned to a parameter of type `Moment | null`  @typescript-eslint/no-unsafe-argument
-  191:55  warning  Unexpected any. Specify a different type                                       @typescript-eslint/no-explicit-any
-  191:68  warning  Unexpected any. Specify a different type                                       @typescript-eslint/no-explicit-any
   263:11  warning  Unsafe assignment of an `any` value                                            @typescript-eslint/no-unsafe-assignment
   289:15  warning  Unsafe assignment of an `any` value                                            @typescript-eslint/no-unsafe-assignment
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Query/Group/GroupingTreeNode.ts
   32:13  warning  Unsafe return of type `Map<any, any>` from function with return type `Map<string[], T[]>`  @typescript-eslint/no-unsafe-return
   41:9   warning  Unsafe return of type `Map<any, any>` from function with return type `Map<string[], T[]>`  @typescript-eslint/no-unsafe-return
-
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Query/Query.ts
-  561:45  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
-  565:44  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/HtmlColumnQueryResultsRenderer.ts
   62:62  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
@@ -108,36 +88,31 @@ Prefer explicitly defining any function parameters and return type              
   493:48  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/ExpandPlaceholders.ts
-   27:60  warning  Unexpected any. Specify a different type                                                                @typescript-eslint/no-explicit-any
-   31:9   warning  Unsafe return of a value of type `any`                                                                  @typescript-eslint/no-unsafe-return
-   73:59  warning  Unexpected any. Specify a different type                                                                @typescript-eslint/no-explicit-any
-   99:19  warning  Unsafe assignment of an `any` value                                                                     @typescript-eslint/no-unsafe-assignment
-  118:19  warning  'result' may use Object's default stringification format ('[object Object]') when stringified           @typescript-eslint/no-base-to-string
-  121:31  warning  Unexpected any. Specify a different type                                                                @typescript-eslint/no-explicit-any
-  122:18  warning  Unsafe member access .query on an `any` value                                                           @typescript-eslint/no-unsafe-member-access
-  148:43  warning  Unexpected any. Specify a different type                                                                @typescript-eslint/no-explicit-any
-  149:27  warning  Unsafe argument of type `any` assigned to a parameter of type `{ [s: string]: any; } | ArrayLike<any>`  @typescript-eslint/no-unsafe-argument
+   27:60  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+   31:9   warning  Unsafe return of a value of type `any`                                                                          @typescript-eslint/no-unsafe-return
+   73:59  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+   99:19  warning  Unsafe assignment of an `any` value                                                                             @typescript-eslint/no-unsafe-assignment
+  118:19  warning  'result' may use Object's default stringification format ('[object Object]') when stringified                   @typescript-eslint/no-base-to-string
+  121:31  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  122:18  warning  Unsafe member access .query on an `any` value                                                                   @typescript-eslint/no-unsafe-member-access
+  148:43  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  149:12  warning  This assertion is unnecessary since the receiver accepts the original type of the expression                    @typescript-eslint/no-unnecessary-type-assertion
+  149:27  warning  Unsafe argument of type `any` assigned to a parameter of type `ArrayLike<unknown> | { [s: string]: unknown; }`  @typescript-eslint/no-unsafe-argument
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/Expression.ts
    6:60  warning  The `Function` type accepts any function-like value.
 Prefer explicitly defining any function parameters and return type  @typescript-eslint/no-unsafe-function-type
-  11:57  warning  Unexpected any. Specify a different type                                                                                 @typescript-eslint/no-explicit-any
   29:39  warning  The `Function` type accepts any function-like value.
 Prefer explicitly defining any function parameters and return type  @typescript-eslint/no-unsafe-function-type
   29:57  warning  Implied eval. Do not use the Function constructor to create functions                                                    @typescript-eslint/no-implied-eval
   29:57  warning  [no-new-func] Using the `Function` constructor is dangerous because it executes arbitrary code, similar to `eval()`      obsidianmd/rule-custom-message
   48:48  warning  The `Function` type accepts any function-like value.
 Prefer explicitly defining any function parameters and return type  @typescript-eslint/no-unsafe-function-type
-  53:60  warning  Unsafe return of a value of type `any`                                                                                   @typescript-eslint/no-unsafe-return
   54:5   warning  Unsafe return of a value of type `any`                                                                                   @typescript-eslint/no-unsafe-return
   54:12  warning  Unsafe call of a `Function` typed value                                                                                  @typescript-eslint/no-unsafe-call
-  54:23  warning  Unsafe spread of an `any[]` array type                                                                                   @typescript-eslint/no-unsafe-argument
   66:55  warning  The `Function` type accepts any function-like value.
 Prefer explicitly defining any function parameters and return type  @typescript-eslint/no-unsafe-function-type
   68:9   warning  Unsafe return of a value of type `any`                                                                                   @typescript-eslint/no-unsafe-return
-
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/QueryContext.ts
-  27:37  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/TaskExpression.ts
   45:5  warning  Unsafe return of a value of type `any`  @typescript-eslint/no-unsafe-return
@@ -145,11 +120,9 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   95:9  warning  Unsafe return of a value of type `any`  @typescript-eslint/no-unsafe-return
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/TasksFile.ts
-   36:13  warning  Unsafe assignment of an `any` value       @typescript-eslint/no-unsafe-assignment
-  224:15  warning  Unsafe assignment of an `any` value       @typescript-eslint/no-unsafe-assignment
-  241:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
-  247:15  warning  Unsafe assignment of an `any` value       @typescript-eslint/no-unsafe-assignment
-  253:48  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+   36:13  warning  Unsafe assignment of an `any` value  @typescript-eslint/no-unsafe-assignment
+  224:15  warning  Unsafe assignment of an `any` value  @typescript-eslint/no-unsafe-assignment
+  247:15  warning  Unsafe assignment of an `any` value  @typescript-eslint/no-unsafe-assignment
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Statuses/StatusValidator.ts
   31:24  warning  '_name' is assigned a value but never used  @typescript-eslint/no-unused-vars
@@ -159,7 +132,6 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   115:9   warning  Unsafe return of a value of type error                                                                                                   @typescript-eslint/no-unsafe-return
   115:16  warning  Unsafe call of a type that could not be resolved                                                                                         @typescript-eslint/no-unsafe-call
   115:26  warning  Unsafe member access .state on a type that cannot be resolved                                                                            @typescript-eslint/no-unsafe-member-access
-  118:44  warning  Unexpected any. Specify a different type                                                                                                 @typescript-eslint/no-explicit-any
   126:5   warning  Promise-returning method provided where a void return was expected by extended/implemented type 'EditorSuggest<SuggestInfoWithContext>'  @typescript-eslint/no-misused-promises
   136:13  warning  Unsafe call of an `any` typed value                                                                                                      @typescript-eslint/no-unsafe-call
   136:24  warning  Unexpected any. Specify a different type                                                                                                 @typescript-eslint/no-explicit-any
@@ -171,7 +143,6 @@ Prefer explicitly defining any function parameters and return type  @typescript-
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Suggestor/Suggestor.ts
    35:1   warning  Avoid using 'globalThis'. Use 'window' or 'activeWindow' for popout window compatibility  obsidianmd/no-global-this
    38:12  warning  Avoid using 'globalThis'. Use 'window' or 'activeWindow' for popout window compatibility  obsidianmd/no-global-this
-  261:59  warning  Unexpected any. Specify a different type                                                  @typescript-eslint/no-explicit-any
   492:57  warning  Invalid type "string | string[]" of template literal expression                           @typescript-eslint/restrict-template-expressions
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Task/ListItem.ts
@@ -196,15 +167,11 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   71:9  warning  Unsafe return of a value of type `any`  @typescript-eslint/no-unsafe-return
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/lib/ExceptionTools.ts
-   6:79  warning  Unexpected any. Specify a different type                                                                                                                                 @typescript-eslint/no-explicit-any
   12:19  warning  Invalid operand for a '+' operation. Operands must each be a number or string, allowing a string + any of: `any`, `boolean`, `null`, `RegExp`, `undefined`. Got `Error`  @typescript-eslint/restrict-plus-operands
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/lib/PerformanceTracker.ts
   56:13  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console  obsidianmd/rule-custom-message
   58:13  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console  obsidianmd/rule-custom-message
-
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/lib/TypeDetection.ts
-  5:37  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/lib/logging.ts
   141:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console  obsidianmd/rule-custom-message
@@ -237,8 +204,8 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   79:20  warning  Use 'activeDocument' instead of 'document' for popout window compatibility        obsidianmd/prefer-active-doc
   84:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 159 problems (0 errors, 159 warnings)
-  0 errors and 47 warnings potentially fixable with the `--fix` option.
+✖ 136 problems (0 errors, 136 warnings)
+  0 errors and 29 warnings potentially fixable with the `--fix` option.
 
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/tests/Obsidian/CacheLoading.test.ts
@@ -254,4 +221,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 25.00s.
+Done in 23.05s.

--- a/lint.txt
+++ b/lint.txt
@@ -207,28 +207,10 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   5:37  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/lib/logging.ts
-   35:14  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
   141:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console  obsidianmd/rule-custom-message
   147:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console  obsidianmd/rule-custom-message
   156:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console  obsidianmd/rule-custom-message
-  212:61  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  220:13  warning  Unsafe assignment of an `any` value                                                                                                                       @typescript-eslint/no-unsafe-assignment
-  240:45  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  243:45  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  246:44  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  249:44  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  252:45  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  261:84  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  269:13  warning  Unsafe assignment of an `any` value                                                                                                                       @typescript-eslint/no-unsafe-assignment
-  276:68  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  279:68  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  282:67  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  285:67  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  288:68  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
   310:33  warning  Prefer using the primitive `object` as a type name, rather than the upper-cased `Object`                                                                  @typescript-eslint/no-wrapper-object-types
-  313:43  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  345:30  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
-  349:53  warning  Unexpected any. Specify a different type                                                                                                                  @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/main.ts
    98:13  warning  Unsafe assignment of an `any` value                                                @typescript-eslint/no-unsafe-assignment
@@ -255,8 +237,8 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   79:20  warning  Use 'activeDocument' instead of 'document' for popout window compatibility        obsidianmd/prefer-active-doc
   84:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 177 problems (0 errors, 177 warnings)
-  0 errors and 63 warnings potentially fixable with the `--fix` option.
+✖ 159 problems (0 errors, 159 warnings)
+  0 errors and 47 warnings potentially fixable with the `--fix` option.
 
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/tests/Obsidian/CacheLoading.test.ts
@@ -272,4 +254,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 23.96s.
+Done in 25.00s.

--- a/lint.txt
+++ b/lint.txt
@@ -77,14 +77,15 @@ Prefer explicitly defining any function parameters and return type              
   62:62  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/HtmlQueryResultsRenderer.ts
-   50:38  warning  Use 'createDiv()' instead of 'document.createElement('div')'                obsidianmd/prefer-create-el
-   50:38  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
-   52:46  warning  Use 'createEl('li')' instead of 'document.createElement('li')'              obsidianmd/prefer-create-el
-   52:46  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
-  307:40  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
-  311:44  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
-  332:42  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
-  340:48  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
+   50:38  warning  Use 'createDiv()' instead of 'document.createElement('div')'                                             obsidianmd/prefer-create-el
+   50:38  warning  Use 'activeDocument' instead of 'document' for popout window compatibility                               obsidianmd/prefer-active-doc
+   52:46  warning  Use 'createEl('li')' instead of 'document.createElement('li')'                                           obsidianmd/prefer-create-el
+   52:46  warning  Use 'activeDocument' instead of 'document' for popout window compatibility                               obsidianmd/prefer-active-doc
+  262:27  warning  Use 'headerEl.ownerDocument.win.createSpan()' instead of 'headerEl.ownerDocument.createElement('span')'  obsidianmd/prefer-create-el
+  307:40  warning  Promise returned in function argument where a void return was expected                                   @typescript-eslint/no-misused-promises
+  311:44  warning  Promise returned in function argument where a void return was expected                                   @typescript-eslint/no-misused-promises
+  332:42  warning  Promise returned in function argument where a void return was expected                                   @typescript-eslint/no-misused-promises
+  340:48  warning  Promise returned in function argument where a void return was expected                                   @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/QueryRenderer.ts
   162:47  warning  Promise returned in function argument where a void return was expected                                     @typescript-eslint/no-misused-promises
@@ -254,20 +255,14 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   79:20  warning  Use 'activeDocument' instead of 'document' for popout window compatibility        obsidianmd/prefer-active-doc
   84:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 176 problems (0 errors, 176 warnings)
+✖ 177 problems (0 errors, 177 warnings)
   0 errors and 63 warnings potentially fixable with the `--fix` option.
 
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/tests/Obsidian/CacheLoading.test.ts
   109:44  warning  Use 'window.setTimeout()' instead of 'setTimeout()' for popout window compatibility  obsidianmd/prefer-window-timers
 
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/tests/TestingTools/AutoApprovingReporter.ts
-  3:12  warning  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
-
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/tests/i18n/i18n.test.ts
-  23:26  warning  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
-
-✖ 3 problems (0 errors, 3 warnings)
+✖ 1 problem (0 errors, 1 warning)
   0 errors and 1 warning potentially fixable with the `--fix` option.
 
 
@@ -277,4 +272,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 25.62s.
+Done in 23.96s.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "esbuild-svelte": "^0.8.2",
     "eslint": "9.26.0",
     "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-obsidianmd": "^0.4.0",
+    "eslint-plugin-obsidianmd": "^0.4.1",
     "eslint-plugin-prettier": "^4.2.5",
     "eslint-plugin-svelte": "^3.19.0",
     "globals": "^13.0.0",

--- a/src/IQuery.ts
+++ b/src/IQuery.ts
@@ -90,7 +90,7 @@ export interface IQuery {
      * @param message
      * @param objects
      */
-    debug(message: string, objects?: any): void;
+    debug(message: string, objects?: unknown): void;
 
     /**
      * Write a warn log message.
@@ -100,5 +100,5 @@ export interface IQuery {
      * @param message
      * @param objects
      */
-    warn(message: string, objects?: any): void;
+    warn(message: string, objects?: unknown): void;
 }

--- a/src/Obsidian/FileParser.ts
+++ b/src/Obsidian/FileParser.ts
@@ -13,7 +13,7 @@ export class FileParser {
     private readonly fileContent: string;
     private readonly listItems: ListItemCache[];
     private readonly logger: Logger;
-    private readonly errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void;
+    private readonly errorReporter: (e: unknown, filePath: string, listItem: ListItemCache, line: string) => void;
 
     private readonly fileLines: string[];
     private readonly line2ListItem: Map<number, ListItem> = new Map();
@@ -25,7 +25,7 @@ export class FileParser {
         fileContent: string,
         listItems: ListItemCache[],
         logger: Logger,
-        errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
+        errorReporter: (e: unknown, filePath: string, listItem: ListItemCache, line: string) => void,
     ) {
         this.tasksFile = tasksFile;
         this.fileContent = fileContent;

--- a/src/Query/Filter/FunctionField.ts
+++ b/src/Query/Filter/FunctionField.ts
@@ -99,7 +99,7 @@ export class FunctionField extends Field {
         return new Sorter(line, this.fieldNameSingular(), comparator, reverse);
     }
 
-    public validateTaskSortKey(sortKey: any) {
+    public validateTaskSortKey(sortKey: unknown) {
         function throwSortKeyTypeError(sortKeyType: string) {
             throw new Error(`"${sortKeyType}" is not a valid sort key`);
         }
@@ -128,7 +128,7 @@ export class FunctionField extends Field {
      * @param valueA - a value that satisfies {@link validateTaskSortKey}.
      * @param valueB - a value that satisfies {@link validateTaskSortKey}.
      */
-    public compareTaskSortKeys(valueA: any, valueB: any) {
+    public compareTaskSortKeys(valueA: unknown, valueB: unknown) {
         // Precondition: Both parameter values have satisfied constraints in validateTaskSortKey().
 
         const valueAType = getValueType(valueA);
@@ -188,7 +188,7 @@ export class FunctionField extends Field {
         return undefined;
     }
 
-    private compareTaskSortKeysIfEitherIsNull(valueA: any, valueB: any) {
+    private compareTaskSortKeysIfEitherIsNull(valueA: unknown, valueB: unknown) {
         if (valueA === null && valueB === null) {
             return 0;
         }

--- a/src/Query/Query.ts
+++ b/src/Query/Query.ts
@@ -558,11 +558,11 @@ ${statement.explainStatement('    ')}
         return queryInstanceCounter.toString().padStart(length, '0');
     }
 
-    public debug(message: string, objects?: any): void {
+    public debug(message: string, objects?: unknown): void {
         this.logger.debugWithId(this._queryId, `"${this.filePath}": ${message}`, objects);
     }
 
-    public warn(message: string, objects?: any): void {
+    public warn(message: string, objects?: unknown): void {
         this.logger.warnWithId(this._queryId, `"${this.filePath}": ${message}`, objects);
     }
 }

--- a/src/Scripting/Expression.ts
+++ b/src/Scripting/Expression.ts
@@ -8,7 +8,7 @@ export class FunctionOrError extends QueryComponentOrError<Function> {}
 /**
  * The name and value of a parameter, as a Tuple, for passing in to {@link parseExpression} and related functions.
  */
-export type ExpressionParameter = [name: string, value: any];
+export type ExpressionParameter = [name: string, value: unknown];
 
 /**
  * Parse a JavaScript expression, and return either a Function or an error message in a string.

--- a/src/Scripting/QueryContext.ts
+++ b/src/Scripting/QueryContext.ts
@@ -24,7 +24,7 @@ export interface QueryContext {
     query: {
         file: TasksFile;
         allTasks: Readonly<Task[]>;
-        searchCache: Record<string, any>; // Added caching capability
+        searchCache: Record<string, unknown>; // Added caching capability
     };
     preset: PresetsMap;
 }

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -238,7 +238,7 @@ export class TasksFile {
      * https://publish.obsidian.md/tasks/Getting+Started/Obsidian+Properties#How+does+Tasks+treat+Obsidian+Properties%3F
      * @param key
      */
-    public property(key: string): any {
+    public property(key: string): unknown {
         const foundKey = this.findKeyInFrontmatter(key);
         if (foundKey === undefined) {
             return null;
@@ -250,7 +250,7 @@ export class TasksFile {
         }
 
         if (Array.isArray(propertyValue)) {
-            return propertyValue.filter((item: any) => item !== null);
+            return propertyValue.filter((item: unknown) => item !== null);
         }
 
         return propertyValue;

--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -115,7 +115,7 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
         return editor.cm.state.field(editorInfoField);
     }
 
-    private canSaveEdits(markdownFileInfo: any) {
+    private canSaveEdits(markdownFileInfo: unknown) {
         return markdownFileInfo instanceof MarkdownView;
     }
 

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -258,7 +258,7 @@ function filterGeneralSuggestionsForWordAtCursor(genericSuggestions: SuggestInfo
     return matchingSuggestions;
 }
 
-function defaultExtractor(symbol: string, suggestionText: any) {
+function defaultExtractor(symbol: string, suggestionText: string) {
     const displayText = `${suggestionText}`;
     const appendText = `${symbol} ${suggestionText}`;
     return { displayText, appendText };

--- a/src/lib/ExceptionTools.ts
+++ b/src/lib/ExceptionTools.ts
@@ -3,7 +3,7 @@
  * @param whatWasHappening - a description of what was happening at the time, preferably including any user inputs.
  * @param exception - object that was caught in a try/catch block.
  */
-export function errorMessageForException(whatWasHappening: string, exception: any): string {
+export function errorMessageForException(whatWasHappening: string, exception: unknown): string {
     const errorMessage = `Error: ${whatWasHappening}.
 The error message was:
     `;

--- a/src/lib/TypeDetection.ts
+++ b/src/lib/TypeDetection.ts
@@ -2,7 +2,7 @@
  * Return a string representation of the {@link value}'s type, for showing to users, such as in error messages.
  * @param value
  */
-export function getValueType(value: any): string {
+export function getValueType(value: unknown): string {
     if (value === null) {
         return 'null';
     }

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -32,7 +32,7 @@ export interface LogEntry {
     module: string;
     location?: string;
     message: string;
-    objects: any;
+    objects: unknown;
 }
 
 /**
@@ -209,7 +209,7 @@ export class Logger {
      * @param logLevel
      * @param message
      */
-    public log(logLevel: string, message: string, objects?: any): void {
+    public log(logLevel: string, message: string, objects?: unknown): void {
         const level = this.levelToInt(logLevel);
         if (level < this.minLevel) return;
 
@@ -237,19 +237,19 @@ export class Logger {
         this.logManager.emit('log', logEntry);
     }
 
-    public trace(message: string, objects?: any): void {
+    public trace(message: string, objects?: unknown): void {
         this.log('trace', message, objects);
     }
-    public debug(message: string, objects?: any): void {
+    public debug(message: string, objects?: unknown): void {
         this.log('debug', message, objects);
     }
-    public info(message: string, objects?: any): void {
+    public info(message: string, objects?: unknown): void {
         this.log('info', message, objects);
     }
-    public warn(message: string, objects?: any): void {
+    public warn(message: string, objects?: unknown): void {
         this.log('warn', message, objects);
     }
-    public error(message: string, objects?: any): void {
+    public error(message: string, objects?: unknown): void {
         this.log('error', message, objects);
     }
 
@@ -258,7 +258,7 @@ export class Logger {
      * @param logLevel
      * @param message
      */
-    public logWithId(logLevel: string, traceId: string, message: string, objects?: any): void {
+    public logWithId(logLevel: string, traceId: string, message: string, objects?: unknown): void {
         const level = this.levelToInt(logLevel);
         if (level < this.minLevel) return;
 
@@ -273,19 +273,19 @@ export class Logger {
         this.logManager.emit('log', logEntry);
     }
 
-    public traceWithId(traceId: string, message: string, objects?: any): void {
+    public traceWithId(traceId: string, message: string, objects?: unknown): void {
         this.logWithId('trace', traceId, message, objects);
     }
-    public debugWithId(traceId: string, message: string, objects?: any): void {
+    public debugWithId(traceId: string, message: string, objects?: unknown): void {
         this.logWithId('debug', traceId, message, objects);
     }
-    public infoWithId(traceId: string, message: string, objects?: any): void {
+    public infoWithId(traceId: string, message: string, objects?: unknown): void {
         this.logWithId('info', traceId, message, objects);
     }
-    public warnWithId(traceId: string, message: string, objects?: any): void {
+    public warnWithId(traceId: string, message: string, objects?: unknown): void {
         this.logWithId('warn', traceId, message, objects);
     }
-    public errorWithId(traceId: string, message: string, objects?: any): void {
+    public errorWithId(traceId: string, message: string, objects?: unknown): void {
         this.logWithId('error', traceId, message, objects);
     }
 }
@@ -310,7 +310,7 @@ const timingMap: TimingMap = {};
 export const logCall = (target: Object, propertyKey: string, descriptor: PropertyDescriptor) => {
     const originalMethod = descriptor.value as (...args: unknown[]) => unknown;
     //const logger = logging.getLogger('taskssql.perf');
-    descriptor.value = function (...args: any[]) {
+    descriptor.value = function (...args: unknown[]) {
         const startTime = new Date(Date.now());
         const result = originalMethod.apply(this, args);
         const endTime = new Date(Date.now());
@@ -342,11 +342,11 @@ export const logCall = (target: Object, propertyKey: string, descriptor: Propert
 };
 
 export function logCallDetails() {
-    return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+    return function (target: unknown, propertyKey: string, descriptor: PropertyDescriptor) {
         const originalMethod = descriptor.value as (...args: unknown[]) => Promise<unknown>;
         const logger = logging.getLogger('tasks');
 
-        descriptor.value = async function (...args: any[]) {
+        descriptor.value = async function (...args: unknown[]) {
             const startTime = new Date(Date.now());
             const result = await originalMethod.apply(this, args);
             const endTime = new Date(Date.now());

--- a/yarn.lock
+++ b/yarn.lock
@@ -3788,10 +3788,10 @@ eslint-plugin-no-unsanitized@^4.1.5:
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.5.tgz#036c7c7ac4561ff0ee34c3d126b3b6e86037641c"
   integrity sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==
 
-eslint-plugin-obsidianmd@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.0.tgz#bb4ce5a7f51496b0977d9b68bf82563eef3f55bd"
-  integrity sha512-qZsh8ydaeO7bC+XADWHGG9+CEwiKjoL7arZo1I93e0UHdQ863Jzt+xRk5VI0vo97SIJrA4vWwuz9K9/fggO35g==
+eslint-plugin-obsidianmd@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.1.tgz#595f8a2784b42332bcae284c0c88cb17cbcef01f"
+  integrity sha512-Nv3593kVsFOS8kir/HWaJ5CR3xcyiPWEPyXst5Pib8mxRYYuLYPpJS2ALMoZXHulHyiGwoYW8AaxvLRc4rhrRg==
   dependencies:
     "@eslint-community/eslint-plugin-eslint-comments" "^4.7.2"
     "@eslint/config-helpers" "^0.4.2"


### PR DESCRIPTION
Changes done by pairing with @ilandikov.

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

- Updated eslint-plugin-obsidianmd from 0.4.0 to 0.4.1
- Addressed the `Unexpected any. Specify a different type @typescript-eslint/no-explicit-any` warnings that did not create new, different warnings
- Updated the `lint.txt` to show the remaining warnings.
    - The total number in the `src/` directory dropped from 176 to 136.

## Motivation and Context

Code quality, and gradually improving the plugin's Scorecard on community.obsidian.com.

## How has this been tested?

Via automated tests and the TypeScript compiler.

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
    - Not all the code changed had automated tests

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
