### PR TITLE
fix: Edit Task modal opens scrolled on mobile

### DIFF
--- a/src/Obsidian/TaskModal.scss
+++ b/src/Obsidian/TaskModal.scss
@@ -32,8 +32,17 @@
 // This has been validated on an iPhone 17 Pro with Obsidian font sizes 10, 16
 // and 24, including iOS text size set to 135%. It is expected to be safe on
 // Android as well, because it only adds temporary scrollable space while editing.
+
+// Declared as a custom property because two things need to agree on it: the padding below, and
+// EditTask.svelte, which waits for the Description field to rise clear of the keyboard before
+// focusing it. Override this one property in a CSS snippet and both stay in step - overriding the
+// padding on its own leaves the plugin working from a number your layout no longer uses.
+.is-mobile .tasks-edit-modal-container {
+    --tasks-keyboard-space-allowance: clamp(220px, 35vh, 360px);
+}
+
 .is-mobile .tasks-edit-modal-container:focus-within {
     .modal-content {
-        padding-bottom: clamp(220px, 35vh, 360px);
+        padding-bottom: var(--tasks-keyboard-space-allowance);
     }
 }

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -9,7 +9,7 @@
     import DateEditor from './DateEditor.svelte';
     import Dependency from './Dependency.svelte';
     import { EditableTask } from './EditableTask';
-    import { labelContentWithAccessKey } from './EditTaskHelpers';
+    import { focusOnceClearOfKeyboard, labelContentWithAccessKey } from './EditTaskHelpers';
     import PriorityEditor from './PriorityEditor.svelte';
     import RecurrenceEditor from './RecurrenceEditor.svelte';
     import StatusEditor from './StatusEditor.svelte';
@@ -72,9 +72,9 @@
 
         mountComplete = true;
 
-        setTimeout(() => {
-            descriptionInput.focus({ preventScroll: true });
-        }, 10);
+        // Put the cursor in the Description field, ready to type. On a phone this has to wait for
+        // the modal to finish sliding up first, or the keyboard drags the form down with it
+        focusOnceClearOfKeyboard(descriptionInput);
     });
 
     const _onClose = () => {

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -36,3 +36,111 @@ export function labelContentWithAccessKey(labelText: string, accessKey: string |
     labelContent = capitalizeFirstLetter(labelContent);
     return labelContent;
 }
+
+/** How long to wait for the element to rise clear of the software keyboard. */
+const riseTimeout = 400;
+
+/**
+ * A modal that is not moving has no transform of its own. Browsers report that as 'none', or as an identity
+ * matrix if a transition happens to settle on one, and jsdom - which does not calculate transforms - as ''.
+ */
+const stationaryTransforms = ['none', '', 'matrix(1, 0, 0, 1, 0, 0)'];
+
+/**
+ * Focus an element, without the software keyboard scrolling the modal it sits in.
+ *
+ * On a phone, Obsidian opens a modal by sliding it up from the bottom of the screen, which takes up to 250ms.
+ * Until that finishes, everything in the modal is lower down the screen than where it will end up.
+ *
+ * Focus something during the slide and WebKit remembers where it was at that moment. The keyboard then
+ * appears, WebKit scrolls the modal's content to bring that remembered spot into view, and the form is left
+ * part way down. `preventScroll` is no help - it only stops the scrolling that `focus()` itself would do.
+ *
+ * Two other fixes were tried first. Waiting for the whole slide is reliable, but then nothing can start the
+ * keyboard until around 300ms in, and it feels sluggish. Focusing straight away and scrolling back afterwards
+ * is fast, but you can see it happen: the browser scrolls on the compositor and paints before we put it back.
+ *
+ * So wait only until the keyboard will not cover the element. From that point WebKit can see all of it and
+ * has no reason to scroll anywhere. That comes well before the slide ends, because the easing covers most of
+ * the distance early on and then inches through the last few pixels.
+ *
+ * @param el the element to focus, which should be near enough the top of the form to fit above the keyboard.
+ */
+export async function focusOnceClearOfKeyboard(el: HTMLElement) {
+    // Obsidian applies the modal's starting transform just after building its content, and so just after this
+    // was called. Wait a frame, or the modal still looks like it is exactly where it is going to end up.
+    await nextAnimationFrame();
+
+    // A modal that is not moving is already where it will end up, so the keyboard has nothing it can scroll.
+    // Same goes for desktop, for animations turned off, and for a form rendered outside a modal altogether.
+    const modalEl = el.closest<HTMLElement>('.modal');
+    if (modalEl && isMoving(modalEl)) {
+        await waitUntilAboveKeyboard(el, modalEl);
+    }
+
+    // Focusing an element that has since been removed does nothing, which is what we want if the modal was
+    // closed while we were waiting.
+    el.focus({ preventScroll: true });
+}
+
+/** Wait until all of the element is above the space the software keyboard is going to take up. */
+async function waitUntilAboveKeyboard(el: HTMLElement, modalEl: HTMLElement) {
+    const view = modalEl.ownerDocument.defaultView;
+    const viewportHeight = view?.visualViewport?.height ?? view?.innerHeight ?? 0;
+    const keyboardTop = viewportHeight - keyboardSpace(modalEl);
+    const giveUpAt = Date.now() + riseTimeout;
+
+    while (Date.now() < giveUpAt) {
+        // Bounding boxes include the transform that is sliding the modal up, so this is where the element is
+        // on screen now, not where it will end up. Closing the modal shrinks the box to nothing, which ends
+        // the wait as well.
+        if (el.getBoundingClientRect().bottom <= keyboardTop) {
+            return;
+        }
+
+        // Once the modal has arrived, the element is as high up as it is ever going to get.
+        if (!isMoving(modalEl)) {
+            return;
+        }
+
+        await nextAnimationFrame();
+    }
+}
+
+/**
+ * How much room the software keyboard is expected to need, in pixels.
+ *
+ * Read from the property TaskModal.scss sets, rather than repeated here, so that a snippet overriding it moves
+ * the padding below the form and this wait together. Measuring a real element resolves whatever units it is
+ * written in - `vh`, `clamp()`, anything - exactly as the browser will.
+ */
+function keyboardSpace(modalEl: HTMLElement) {
+    const probe = modalEl.ownerDocument.createElement('div');
+    probe.style.cssText =
+        'position:absolute;visibility:hidden;pointer-events:none;width:0;' +
+        'height:var(--tasks-keyboard-space-allowance, clamp(220px, 35vh, 360px))';
+
+    modalEl.appendChild(probe);
+    const space = probe.offsetHeight;
+    probe.remove();
+
+    return space;
+}
+
+function isMoving(modalEl: HTMLElement) {
+    // Ask the modal's own window, as Obsidian can open modals in pop-out windows.
+    const transform = modalEl.ownerDocument.defaultView?.getComputedStyle(modalEl).transform;
+
+    return transform !== undefined && !stationaryTransforms.includes(transform);
+}
+
+function nextAnimationFrame() {
+    return new Promise<void>((resolve) => {
+        if (typeof requestAnimationFrame === 'function') {
+            requestAnimationFrame(() => resolve());
+        } else {
+            // Test environments that have no rendering loop to wait for.
+            setTimeout(resolve, 0);
+        }
+    });
+}

--- a/tests/ui/EditTaskHelpers.test.ts
+++ b/tests/ui/EditTaskHelpers.test.ts
@@ -1,4 +1,7 @@
-import { labelContentWithAccessKey } from '../../src/ui/EditTaskHelpers';
+/**
+ * @jest-environment jsdom
+ */
+import { focusOnceClearOfKeyboard, labelContentWithAccessKey } from '../../src/ui/EditTaskHelpers';
 
 describe('labelContentWithAccessKey() tests', () => {
     it.each([
@@ -36,5 +39,179 @@ describe('labelContentWithAccessKey() tests', () => {
         ['should not add an access key span here', null, 'Should not add an access key span here'],
     ])("label text '%s' with access key '%s' should have label content '%s'", (labelText, accessKey, labelContent) => {
         expect(labelContentWithAccessKey(labelText, accessKey)).toEqual(labelContent);
+    });
+});
+
+describe('focusOnceClearOfKeyboard() tests', () => {
+    // jsdom calculates no layout, so the two things the wait actually reads have to be supplied here: the
+    // modal's transform, which is how it tells that the modal is still sliding in, and where the field is on
+    // the screen.
+    //
+    // jsdom's viewport is 768px tall and an element measures 0, so unless a test says otherwise the keyboard
+    // is expected to need no room, and anything ending above 768 counts as clear of it.
+    const viewportHeight = 768;
+    const realGetComputedStyle = window.getComputedStyle;
+    const realOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+
+    let modalEl: HTMLElement;
+    let fieldEl: HTMLTextAreaElement;
+    let transform: string;
+
+    beforeEach(() => {
+        transform = 'none';
+
+        modalEl = document.createElement('div');
+        modalEl.classList.add('modal');
+
+        fieldEl = document.createElement('textarea');
+        modalEl.appendChild(fieldEl);
+        document.body.appendChild(modalEl);
+        putFieldAt(0);
+
+        jest.spyOn(window, 'getComputedStyle').mockImplementation((...args: unknown[]) => {
+            const [el, pseudoEl] = args as [Element, string | null | undefined];
+
+            return el === modalEl
+                ? ({ transform } as unknown as CSSStyleDeclaration)
+                : realGetComputedStyle(el, pseudoEl);
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        if (realOffsetHeight) {
+            Object.defineProperty(HTMLElement.prototype, 'offsetHeight', realOffsetHeight);
+        }
+        document.body.innerHTML = '';
+    });
+
+    /** Start the modal sliding up from the bottom of the screen, as Obsidian does on a phone. */
+    function startSlidingIn() {
+        transform = 'matrix(1, 0, 0, 1, 0, 800)';
+    }
+
+    /** Land the modal where it is going to stay. */
+    function finishSlidingIn() {
+        transform = 'none';
+    }
+
+    function putFieldAt(bottom: number) {
+        fieldEl.getBoundingClientRect = () => ({ bottom } as DOMRect);
+    }
+
+    /** Pretend the keyboard needs this much room, by giving the element that measures it a height. */
+    function expectKeyboardToNeed(height: number) {
+        Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => height });
+    }
+
+    async function waitForFrames(count: number) {
+        for (let frame = 0; frame < count; frame++) {
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+    }
+
+    it('should focus a field that is not in a modal', async () => {
+        const looseFieldEl = document.createElement('textarea');
+        document.body.appendChild(looseFieldEl);
+
+        await focusOnceClearOfKeyboard(looseFieldEl);
+
+        expect(document.activeElement).toBe(looseFieldEl);
+    });
+
+    it('should focus the field without waiting, when the modal is not moving', async () => {
+        // Where the field is does not matter: a modal that has stopped moving is where it is going to stay,
+        // so the keyboard appearing cannot move the field out from under it.
+        putFieldAt(viewportHeight * 10);
+
+        await focusOnceClearOfKeyboard(fieldEl);
+
+        expect(document.activeElement).toBe(fieldEl);
+    });
+
+    it('should not focus the field until it has risen clear of the keyboard', async () => {
+        startSlidingIn();
+        putFieldAt(viewportHeight * 2);
+
+        const focused = focusOnceClearOfKeyboard(fieldEl);
+        await waitForFrames(5);
+        expect(document.activeElement).not.toBe(fieldEl);
+
+        putFieldAt(viewportHeight / 2);
+        await focused;
+
+        expect(document.activeElement).toBe(fieldEl);
+    });
+
+    it('should count the space the keyboard is going to need as out of reach', async () => {
+        expectKeyboardToNeed(300);
+        startSlidingIn();
+
+        // Inside the viewport, but inside the bottom 300px of it that the keyboard is going to cover.
+        putFieldAt(600);
+
+        const focused = focusOnceClearOfKeyboard(fieldEl);
+        await waitForFrames(5);
+        expect(document.activeElement).not.toBe(fieldEl);
+
+        putFieldAt(400);
+        await focused;
+
+        expect(document.activeElement).toBe(fieldEl);
+    });
+
+    it('should focus the field once the modal has arrived, even if it never rose clear', async () => {
+        startSlidingIn();
+        putFieldAt(viewportHeight * 2);
+
+        const focused = focusOnceClearOfKeyboard(fieldEl);
+        await waitForFrames(3);
+        expect(document.activeElement).not.toBe(fieldEl);
+
+        finishSlidingIn();
+        await focused;
+
+        expect(document.activeElement).toBe(fieldEl);
+    });
+
+    it('should give up waiting, and focus the field anyway, when the modal never stops moving', async () => {
+        const now = jest.spyOn(Date, 'now').mockReturnValue(0);
+        startSlidingIn();
+        putFieldAt(viewportHeight * 2);
+
+        const focused = focusOnceClearOfKeyboard(fieldEl);
+        await waitForFrames(3);
+        expect(document.activeElement).not.toBe(fieldEl);
+
+        // Well past the point where it stops waiting for a modal that is going nowhere.
+        now.mockReturnValue(60_000);
+        await focused;
+
+        expect(document.activeElement).toBe(fieldEl);
+    });
+
+    it('should not let focusing the field scroll it into view', async () => {
+        // Focus does its own scrolling to reveal the field, which would undo the point of the wait.
+        const focus = jest.spyOn(fieldEl, 'focus');
+
+        await focusOnceClearOfKeyboard(fieldEl);
+
+        expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
+    it('should quietly do nothing if the modal is closed while the field is still rising', async () => {
+        startSlidingIn();
+        putFieldAt(viewportHeight * 2);
+
+        const focused = focusOnceClearOfKeyboard(fieldEl);
+        await waitForFrames(2);
+
+        // Closing the modal takes the field out of the document with it, and a field that is not in the
+        // document has no size and cannot be focused.
+        modalEl.remove();
+        putFieldAt(0);
+
+        await expect(focused).resolves.toBeUndefined();
+        expect(document.activeElement).not.toBe(fieldEl);
     });
 });


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #3988

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

On a phone, the Edit Task modal often opens already scrolled part way down the form, with the Description field off the top of the screen — most reliably on the first open after Obsidian restarts. The cause is that EditTask.svelte focuses the Description field on a fixed delay after mount, but Modal.open() builds the component before it starts sliding the modal up from the bottom of the screen, and that slide is applied from a batched setTimeout(…, 0) that cannot run until the main thread is free. 

Measured on an 814px modal, the modal had not moved at all 50ms after opening and did not finish arriving until 296–343ms, so focus() was landing on a field a full modal height below its final position; WebKit remembered that position and scrolled .modal-content to reveal it when the software keyboard appeared. preventScroll does not help, as it only suppresses the scrolling focus() itself performs, and no fixed delay can be correct because it would have to cover an unpredictable wait for the main thread as well as the slide. 

This PR waits instead until the field has risen above where the keyboard will be, at which point WebKit can see all of it and has no reason to scroll — a point reached well before the slide ends, since the easing covers most of the distance early, so the keyboard still appears promptly. The keyboard's expected size now comes from a new --tasks-keyboard-space-allowance custom property that the existing keyboard-padding rule also uses, so a CSS snippet overriding it keeps the padding and the wait in step.

## Motivation and Context

Fixes #3988 

## How has this been tested?

unit testing, manual verification on device (both desktop and mobile)

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
