### PR TITLE
fix: improve Quick Search layout on narrow screens

### DIFF
--- a/src/Commands/QuickSearchTasks.scss
+++ b/src/Commands/QuickSearchTasks.scss
@@ -49,7 +49,7 @@
     }
 }
 
-@media (max-width: 499px) {
+@media (max-width: 799px) {
     .tasks-quick-search-result {
         grid-template-columns: auto minmax(0, 1fr);
 

--- a/src/Commands/QuickSearchTasks.scss
+++ b/src/Commands/QuickSearchTasks.scss
@@ -48,3 +48,21 @@
         white-space: nowrap;
     }
 }
+
+@media (max-width: 499px) {
+    .tasks-quick-search-result {
+        grid-template-columns: auto minmax(0, 1fr);
+
+        .tasks-quick-search-result-checkbox {
+            grid-row: 1 / span 3;
+        }
+
+        .tasks-quick-search-result-metadata {
+            grid-column: 2;
+            grid-row: 3;
+            max-width: none;
+            margin-top: var(--size-2-1);
+            text-align: start;
+        }
+    }
+}


### PR DESCRIPTION
# Types of changes

Changes visible to users:

- [x] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
  - Issue/discussion: #4004

## Description

Change Quick Search results to a two-column, three-row layout at viewport widths up to 799px. The task description, source location, and metadata then share the full content width instead of reserving a separate metadata column.

The existing three-column layout is unchanged at viewport widths of 800px and above.

## Motivation and Context

Fixes #4004.

On an Android phone-sized viewport, the metadata column occupied about 675 physical pixels and left only 200 pixels for the description. With the responsive layout, all three text rows receive about 882 pixels, making the example task descriptions readable.

## How has this been tested?

- `yarn lint:no-fix`
- `yarn test tests/Commands/QuickSearchTasks.test.ts --runInBand` — 12 tests passed
- `yarn build:dev`
- Obsidian 1.13.7 on an Android 16 / API 36 emulator
- Reproduced with the exact Markdown from #4004
- Verified that selecting a Quick Search result still opens the correct source note

## Screenshots

Android verification after the fix:

<img width="360" alt="Quick Search results after the responsive layout fix on Android 16" src="https://github.com/user-attachments/assets/40a2c8f5-61a6-4bcb-b2fb-fdf35aa59b86" />

## Checklist

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes the lint checks.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage.

## Terms

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
