### PR TITLE
refactor: Use Obsidian DOM extensions, by providing test implementations of some of them

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -87,8 +87,8 @@ const typescriptCommonRules = {
     'obsidianmd/no-global-this': on_or_off,
     'obsidianmd/no-nodejs-modules': 1, // Can disable this on test files
     'obsidianmd/no-static-styles-assignment': 1,
-    'obsidianmd/prefer-active-doc': on_or_off,
-    'obsidianmd/prefer-create-el': on_or_off,
+    'obsidianmd/prefer-active-doc': 1,
+    'obsidianmd/prefer-create-el': 1,
     'obsidianmd/prefer-get-language': 1,
     'obsidianmd/prefer-window-timers': on_or_off,
     'obsidianmd/rule-custom-message': on_or_off,

--- a/lint.txt
+++ b/lint.txt
@@ -13,7 +13,6 @@ $ eslint ./src       && eslint ./tests       && tsc --noEmit --pretty && svelte-
 Prefer explicitly defining any function parameters and return type                                                                                    @typescript-eslint/no-unsafe-function-type
     78:9   warning  Use 'window.requestAnimationFrame()' instead of 'requestAnimationFrame()' for popout window compatibility                                                                                                  obsidianmd/prefer-window-timers
    714:17  warning  Unsafe call of a `Function` typed value                                                                                                                                                                    @typescript-eslint/no-unsafe-call
-   821:9   warning  Use 'containerEl.createDiv()' instead of 'containerEl.createEl('div')'                                                                                                                                     obsidianmd/prefer-create-el
   1009:9   warning  Unsafe call of a type that could not be resolved                                                                                                                                                           @typescript-eslint/no-unsafe-call
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/DateTime/TasksDate.ts
@@ -33,9 +32,7 @@ Prefer explicitly defining any function parameters and return type              
   152:13  warning  Use 'window.setTimeout()' instead of 'setTimeout()' for popout window compatibility  obsidianmd/prefer-window-timers
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Obsidian/TaskModal.ts
-  45:31  warning  Use 'createEl('button')' instead of 'document.createElement('button')'            obsidianmd/prefer-create-el
-  45:31  warning  Use 'activeDocument' instead of 'document' for popout window compatibility        obsidianmd/prefer-active-doc
-  54:17  warning  Promise-returning function provided to property where a void return was expected  @typescript-eslint/no-misused-promises
+  59:17  warning  Promise-returning function provided to property where a void return was expected  @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Query/Filter/BooleanField.ts
   193:62  warning  Invalid operand for a '+' operation. Operands must each be a number or string, allowing a string + any of: `any`, `boolean`, `null`, `RegExp`, `undefined`. Got `Token`  @typescript-eslint/restrict-plus-operands
@@ -54,13 +51,9 @@ Prefer explicitly defining any function parameters and return type              
   41:9   warning  Unsafe return of type `Map<any, any>` from function with return type `Map<string[], T[]>`  @typescript-eslint/no-unsafe-return
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/HtmlColumnQueryResultsRenderer.ts
-  62:62  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
+  61:62  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/HtmlQueryResultsRenderer.ts
-   50:38  warning  Use 'createDiv()' instead of 'document.createElement('div')'                                             obsidianmd/prefer-create-el
-   50:38  warning  Use 'activeDocument' instead of 'document' for popout window compatibility                               obsidianmd/prefer-active-doc
-   52:46  warning  Use 'createEl('li')' instead of 'document.createElement('li')'                                           obsidianmd/prefer-create-el
-   52:46  warning  Use 'activeDocument' instead of 'document' for popout window compatibility                               obsidianmd/prefer-active-doc
   262:27  warning  Use 'headerEl.ownerDocument.win.createSpan()' instead of 'headerEl.ownerDocument.createElement('span')'  obsidianmd/prefer-create-el
   307:40  warning  Promise returned in function argument where a void return was expected                                   @typescript-eslint/no-misused-promises
   311:44  warning  Promise returned in function argument where a void return was expected                                   @typescript-eslint/no-misused-promises
@@ -82,10 +75,8 @@ Prefer explicitly defining any function parameters and return type              
   261:46  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/TaskLineRenderer.ts
-   52:42  warning  Use 'createEl(tagName)' instead of 'document.createElement(tagName)'        obsidianmd/prefer-create-el
-   52:42  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
-  198:48  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
-  493:48  warning  Promise returned in function argument where a void return was expected      @typescript-eslint/no-misused-promises
+  171:48  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
+  466:48  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/ExpandPlaceholders.ts
    27:60  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
@@ -197,14 +188,10 @@ Prefer explicitly defining any function parameters and return type  @typescript-
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/ui/Menus/DatePicker.ts
   37:9   warning  Promise-returning function provided to property where a void return was expected  @typescript-eslint/no-misused-promises
-  47:37  warning  Use 'createDiv()' instead of 'document.createElement('div')'                      obsidianmd/prefer-create-el
-  47:37  warning  Use 'activeDocument' instead of 'document' for popout window compatibility        obsidianmd/prefer-active-doc
-  79:20  warning  Use 'createEl('button')' instead of 'document.createElement('button')'            obsidianmd/prefer-create-el
-  79:20  warning  Use 'activeDocument' instead of 'document' for popout window compatibility        obsidianmd/prefer-active-doc
-  84:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
+  76:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 135 problems (0 errors, 135 warnings)
-  0 errors and 28 warnings potentially fixable with the `--fix` option.
+✖ 122 problems (0 errors, 122 warnings)
+  0 errors and 21 warnings potentially fixable with the `--fix` option.
 
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/tests/Obsidian/CacheLoading.test.ts
@@ -220,4 +207,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 21.45s.
+Done in 22.32s.

--- a/lint.txt
+++ b/lint.txt
@@ -1,11 +1,6 @@
 yarn run v1.22.19
 $ eslint ./src       && eslint ./tests       && tsc --noEmit --pretty && svelte-check
 
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Commands/QuickSearchTasks.ts
-   87:29  warning  Use 'el.createDiv()' instead of 'el.createEl('div')'  obsidianmd/prefer-create-el
-   96:26  warning  Use 'el.createDiv()' instead of 'el.createEl('div')'  obsidianmd/prefer-create-el
-  100:26  warning  Use 'el.createDiv()' instead of 'el.createEl('div')'  obsidianmd/prefer-create-el
-
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Config/PresetsSettingsUI.ts
   286:28  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
 
@@ -208,8 +203,8 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   79:20  warning  Use 'activeDocument' instead of 'document' for popout window compatibility        obsidianmd/prefer-active-doc
   84:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 138 problems (0 errors, 138 warnings)
-  0 errors and 31 warnings potentially fixable with the `--fix` option.
+✖ 135 problems (0 errors, 135 warnings)
+  0 errors and 28 warnings potentially fixable with the `--fix` option.
 
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/tests/Obsidian/CacheLoading.test.ts
@@ -225,4 +220,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 21.27s.
+Done in 21.45s.

--- a/lint.txt
+++ b/lint.txt
@@ -1,9 +1,6 @@
 yarn run v1.22.19
 $ eslint ./src       && eslint ./tests       && tsc --noEmit --pretty && svelte-check
 
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Config/PresetsSettingsUI.ts
-  286:28  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
-
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Config/Settings.ts
   224:5  warning  Unsafe assignment of an `any` value  @typescript-eslint/no-unsafe-assignment
 
@@ -54,11 +51,10 @@ Prefer explicitly defining any function parameters and return type              
   61:62  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/HtmlQueryResultsRenderer.ts
-  262:27  warning  Use 'headerEl.ownerDocument.win.createSpan()' instead of 'headerEl.ownerDocument.createElement('span')'  obsidianmd/prefer-create-el
-  307:40  warning  Promise returned in function argument where a void return was expected                                   @typescript-eslint/no-misused-promises
-  311:44  warning  Promise returned in function argument where a void return was expected                                   @typescript-eslint/no-misused-promises
-  332:42  warning  Promise returned in function argument where a void return was expected                                   @typescript-eslint/no-misused-promises
-  340:48  warning  Promise returned in function argument where a void return was expected                                   @typescript-eslint/no-misused-promises
+  307:40  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
+  311:44  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
+  332:42  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
+  340:48  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/QueryRenderer.ts
   162:47  warning  Promise returned in function argument where a void return was expected                                     @typescript-eslint/no-misused-promises
@@ -190,7 +186,7 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   37:9   warning  Promise-returning function provided to property where a void return was expected  @typescript-eslint/no-misused-promises
   76:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 122 problems (0 errors, 122 warnings)
+✖ 120 problems (0 errors, 120 warnings)
   0 errors and 21 warnings potentially fixable with the `--fix` option.
 
 
@@ -207,4 +203,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 22.32s.
+Done in 21.30s.

--- a/lint.txt
+++ b/lint.txt
@@ -2,14 +2,9 @@ yarn run v1.22.19
 $ eslint ./src       && eslint ./tests       && tsc --noEmit --pretty && svelte-check
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Commands/QuickSearchTasks.ts
-   80:26  warning  Use 'createEl('input')' instead of 'document.createElement('input')'        obsidianmd/prefer-create-el
-   80:26  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
-   88:29  warning  Use 'createDiv()' instead of 'document.createElement('div')'                obsidianmd/prefer-create-el
-   88:29  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
-   98:26  warning  Use 'createDiv()' instead of 'document.createElement('div')'                obsidianmd/prefer-create-el
-   98:26  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
-  103:26  warning  Use 'createDiv()' instead of 'document.createElement('div')'                obsidianmd/prefer-create-el
-  103:26  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
+   87:29  warning  Use 'el.createDiv()' instead of 'el.createEl('div')'  obsidianmd/prefer-create-el
+   96:26  warning  Use 'el.createDiv()' instead of 'el.createEl('div')'  obsidianmd/prefer-create-el
+  100:26  warning  Use 'el.createDiv()' instead of 'el.createEl('div')'  obsidianmd/prefer-create-el
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Config/PresetsSettingsUI.ts
   286:28  warning  Use 'activeDocument' instead of 'document' for popout window compatibility  obsidianmd/prefer-active-doc
@@ -213,8 +208,8 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   79:20  warning  Use 'activeDocument' instead of 'document' for popout window compatibility        obsidianmd/prefer-active-doc
   84:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 143 problems (0 errors, 143 warnings)
-  0 errors and 32 warnings potentially fixable with the `--fix` option.
+✖ 138 problems (0 errors, 138 warnings)
+  0 errors and 31 warnings potentially fixable with the `--fix` option.
 
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/tests/Obsidian/CacheLoading.test.ts
@@ -230,4 +225,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 22.05s.
+Done in 21.27s.

--- a/lint.txt
+++ b/lint.txt
@@ -106,7 +106,6 @@ Prefer explicitly defining any function parameters and return type              
   121:31  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
   122:18  warning  Unsafe member access .query on an `any` value                                                                   @typescript-eslint/no-unsafe-member-access
   148:43  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
-  149:12  warning  This assertion is unnecessary since the receiver accepts the original type of the expression                    @typescript-eslint/no-unnecessary-type-assertion
   149:27  warning  Unsafe argument of type `any` assigned to a parameter of type `ArrayLike<unknown> | { [s: string]: unknown; }`  @typescript-eslint/no-unsafe-argument
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/Expression.ts
@@ -214,8 +213,8 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   79:20  warning  Use 'activeDocument' instead of 'document' for popout window compatibility        obsidianmd/prefer-active-doc
   84:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 144 problems (0 errors, 144 warnings)
-  0 errors and 33 warnings potentially fixable with the `--fix` option.
+✖ 143 problems (0 errors, 143 warnings)
+  0 errors and 32 warnings potentially fixable with the `--fix` option.
 
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/tests/Obsidian/CacheLoading.test.ts
@@ -231,4 +230,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 21.63s.
+Done in 22.05s.

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -77,17 +77,15 @@ export class QuickSearchTasksModal extends SuggestModal<Task> {
         const suggestion = taskSearchSuggestionText(task);
         el.classList.add('tasks-quick-search-result');
 
-        const checkbox = document.createElement('input');
+        const checkbox = el.createEl('input');
         checkbox.type = 'checkbox';
         checkbox.checked = task.isDone;
         checkbox.tabIndex = -1;
         checkbox.classList.add('task-list-item-checkbox', 'tasks-quick-search-result-checkbox');
         checkbox.setAttribute('aria-label', `Task status: ${task.status.name}`);
-        el.appendChild(checkbox);
 
-        const description = document.createElement('div');
+        const description = el.createEl('div');
         description.classList.add('tasks-quick-search-result-description');
-        el.appendChild(description);
         const renderComponent = new Component();
         renderComponent.load();
         this.renderComponents.push(renderComponent);
@@ -95,15 +93,13 @@ export class QuickSearchTasksModal extends SuggestModal<Task> {
             description.textContent = suggestion.description;
         });
 
-        const location = document.createElement('div');
+        const location = el.createEl('div');
         location.classList.add('tasks-quick-search-result-location');
         location.textContent = `${suggestion.source} · ${suggestion.heading}`;
-        el.appendChild(location);
 
-        const metadata = document.createElement('div');
+        const metadata = el.createEl('div');
         metadata.classList.add('tasks-quick-search-result-metadata');
         metadata.textContent = taskSearchMetadataText(task).join(' ');
-        el.appendChild(metadata);
     }
 
     public onChooseSuggestion(task: Task, _evt: MouseEvent | KeyboardEvent): void {

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -77,10 +77,12 @@ export class QuickSearchTasksModal extends SuggestModal<Task> {
         const suggestion = taskSearchSuggestionText(task);
         el.classList.add('tasks-quick-search-result');
 
-        const checkbox = el.createEl('input', { type: 'checkbox' });
+        const checkbox = el.createEl('input', {
+            type: 'checkbox',
+            cls: ['task-list-item-checkbox', 'tasks-quick-search-result-checkbox'],
+        });
         checkbox.checked = task.isDone;
         checkbox.tabIndex = -1;
-        checkbox.classList.add('task-list-item-checkbox', 'tasks-quick-search-result-checkbox');
         checkbox.setAttribute('aria-label', `Task status: ${task.status.name}`);
 
         const description = el.createDiv();

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -85,8 +85,7 @@ export class QuickSearchTasksModal extends SuggestModal<Task> {
         checkbox.tabIndex = -1;
         checkbox.setAttribute('aria-label', `Task status: ${task.status.name}`);
 
-        const description = el.createDiv();
-        description.classList.add('tasks-quick-search-result-description');
+        const description = el.createDiv({ cls: 'tasks-quick-search-result-description' });
         const renderComponent = new Component();
         renderComponent.load();
         this.renderComponents.push(renderComponent);
@@ -94,12 +93,10 @@ export class QuickSearchTasksModal extends SuggestModal<Task> {
             description.textContent = suggestion.description;
         });
 
-        const location = el.createDiv();
-        location.classList.add('tasks-quick-search-result-location');
+        const location = el.createDiv({ cls: 'tasks-quick-search-result-location' });
         location.textContent = `${suggestion.source} · ${suggestion.heading}`;
 
-        const metadata = el.createDiv();
-        metadata.classList.add('tasks-quick-search-result-metadata');
+        const metadata = el.createDiv({ cls: 'tasks-quick-search-result-metadata' });
         metadata.textContent = taskSearchMetadataText(task).join(' ');
     }
 

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -93,11 +93,15 @@ export class QuickSearchTasksModal extends SuggestModal<Task> {
             description.textContent = suggestion.description;
         });
 
-        const location = el.createDiv({ cls: 'tasks-quick-search-result-location' });
-        location.textContent = `${suggestion.source} · ${suggestion.heading}`;
+        el.createDiv({
+            cls: 'tasks-quick-search-result-location',
+            text: `${suggestion.source} · ${suggestion.heading}`,
+        });
 
-        const metadata = el.createDiv({ cls: 'tasks-quick-search-result-metadata' });
-        metadata.textContent = taskSearchMetadataText(task).join(' ');
+        el.createDiv({
+            cls: 'tasks-quick-search-result-metadata',
+            text: taskSearchMetadataText(task).join(' '),
+        });
     }
 
     public onChooseSuggestion(task: Task, _evt: MouseEvent | KeyboardEvent): void {

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -84,7 +84,7 @@ export class QuickSearchTasksModal extends SuggestModal<Task> {
         checkbox.classList.add('task-list-item-checkbox', 'tasks-quick-search-result-checkbox');
         checkbox.setAttribute('aria-label', `Task status: ${task.status.name}`);
 
-        const description = el.createEl('div');
+        const description = el.createDiv();
         description.classList.add('tasks-quick-search-result-description');
         const renderComponent = new Component();
         renderComponent.load();
@@ -93,11 +93,11 @@ export class QuickSearchTasksModal extends SuggestModal<Task> {
             description.textContent = suggestion.description;
         });
 
-        const location = el.createEl('div');
+        const location = el.createDiv();
         location.classList.add('tasks-quick-search-result-location');
         location.textContent = `${suggestion.source} · ${suggestion.heading}`;
 
-        const metadata = el.createEl('div');
+        const metadata = el.createDiv();
         metadata.classList.add('tasks-quick-search-result-metadata');
         metadata.textContent = taskSearchMetadataText(task).join(' ');
     }

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -77,8 +77,7 @@ export class QuickSearchTasksModal extends SuggestModal<Task> {
         const suggestion = taskSearchSuggestionText(task);
         el.classList.add('tasks-quick-search-result');
 
-        const checkbox = el.createEl('input');
-        checkbox.type = 'checkbox';
+        const checkbox = el.createEl('input', { type: 'checkbox' });
         checkbox.checked = task.isDone;
         checkbox.tabIndex = -1;
         checkbox.classList.add('task-list-item-checkbox', 'tasks-quick-search-result-checkbox');

--- a/src/Config/PresetsSettingsUI.ts
+++ b/src/Config/PresetsSettingsUI.ts
@@ -283,7 +283,7 @@ export class PresetsSettingsUI {
      * Clears all drop indicators
      */
     private clearDropIndicators() {
-        const containers = document.querySelectorAll('.tasks-presets-wrapper');
+        const containers = activeDocument.querySelectorAll('.tasks-presets-wrapper');
         containers.forEach((container) => {
             this.clearDropIndicator(container as HTMLElement);
         });

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -818,7 +818,7 @@ export class SettingsTab extends PluginSettingTab {
             );
         });
 
-        containerEl.createEl('div');
+        containerEl.createDiv();
 
         /* -------------------- 'Add New Task Status' button -------------------- */
         const setting = new Setting(containerEl).addButton((button) => {

--- a/src/Obsidian/InlineRenderer.ts
+++ b/src/Obsidian/InlineRenderer.ts
@@ -5,7 +5,7 @@ import { TaskLayoutOptions } from '../Layout/TaskLayoutOptions';
 import { QueryLayoutOptions } from '../Layout/QueryLayoutOptions';
 import { TasksFile } from '../Scripting/TasksFile';
 import { Task } from '../Task/Task';
-import { TaskLineRenderer, createAndAppendElement, reconcileReplacementTask } from '../Renderer/TaskLineRenderer';
+import { TaskLineRenderer, reconcileReplacementTask } from '../Renderer/TaskLineRenderer';
 import { TaskLocation } from '../Task/TaskLocation';
 
 /**
@@ -134,7 +134,7 @@ export class InlineRenderer {
             }
             const dataLine: string = renderedElement.getAttr('data-line') ?? '0';
             const taskIndex: number = Number.parseInt(dataLine, 10);
-            const taskElement = createAndAppendElement('li', element);
+            const taskElement = element.createEl('li');
             await taskLineRenderer.renderTaskLine({
                 li: taskElement,
                 task,

--- a/src/Obsidian/TaskModal.ts
+++ b/src/Obsidian/TaskModal.ts
@@ -42,7 +42,7 @@ export class TaskModal extends Modal {
         this.titleEl.setText('Create or edit Task');
         this.modalEl.addClass('tasks-edit-modal-container');
 
-        const optionsButton = document.createElement('button');
+        const optionsButton = this.modalEl.createEl('button');
         // Add same classes as the default Obsidian modal close button.
         optionsButton.addClasses(['modal-close-button', 'mod-raised', 'clickable-icon']);
         // But overload the 'inset-inline-end' property for a correct position.
@@ -55,7 +55,6 @@ export class TaskModal extends Modal {
             });
             optionsModal.open();
         };
-        this.modalEl.appendChild(optionsButton);
 
         const { contentEl } = this;
 

--- a/src/Obsidian/TaskModal.ts
+++ b/src/Obsidian/TaskModal.ts
@@ -42,11 +42,16 @@ export class TaskModal extends Modal {
         this.titleEl.setText('Create or edit Task');
         this.modalEl.addClass('tasks-edit-modal-container');
 
-        const optionsButton = this.modalEl.createEl('button');
-        // Add same classes as the default Obsidian modal close button.
-        optionsButton.addClasses(['modal-close-button', 'mod-raised', 'clickable-icon']);
-        // But overload the 'inset-inline-end' property for a correct position.
-        optionsButton.addClass('modal-option-button');
+        const optionsButton = this.modalEl.createEl('button', {
+            cls: [
+                // Add same classes as the default Obsidian modal close button:
+                'modal-close-button',
+                'mod-raised',
+                'clickable-icon',
+                // But overload the 'inset-inline-end' property for a correct position:
+                'modal-option-button',
+            ],
+        });
         setIcon(optionsButton, 'settings');
         optionsButton.onclick = () => {
             const optionsModal = new OptionsModal({

--- a/src/Renderer/HtmlColumnQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlColumnQueryResultsRenderer.ts
@@ -5,7 +5,6 @@ import type { TaskGroup } from '../Query/Group/TaskGroup';
 import { createEditingInstructionForGroup } from '../ui/EditInstructions/CreateEditingInstructionForGroup';
 import { DragState } from './DragState';
 import { HtmlQueryResultsRenderer } from './HtmlQueryResultsRenderer';
-import { createAndAppendElement } from './TaskLineRenderer';
 
 export class HtmlColumnQueryResultsRenderer extends HtmlQueryResultsRenderer {
     private readonly dragState = new DragState();
@@ -17,7 +16,7 @@ export class HtmlColumnQueryResultsRenderer extends HtmlQueryResultsRenderer {
         this.columnContainers.length = 0;
         this.activeDropColumn = null;
 
-        const columnsContainer = createAndAppendElement('div', originalParent);
+        const columnsContainer = originalParent.createEl('div');
         columnsContainer.classList.add('tasks-columns');
 
         for (const group of tasksSortedLimitedGrouped.groups) {
@@ -26,7 +25,7 @@ export class HtmlColumnQueryResultsRenderer extends HtmlQueryResultsRenderer {
             }
 
             if (group.groupHeadings.length == 0 || group.groupHeadings[0].nestingLevel === 0) {
-                const columnContainer = createAndAppendElement('div', columnsContainer);
+                const columnContainer = columnsContainer.createEl('div');
                 columnContainer.classList.add('tasks-columns-column');
                 this.columnContainers.push(columnContainer);
 

--- a/src/Renderer/HtmlColumnQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlColumnQueryResultsRenderer.ts
@@ -16,7 +16,7 @@ export class HtmlColumnQueryResultsRenderer extends HtmlQueryResultsRenderer {
         this.columnContainers.length = 0;
         this.activeDropColumn = null;
 
-        const columnsContainer = originalParent.createEl('div');
+        const columnsContainer = originalParent.createDiv();
         columnsContainer.classList.add('tasks-columns');
 
         for (const group of tasksSortedLimitedGrouped.groups) {
@@ -25,7 +25,7 @@ export class HtmlColumnQueryResultsRenderer extends HtmlQueryResultsRenderer {
             }
 
             if (group.groupHeadings.length == 0 || group.groupHeadings[0].nestingLevel === 0) {
-                const columnContainer = columnsContainer.createEl('div');
+                const columnContainer = columnsContainer.createDiv();
                 columnContainer.classList.add('tasks-columns-column');
                 this.columnContainers.push(columnContainer);
 

--- a/src/Renderer/HtmlQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlQueryResultsRenderer.ts
@@ -45,9 +45,9 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
 
     private readonly taskLineRenderer: TaskLineRenderer;
 
-    // document.createElement() creates dummy elements that must be overwritten later
+    // createDiv() creates dummy elements that must be overwritten later
     // with the values of elements that will be rendered
-    public content: HTMLDivElement = document.createElement('div');
+    public content: HTMLDivElement = createDiv();
     private readonly ulElementStack: HTMLUListElement[] = [];
     protected lastLIElement: HTMLLIElement = createEl('li');
 
@@ -259,7 +259,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
     }
 
     private appendGroupTaskCount(headerEl: HTMLElement, groupTaskCountText: string): void {
-        const countSpan = headerEl.ownerDocument.createElement('span');
+        const countSpan = createSpan();
         countSpan.classList.add('tasks-group-count');
         countSpan.textContent = groupTaskCountText;
 

--- a/src/Renderer/HtmlQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlQueryResultsRenderer.ts
@@ -13,7 +13,7 @@ import { PostponeMenu } from '../ui/Menus/PostponeMenu';
 import { showMenu } from '../ui/Menus/TaskEditingMenu';
 import type { BacklinksEventHandler, EditButtonClickHandler } from './QueryResultsRenderer';
 import { QueryResultsRendererBase } from './QueryResultsRendererBase';
-import { TaskLineRenderer, type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
+import { TaskLineRenderer, type TextRenderer } from './TaskLineRenderer';
 
 /**
  * Represent the parameters required for rendering a query with {@link QueryResultsRenderer}.
@@ -102,8 +102,8 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
     }
 
     protected renderErrorMessage(errorMessage: string): void {
-        const container = createAndAppendElement('div', this.content);
-        const pre = createAndAppendElement('pre', container);
+        const container = this.content.createEl('div');
+        const pre = container.createEl('pre');
         pre.textContent = `Tasks query: ${errorMessage}`;
     }
 
@@ -112,7 +112,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
     }
 
     protected renderExplanation(explanation: string | null) {
-        const explanationsBlock = createAndAppendElement('pre', this.content);
+        const explanationsBlock = this.content.createEl('pre');
         explanationsBlock.classList.add('plugin-tasks-query-explanation');
         explanationsBlock.textContent = explanation;
     }
@@ -120,7 +120,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
     protected beginTaskList(): void {
         const isFirstTaskListInContainer = this.ulElementStack.length === 0;
         const taskListContainer = isFirstTaskListInContainer ? this.content : this.lastLIElement;
-        const taskList = createAndAppendElement('ul', taskListContainer);
+        const taskList = taskListContainer.createEl('ul');
 
         taskList.classList.add(
             'contains-task-list',
@@ -143,7 +143,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
 
     protected beginListItem(): void {
         const taskList = this.currentULElement();
-        this.lastLIElement = createAndAppendElement('li', taskList);
+        this.lastLIElement = taskList.createEl('li');
     }
 
     protected async addListItem(listItem: ListItem, listItemIndex: number): Promise<void> {
@@ -168,7 +168,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
         const footnotes = listItem.querySelectorAll('[data-footnote-id]');
         footnotes.forEach((footnote) => footnote.remove());
 
-        const extrasSpan = createAndAppendElement('span', listItem);
+        const extrasSpan = listItem.createEl('span');
         extrasSpan.classList.add('task-extras');
 
         if (!this.query.queryLayoutOptions.hideUrgency) {
@@ -202,7 +202,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
     protected extendTaskBehaviour(_listItem: HTMLLIElement, _task: Task) {}
 
     private addEditButton(listItem: HTMLElement, task: Task) {
-        const editTaskPencil = createAndAppendElement('a', listItem);
+        const editTaskPencil = listItem.createEl('a');
         editTaskPencil.classList.add('tasks-edit');
         editTaskPencil.title = 'Edit task';
         editTaskPencil.href = '#';
@@ -218,7 +218,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
 
     private addUrgency(listItem: HTMLElement, task: Task) {
         const text = new Intl.NumberFormat().format(task.urgency);
-        const span = createAndAppendElement('span', listItem);
+        const span = listItem.createEl('span');
         span.textContent = text;
         span.classList.add('tasks-urgency');
     }
@@ -232,7 +232,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
             header = 'h5';
         }
 
-        const headerEl = createAndAppendElement(header, this.content);
+        const headerEl = this.content.createEl(header);
         headerEl.classList.add('tasks-group-heading');
 
         await this.renderGroupHeadingText(headerEl, group.displayName);
@@ -278,14 +278,14 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
     }
 
     private addBacklinks(listItem: HTMLElement, task: Task, shortMode: boolean, isFilenameUnique: boolean | undefined) {
-        const backLink = createAndAppendElement('span', listItem);
+        const backLink = listItem.createEl('span');
         backLink.classList.add('tasks-backlink');
 
         if (!shortMode) {
             backLink.append(' (');
         }
 
-        const link = createAndAppendElement('a', backLink);
+        const link = backLink.createEl('a');
 
         link.rel = 'noopener';
         link.target = '_blank';
@@ -322,7 +322,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
         const timeUnit = 'day';
         const buttonTooltipText = postponeButtonTitle(task, amount, timeUnit);
 
-        const button = createAndAppendElement('a', listItem);
+        const button = listItem.createEl('a');
         button.classList.add('tasks-postpone');
         if (shortMode) {
             button.classList.add('tasks-postpone-short-mode');
@@ -344,7 +344,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
 
     private addTaskCount(queryResult: QueryResult) {
         if (!this.query.queryLayoutOptions.hideTaskCount) {
-            const taskCount = createAndAppendElement('div', this.content);
+            const taskCount = this.content.createEl('div');
             taskCount.classList.add('task-count');
             taskCount.textContent = queryResult.totalTasksCountDisplayText();
         }

--- a/src/Renderer/HtmlQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlQueryResultsRenderer.ts
@@ -49,7 +49,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
     // with the values of elements that will be rendered
     public content: HTMLDivElement = document.createElement('div');
     private readonly ulElementStack: HTMLUListElement[] = [];
-    protected lastLIElement: HTMLLIElement = document.createElement('li');
+    protected lastLIElement: HTMLLIElement = createEl('li');
 
     private readonly htmlQueryRendererParameters: HTMLQueryRendererParameters;
 

--- a/src/Renderer/HtmlQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlQueryResultsRenderer.ts
@@ -45,7 +45,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
 
     private readonly taskLineRenderer: TaskLineRenderer;
 
-    // createDiv() creates dummy elements that must be overwritten later
+    // createDiv() and createEl() create dummy elements that must be overwritten later
     // with the values of elements that will be rendered
     public content: HTMLDivElement = createDiv();
     private readonly ulElementStack: HTMLUListElement[] = [];

--- a/src/Renderer/HtmlQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlQueryResultsRenderer.ts
@@ -102,7 +102,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
     }
 
     protected renderErrorMessage(errorMessage: string): void {
-        const container = this.content.createEl('div');
+        const container = this.content.createDiv();
         const pre = container.createEl('pre');
         pre.textContent = `Tasks query: ${errorMessage}`;
     }
@@ -344,7 +344,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
 
     private addTaskCount(queryResult: QueryResult) {
         if (!this.query.queryLayoutOptions.hideTaskCount) {
-            const taskCount = this.content.createEl('div');
+            const taskCount = this.content.createDiv();
             taskCount.classList.add('task-count');
             taskCount.textContent = queryResult.totalTasksCountDisplayText();
         }

--- a/src/Renderer/HtmlQueryResultsRenderer.ts
+++ b/src/Renderer/HtmlQueryResultsRenderer.ts
@@ -168,7 +168,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
         const footnotes = listItem.querySelectorAll('[data-footnote-id]');
         footnotes.forEach((footnote) => footnote.remove());
 
-        const extrasSpan = listItem.createEl('span');
+        const extrasSpan = listItem.createSpan();
         extrasSpan.classList.add('task-extras');
 
         if (!this.query.queryLayoutOptions.hideUrgency) {
@@ -218,7 +218,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
 
     private addUrgency(listItem: HTMLElement, task: Task) {
         const text = new Intl.NumberFormat().format(task.urgency);
-        const span = listItem.createEl('span');
+        const span = listItem.createSpan();
         span.textContent = text;
         span.classList.add('tasks-urgency');
     }
@@ -278,7 +278,7 @@ export class HtmlQueryResultsRenderer extends QueryResultsRendererBase {
     }
 
     private addBacklinks(listItem: HTMLElement, task: Task, shortMode: boolean, isFilenameUnique: boolean | undefined) {
-        const backLink = listItem.createEl('span');
+        const backLink = listItem.createSpan();
         backLink.classList.add('tasks-backlink');
 
         if (!shortMode) {

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -340,7 +340,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private async renderResults(state: State, tasks: Task[]) {
-        const content = this.containerEl.createEl('div');
+        const content = this.containerEl.createDiv();
         await this.queryResultsRenderer.render(state, tasks, content);
 
         this.containerEl.firstChild?.replaceWith(content);

--- a/src/Renderer/QueryRenderer.ts
+++ b/src/Renderer/QueryRenderer.ts
@@ -21,7 +21,7 @@ import { TasksFile } from '../Scripting/TasksFile';
 import { DateFallback } from '../DateTime/DateFallback';
 import type { Task } from '../Task/Task';
 import { type BacklinksEventHandler, type EditButtonClickHandler, QueryResultsRenderer } from './QueryResultsRenderer';
-import { TaskLineRenderer, createAndAppendElement } from './TaskLineRenderer';
+import { TaskLineRenderer } from './TaskLineRenderer';
 
 type RenderParams = { tasks: Task[]; state: State };
 
@@ -340,7 +340,7 @@ class QueryRenderChild extends MarkdownRenderChild {
     }
 
     private async renderResults(state: State, tasks: Task[]) {
-        const content = createAndAppendElement('div', this.containerEl);
+        const content = this.containerEl.createEl('div');
         await this.queryResultsRenderer.render(state, tasks, content);
 
         this.containerEl.firstChild?.replaceWith(content);

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -12,7 +12,7 @@ import type { Task } from '../Task/Task';
 import { HtmlColumnQueryResultsRenderer } from './HtmlColumnQueryResultsRenderer';
 import { type HTMLQueryRendererParameters, HtmlQueryResultsRenderer } from './HtmlQueryResultsRenderer';
 import { MarkdownQueryResultsRenderer } from './MarkdownQueryResultsRenderer';
-import { type TextRenderer, createAndAppendElement } from './TaskLineRenderer';
+import type { TextRenderer } from './TaskLineRenderer';
 
 export type BacklinksEventHandler = (ev: MouseEvent, task: Task) => Promise<void>;
 export type EditButtonClickHandler = (event: MouseEvent, task: Task, allTasks: Task[]) => void;
@@ -193,16 +193,16 @@ export class QueryResultsRenderer {
             return;
         }
 
-        const toolbar = createAndAppendElement('div', content);
+        const toolbar = content.createEl('div');
         toolbar.classList.add('plugin-tasks-toolbar');
         this.addSearchBox(toolbar, content);
         this.addCopyButton(toolbar);
     }
 
     private addSearchBox(toolbar: HTMLDivElement, content: HTMLDivElement) {
-        const label = createAndAppendElement('label', toolbar);
+        const label = toolbar.createEl('label');
         setIcon(label, 'lucide-filter');
-        const searchBox = createAndAppendElement('input', label);
+        const searchBox = label.createEl('input');
         searchBox.value = this._filterString;
         searchBox.placeholder = 'Filter by description...';
         setTooltip(searchBox, 'Filter results');
@@ -255,7 +255,7 @@ export class QueryResultsRenderer {
     }
 
     private addCopyButton(toolbar: HTMLDivElement) {
-        const copyButton = createAndAppendElement('button', toolbar);
+        const copyButton = toolbar.createEl('button');
         setIcon(copyButton, 'lucide-copy');
         setTooltip(copyButton, 'Copy results');
         copyButton.addEventListener('click', async () => {

--- a/src/Renderer/QueryResultsRenderer.ts
+++ b/src/Renderer/QueryResultsRenderer.ts
@@ -193,7 +193,7 @@ export class QueryResultsRenderer {
             return;
         }
 
-        const toolbar = content.createEl('div');
+        const toolbar = content.createDiv();
         toolbar.classList.add('plugin-tasks-toolbar');
         this.addSearchBox(toolbar, content);
         this.addCopyButton(toolbar);

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -30,8 +30,8 @@ export type TextRenderer = (
 /**
  * Create an HTML element, and append it to a parent element.
  *
- * Unlike the equivalent Obsidian convenience function li.createEl(),
- * this can be called from our automated tests.
+ * This could actually now be inlined, as our tests do have a partial implementation
+ * of el.createEl()
  *
  * @param tagName - the type of element to be created, for example 'ul', 'div', 'span', 'li'.
  * @param parentElement - the parent element, to which the created element will be appended.
@@ -43,15 +43,7 @@ export function createAndAppendElement<K extends keyof HTMLElementTagNameMap>(
     tagName: K,
     parentElement: HTMLElement,
 ): HTMLElementTagNameMap[K] {
-    // Maintenance note:
-    //  We don't use the Obsidian convenience function li.createEl() here, because we don't have it available
-    //  when running tests, and we want the tests to be able to create the full div and span structure,
-    //  so had to convert all of these to the equivalent but more elaborate document.createElement() and
-    //  appendChild() calls.
-
-    const el: HTMLElementTagNameMap[K] = document.createElement(tagName);
-    parentElement.appendChild(el);
-    return el;
+    return parentElement.createEl(tagName);
 }
 
 /**

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -28,25 +28,6 @@ export type TextRenderer = (
 ) => Promise<void>;
 
 /**
- * Create an HTML element, and append it to a parent element.
- *
- * This could actually now be inlined, as our tests do have a partial implementation
- * of el.createEl()
- *
- * @param tagName - the type of element to be created, for example 'ul', 'div', 'span', 'li'.
- * @param parentElement - the parent element, to which the created element will be appended.
- *
- * @example <caption>Example call:</caption>
- * const li = createAndAppendElement('li', parentElement);
- */
-export function createAndAppendElement<K extends keyof HTMLElementTagNameMap>(
-    tagName: K,
-    parentElement: HTMLElement,
-): HTMLElementTagNameMap[K] {
-    return parentElement.createEl(tagName);
-}
-
-/**
  * Replace the original list item that Obsidian rendered in Reading View with the one
  * that Tasks has rendered.
  *
@@ -168,13 +149,13 @@ export class TaskLineRenderer {
     }): Promise<void> {
         li.classList.add('task-list-item', 'plugin-tasks-list-item');
 
-        const textSpan = createAndAppendElement('span', li);
+        const textSpan = li.createEl('span');
         textSpan.classList.add('tasks-list-text');
         await this.taskToHtml(task, textSpan, li, isTaskInQueryFile);
 
         // NOTE: this area is mentioned in `CONTRIBUTING.md` under "How does Tasks handle status changes". When
         // moving the code, remember to update that reference too.
-        const checkbox = createAndAppendElement('input', li);
+        const checkbox = li.createEl('input');
         checkbox.classList.add('task-list-item-checkbox');
         checkbox.type = 'checkbox';
         if (task.status.symbol !== ' ') {
@@ -239,13 +220,13 @@ export class TaskLineRenderer {
             );
             if (componentString) {
                 // Create the text span that will hold the rendered component
-                const span = createAndAppendElement('span', parentElement);
+                const span = parentElement.createEl('span');
 
                 // Inside that text span, we are creating another internal span, that will hold the text itself.
                 // This may seem redundant, and by default it indeed does nothing, but we do it to allow the CSS
                 // to differentiate between the container of the text and the text itself, so it will be possible
                 // to do things like surrounding only the text (rather than its whole placeholder) with a highlight
-                const internalSpan = createAndAppendElement('span', span);
+                const internalSpan = span.createEl('span');
                 await this.renderComponentText(internalSpan, componentString, component, task, isTaskInQueryFile);
                 this.addInternalClasses(component, internalSpan);
 
@@ -478,7 +459,7 @@ export class TaskLineRenderer {
     public async renderListItem(li: HTMLLIElement, listItem: ListItem, listItemIndex: number): Promise<HTMLLIElement> {
         if (listItem.statusCharacter) {
             // special case: handle toggling of task lines without the global query, in Tasks search results
-            const checkbox = createAndAppendElement('input', li);
+            const checkbox = li.createEl('input');
             checkbox.classList.add('task-list-item-checkbox');
             checkbox.type = 'checkbox';
 
@@ -508,7 +489,7 @@ export class TaskLineRenderer {
             li.setAttribute('data-line', listItemIndex.toString());
         }
 
-        const span = createAndAppendElement('span', li);
+        const span = li.createEl('span');
         await this.textRenderer(
             this.obsidianApp,
             listItem.description,

--- a/src/Renderer/TaskLineRenderer.ts
+++ b/src/Renderer/TaskLineRenderer.ts
@@ -149,7 +149,7 @@ export class TaskLineRenderer {
     }): Promise<void> {
         li.classList.add('task-list-item', 'plugin-tasks-list-item');
 
-        const textSpan = li.createEl('span');
+        const textSpan = li.createSpan();
         textSpan.classList.add('tasks-list-text');
         await this.taskToHtml(task, textSpan, li, isTaskInQueryFile);
 
@@ -220,13 +220,13 @@ export class TaskLineRenderer {
             );
             if (componentString) {
                 // Create the text span that will hold the rendered component
-                const span = parentElement.createEl('span');
+                const span = parentElement.createSpan();
 
                 // Inside that text span, we are creating another internal span, that will hold the text itself.
                 // This may seem redundant, and by default it indeed does nothing, but we do it to allow the CSS
                 // to differentiate between the container of the text and the text itself, so it will be possible
                 // to do things like surrounding only the text (rather than its whole placeholder) with a highlight
-                const internalSpan = span.createEl('span');
+                const internalSpan = span.createSpan();
                 await this.renderComponentText(internalSpan, componentString, component, task, isTaskInQueryFile);
                 this.addInternalClasses(component, internalSpan);
 
@@ -489,7 +489,7 @@ export class TaskLineRenderer {
             li.setAttribute('data-line', listItemIndex.toString());
         }
 
-        const span = li.createEl('span');
+        const span = li.createSpan();
         await this.textRenderer(
             this.obsidianApp,
             listItem.description,

--- a/src/Scripting/ExpandPlaceholders.ts
+++ b/src/Scripting/ExpandPlaceholders.ts
@@ -146,5 +146,5 @@ function isPlainMustachePlaceholder(reconstructed: string): boolean {
 }
 
 function createExpressionParameters(view: any): ExpressionParameter[] {
-    return Object.entries(view) as ExpressionParameter[];
+    return Object.entries(view);
 }

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -44,8 +44,7 @@ export function promptForDate(
         },
         onReady: (_selectedDates, _dateStr, instance) => {
             // Add custom buttons dynamically
-            const buttonContainer = instance.calendarContainer.createDiv();
-            buttonContainer.classList.add('tasks-date-picker-buttons');
+            const buttonContainer = instance.calendarContainer.createDiv({ cls: 'tasks-date-picker-buttons' });
 
             // Create "Clear" button
             addButton(buttonContainer, instance, task, taskSaver, 'Clear', () => {

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -76,8 +76,7 @@ function addButton(
     buttonName: string,
     applyDate: () => Task[],
 ) {
-    const button = document.createElement('button');
-    button.type = 'button';
+    const button = buttonContainer.createEl('button');
     button.textContent = buttonName;
     button.classList.add('flatpickr-button');
 
@@ -86,5 +85,4 @@ function addButton(
         await taskSaver(task, newTask);
         instance.destroy();
     });
-    buttonContainer.appendChild(button);
 }

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -71,9 +71,7 @@ function addButton(
     buttonName: string,
     applyDate: () => Task[],
 ) {
-    const button = buttonContainer.createEl('button');
-    button.textContent = buttonName;
-    button.classList.add('flatpickr-button');
+    const button = buttonContainer.createEl('button', { cls: 'flatpickr-button', text: buttonName });
 
     button.addEventListener('click', async () => {
         const newTask = applyDate();

--- a/src/ui/Menus/DatePicker.ts
+++ b/src/ui/Menus/DatePicker.ts
@@ -44,7 +44,7 @@ export function promptForDate(
         },
         onReady: (_selectedDates, _dateStr, instance) => {
             // Add custom buttons dynamically
-            const buttonContainer = document.createElement('div');
+            const buttonContainer = instance.calendarContainer.createDiv();
             buttonContainer.classList.add('tasks-date-picker-buttons');
 
             // Create "Clear" button
@@ -57,10 +57,6 @@ export function promptForDate(
                 const today = new Date();
                 return new SetTaskDate(dateFieldToEdit, today).apply(task);
             });
-
-            // Append the button container to the Flatpickr calendar container
-            const calendarContainer = instance.calendarContainer;
-            calendarContainer.appendChild(buttonContainer);
         },
     });
 

--- a/tests/Renderer/TaskLineRenderer.test.ts
+++ b/tests/Renderer/TaskLineRenderer.test.ts
@@ -10,11 +10,7 @@ import { QueryLayoutOptions } from '../../src/Layout/QueryLayoutOptions';
 import { TaskLayoutComponent, TaskLayoutOptions, taskLayoutComponents } from '../../src/Layout/TaskLayoutOptions';
 import { DateParser } from '../../src/DateTime/DateParser';
 import type { TextRenderer } from '../../src/Renderer/TaskLineRenderer';
-import {
-    TaskLineRenderer,
-    createAndAppendElement,
-    reconcileReplacementTask,
-} from '../../src/Renderer/TaskLineRenderer';
+import { TaskLineRenderer, reconcileReplacementTask } from '../../src/Renderer/TaskLineRenderer';
 import type { Task } from '../../src/Task/Task';
 import { TaskRegularExpressions } from '../../src/Task/TaskRegularExpressions';
 import { verifyWithFileExtension } from '../TestingTools/ApprovalTestHelpers';
@@ -52,7 +48,7 @@ async function renderListItem(
         queryLayoutOptions: queryLayoutOptions ?? new QueryLayoutOptions(),
     });
     const divElement = document.createElement('div');
-    const li = createAndAppendElement('li', divElement);
+    const li = divElement.createEl('li');
     await taskLineRenderer.renderTaskLine({
         li: li,
         task: task,
@@ -584,7 +580,7 @@ describe('task line rendering - preserving classes and data attributes', () => {
      */
     const originalAndReplacement = () => {
         const list = document.createElement('ul');
-        const original = createAndAppendElement('li', list);
+        const original = list.createEl('li');
         const replacement = document.createElement('li');
         return { original, replacement };
     };
@@ -629,7 +625,7 @@ describe('task line rendering - preserving classes and data attributes', () => {
     const originalAndRenderedReplacement = async (taskLine: string) => {
         const replacement = await renderListItem(fromLine({ line: taskLine }));
         const list = document.createElement('ul');
-        const original = createAndAppendElement('li', list);
+        const original = list.createEl('li');
         return { original, replacement };
     };
 

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -110,20 +110,20 @@ describe('HTMLElement.createEl()', () => {
 });
 
 describe('global createDiv()', () => {
-    it.failing('createDiv() should create a div', () => {
+    it('createDiv() should create a div', () => {
         const child = createDiv();
 
         expect(child.tagName).toBe('DIV');
     });
 
-    it.failing('createDiv() should treat a string argument as a class name', () => {
+    it('createDiv() should treat a string argument as a class name', () => {
         const div = createDiv('single-class-value');
 
         expect(div.tagName).toBe('DIV');
         expectElementToHaveClasses(div, 'single-class-value');
     });
 
-    it.failing('createDiv() should apply classes from the cls option', () => {
+    it('createDiv() should apply classes from the cls option', () => {
         const child = createDiv({
             cls: ['first-class', 'second-class'],
         });
@@ -131,7 +131,7 @@ describe('global createDiv()', () => {
         expectElementToHaveClasses(child, ['first-class', 'second-class']);
     });
 
-    it.failing('createDiv() should apply a class from the cls option', () => {
+    it('createDiv() should apply a class from the cls option', () => {
         const child = createDiv({
             cls: 'single-class-value',
         });
@@ -139,7 +139,7 @@ describe('global createDiv()', () => {
         expectElementToHaveClasses(child, 'single-class-value');
     });
 
-    it.failing('createDiv() should apply text from the text option', () => {
+    it('createDiv() should apply text from the text option', () => {
         const child = createDiv({
             text: 'example text content',
         });
@@ -147,7 +147,7 @@ describe('global createDiv()', () => {
         expect(child.textContent).toBe('example text content');
     });
 
-    it.failing('createDiv() should apply DocumentFragment text content', () => {
+    it('createDiv() should apply DocumentFragment text content', () => {
         const fragment = document.createDocumentFragment();
         const childSpan = document.createElement('span');
         childSpan.textContent = 'fragment text content';
@@ -163,7 +163,7 @@ describe('global createDiv()', () => {
         expect(child.textContent).toBe('fragment text content');
     });
 
-    it.failing('createDiv() should apply both cls and text options', () => {
+    it('createDiv() should apply both cls and text options', () => {
         const div = createDiv({
             cls: ['first-class', 'second-class'],
             text: 'example text content',
@@ -173,7 +173,7 @@ describe('global createDiv()', () => {
         expect(div.textContent).toBe('example text content');
     });
 
-    it.failing('createDiv() should call the callback with the created div', () => {
+    it('createDiv() should call the callback with the created div', () => {
         const callback = jest.fn();
 
         const div = createDiv(undefined, callback);
@@ -183,7 +183,7 @@ describe('global createDiv()', () => {
         expect(callback).toHaveBeenCalledWith(div);
     });
 
-    it.failing('createDiv() should apply text before calling the callback', () => {
+    it('createDiv() should apply text before calling the callback', () => {
         const callback = jest.fn();
 
         const div = createDiv({ text: 'example text content' }, callback);

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -23,6 +23,16 @@ function createParentWithCreateDiv(): HTMLElementWithCreateDiv {
     return document.createElement('section') as HTMLElementWithCreateDiv;
 }
 
+function expectCorrectTagNameAndParentChildStructure(
+    parent: HTMLElement,
+    child: HTMLInputElement,
+    expectedTagName: string,
+) {
+    expect(child.tagName).toBe(expectedTagName);
+    expect(parent.children).toHaveLength(1);
+    expect(parent.firstElementChild).toBe(child);
+}
+
 function expectElementToHaveClasses(element: Element, expectedClasses: string[] | string) {
     const classes = Array.isArray(expectedClasses) ? expectedClasses : [expectedClasses];
 
@@ -38,9 +48,7 @@ describe('Obsidian DOM extensions in tests - createEl()', () => {
         // This documents the baseline behavior we rely on from Obsidian's createEl().
         const child = parent.createEl('input');
 
-        expect(child.tagName).toBe('INPUT');
-        expect(parent.children).toHaveLength(1);
-        expect(parent.firstElementChild).toBe(child);
+        expectCorrectTagNameAndParentChildStructure(parent, child, 'INPUT');
     });
 
     it('createEl() should apply the type option to an input element', () => {

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -10,7 +10,7 @@ type HTMLElementWithCreateEl = HTMLElement & {
 };
 
 type HTMLElementWithCreateDiv = HTMLElement & {
-    createDiv(o?: { cls?: string[] | string }): HTMLDivElement;
+    createDiv(o?: { cls?: string[] | string; text?: string }): HTMLDivElement;
 };
 
 function expectElementToHaveClasses(element: Element, expectedClasses: string[] | string) {
@@ -90,5 +90,15 @@ describe('Obsidian DOM extensions in tests', () => {
         });
 
         expectElementToHaveClasses(child, 'single-class-value');
+    });
+
+    it('createDiv() should apply text from the text option', () => {
+        const parent = document.createElement('section') as HTMLElementWithCreateDiv;
+
+        const child = parent.createDiv({
+            text: 'example text content',
+        });
+
+        expect(child.textContent).toBe('example text content');
     });
 });

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -266,6 +266,16 @@ describe('HTMLElement.createDiv()', () => {
         expect(child.firstElementChild?.tagName).toBe('SPAN');
         expect(child.textContent).toBe('fragment text content');
     });
+
+    it.failing('createDiv() should call the callback with the created div', () => {
+        const callback = jest.fn();
+
+        const div = parent.createDiv(undefined, callback);
+
+        expect(div.tagName).toBe('DIV');
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(div);
+    });
 });
 
 describe('HTMLElement.createSpan()', () => {

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -30,6 +30,14 @@ function createParentWithCreateSpan(): HTMLElementWithCreateSpan {
     return document.createElement('span') as HTMLElementWithCreateSpan;
 }
 
+function createDocumentFragment(): DocumentFragment {
+    const fragment = document.createDocumentFragment();
+    const childSpan = document.createElement('span');
+    childSpan.textContent = 'fragment text content';
+    fragment.appendChild(childSpan);
+    return fragment;
+}
+
 function expectCorrectTagNameAndParentChildStructure(parent: HTMLElement, child: HTMLElement, expectedTagName: string) {
     expect(child.tagName).toBe(expectedTagName);
     expect(parent.children).toHaveLength(1);
@@ -165,10 +173,7 @@ describe('global createDiv()', () => {
     });
 
     it('createDiv() should apply DocumentFragment text content', () => {
-        const fragment = document.createDocumentFragment();
-        const childSpan = document.createElement('span');
-        childSpan.textContent = 'fragment text content';
-        fragment.appendChild(childSpan);
+        const fragment = createDocumentFragment();
 
         const child = createDiv({
             text: fragment,
@@ -254,10 +259,7 @@ describe('HTMLElement.createDiv()', () => {
     });
 
     it('createDiv() should apply DocumentFragment text content', () => {
-        const fragment = document.createDocumentFragment();
-        const childSpan = document.createElement('span');
-        childSpan.textContent = 'fragment text content';
-        fragment.appendChild(childSpan);
+        const fragment = createDocumentFragment();
 
         const child = parent.createDiv({
             text: fragment,

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -233,7 +233,7 @@ describe('HTMLElement.createDiv()', () => {
         expect(child.textContent).toBe('example text content');
     });
 
-    it.failing('createDiv() should apply DocumentFragment text content', () => {
+    it('createDiv() should apply DocumentFragment text content', () => {
         const parent = createParentWithCreateDiv();
 
         const fragment = document.createDocumentFragment();

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -44,6 +44,11 @@ function expectElementToHaveClasses(element: Element, expectedClasses: string[] 
     }
 }
 
+function expectCallbackToHaveBeenCalledOnceWith(callback: jest.Mock<any, any, any>, child: HTMLButtonElement): void {
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(child);
+}
+
 describe('global createEl()', () => {
     it('createEl() should create an element and return it', () => {
         const child = createEl('input');
@@ -64,8 +69,7 @@ describe('global createEl()', () => {
         const child = createEl('button', undefined, callback);
 
         expect(child.tagName).toBe('BUTTON');
-        expect(callback).toHaveBeenCalledTimes(1);
-        expect(callback).toHaveBeenCalledWith(child);
+        expectCallbackToHaveBeenCalledOnceWith(callback, child);
     });
 });
 

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -22,7 +22,7 @@ describe('Obsidian DOM extensions in tests', () => {
         expect(parent.firstElementChild).toBe(child);
     });
 
-    it.failing('createDiv() should create a div, append it to the parent, and return it', () => {
+    it('createDiv() should create a div, append it to the parent, and return it', () => {
         const parent = document.createElement('section') as HTMLElementWithCreateDiv;
 
         const child = parent.createDiv();

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -82,6 +82,13 @@ describe('HTMLElement.createEl()', () => {
         expectCorrectTagNameAndParentChildStructure(parent, child, 'INPUT');
     });
 
+    it('createEl() should treat a string second argument as a class name', () => {
+        const child = parent.createEl('p', 'single-class-value');
+
+        expect(child.tagName).toBe('P');
+        expectElementToHaveClasses(child, 'single-class-value');
+    });
+
     it('createEl() should apply the type option to an input element', () => {
         const child = parent.createEl('input', { type: 'checkbox' });
 

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -23,11 +23,7 @@ function createParentWithCreateDiv(): HTMLElementWithCreateDiv {
     return document.createElement('section') as HTMLElementWithCreateDiv;
 }
 
-function expectCorrectTagNameAndParentChildStructure(
-    parent: HTMLElement,
-    child: HTMLInputElement,
-    expectedTagName: string,
-) {
+function expectCorrectTagNameAndParentChildStructure(parent: HTMLElement, child: HTMLElement, expectedTagName: string) {
     expect(child.tagName).toBe(expectedTagName);
     expect(parent.children).toHaveLength(1);
     expect(parent.firstElementChild).toBe(child);
@@ -87,9 +83,7 @@ describe('Obsidian DOM extensions in tests - createDiv()', () => {
 
         const child = parent.createDiv();
 
-        expect(child.tagName).toBe('DIV');
-        expect(parent.children).toHaveLength(1);
-        expect(parent.firstElementChild).toBe(child);
+        expectCorrectTagNameAndParentChildStructure(parent, child, 'DIV');
     });
 
     it('createDiv() should apply classes from the cls option', () => {

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -50,6 +50,23 @@ describe('global createEl()', () => {
 
         expect(child.tagName).toBe('INPUT');
     });
+
+    it('createEl() should treat a string second argument as a class name', () => {
+        const child = createEl('p', 'single-class-value');
+
+        expect(child.tagName).toBe('P');
+        expectElementToHaveClasses(child, 'single-class-value');
+    });
+
+    it('createEl() should call the callback with the created element', () => {
+        const callback = jest.fn();
+
+        const child = createEl('button', undefined, callback);
+
+        expect(child.tagName).toBe('BUTTON');
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(child);
+    });
 });
 
 describe('HTMLElement.createEl()', () => {

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -147,6 +147,22 @@ describe('global createDiv()', () => {
         expect(child.textContent).toBe('example text content');
     });
 
+    it.failing('createDiv() should apply DocumentFragment text content', () => {
+        const fragment = document.createDocumentFragment();
+        const childSpan = document.createElement('span');
+        childSpan.textContent = 'fragment text content';
+        fragment.appendChild(childSpan);
+
+        const child = createDiv({
+            text: fragment,
+        });
+
+        expect(child.tagName).toBe('DIV');
+        expect(child.childElementCount).toBe(1);
+        expect(child.firstElementChild?.tagName).toBe('SPAN');
+        expect(child.textContent).toBe('fragment text content');
+    });
+
     it.failing('createDiv() should apply both cls and text options', () => {
         const div = createDiv({
             cls: ['first-class', 'second-class'],
@@ -215,6 +231,24 @@ describe('HTMLElement.createDiv()', () => {
         });
 
         expect(child.textContent).toBe('example text content');
+    });
+
+    it.failing('createDiv() should apply DocumentFragment text content', () => {
+        const parent = createParentWithCreateDiv();
+
+        const fragment = document.createDocumentFragment();
+        const childSpan = document.createElement('span');
+        childSpan.textContent = 'fragment text content';
+        fragment.appendChild(childSpan);
+
+        const child = parent.createDiv({
+            text: fragment,
+        });
+
+        expectCorrectTagNameAndParentChildStructure(parent, child, 'DIV');
+        expect(child.childElementCount).toBe(1);
+        expect(child.firstElementChild?.tagName).toBe('SPAN');
+        expect(child.textContent).toBe('fragment text content');
     });
 });
 

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -147,6 +147,16 @@ describe('global createDiv()', () => {
         expect(child.textContent).toBe('example text content');
     });
 
+    it.failing('createDiv() should apply both cls and text options', () => {
+        const div = createDiv({
+            cls: ['first-class', 'second-class'],
+            text: 'example text content',
+        });
+
+        expectElementToHaveClasses(div, ['first-class', 'second-class']);
+        expect(div.textContent).toBe('example text content');
+    });
+
     it.failing('createDiv() should call the callback with the created div', () => {
         const callback = jest.fn();
 
@@ -155,6 +165,16 @@ describe('global createDiv()', () => {
         expect(div.tagName).toBe('DIV');
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith(div);
+    });
+
+    it.failing('createDiv() should apply text before calling the callback', () => {
+        const callback = jest.fn();
+
+        const div = createDiv({ text: 'example text content' }, callback);
+
+        expect(div.textContent).toBe('example text content');
+        expect(callback).toHaveBeenCalledWith(div);
+        expect((callback.mock.calls[0][0] as HTMLDivElement).textContent).toBe('example text content');
     });
 });
 

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -10,7 +10,7 @@ type HTMLElementWithCreateEl = HTMLElement & {
 };
 
 type HTMLElementWithCreateDiv = HTMLElement & {
-    createDiv(): HTMLDivElement;
+    createDiv(o?: { cls?: string[] | string }): HTMLDivElement;
 };
 
 function expectElementToHaveClasses(element: Element, expectedClasses: string[] | string) {
@@ -70,5 +70,25 @@ describe('Obsidian DOM extensions in tests', () => {
         expect(child.tagName).toBe('DIV');
         expect(parent.children).toHaveLength(1);
         expect(parent.firstElementChild).toBe(child);
+    });
+
+    it('createDiv() should apply classes from the cls option', () => {
+        const parent = document.createElement('section') as HTMLElementWithCreateDiv;
+
+        const child = parent.createDiv({
+            cls: ['first-class', 'second-class'],
+        });
+
+        expectElementToHaveClasses(child, ['first-class', 'second-class']);
+    });
+
+    it('createDiv() should apply a class from the cls option', () => {
+        const parent = document.createElement('section') as HTMLElementWithCreateDiv;
+
+        const child = parent.createDiv({
+            cls: 'single-class-value',
+        });
+
+        expectElementToHaveClasses(child, 'single-class-value');
     });
 });

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -2,11 +2,15 @@
  * @jest-environment jsdom
  */
 
-describe('Obsidian DOM extensions in tests', () => {
-    it.failing('createEl() should create an element, append it to the parent, and return it', () => {
-        const parent = document.createElement('div');
+type HTMLElementWithCreateEl = HTMLElement & {
+    createEl<K extends keyof HTMLElementTagNameMap>(tag: K): HTMLElementTagNameMap[K];
+};
 
-        // Fails with parent.createEl is not a function
+describe('Obsidian DOM extensions in tests', () => {
+    it('createEl() should create an element, append it to the parent, and return it', () => {
+        const parent = document.createElement('div') as HTMLElementWithCreateEl;
+
+        // This documents the baseline behavior we rely on from Obsidian's createEl().
         const child = parent.createEl('input');
 
         expect(child.tagName).toBe('INPUT');

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -279,20 +279,20 @@ describe('HTMLElement.createDiv()', () => {
 });
 
 describe('global createSpan()', () => {
-    it.failing('createSpan() should create a span', () => {
+    it('createSpan() should create a span', () => {
         const child = createSpan();
 
         expect(child.tagName).toBe('SPAN');
     });
 
-    it.failing('createSpan() should treat a string argument as a class name', () => {
+    it('createSpan() should treat a string argument as a class name', () => {
         const span = createSpan('single-class-value');
 
         expect(span.tagName).toBe('SPAN');
         expectElementToHaveClasses(span, 'single-class-value');
     });
 
-    it.failing('createSpan() should call the callback with the created span', () => {
+    it('createSpan() should call the callback with the created span', () => {
         const callback = jest.fn();
 
         const span = createSpan(undefined, callback);
@@ -302,7 +302,7 @@ describe('global createSpan()', () => {
         expect(callback).toHaveBeenCalledWith(span);
     });
 
-    it.failing('createSpan() should apply a class from the cls option', () => {
+    it('createSpan() should apply a class from the cls option', () => {
         const span = createSpan({
             cls: 'single-class-value',
         });

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -1,17 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-
-type HTMLElementWithCreateEl = HTMLElement & {
-    createEl<K extends keyof HTMLElementTagNameMap>(
-        tag: K,
-        o?: { type?: string; cls?: string[] | string },
-    ): HTMLElementTagNameMap[K];
-};
-
-type HTMLElementWithCreateDiv = HTMLElement & {
-    createDiv(o?: { cls?: string[] | string; text?: string }): HTMLDivElement;
-};
+import type { HTMLElementWithCreateDiv, HTMLElementWithCreateEl } from './DOMExtensions';
 
 /**
  * Create a parent element typed for tests that exercise createEl().

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -5,13 +5,21 @@
 type HTMLElementWithCreateEl = HTMLElement & {
     createEl<K extends keyof HTMLElementTagNameMap>(
         tag: K,
-        o?: { type?: string; cls?: string[] },
+        o?: { type?: string; cls?: string[] | string },
     ): HTMLElementTagNameMap[K];
 };
 
 type HTMLElementWithCreateDiv = HTMLElement & {
     createDiv(): HTMLDivElement;
 };
+
+function expectElementToHaveClasses(element: Element, expectedClasses: string[] | string) {
+    const classes = Array.isArray(expectedClasses) ? expectedClasses : [expectedClasses];
+
+    for (const className of classes) {
+        expect(element.classList).toContain(className);
+    }
+}
 
 describe('Obsidian DOM extensions in tests', () => {
     it('createEl() should create an element, append it to the parent, and return it', () => {
@@ -41,8 +49,7 @@ describe('Obsidian DOM extensions in tests', () => {
             cls: ['task-list-item-checkbox', 'tasks-quick-search-result-checkbox'],
         });
 
-        expect(child.classList).toContain('task-list-item-checkbox');
-        expect(child.classList).toContain('tasks-quick-search-result-checkbox');
+        expectElementToHaveClasses(child, ['task-list-item-checkbox', 'tasks-quick-search-result-checkbox']);
     });
 
     it('createEl() should apply a class from the cls option', () => {
@@ -52,7 +59,7 @@ describe('Obsidian DOM extensions in tests', () => {
             cls: 'single-class-value',
         });
 
-        expect(child.classList).toContain('single-class-value');
+        expectElementToHaveClasses(child, 'single-class-value');
     });
 
     it('createDiv() should create a div, append it to the parent, and return it', () => {

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -6,6 +6,10 @@ type HTMLElementWithCreateEl = HTMLElement & {
     createEl<K extends keyof HTMLElementTagNameMap>(tag: K): HTMLElementTagNameMap[K];
 };
 
+type HTMLElementWithCreateDiv = HTMLElement & {
+    createDiv(): HTMLDivElement;
+};
+
 describe('Obsidian DOM extensions in tests', () => {
     it('createEl() should create an element, append it to the parent, and return it', () => {
         const parent = document.createElement('div') as HTMLElementWithCreateEl;
@@ -14,6 +18,16 @@ describe('Obsidian DOM extensions in tests', () => {
         const child = parent.createEl('input');
 
         expect(child.tagName).toBe('INPUT');
+        expect(parent.children).toHaveLength(1);
+        expect(parent.firstElementChild).toBe(child);
+    });
+
+    it.failing('createDiv() should create a div, append it to the parent, and return it', () => {
+        const parent = document.createElement('section') as HTMLElementWithCreateDiv;
+
+        const child = parent.createDiv();
+
+        expect(child.tagName).toBe('DIV');
         expect(parent.children).toHaveLength(1);
         expect(parent.firstElementChild).toBe(child);
     });

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -45,7 +45,7 @@ describe('Obsidian DOM extensions in tests', () => {
         expect(child.classList).toContain('tasks-quick-search-result-checkbox');
     });
 
-    it.failing('createEl() should apply a class from the cls option', () => {
+    it('createEl() should apply a class from the cls option', () => {
         const parent = document.createElement('div') as HTMLElementWithCreateEl;
 
         const child = parent.createEl('input', {

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -267,7 +267,7 @@ describe('HTMLElement.createDiv()', () => {
         expect(child.textContent).toBe('fragment text content');
     });
 
-    it.failing('createDiv() should call the callback with the created div', () => {
+    it('createDiv() should call the callback with the created div', () => {
         const callback = jest.fn();
 
         const div = parent.createDiv(undefined, callback);

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -34,7 +34,7 @@ describe('Obsidian DOM extensions in tests', () => {
         expect(child.type).toBe('checkbox');
     });
 
-    it.failing('createEl() should apply classes from the cls option', () => {
+    it('createEl() should apply classes from the cls option', () => {
         const parent = document.createElement('div') as HTMLElementWithCreateEl;
 
         const child = parent.createEl('input', {

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -31,11 +31,19 @@ function createParentWithCreateSpan(): HTMLElementWithCreateSpan {
 }
 
 function createDocumentFragment(): DocumentFragment {
+    // See expectDocumentFragmentToHaveBeenUsed()
     const fragment = document.createDocumentFragment();
     const childSpan = document.createElement('span');
     childSpan.textContent = 'fragment text content';
     fragment.appendChild(childSpan);
     return fragment;
+}
+
+function expectDocumentFragmentToHaveBeenUsed(child: HTMLDivElement): void {
+    // See createDocumentFragment()
+    expect(child.childElementCount).toBe(1);
+    expect(child.firstElementChild?.tagName).toBe('SPAN');
+    expect(child.textContent).toBe('fragment text content');
 }
 
 function expectCorrectTagNameAndParentChildStructure(parent: HTMLElement, child: HTMLElement, expectedTagName: string) {
@@ -180,9 +188,7 @@ describe('global createDiv()', () => {
         });
 
         expect(child.tagName).toBe('DIV');
-        expect(child.childElementCount).toBe(1);
-        expect(child.firstElementChild?.tagName).toBe('SPAN');
-        expect(child.textContent).toBe('fragment text content');
+        expectDocumentFragmentToHaveBeenUsed(child);
     });
 
     it('createDiv() should apply both cls and text options', () => {
@@ -266,9 +272,7 @@ describe('HTMLElement.createDiv()', () => {
         });
 
         expectCorrectTagNameAndParentChildStructure(parent, child, 'DIV');
-        expect(child.childElementCount).toBe(1);
-        expect(child.firstElementChild?.tagName).toBe('SPAN');
-        expect(child.textContent).toBe('fragment text content');
+        expectDocumentFragmentToHaveBeenUsed(child);
     });
 
     it('createDiv() should call the callback with the created div', () => {

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -21,7 +21,7 @@ function expectElementToHaveClasses(element: Element, expectedClasses: string[] 
     }
 }
 
-describe('Obsidian DOM extensions in tests', () => {
+describe('Obsidian DOM extensions in tests - createEl()', () => {
     it('createEl() should create an element, append it to the parent, and return it', () => {
         const parent = document.createElement('div') as HTMLElementWithCreateEl;
 
@@ -61,7 +61,9 @@ describe('Obsidian DOM extensions in tests', () => {
 
         expectElementToHaveClasses(child, 'single-class-value');
     });
+});
 
+describe('Obsidian DOM extensions in tests - createDiv()', () => {
     it('createDiv() should create a div, append it to the parent, and return it', () => {
         const parent = document.createElement('section') as HTMLElementWithCreateDiv;
 

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -45,7 +45,7 @@ function expectElementToHaveClasses(element: Element, expectedClasses: string[] 
 }
 
 describe('global createEl()', () => {
-    it.failing('createEl() should create an element and return it', () => {
+    it('createEl() should create an element and return it', () => {
         const child = createEl('input');
 
         expect(child.tagName).toBe('INPUT');

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -22,7 +22,7 @@ describe('Obsidian DOM extensions in tests', () => {
         expect(parent.firstElementChild).toBe(child);
     });
 
-    it.failing('createEl() should apply the type option to an input element', () => {
+    it('createEl() should apply the type option to an input element', () => {
         const parent = document.createElement('div') as HTMLElementWithCreateEl;
 
         const child = parent.createEl('input', { type: 'checkbox' });

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -111,6 +111,16 @@ describe('HTMLElement.createEl()', () => {
 
         expectElementToHaveClasses(child, 'single-class-value');
     });
+
+    it.failing('createEl() should call the callback with the created element', () => {
+        const callback = jest.fn();
+
+        const child = parent.createEl('button', undefined, callback);
+
+        expect(child.tagName).toBe('BUTTON');
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(child);
+    });
 });
 
 describe('global createDiv()', () => {

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -205,7 +205,7 @@ describe('global createDiv()', () => {
         const div = createDiv({ text: 'example text content' }, callback);
 
         expect(div.textContent).toBe('example text content');
-        expect(callback).toHaveBeenCalledWith(div);
+        expectCallbackToHaveBeenCalledOnceWith(callback, div);
         expect((callback.mock.calls[0][0] as HTMLDivElement).textContent).toBe('example text content');
     });
 });

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import type { HTMLElementWithCreateDiv, HTMLElementWithCreateEl } from './DOMExtensions';
+import type { HTMLElementWithCreateDiv, HTMLElementWithCreateEl, HTMLElementWithCreateSpan } from './DOMExtensions';
 
 /**
  * Create a parent element typed for tests that exercise createEl().
@@ -21,6 +21,13 @@ function createParentWithCreateEl(): HTMLElementWithCreateEl {
  */
 function createParentWithCreateDiv(): HTMLElementWithCreateDiv {
     return document.createElement('section') as HTMLElementWithCreateDiv;
+}
+
+/**
+ * Create a parent element typed for tests that exercise createSpan().
+ */
+function createParentWithCreateSpan(): HTMLElementWithCreateSpan {
+    return document.createElement('span') as HTMLElementWithCreateSpan;
 }
 
 function expectCorrectTagNameAndParentChildStructure(parent: HTMLElement, child: HTMLElement, expectedTagName: string) {
@@ -114,5 +121,15 @@ describe('Obsidian DOM extensions in tests - createDiv()', () => {
         });
 
         expect(child.textContent).toBe('example text content');
+    });
+});
+
+describe('Obsidian DOM extensions in tests - createSpan()', () => {
+    it('createSpan() should create a span, append it to the parent, and return it', () => {
+        const parent = createParentWithCreateSpan();
+
+        const child = parent.createSpan();
+
+        expectCorrectTagNameAndParentChildStructure(parent, child, 'SPAN');
     });
 });

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -3,7 +3,10 @@
  */
 
 type HTMLElementWithCreateEl = HTMLElement & {
-    createEl<K extends keyof HTMLElementTagNameMap>(tag: K, o?: { type?: string }): HTMLElementTagNameMap[K];
+    createEl<K extends keyof HTMLElementTagNameMap>(
+        tag: K,
+        o?: { type?: string; cls?: string[] },
+    ): HTMLElementTagNameMap[K];
 };
 
 type HTMLElementWithCreateDiv = HTMLElement & {
@@ -29,6 +32,17 @@ describe('Obsidian DOM extensions in tests', () => {
 
         expect(child.tagName).toBe('INPUT');
         expect(child.type).toBe('checkbox');
+    });
+
+    it.failing('createEl() should apply classes from the cls option', () => {
+        const parent = document.createElement('div') as HTMLElementWithCreateEl;
+
+        const child = parent.createEl('input', {
+            cls: ['task-list-item-checkbox', 'tasks-quick-search-result-checkbox'],
+        });
+
+        expect(child.classList).toContain('task-list-item-checkbox');
+        expect(child.classList).toContain('tasks-quick-search-result-checkbox');
     });
 
     it('createDiv() should create a div, append it to the parent, and return it', () => {

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -3,7 +3,7 @@
  */
 
 type HTMLElementWithCreateEl = HTMLElement & {
-    createEl<K extends keyof HTMLElementTagNameMap>(tag: K): HTMLElementTagNameMap[K];
+    createEl<K extends keyof HTMLElementTagNameMap>(tag: K, o?: { type?: string }): HTMLElementTagNameMap[K];
 };
 
 type HTMLElementWithCreateDiv = HTMLElement & {
@@ -20,6 +20,15 @@ describe('Obsidian DOM extensions in tests', () => {
         expect(child.tagName).toBe('INPUT');
         expect(parent.children).toHaveLength(1);
         expect(parent.firstElementChild).toBe(child);
+    });
+
+    it.failing('createEl() should apply the type option to an input element', () => {
+        const parent = document.createElement('div') as HTMLElementWithCreateEl;
+
+        const child = parent.createEl('input', { type: 'checkbox' });
+
+        expect(child.tagName).toBe('INPUT');
+        expect(child.type).toBe('checkbox');
     });
 
     it('createDiv() should create a div, append it to the parent, and return it', () => {

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -44,7 +44,7 @@ function expectElementToHaveClasses(element: Element, expectedClasses: string[] 
     }
 }
 
-function expectCallbackToHaveBeenCalledOnceWith(callback: jest.Mock<any, any, any>, child: HTMLButtonElement): void {
+function expectCallbackToHaveBeenCalledOnceWith(callback: jest.Mock<any, any, any>, child: HTMLElement): void {
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback).toHaveBeenCalledWith(child);
 }
@@ -122,8 +122,7 @@ describe('HTMLElement.createEl()', () => {
         const child = parent.createEl('button', undefined, callback);
 
         expect(child.tagName).toBe('BUTTON');
-        expect(callback).toHaveBeenCalledTimes(1);
-        expect(callback).toHaveBeenCalledWith(child);
+        expectCallbackToHaveBeenCalledOnceWith(callback, child);
     });
 });
 
@@ -197,8 +196,7 @@ describe('global createDiv()', () => {
         const div = createDiv(undefined, callback);
 
         expect(div.tagName).toBe('DIV');
-        expect(callback).toHaveBeenCalledTimes(1);
-        expect(callback).toHaveBeenCalledWith(div);
+        expectCallbackToHaveBeenCalledOnceWith(callback, div);
     });
 
     it('createDiv() should apply text before calling the callback', () => {
@@ -277,8 +275,7 @@ describe('HTMLElement.createDiv()', () => {
         const div = parent.createDiv(undefined, callback);
 
         expect(div.tagName).toBe('DIV');
-        expect(callback).toHaveBeenCalledTimes(1);
-        expect(callback).toHaveBeenCalledWith(div);
+        expectCallbackToHaveBeenCalledOnceWith(callback, div);
     });
 });
 
@@ -302,8 +299,7 @@ describe('global createSpan()', () => {
         const span = createSpan(undefined, callback);
 
         expect(span.tagName).toBe('SPAN');
-        expect(callback).toHaveBeenCalledTimes(1);
-        expect(callback).toHaveBeenCalledWith(span);
+        expectCallbackToHaveBeenCalledOnceWith(callback, span);
     });
 
     it('createSpan() should apply a class from the cls option', () => {

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -70,9 +70,12 @@ describe('global createEl()', () => {
 });
 
 describe('HTMLElement.createEl()', () => {
-    it('createEl() should create an element, append it to the parent, and return it', () => {
-        const parent = createParentWithCreateEl();
+    let parent: HTMLElementWithCreateEl;
+    beforeEach(() => {
+        parent = createParentWithCreateEl();
+    });
 
+    it('createEl() should create an element, append it to the parent, and return it', () => {
         // This documents the baseline behavior we rely on from Obsidian's createEl().
         const child = parent.createEl('input');
 
@@ -80,8 +83,6 @@ describe('HTMLElement.createEl()', () => {
     });
 
     it('createEl() should apply the type option to an input element', () => {
-        const parent = createParentWithCreateEl();
-
         const child = parent.createEl('input', { type: 'checkbox' });
 
         expect(child.tagName).toBe('INPUT');
@@ -89,8 +90,6 @@ describe('HTMLElement.createEl()', () => {
     });
 
     it('createEl() should apply classes from the cls option', () => {
-        const parent = createParentWithCreateEl();
-
         const child = parent.createEl('input', {
             cls: ['task-list-item-checkbox', 'tasks-quick-search-result-checkbox'],
         });
@@ -99,8 +98,6 @@ describe('HTMLElement.createEl()', () => {
     });
 
     it('createEl() should apply a class from the cls option', () => {
-        const parent = createParentWithCreateEl();
-
         const child = parent.createEl('input', {
             cls: 'single-class-value',
         });

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -45,6 +45,16 @@ describe('Obsidian DOM extensions in tests', () => {
         expect(child.classList).toContain('tasks-quick-search-result-checkbox');
     });
 
+    it.failing('createEl() should apply a class from the cls option', () => {
+        const parent = document.createElement('div') as HTMLElementWithCreateEl;
+
+        const child = parent.createEl('input', {
+            cls: 'single-class-value',
+        });
+
+        expect(child.classList).toContain('single-class-value');
+    });
+
     it('createDiv() should create a div, append it to the parent, and return it', () => {
         const parent = document.createElement('section') as HTMLElementWithCreateDiv;
 

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -337,7 +337,7 @@ describe('HTMLElement.createSpan()', () => {
         expectElementToHaveClasses(span, 'single-class-value');
     });
 
-    it.failing('createSpan() should call the callback with the created span', () => {
+    it('createSpan() should call the callback with the created span', () => {
         const callback = jest.fn();
 
         const span = parent.createSpan(undefined, callback);

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -313,9 +313,12 @@ describe('global createSpan()', () => {
 });
 
 describe('HTMLElement.createSpan()', () => {
-    it('createSpan() should create a span, append it to the parent, and return it', () => {
-        const parent = createParentWithCreateSpan();
+    let parent: HTMLElementWithCreateSpan;
+    beforeEach(() => {
+        parent = createParentWithCreateSpan();
+    });
 
+    it('createSpan() should create a span, append it to the parent, and return it', () => {
         const child = parent.createSpan();
 
         expectCorrectTagNameAndParentChildStructure(parent, child, 'SPAN');

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -109,6 +109,55 @@ describe('HTMLElement.createEl()', () => {
     });
 });
 
+describe('global createDiv()', () => {
+    it.failing('createDiv() should create a div', () => {
+        const child = createDiv();
+
+        expect(child.tagName).toBe('DIV');
+    });
+
+    it.failing('createDiv() should treat a string argument as a class name', () => {
+        const div = createDiv('single-class-value');
+
+        expect(div.tagName).toBe('DIV');
+        expectElementToHaveClasses(div, 'single-class-value');
+    });
+
+    it.failing('createDiv() should apply classes from the cls option', () => {
+        const child = createDiv({
+            cls: ['first-class', 'second-class'],
+        });
+
+        expectElementToHaveClasses(child, ['first-class', 'second-class']);
+    });
+
+    it.failing('createDiv() should apply a class from the cls option', () => {
+        const child = createDiv({
+            cls: 'single-class-value',
+        });
+
+        expectElementToHaveClasses(child, 'single-class-value');
+    });
+
+    it.failing('createDiv() should apply text from the text option', () => {
+        const child = createDiv({
+            text: 'example text content',
+        });
+
+        expect(child.textContent).toBe('example text content');
+    });
+
+    it.failing('createDiv() should call the callback with the created div', () => {
+        const callback = jest.fn();
+
+        const div = createDiv(undefined, callback);
+
+        expect(div.tagName).toBe('DIV');
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(div);
+    });
+});
+
 describe('HTMLElement.createDiv()', () => {
     it('createDiv() should create a div, append it to the parent, and return it', () => {
         const parent = createParentWithCreateDiv();

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -220,6 +220,13 @@ describe('HTMLElement.createDiv()', () => {
         expectCorrectTagNameAndParentChildStructure(parent, child, 'DIV');
     });
 
+    it('createDiv() should treat a string argument as a class name', () => {
+        const div = parent.createDiv('single-class-value');
+
+        expect(div.tagName).toBe('DIV');
+        expectElementToHaveClasses(div, 'single-class-value');
+    });
+
     it('createDiv() should apply classes from the cls option', () => {
         const child = parent.createDiv({
             cls: ['first-class', 'second-class'],

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -323,4 +323,29 @@ describe('HTMLElement.createSpan()', () => {
 
         expectCorrectTagNameAndParentChildStructure(parent, child, 'SPAN');
     });
+
+    it('createSpan() should treat a string argument as a class name', () => {
+        const span = parent.createSpan('single-class-value');
+
+        expect(span.tagName).toBe('SPAN');
+        expectElementToHaveClasses(span, 'single-class-value');
+    });
+
+    it.failing('createSpan() should call the callback with the created span', () => {
+        const callback = jest.fn();
+
+        const span = parent.createSpan(undefined, callback);
+
+        expect(span.tagName).toBe('SPAN');
+        expectCallbackToHaveBeenCalledOnceWith(callback, span);
+    });
+
+    it('createSpan() should apply a class from the cls option', () => {
+        const span = parent.createSpan({
+            cls: 'single-class-value',
+        });
+
+        expect(span.tagName).toBe('SPAN');
+        expectElementToHaveClasses(span, 'single-class-value');
+    });
 });

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -44,7 +44,7 @@ function expectElementToHaveClasses(element: Element, expectedClasses: string[] 
     }
 }
 
-describe('Obsidian DOM extensions in tests - createEl()', () => {
+describe('HTMLElement.createEl()', () => {
     it('createEl() should create an element, append it to the parent, and return it', () => {
         const parent = createParentWithCreateEl();
 
@@ -84,7 +84,7 @@ describe('Obsidian DOM extensions in tests - createEl()', () => {
     });
 });
 
-describe('Obsidian DOM extensions in tests - createDiv()', () => {
+describe('HTMLElement.createDiv()', () => {
     it('createDiv() should create a div, append it to the parent, and return it', () => {
         const parent = createParentWithCreateDiv();
 
@@ -124,7 +124,7 @@ describe('Obsidian DOM extensions in tests - createDiv()', () => {
     });
 });
 
-describe('Obsidian DOM extensions in tests - createSpan()', () => {
+describe('HTMLElement.createSpan()', () => {
     it('createSpan() should create a span, append it to the parent, and return it', () => {
         const parent = createParentWithCreateSpan();
 

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -278,6 +278,40 @@ describe('HTMLElement.createDiv()', () => {
     });
 });
 
+describe('global createSpan()', () => {
+    it.failing('createSpan() should create a span', () => {
+        const child = createSpan();
+
+        expect(child.tagName).toBe('SPAN');
+    });
+
+    it.failing('createSpan() should treat a string argument as a class name', () => {
+        const span = createSpan('single-class-value');
+
+        expect(span.tagName).toBe('SPAN');
+        expectElementToHaveClasses(span, 'single-class-value');
+    });
+
+    it.failing('createSpan() should call the callback with the created span', () => {
+        const callback = jest.fn();
+
+        const span = createSpan(undefined, callback);
+
+        expect(span.tagName).toBe('SPAN');
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(span);
+    });
+
+    it.failing('createSpan() should apply a class from the cls option', () => {
+        const span = createSpan({
+            cls: 'single-class-value',
+        });
+
+        expect(span.tagName).toBe('SPAN');
+        expectElementToHaveClasses(span, 'single-class-value');
+    });
+});
+
 describe('HTMLElement.createSpan()', () => {
     it('createSpan() should create a span, append it to the parent, and return it', () => {
         const parent = createParentWithCreateSpan();

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -13,6 +13,26 @@ type HTMLElementWithCreateDiv = HTMLElement & {
     createDiv(o?: { cls?: string[] | string; text?: string }): HTMLDivElement;
 };
 
+/**
+ * Create a parent element typed for tests that exercise createEl().
+ *
+ * The choice of a <div> parent is arbitrary: these tests only care that
+ * createEl() creates and appends a child to some HTMLElement parent.
+ */
+function createParentWithCreateEl(): HTMLElementWithCreateEl {
+    return document.createElement('div') as HTMLElementWithCreateEl;
+}
+
+/**
+ * Create a parent element typed for tests that exercise createDiv().
+ *
+ * The choice of a <section> parent is also arbitrary and is only used to
+ * show that createDiv() works with any HTMLElement parent, not just <div>.
+ */
+function createParentWithCreateDiv(): HTMLElementWithCreateDiv {
+    return document.createElement('section') as HTMLElementWithCreateDiv;
+}
+
 function expectElementToHaveClasses(element: Element, expectedClasses: string[] | string) {
     const classes = Array.isArray(expectedClasses) ? expectedClasses : [expectedClasses];
 
@@ -23,7 +43,7 @@ function expectElementToHaveClasses(element: Element, expectedClasses: string[] 
 
 describe('Obsidian DOM extensions in tests - createEl()', () => {
     it('createEl() should create an element, append it to the parent, and return it', () => {
-        const parent = document.createElement('div') as HTMLElementWithCreateEl;
+        const parent = createParentWithCreateEl();
 
         // This documents the baseline behavior we rely on from Obsidian's createEl().
         const child = parent.createEl('input');
@@ -34,7 +54,7 @@ describe('Obsidian DOM extensions in tests - createEl()', () => {
     });
 
     it('createEl() should apply the type option to an input element', () => {
-        const parent = document.createElement('div') as HTMLElementWithCreateEl;
+        const parent = createParentWithCreateEl();
 
         const child = parent.createEl('input', { type: 'checkbox' });
 
@@ -43,7 +63,7 @@ describe('Obsidian DOM extensions in tests - createEl()', () => {
     });
 
     it('createEl() should apply classes from the cls option', () => {
-        const parent = document.createElement('div') as HTMLElementWithCreateEl;
+        const parent = createParentWithCreateEl();
 
         const child = parent.createEl('input', {
             cls: ['task-list-item-checkbox', 'tasks-quick-search-result-checkbox'],
@@ -53,7 +73,7 @@ describe('Obsidian DOM extensions in tests - createEl()', () => {
     });
 
     it('createEl() should apply a class from the cls option', () => {
-        const parent = document.createElement('div') as HTMLElementWithCreateEl;
+        const parent = createParentWithCreateEl();
 
         const child = parent.createEl('input', {
             cls: 'single-class-value',
@@ -65,7 +85,7 @@ describe('Obsidian DOM extensions in tests - createEl()', () => {
 
 describe('Obsidian DOM extensions in tests - createDiv()', () => {
     it('createDiv() should create a div, append it to the parent, and return it', () => {
-        const parent = document.createElement('section') as HTMLElementWithCreateDiv;
+        const parent = createParentWithCreateDiv();
 
         const child = parent.createDiv();
 
@@ -75,7 +95,7 @@ describe('Obsidian DOM extensions in tests - createDiv()', () => {
     });
 
     it('createDiv() should apply classes from the cls option', () => {
-        const parent = document.createElement('section') as HTMLElementWithCreateDiv;
+        const parent = createParentWithCreateDiv();
 
         const child = parent.createDiv({
             cls: ['first-class', 'second-class'],
@@ -85,7 +105,7 @@ describe('Obsidian DOM extensions in tests - createDiv()', () => {
     });
 
     it('createDiv() should apply a class from the cls option', () => {
-        const parent = document.createElement('section') as HTMLElementWithCreateDiv;
+        const parent = createParentWithCreateDiv();
 
         const child = parent.createDiv({
             cls: 'single-class-value',
@@ -95,7 +115,7 @@ describe('Obsidian DOM extensions in tests - createDiv()', () => {
     });
 
     it('createDiv() should apply text from the text option', () => {
-        const parent = document.createElement('section') as HTMLElementWithCreateDiv;
+        const parent = createParentWithCreateDiv();
 
         const child = parent.createDiv({
             text: 'example text content',

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe('Obsidian DOM extensions in tests', () => {
+    it.failing('createEl() should create an element, append it to the parent, and return it', () => {
+        const parent = document.createElement('div');
+
+        // Fails with parent.createEl is not a function
+        const child = parent.createEl('input');
+
+        expect(child.tagName).toBe('INPUT');
+        expect(parent.children).toHaveLength(1);
+        expect(parent.firstElementChild).toBe(child);
+    });
+});

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -39,7 +39,7 @@ function createDocumentFragment(): DocumentFragment {
     return fragment;
 }
 
-function expectDocumentFragmentToHaveBeenUsed(child: HTMLDivElement): void {
+function expectDocumentFragmentToHaveBeenUsed(child: HTMLElement): void {
     // See createDocumentFragment()
     expect(child.childElementCount).toBe(1);
     expect(child.firstElementChild?.tagName).toBe('SPAN');
@@ -353,5 +353,16 @@ describe('HTMLElement.createSpan()', () => {
 
         expect(span.tagName).toBe('SPAN');
         expectElementToHaveClasses(span, 'single-class-value');
+    });
+
+    it('createSpan() should apply DocumentFragment text content', () => {
+        const fragment = createDocumentFragment();
+
+        const child = parent.createSpan({
+            text: fragment,
+        });
+
+        expectCorrectTagNameAndParentChildStructure(parent, child, 'SPAN');
+        expectDocumentFragmentToHaveBeenUsed(child);
     });
 });

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -44,6 +44,14 @@ function expectElementToHaveClasses(element: Element, expectedClasses: string[] 
     }
 }
 
+describe('global createEl()', () => {
+    it.failing('createEl() should create an element and return it', () => {
+        const child = createEl('input');
+
+        expect(child.tagName).toBe('INPUT');
+    });
+});
+
 describe('HTMLElement.createEl()', () => {
     it('createEl() should create an element, append it to the parent, and return it', () => {
         const parent = createParentWithCreateEl();

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -112,7 +112,7 @@ describe('HTMLElement.createEl()', () => {
         expectElementToHaveClasses(child, 'single-class-value');
     });
 
-    it.failing('createEl() should call the callback with the created element', () => {
+    it('createEl() should call the callback with the created element', () => {
         const callback = jest.fn();
 
         const child = parent.createEl('button', undefined, callback);

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -192,17 +192,18 @@ describe('global createDiv()', () => {
 });
 
 describe('HTMLElement.createDiv()', () => {
-    it('createDiv() should create a div, append it to the parent, and return it', () => {
-        const parent = createParentWithCreateDiv();
+    let parent: HTMLElementWithCreateDiv;
+    beforeEach(() => {
+        parent = createParentWithCreateDiv();
+    });
 
+    it('createDiv() should create a div, append it to the parent, and return it', () => {
         const child = parent.createDiv();
 
         expectCorrectTagNameAndParentChildStructure(parent, child, 'DIV');
     });
 
     it('createDiv() should apply classes from the cls option', () => {
-        const parent = createParentWithCreateDiv();
-
         const child = parent.createDiv({
             cls: ['first-class', 'second-class'],
         });
@@ -211,8 +212,6 @@ describe('HTMLElement.createDiv()', () => {
     });
 
     it('createDiv() should apply a class from the cls option', () => {
-        const parent = createParentWithCreateDiv();
-
         const child = parent.createDiv({
             cls: 'single-class-value',
         });
@@ -221,8 +220,6 @@ describe('HTMLElement.createDiv()', () => {
     });
 
     it('createDiv() should apply text from the text option', () => {
-        const parent = createParentWithCreateDiv();
-
         const child = parent.createDiv({
             text: 'example text content',
         });
@@ -231,8 +228,6 @@ describe('HTMLElement.createDiv()', () => {
     });
 
     it('createDiv() should apply DocumentFragment text content', () => {
-        const parent = createParentWithCreateDiv();
-
         const fragment = document.createDocumentFragment();
         const childSpan = document.createElement('span');
         childSpan.textContent = 'fragment text content';

--- a/tests/TestingTools/DOMExtensions.ts
+++ b/tests/TestingTools/DOMExtensions.ts
@@ -1,0 +1,10 @@
+export type HTMLElementWithCreateEl = HTMLElement & {
+    createEl<K extends keyof HTMLElementTagNameMap>(
+        tag: K,
+        o?: { type?: string; cls?: string[] | string },
+    ): HTMLElementTagNameMap[K];
+};
+
+export type HTMLElementWithCreateDiv = HTMLElement & {
+    createDiv(o?: { cls?: string[] | string; text?: string }): HTMLDivElement;
+};

--- a/tests/TestingTools/DOMExtensions.ts
+++ b/tests/TestingTools/DOMExtensions.ts
@@ -13,7 +13,11 @@ export type CreateSpanOptions = {};
 
 // See jest.setup.ts for the test implementations of these functions.
 export type HTMLElementWithCreateEl = HTMLElement & {
-    createEl<K extends keyof HTMLElementTagNameMap>(tag: K, o?: string | CreateElOptions): HTMLElementTagNameMap[K];
+    createEl<K extends keyof HTMLElementTagNameMap>(
+        tag: K,
+        o?: string | CreateElOptions,
+        callback?: (el: HTMLElementTagNameMap[K]) => void,
+    ): HTMLElementTagNameMap[K];
 };
 
 export type HTMLElementWithCreateDiv = HTMLElement & {

--- a/tests/TestingTools/DOMExtensions.ts
+++ b/tests/TestingTools/DOMExtensions.ts
@@ -5,7 +5,7 @@ export type CreateElOptions = {
 
 export type CreateDivOptions = {
     cls?: string[] | string;
-    text?: string;
+    text?: string | DocumentFragment;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- types will likely be added in future

--- a/tests/TestingTools/DOMExtensions.ts
+++ b/tests/TestingTools/DOMExtensions.ts
@@ -21,7 +21,7 @@ export type HTMLElementWithCreateEl = HTMLElement & {
 };
 
 export type HTMLElementWithCreateDiv = HTMLElement & {
-    createDiv(o?: CreateDivOptions): HTMLDivElement;
+    createDiv(o?: string | CreateDivOptions): HTMLDivElement;
 };
 
 export type HTMLElementWithCreateSpan = HTMLElement & {

--- a/tests/TestingTools/DOMExtensions.ts
+++ b/tests/TestingTools/DOMExtensions.ts
@@ -13,7 +13,7 @@ export type CreateSpanOptions = {};
 
 // See jest.setup.ts for the test implementations of these functions.
 export type HTMLElementWithCreateEl = HTMLElement & {
-    createEl<K extends keyof HTMLElementTagNameMap>(tag: K, o?: CreateElOptions): HTMLElementTagNameMap[K];
+    createEl<K extends keyof HTMLElementTagNameMap>(tag: K, o?: string | CreateElOptions): HTMLElementTagNameMap[K];
 };
 
 export type HTMLElementWithCreateDiv = HTMLElement & {

--- a/tests/TestingTools/DOMExtensions.ts
+++ b/tests/TestingTools/DOMExtensions.ts
@@ -8,6 +8,9 @@ export type CreateDivOptions = {
     text?: string;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- types will likely be added in future
+export type CreateSpanOptions = {};
+
 // See jest.setup.ts for the test implementations of these functions.
 export type HTMLElementWithCreateEl = HTMLElement & {
     createEl<K extends keyof HTMLElementTagNameMap>(tag: K, o?: CreateElOptions): HTMLElementTagNameMap[K];
@@ -15,4 +18,8 @@ export type HTMLElementWithCreateEl = HTMLElement & {
 
 export type HTMLElementWithCreateDiv = HTMLElement & {
     createDiv(o?: CreateDivOptions): HTMLDivElement;
+};
+
+export type HTMLElementWithCreateSpan = HTMLElement & {
+    createSpan(o?: CreateSpanOptions): HTMLSpanElement;
 };

--- a/tests/TestingTools/DOMExtensions.ts
+++ b/tests/TestingTools/DOMExtensions.ts
@@ -25,5 +25,5 @@ export type HTMLElementWithCreateDiv = HTMLElement & {
 };
 
 export type HTMLElementWithCreateSpan = HTMLElement & {
-    createSpan(o?: CreateSpanOptions): HTMLSpanElement;
+    createSpan(o?: CreateSpanOptions, callback?: (el: HTMLSpanElement) => void): HTMLSpanElement;
 };

--- a/tests/TestingTools/DOMExtensions.ts
+++ b/tests/TestingTools/DOMExtensions.ts
@@ -1,10 +1,17 @@
+export type CreateElOptions = {
+    type?: string;
+    cls?: string[] | string;
+};
+
+export type CreateDivOptions = {
+    cls?: string[] | string;
+    text?: string;
+};
+
 export type HTMLElementWithCreateEl = HTMLElement & {
-    createEl<K extends keyof HTMLElementTagNameMap>(
-        tag: K,
-        o?: { type?: string; cls?: string[] | string },
-    ): HTMLElementTagNameMap[K];
+    createEl<K extends keyof HTMLElementTagNameMap>(tag: K, o?: CreateElOptions): HTMLElementTagNameMap[K];
 };
 
 export type HTMLElementWithCreateDiv = HTMLElement & {
-    createDiv(o?: { cls?: string[] | string; text?: string }): HTMLDivElement;
+    createDiv(o?: CreateDivOptions): HTMLDivElement;
 };

--- a/tests/TestingTools/DOMExtensions.ts
+++ b/tests/TestingTools/DOMExtensions.ts
@@ -21,7 +21,7 @@ export type HTMLElementWithCreateEl = HTMLElement & {
 };
 
 export type HTMLElementWithCreateDiv = HTMLElement & {
-    createDiv(o?: string | CreateDivOptions): HTMLDivElement;
+    createDiv(o?: string | CreateDivOptions, callback?: (el: HTMLDivElement) => void): HTMLDivElement;
 };
 
 export type HTMLElementWithCreateSpan = HTMLElement & {

--- a/tests/TestingTools/DOMExtensions.ts
+++ b/tests/TestingTools/DOMExtensions.ts
@@ -8,8 +8,10 @@ export type CreateDivOptions = {
     text?: string | DocumentFragment;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- types will likely be added in future
-export type CreateSpanOptions = {};
+export type CreateSpanOptions = {
+    cls?: string[] | string;
+    text?: string | DocumentFragment;
+};
 
 // See jest.setup.ts for the test implementations of these functions.
 export type HTMLElementWithCreateEl = HTMLElement & {
@@ -25,5 +27,5 @@ export type HTMLElementWithCreateDiv = HTMLElement & {
 };
 
 export type HTMLElementWithCreateSpan = HTMLElement & {
-    createSpan(o?: CreateSpanOptions, callback?: (el: HTMLSpanElement) => void): HTMLSpanElement;
+    createSpan(o?: string | CreateSpanOptions, callback?: (el: HTMLSpanElement) => void): HTMLSpanElement;
 };

--- a/tests/TestingTools/DOMExtensions.ts
+++ b/tests/TestingTools/DOMExtensions.ts
@@ -8,6 +8,7 @@ export type CreateDivOptions = {
     text?: string;
 };
 
+// See jest.setup.ts for the test implementations of these functions.
 export type HTMLElementWithCreateEl = HTMLElement & {
     createEl<K extends keyof HTMLElementTagNameMap>(tag: K, o?: CreateElOptions): HTMLElementTagNameMap[K];
 };

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -3,18 +3,7 @@ import { InMemoryLocalStorageProvider } from '../src/Config/InMemoryLocalStorage
 import { initializeI18n } from '../src/i18n/i18n';
 import type { CreateDivOptions, CreateElOptions, CreateSpanOptions } from './TestingTools/DOMExtensions';
 
-/**
- * Provide the minimal Obsidian-style createEl() behaviour in Jest:
- * create the requested element, append it to the parent, and return it.
- *
- * This is a partial re-implementation of:
- * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createEl/.
- *
- * See also the following, which is not yet supported in tests:
- * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/functions/createEl/
- */
-HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap>(
-    this: HTMLElement,
+function createElementWithObsidianOptions<K extends keyof HTMLElementTagNameMap>(
     tag: K,
     o?: CreateElOptions,
 ): HTMLElementTagNameMap[K] {
@@ -28,6 +17,41 @@ HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap
         const classes = Array.isArray(o.cls) ? o.cls : [o.cls];
         el.classList.add(...classes);
     }
+
+    return el;
+}
+
+/**
+ * Provide the minimal Obsidian-style createEl() behaviour in Jest:
+ * create the requested element, append it to the parent, and return it.
+ *
+ * This is a partial re-implementation of:
+ * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/functions/createEl/
+ */
+globalThis.createEl = function <K extends keyof HTMLElementTagNameMap>(
+    tag: K,
+    o?: string | CreateElOptions,
+    callback?: (el: HTMLElementTagNameMap[K]) => void,
+): HTMLElementTagNameMap[K] {
+    const options: CreateElOptions | undefined = typeof o === 'string' ? { cls: o } : o;
+    const el = createElementWithObsidianOptions(tag, options);
+    callback?.(el);
+    return el;
+};
+
+/**
+ * Provide the minimal Obsidian-style createEl() behaviour in Jest:
+ * create the requested element, append it to the parent, and return it.
+ *
+ * This is a partial re-implementation of:
+ * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createEl/.
+ */
+HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap>(
+    this: HTMLElement,
+    tag: K,
+    o?: CreateElOptions,
+): HTMLElementTagNameMap[K] {
+    const el = createElementWithObsidianOptions(tag, o);
 
     this.appendChild(el);
     return el;

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -53,11 +53,34 @@ HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap
  * Provide the minimal Obsidian-style createDiv() behaviour in Jest
  * by delegating to createEl('div').
  *
- * This is a partial re-implementation of
- * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createDiv/.
- *
  * See also the following, which is not yet supported in tests:
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/functions/createDiv/
+ */
+globalThis.createDiv = function (
+    o?: string | CreateDivOptions,
+    callback?: (el: HTMLDivElement) => void,
+): HTMLDivElement {
+    const options: CreateDivOptions | undefined = typeof o === 'string' ? { cls: o } : o;
+    const div = createEl('div', options);
+
+    if (options?.text !== undefined) {
+        if (typeof options.text === 'string') {
+            div.textContent = options.text;
+        } else {
+            div.replaceChildren(options.text);
+        }
+    }
+
+    callback?.(div);
+    return div;
+};
+
+/**
+ * Provide the minimal Obsidian-style createDiv() behaviour in Jest
+ * by delegating to createEl('div').
+ *
+ * This is a partial re-implementation of
+ * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createDiv/.
  */
 HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: CreateDivOptions): HTMLDivElement {
     const div = this.createEl('div', o);

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -9,6 +9,9 @@ import type { CreateDivOptions, CreateElOptions } from './TestingTools/DOMExtens
  *
  * This is a partial re-implementation of:
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createEl/.
+ *
+ * See also the following, which is not yet supported in tests:
+ * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/functions/createEl/
  */
 if (HTMLElement.prototype.createEl === undefined) {
     HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap>(
@@ -38,7 +41,9 @@ if (HTMLElement.prototype.createEl === undefined) {
  *
  * This is a partial re-implementation of
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createDiv/.
- */
+ *
+ * See also the following, which is not yet supported in tests:
+ * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/functions/createDiv/ */
 if (HTMLElement.prototype.createDiv === undefined) {
     HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: CreateDivOptions): HTMLDivElement {
         const div = this.createEl('div', o);

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -83,16 +83,9 @@ globalThis.createDiv = function (
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createDiv/.
  */
 HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: CreateDivOptions): HTMLDivElement {
-    const div = this.createEl('div', o);
+    const div = createDiv(o);
 
-    if (o?.text !== undefined) {
-        if (typeof o.text === 'string') {
-            div.textContent = o.text;
-        } else {
-            div.replaceChildren(o.text);
-        }
-    }
-
+    this.appendChild(div);
     return div;
 };
 

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -141,7 +141,7 @@ globalThis.createSpan = function (
  */
 HTMLElement.prototype.createSpan = function (
     this: HTMLElement,
-    o?: CreateSpanOptions,
+    o?: string | CreateSpanOptions,
     callback?: (el: HTMLSpanElement) => void,
 ): HTMLSpanElement {
     const span = createSpan(o, callback);

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -7,6 +7,23 @@ import type { CreateDivOptions, CreateElOptions, CreateSpanOptions } from './Tes
 // Mimics of Obsidian's createEl() implementations
 // ------------------------------------------------------------------
 
+function applyTextAndInvokeCallback<T extends HTMLElement>(
+    element: T,
+    options: { text?: string | DocumentFragment } | undefined,
+    callback?: (el: T) => void,
+): T {
+    if (options?.text !== undefined) {
+        if (typeof options.text === 'string') {
+            element.textContent = options.text;
+        } else {
+            element.replaceChildren(options.text);
+        }
+    }
+
+    callback?.(element);
+    return element;
+}
+
 /**
  * Provide the minimal Obsidian-style createEl() behaviour in Jest:
  * create the requested element, append it to the parent, and return it.
@@ -71,17 +88,7 @@ globalThis.createDiv = function (
 ): HTMLDivElement {
     const options: CreateDivOptions | undefined = typeof o === 'string' ? { cls: o } : o;
     const div = createEl('div', options);
-
-    if (options?.text !== undefined) {
-        if (typeof options.text === 'string') {
-            div.textContent = options.text;
-        } else {
-            div.replaceChildren(options.text);
-        }
-    }
-
-    callback?.(div);
-    return div;
+    return applyTextAndInvokeCallback(div, options, callback);
 };
 
 /**
@@ -119,17 +126,7 @@ globalThis.createSpan = function (
 ): HTMLSpanElement {
     const options: CreateDivOptions | undefined = typeof o === 'string' ? { cls: o } : o;
     const span = createEl('span', options);
-
-    if (options?.text !== undefined) {
-        if (typeof options.text === 'string') {
-            span.textContent = options.text;
-        } else {
-            span.replaceChildren(options.text);
-        }
-    }
-
-    callback?.(span);
-    return span;
+    return applyTextAndInvokeCallback(span, options, callback);
 };
 
 /**

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -10,12 +10,16 @@ if (HTMLElement.prototype.createEl === undefined) {
     HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap>(
         this: HTMLElement,
         tag: K,
-        o?: { type?: string },
+        o?: { type?: string; cls?: string[] },
     ): HTMLElementTagNameMap[K] {
         const el = document.createElement(tag) as HTMLElementTagNameMap[K];
 
         if (o?.type !== undefined && el instanceof HTMLInputElement) {
             el.type = o.type;
+        }
+
+        if (o?.cls !== undefined) {
+            el.classList.add(...o.cls);
         }
 
         this.appendChild(el);

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -110,11 +110,34 @@ HTMLElement.prototype.createDiv = function (
  * Provide the minimal Obsidian-style createSpan() behaviour in Jest
  * by delegating to createEl('span').
  *
- * This is a partial re-implementation of
- * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createSpan/.
- *
  * See also the following, which is not yet supported in tests:
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/functions/createSpan/
+ */
+globalThis.createSpan = function (
+    o?: string | CreateDivOptions,
+    callback?: (el: HTMLSpanElement) => void,
+): HTMLSpanElement {
+    const options: CreateDivOptions | undefined = typeof o === 'string' ? { cls: o } : o;
+    const span = createEl('span', options);
+
+    if (options?.text !== undefined) {
+        if (typeof options.text === 'string') {
+            span.textContent = options.text;
+        } else {
+            span.replaceChildren(options.text);
+        }
+    }
+
+    callback?.(span);
+    return span;
+};
+
+/**
+ * Provide the minimal Obsidian-style createSpan() behaviour in Jest
+ * by delegating to createEl('span').
+ *
+ * This is a partial re-implementation of
+ * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createSpan/.
  */
 HTMLElement.prototype.createSpan = function (this: HTMLElement, o?: CreateSpanOptions): HTMLSpanElement {
     return this.createEl('span', o);

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -3,24 +3,6 @@ import { InMemoryLocalStorageProvider } from '../src/Config/InMemoryLocalStorage
 import { initializeI18n } from '../src/i18n/i18n';
 import type { CreateDivOptions, CreateElOptions, CreateSpanOptions } from './TestingTools/DOMExtensions';
 
-function createElementWithObsidianOptions<K extends keyof HTMLElementTagNameMap>(
-    tag: K,
-    o?: CreateElOptions,
-): HTMLElementTagNameMap[K] {
-    const el = document.createElement(tag) as HTMLElementTagNameMap[K];
-
-    if (o?.type !== undefined && el instanceof HTMLInputElement) {
-        el.type = o.type;
-    }
-
-    if (o?.cls !== undefined) {
-        const classes = Array.isArray(o.cls) ? o.cls : [o.cls];
-        el.classList.add(...classes);
-    }
-
-    return el;
-}
-
 /**
  * Provide the minimal Obsidian-style createEl() behaviour in Jest:
  * create the requested element, append it to the parent, and return it.
@@ -34,7 +16,17 @@ globalThis.createEl = function <K extends keyof HTMLElementTagNameMap>(
     callback?: (el: HTMLElementTagNameMap[K]) => void,
 ): HTMLElementTagNameMap[K] {
     const options: CreateElOptions | undefined = typeof o === 'string' ? { cls: o } : o;
-    const el = createElementWithObsidianOptions(tag, options);
+    const el = document.createElement(tag) as HTMLElementTagNameMap[K];
+
+    if (options?.type !== undefined && el instanceof HTMLInputElement) {
+        el.type = options.type;
+    }
+
+    if (options?.cls !== undefined) {
+        const classes = Array.isArray(options.cls) ? options.cls : [options.cls];
+        el.classList.add(...classes);
+    }
+
     callback?.(el);
     return el;
 };

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -33,8 +33,8 @@ if (HTMLElement.prototype.createEl === undefined) {
  * by delegating to createEl('div').
  */
 if (HTMLElement.prototype.createDiv === undefined) {
-    HTMLElement.prototype.createDiv = function (this: HTMLElement): HTMLDivElement {
-        return this.createEl('div');
+    HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: { cls?: string[] | string }): HTMLDivElement {
+        return this.createEl('div', o);
     };
 }
 

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -91,7 +91,7 @@ globalThis.createDiv = function (
  * This is a partial re-implementation of
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createDiv/.
  */
-HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: CreateDivOptions): HTMLDivElement {
+HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: string | CreateDivOptions): HTMLDivElement {
     const div = createDiv(o);
 
     this.appendChild(div);

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -42,8 +42,9 @@ HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap
     this: HTMLElement,
     tag: K,
     o?: string | CreateElOptions,
+    callback?: (el: HTMLElementTagNameMap[K]) => void,
 ): HTMLElementTagNameMap[K] {
-    const el = createEl(tag, o);
+    const el = createEl(tag, o, callback);
 
     this.appendChild(el);
     return el;

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -10,7 +10,7 @@ if (HTMLElement.prototype.createEl === undefined) {
     HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap>(
         this: HTMLElement,
         tag: K,
-        o?: { type?: string; cls?: string[] },
+        o?: { type?: string; cls?: string[] | string },
     ): HTMLElementTagNameMap[K] {
         const el = document.createElement(tag) as HTMLElementTagNameMap[K];
 
@@ -19,7 +19,8 @@ if (HTMLElement.prototype.createEl === undefined) {
         }
 
         if (o?.cls !== undefined) {
-            el.classList.add(...o.cls);
+            const classes = Array.isArray(o.cls) ? o.cls : [o.cls];
+            el.classList.add(...classes);
         }
 
         this.appendChild(el);

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -17,6 +17,16 @@ if (HTMLElement.prototype.createEl === undefined) {
     };
 }
 
+/**
+ * Provide the minimal Obsidian-style createDiv() behaviour in Jest
+ * by delegating to createEl('div').
+ */
+if (HTMLElement.prototype.createDiv === undefined) {
+    HTMLElement.prototype.createDiv = function (this: HTMLElement): HTMLDivElement {
+        return this.createEl('div');
+    };
+}
+
 // Tests should default to allowing JavaScript in Tasks queries.
 // Production code initialises this singleton separately in main.ts, using Obsidian local storage.
 EnableJsInTasksQueries.initialise(new InMemoryLocalStorageProvider());

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -10,8 +10,14 @@ if (HTMLElement.prototype.createEl === undefined) {
     HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap>(
         this: HTMLElement,
         tag: K,
+        o?: { type?: string },
     ): HTMLElementTagNameMap[K] {
         const el = document.createElement(tag) as HTMLElementTagNameMap[K];
+
+        if (o?.type !== undefined && el instanceof HTMLInputElement) {
+            el.type = o.type;
+        }
+
         this.appendChild(el);
         return el;
     };

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -91,8 +91,12 @@ globalThis.createDiv = function (
  * This is a partial re-implementation of
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createDiv/.
  */
-HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: string | CreateDivOptions): HTMLDivElement {
-    const div = createDiv(o);
+HTMLElement.prototype.createDiv = function (
+    this: HTMLElement,
+    o?: string | CreateDivOptions,
+    callback?: (el: HTMLDivElement) => void,
+): HTMLDivElement {
+    const div = createDiv(o, callback);
 
     this.appendChild(div);
     return div;

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -2,6 +2,21 @@ import { EnableJsInTasksQueries } from '../src/Config/EnableJsInTasksQueries';
 import { InMemoryLocalStorageProvider } from '../src/Config/InMemoryLocalStorageProvider';
 import { initializeI18n } from '../src/i18n/i18n';
 
+/**
+ * Provide the minimal Obsidian-style createEl() behaviour in Jest:
+ * create the requested element, append it to the parent, and return it.
+ */
+if (HTMLElement.prototype.createEl === undefined) {
+    HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap>(
+        this: HTMLElement,
+        tag: K,
+    ): HTMLElementTagNameMap[K] {
+        const el = document.createElement(tag) as HTMLElementTagNameMap[K];
+        this.appendChild(el);
+        return el;
+    };
+}
+
 // Tests should default to allowing JavaScript in Tasks queries.
 // Production code initialises this singleton separately in main.ts, using Obsidian local storage.
 EnableJsInTasksQueries.initialise(new InMemoryLocalStorageProvider());

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,6 +1,7 @@
 import { EnableJsInTasksQueries } from '../src/Config/EnableJsInTasksQueries';
 import { InMemoryLocalStorageProvider } from '../src/Config/InMemoryLocalStorageProvider';
 import { initializeI18n } from '../src/i18n/i18n';
+import type { CreateDivOptions, CreateElOptions } from './TestingTools/DOMExtensions';
 
 /**
  * Provide the minimal Obsidian-style createEl() behaviour in Jest:
@@ -10,7 +11,7 @@ if (HTMLElement.prototype.createEl === undefined) {
     HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap>(
         this: HTMLElement,
         tag: K,
-        o?: { type?: string; cls?: string[] | string },
+        o?: CreateElOptions,
     ): HTMLElementTagNameMap[K] {
         const el = document.createElement(tag) as HTMLElementTagNameMap[K];
 
@@ -33,10 +34,7 @@ if (HTMLElement.prototype.createEl === undefined) {
  * by delegating to createEl('div').
  */
 if (HTMLElement.prototype.createDiv === undefined) {
-    HTMLElement.prototype.createDiv = function (
-        this: HTMLElement,
-        o?: { cls?: string[] | string; text?: string },
-    ): HTMLDivElement {
+    HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: CreateDivOptions): HTMLDivElement {
         const div = this.createEl('div', o);
 
         if (o?.text !== undefined) {

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -41,7 +41,7 @@ globalThis.createEl = function <K extends keyof HTMLElementTagNameMap>(
 HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap>(
     this: HTMLElement,
     tag: K,
-    o?: CreateElOptions,
+    o?: string | CreateElOptions,
 ): HTMLElementTagNameMap[K] {
     const el = createEl(tag, o);
 

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -139,8 +139,12 @@ globalThis.createSpan = function (
  * This is a partial re-implementation of
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createSpan/.
  */
-HTMLElement.prototype.createSpan = function (this: HTMLElement, o?: CreateSpanOptions): HTMLSpanElement {
-    const span = createSpan(o);
+HTMLElement.prototype.createSpan = function (
+    this: HTMLElement,
+    o?: CreateSpanOptions,
+    callback?: (el: HTMLSpanElement) => void,
+): HTMLSpanElement {
+    const span = createSpan(o, callback);
 
     this.appendChild(span);
     return span;

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -13,27 +13,25 @@ import type { CreateDivOptions, CreateElOptions, CreateSpanOptions } from './Tes
  * See also the following, which is not yet supported in tests:
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/functions/createEl/
  */
-if (HTMLElement.prototype.createEl === undefined) {
-    HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap>(
-        this: HTMLElement,
-        tag: K,
-        o?: CreateElOptions,
-    ): HTMLElementTagNameMap[K] {
-        const el = document.createElement(tag) as HTMLElementTagNameMap[K];
+HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap>(
+    this: HTMLElement,
+    tag: K,
+    o?: CreateElOptions,
+): HTMLElementTagNameMap[K] {
+    const el = document.createElement(tag) as HTMLElementTagNameMap[K];
 
-        if (o?.type !== undefined && el instanceof HTMLInputElement) {
-            el.type = o.type;
-        }
+    if (o?.type !== undefined && el instanceof HTMLInputElement) {
+        el.type = o.type;
+    }
 
-        if (o?.cls !== undefined) {
-            const classes = Array.isArray(o.cls) ? o.cls : [o.cls];
-            el.classList.add(...classes);
-        }
+    if (o?.cls !== undefined) {
+        const classes = Array.isArray(o.cls) ? o.cls : [o.cls];
+        el.classList.add(...classes);
+    }
 
-        this.appendChild(el);
-        return el;
-    };
-}
+    this.appendChild(el);
+    return el;
+};
 
 /**
  * Provide the minimal Obsidian-style createDiv() behaviour in Jest
@@ -45,17 +43,15 @@ if (HTMLElement.prototype.createEl === undefined) {
  * See also the following, which is not yet supported in tests:
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/functions/createDiv/
  */
-if (HTMLElement.prototype.createDiv === undefined) {
-    HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: CreateDivOptions): HTMLDivElement {
-        const div = this.createEl('div', o);
+HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: CreateDivOptions): HTMLDivElement {
+    const div = this.createEl('div', o);
 
-        if (o?.text !== undefined) {
-            div.textContent = o.text;
-        }
+    if (o?.text !== undefined) {
+        div.textContent = o.text;
+    }
 
-        return div;
-    };
-}
+    return div;
+};
 
 /**
  * Provide the minimal Obsidian-style createSpan() behaviour in Jest
@@ -67,11 +63,9 @@ if (HTMLElement.prototype.createDiv === undefined) {
  * See also the following, which is not yet supported in tests:
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/functions/createSpan/
  */
-if (HTMLElement.prototype.createSpan === undefined) {
-    HTMLElement.prototype.createSpan = function (this: HTMLElement, o?: CreateSpanOptions): HTMLSpanElement {
-        return this.createEl('span', o);
-    };
-}
+HTMLElement.prototype.createSpan = function (this: HTMLElement, o?: CreateSpanOptions): HTMLSpanElement {
+    return this.createEl('span', o);
+};
 
 // Tests should default to allowing JavaScript in Tasks queries.
 // Production code initialises this singleton separately in main.ts, using Obsidian local storage.

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,7 +1,7 @@
 import { EnableJsInTasksQueries } from '../src/Config/EnableJsInTasksQueries';
 import { InMemoryLocalStorageProvider } from '../src/Config/InMemoryLocalStorageProvider';
 import { initializeI18n } from '../src/i18n/i18n';
-import type { CreateDivOptions, CreateElOptions } from './TestingTools/DOMExtensions';
+import type { CreateDivOptions, CreateElOptions, CreateSpanOptions } from './TestingTools/DOMExtensions';
 
 /**
  * Provide the minimal Obsidian-style createEl() behaviour in Jest:
@@ -43,7 +43,8 @@ if (HTMLElement.prototype.createEl === undefined) {
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createDiv/.
  *
  * See also the following, which is not yet supported in tests:
- * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/functions/createDiv/ */
+ * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/functions/createDiv/
+ */
 if (HTMLElement.prototype.createDiv === undefined) {
     HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: CreateDivOptions): HTMLDivElement {
         const div = this.createEl('div', o);
@@ -53,6 +54,22 @@ if (HTMLElement.prototype.createDiv === undefined) {
         }
 
         return div;
+    };
+}
+
+/**
+ * Provide the minimal Obsidian-style createSpan() behaviour in Jest
+ * by delegating to createEl('span').
+ *
+ * This is a partial re-implementation of
+ * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createSpan/.
+ *
+ * See also the following, which is not yet supported in tests:
+ * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/functions/createSpan/
+ */
+if (HTMLElement.prototype.createSpan === undefined) {
+    HTMLElement.prototype.createSpan = function (this: HTMLElement, o?: CreateSpanOptions): HTMLSpanElement {
+        return this.createEl('span', o);
     };
 }
 

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -6,6 +6,9 @@ import type { CreateDivOptions, CreateElOptions } from './TestingTools/DOMExtens
 /**
  * Provide the minimal Obsidian-style createEl() behaviour in Jest:
  * create the requested element, append it to the parent, and return it.
+ *
+ * This is a partial re-implementation of:
+ * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createEl/.
  */
 if (HTMLElement.prototype.createEl === undefined) {
     HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap>(
@@ -32,6 +35,9 @@ if (HTMLElement.prototype.createEl === undefined) {
 /**
  * Provide the minimal Obsidian-style createDiv() behaviour in Jest
  * by delegating to createEl('div').
+ *
+ * This is a partial re-implementation of
+ * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createDiv/.
  */
 if (HTMLElement.prototype.createDiv === undefined) {
     HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: CreateDivOptions): HTMLDivElement {

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -3,6 +3,10 @@ import { InMemoryLocalStorageProvider } from '../src/Config/InMemoryLocalStorage
 import { initializeI18n } from '../src/i18n/i18n';
 import type { CreateDivOptions, CreateElOptions, CreateSpanOptions } from './TestingTools/DOMExtensions';
 
+// ------------------------------------------------------------------
+// Mimics of Obsidian's createEl() implementations
+// ------------------------------------------------------------------
+
 /**
  * Provide the minimal Obsidian-style createEl() behaviour in Jest:
  * create the requested element, append it to the parent, and return it.
@@ -50,6 +54,10 @@ HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap
     return el;
 };
 
+// ------------------------------------------------------------------
+// Mimics of Obsidian's createDiv() implementations
+// ------------------------------------------------------------------
+
 /**
  * Provide the minimal Obsidian-style createDiv() behaviour in Jest
  * by delegating to createEl('div').
@@ -90,6 +98,10 @@ HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: CreateDivOpti
     return div;
 };
 
+// ------------------------------------------------------------------
+// Mimics of Obsidian's createSpan() implementations
+// ------------------------------------------------------------------
+
 /**
  * Provide the minimal Obsidian-style createSpan() behaviour in Jest
  * by delegating to createEl('span').
@@ -103,6 +115,10 @@ HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: CreateDivOpti
 HTMLElement.prototype.createSpan = function (this: HTMLElement, o?: CreateSpanOptions): HTMLSpanElement {
     return this.createEl('span', o);
 };
+
+// ------------------------------------------------------------------
+// Other global test code
+// ------------------------------------------------------------------
 
 // Tests should default to allowing JavaScript in Tasks queries.
 // Production code initialises this singleton separately in main.ts, using Obsidian local storage.

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -33,8 +33,17 @@ if (HTMLElement.prototype.createEl === undefined) {
  * by delegating to createEl('div').
  */
 if (HTMLElement.prototype.createDiv === undefined) {
-    HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: { cls?: string[] | string }): HTMLDivElement {
-        return this.createEl('div', o);
+    HTMLElement.prototype.createDiv = function (
+        this: HTMLElement,
+        o?: { cls?: string[] | string; text?: string },
+    ): HTMLDivElement {
+        const div = this.createEl('div', o);
+
+        if (o?.text !== undefined) {
+            div.textContent = o.text;
+        }
+
+        return div;
     };
 }
 

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -51,7 +51,7 @@ HTMLElement.prototype.createEl = function <K extends keyof HTMLElementTagNameMap
     tag: K,
     o?: CreateElOptions,
 ): HTMLElementTagNameMap[K] {
-    const el = createElementWithObsidianOptions(tag, o);
+    const el = createEl(tag, o);
 
     this.appendChild(el);
     return el;

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -140,7 +140,10 @@ globalThis.createSpan = function (
  * https://obsidian-typings.github.io/obsidian-typings/public/api/globals/augmentations/Node/createSpan/.
  */
 HTMLElement.prototype.createSpan = function (this: HTMLElement, o?: CreateSpanOptions): HTMLSpanElement {
-    return this.createEl('span', o);
+    const span = createSpan(o);
+
+    this.appendChild(span);
+    return span;
 };
 
 // ------------------------------------------------------------------

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -63,7 +63,11 @@ HTMLElement.prototype.createDiv = function (this: HTMLElement, o?: CreateDivOpti
     const div = this.createEl('div', o);
 
     if (o?.text !== undefined) {
-        div.textContent = o.text;
+        if (typeof o.text === 'string') {
+            div.textContent = o.text;
+        } else {
+            div.replaceChildren(o.text);
+        }
     }
 
     return div;


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

Add partial test implementations of the following functions from the Obsidian API:

```ts
    interface Node {
        /**
         * Create an element and append it to this node.
         */
        createEl<K extends keyof HTMLElementTagNameMap>(tag: K, o?: DomElementInfo | string, callback?: (el: HTMLElementTagNameMap[K]) => void): HTMLElementTagNameMap[K];
        createDiv(o?: DomElementInfo | string, callback?: (el: HTMLDivElement) => void): HTMLDivElement;
        createSpan(o?: DomElementInfo | string, callback?: (el: HTMLSpanElement) => void): HTMLSpanElement;
    }
    function createEl<K extends keyof HTMLElementTagNameMap>(tag: K, o?: DomElementInfo | string, callback?: (el: HTMLElementTagNameMap[K]) => void): HTMLElementTagNameMap[K];
    function createDiv(o?: DomElementInfo | string, callback?: (el: HTMLDivElement) => void): HTMLDivElement;
    function createSpan(o?: DomElementInfo | string, callback?: (el: HTMLSpanElement) => void): HTMLSpanElement;
```

This enabled me to refactor our existing code to create HTML elements, so that the code satisfies warnings from the Obsidian ESLint plugin.

In turn, this reduces the number of remaining ESLint issues on 'src/'

from:

```
144 problems (0 errors, 144 warnings)
  0 errors and 33 warnings potentially fixable with the `--fix` option.
```

to:

```
120 problems (0 errors, 120 warnings)
  0 errors and 21 warnings potentially fixable with the `--fix` option.
```

(I also fixed an ESLint warning on `ExpandPlaceholders.ts` as it kept getting under my feet.

## Motivation and Context


1. To fix a number of ESLint warnings on our code, as Obsidian didn't make implementations of these functions available for plugin tests to use
2. It turns out that the parameters of these functions can enable calling code to be tidied up/simplified somewhat.

I gave up tidying up all the calls of these functions, as this has already taken way more time to implement than I expected, and not all affected areas of our code had tests.

## How has this been tested?

- Adding tests for the new code
- Checking that existing code had tests before updating it
- And for code which didn't, by testing it by hand.


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
