### PR TITLE
refactor: Fix all 'obsidianmd/no-global-this' ESLint warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -84,7 +84,7 @@ const typescriptCommonRules = {
     'no-unsanitized/method': 1,
     'no-unsanitized/property': 1,
     'obsidianmd/hardcoded-config-path': 0, // These were all 'https://publish.obsidian.md/tasks/' references!!!
-    'obsidianmd/no-global-this': on_or_off,
+    'obsidianmd/no-global-this': 1,
     'obsidianmd/no-nodejs-modules': 1, // Can disable this on test files
     'obsidianmd/no-static-styles-assignment': 1,
     'obsidianmd/prefer-active-doc': 1,

--- a/lint.txt
+++ b/lint.txt
@@ -119,9 +119,7 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   213:36  warning  Unsafe member access .save on a type that cannot be resolved                                                                             @typescript-eslint/no-unsafe-member-access
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Suggestor/Suggestor.ts
-   35:1   warning  Avoid using 'globalThis'. Use 'window' or 'activeWindow' for popout window compatibility  obsidianmd/no-global-this
-   38:12  warning  Avoid using 'globalThis'. Use 'window' or 'activeWindow' for popout window compatibility  obsidianmd/no-global-this
-  492:57  warning  Invalid type "string | string[]" of template literal expression                           @typescript-eslint/restrict-template-expressions
+  492:57  warning  Invalid type "string | string[]" of template literal expression  @typescript-eslint/restrict-template-expressions
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Task/ListItem.ts
   143:19  warning  Unsafe assignment of an `any` value                                                               @typescript-eslint/no-unsafe-assignment
@@ -181,8 +179,8 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   37:9   warning  Promise-returning function provided to property where a void return was expected  @typescript-eslint/no-misused-promises
   76:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 115 problems (0 errors, 115 warnings)
-  0 errors and 15 warnings potentially fixable with the `--fix` option.
+✖ 113 problems (0 errors, 113 warnings)
+  0 errors and 13 warnings potentially fixable with the `--fix` option.
 
 
 ====================================
@@ -191,4 +189,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 25.20s.
+Done in 24.51s.

--- a/lint.txt
+++ b/lint.txt
@@ -119,7 +119,7 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   213:36  warning  Unsafe member access .save on a type that cannot be resolved                                                                             @typescript-eslint/no-unsafe-member-access
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Suggestor/Suggestor.ts
-  492:57  warning  Invalid type "string | string[]" of template literal expression  @typescript-eslint/restrict-template-expressions
+  483:57  warning  Invalid type "string | string[]" of template literal expression  @typescript-eslint/restrict-template-expressions
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Task/ListItem.ts
   143:19  warning  Unsafe assignment of an `any` value                                                               @typescript-eslint/no-unsafe-assignment
@@ -189,4 +189,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 24.51s.
+Done in 30.80s.

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -32,10 +32,10 @@ declare global {
 
 // Set default value for production to off, temporarily. It will be turned on in tests.
 export const showDependencySuggestionsDefault = true;
-globalThis.SHOW_DEPENDENCY_SUGGESTIONS = showDependencySuggestionsDefault;
+window.SHOW_DEPENDENCY_SUGGESTIONS = showDependencySuggestionsDefault;
 
 function includeDependencySuggestions(canSaveEdits: boolean) {
-    return globalThis.SHOW_DEPENDENCY_SUGGESTIONS && canSaveEdits;
+    return window.SHOW_DEPENDENCY_SUGGESTIONS && canSaveEdits;
 }
 
 export interface SuggestorParameters {

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -25,15 +25,6 @@ import type { SuggestInfo, SuggestionBuilder } from '.';
  */
 export const DEFAULT_MAX_GENERIC_SUGGESTIONS = 5;
 
-declare global {
-    // eslint-disable-next-line no-var -- required to declare a globalThis property in TypeScript
-    var SHOW_DEPENDENCY_SUGGESTIONS: boolean;
-}
-
-// Set default value for production to off, temporarily. It will be turned on in tests.
-export const showDependencySuggestionsDefault = true;
-window.SHOW_DEPENDENCY_SUGGESTIONS = showDependencySuggestionsDefault;
-
 function includeDependencySuggestions(canSaveEdits: boolean) {
     return canSaveEdits;
 }

--- a/src/Suggestor/Suggestor.ts
+++ b/src/Suggestor/Suggestor.ts
@@ -35,7 +35,7 @@ export const showDependencySuggestionsDefault = true;
 window.SHOW_DEPENDENCY_SUGGESTIONS = showDependencySuggestionsDefault;
 
 function includeDependencySuggestions(canSaveEdits: boolean) {
-    return window.SHOW_DEPENDENCY_SUGGESTIONS && canSaveEdits;
+    return canSaveEdits;
 }
 
 export interface SuggestorParameters {

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -93,15 +93,6 @@ describe.each([
         MAX_GENERIC_SUGGESTIONS_FOR_TESTS,
         name === 'dataview',
     );
-    beforeEach(() => {
-        // Note: Dependency suggestions are temporarily turned off in the released plugin,
-        //       but turned on in tests so that we continue to check the behaviour.
-        global.SHOW_DEPENDENCY_SUGGESTIONS = true;
-    });
-
-    afterEach(() => {
-        global.SHOW_DEPENDENCY_SUGGESTIONS = false;
-    });
 
     /** Build suggestions for the simple case where the cursor is at the very end of the line.
      */

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -475,10 +475,9 @@ ${JSON.stringify(suggestions[0], null, 4)}
             `- [ ] some task ${scheduledDateSymbol} `,
             `- [ ] some task ${startDateSymbol} `,
             `- [ ] some task ${onCompletionSymbol} `,
+            `- [ ] some task ${idSymbol} `,
+            `- [ ] some task ${dependsOnSymbol} `,
         ];
-        lines.push(`- [ ] some task ${idSymbol} `);
-        lines.push(`- [ ] some task ${dependsOnSymbol} `);
-
         const markdownTable = new MarkdownTable(['Searchable Text', 'Text that is added']);
         for (const line of lines) {
             let suggestions = buildSuggestions(line, line.length - 1, originalSettings, [], CAN_SAVE_EDITS);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -476,10 +476,9 @@ ${JSON.stringify(suggestions[0], null, 4)}
             `- [ ] some task ${startDateSymbol} `,
             `- [ ] some task ${onCompletionSymbol} `,
         ];
-        if (global.SHOW_DEPENDENCY_SUGGESTIONS) {
-            lines.push(`- [ ] some task ${idSymbol} `);
-            lines.push(`- [ ] some task ${dependsOnSymbol} `);
-        }
+        lines.push(`- [ ] some task ${idSymbol} `);
+        lines.push(`- [ ] some task ${dependsOnSymbol} `);
+
         const markdownTable = new MarkdownTable(['Searchable Text', 'Text that is added']);
         for (const line of lines) {
             let suggestions = buildSuggestions(line, line.length - 1, originalSettings, [], CAN_SAVE_EDITS);

--- a/tests/Suggestor/Suggestor.test.ts
+++ b/tests/Suggestor/Suggestor.test.ts
@@ -12,7 +12,6 @@ import {
     lastOpenBracket,
     makeDefaultSuggestionBuilder,
     onlySuggestIfBracketOpen,
-    showDependencySuggestionsDefault,
 } from '../../src/Suggestor/Suggestor';
 import { DEFAULT_SYMBOLS } from '../../src/TaskSerializer/DefaultTaskSerializer';
 import { DATAVIEW_SYMBOLS } from '../../src/TaskSerializer/DataviewTaskSerializer';
@@ -464,11 +463,6 @@ ${JSON.stringify(suggestions[0], null, 4)}
     });
 
     it('show all suggested text', () => {
-        // Turn off dependency suggestions for now, as per default value,
-        // as the outputs of this test are embedded in the documentation,
-        // and I wish to hide ID and dependsOn there.
-        global.SHOW_DEPENDENCY_SUGGESTIONS = showDependencySuggestionsDefault;
-
         const originalSettings = getSettings();
         originalSettings.autoSuggestMaxItems = 200;
 


### PR DESCRIPTION
# Types of changes

Done by pairing with @ilandikov.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

Fix all `'obsidianmd/no-global-this'` warnings, and leave that option turned on, to prevent future re-occurrences of this message.

As part of this change, we spotted some significant simplifications to the code, left over from when the Dependencies facilities was in development, and not yet released.

## Motivation and Context

Wanting to reduce the number of warnings shown on the plugin's Scorecard on the Community site:

https://community.obsidian.md/plugins/obsidian-tasks-plugin


## How has this been tested?

- Automated tests
- Manual exploratory testing

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
