### PR TITLE
feat: Honour the 'Remove global filter' setting in "Quick Search" results display

### DIFF
--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -3,6 +3,7 @@ import { TASK_FORMATS } from '../Config/Settings';
 import { TaskLayoutComponent } from '../Layout/TaskLayoutOptions';
 import type { Task } from '../Task/Task';
 import { getTaskLineAndFile } from '../Obsidian/File';
+import { GlobalFilter } from '../Config/GlobalFilter';
 
 export interface TaskSearchSuggestionText {
     description: string;
@@ -89,7 +90,7 @@ export class QuickSearchTasksModal extends SuggestModal<Task> {
         const renderComponent = new Component();
         renderComponent.load();
         this.renderComponents.push(renderComponent);
-        const markdown = task.description;
+        const markdown = GlobalFilter.getInstance().removeAsWordFromDependingOnSettings(task.description);
         void MarkdownRenderer.render(this.app, markdown, description, task.path, renderComponent).catch(() => {
             description.textContent = suggestion.description;
         });

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -89,7 +89,8 @@ export class QuickSearchTasksModal extends SuggestModal<Task> {
         const renderComponent = new Component();
         renderComponent.load();
         this.renderComponents.push(renderComponent);
-        void MarkdownRenderer.render(this.app, task.description, description, task.path, renderComponent).catch(() => {
+        const markdown = task.description;
+        void MarkdownRenderer.render(this.app, markdown, description, task.path, renderComponent).catch(() => {
             description.textContent = suggestion.description;
         });
 

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -111,20 +111,32 @@ describe('Describing matching task', () => {
 });
 
 describe('Rendering matching tasks', () => {
+    function getCheckbox(element: HTMLDivElement): HTMLElement | null {
+        return element.querySelector('.tasks-quick-search-result-checkbox');
+    }
+
+    function getDescriptionTextContent(element: HTMLDivElement): string | null | undefined {
+        return element.querySelector('.tasks-quick-search-result-description')?.textContent;
+    }
+
+    function getLocationTextContent(element: HTMLDivElement): string | null | undefined {
+        return element.querySelector('.tasks-quick-search-result-location')?.textContent;
+    }
+
+    function getMetadata(element: HTMLDivElement): HTMLElement | null {
+        return element.querySelector('.tasks-quick-search-result-metadata');
+    }
+
     it('should render the checkbox, description, location, and metadata elements', () => {
         const modal = new QuickSearchTasksModal({} as any, () => tasks);
         const element = document.createElement('div');
 
         modal.renderSuggestion(tasks[0], element);
 
-        expect(element.querySelector('.tasks-quick-search-result-checkbox')).not.toBeNull();
-        expect(element.querySelector('.tasks-quick-search-result-description')?.textContent).toEqual(
-            'Write release notes',
-        );
-        expect(element.querySelector('.tasks-quick-search-result-location')?.textContent).toEqual(
-            'Release.md · Preparation',
-        );
-        expect(element.querySelector('.tasks-quick-search-result-metadata')).not.toBeNull();
+        expect(getCheckbox(element)).not.toBeNull();
+        expect(getDescriptionTextContent(element)).toEqual('Write release notes');
+        expect(getLocationTextContent(element)).toEqual('Release.md · Preparation');
+        expect(getMetadata(element)).not.toBeNull();
     });
 
     it('should only check the checkbox for completed tasks', () => {

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -12,6 +12,8 @@ import { getTaskLineAndFile } from '../../src/Obsidian/File';
 import { Priority } from '../../src/Task/Priority';
 import { Status } from '../../src/Statuses/Status';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
+import { GlobalFilter } from '../../src/Config/GlobalFilter';
+import { fromMarkdown } from '../TestingTools/TestHelpers';
 
 jest.mock('obsidian', () => ({
     ...jest.requireActual('../__mocks__/obsidian'),
@@ -38,6 +40,11 @@ const tasks = [
     new TaskBuilder().description('Release completed').status(Status.DONE).path('Archive.md').build(),
     new TaskBuilder().description('Review a document').tags(['#release']).path('Projects/Review.md').build(),
 ];
+
+afterEach(() => {
+    GlobalFilter.getInstance().reset();
+    GlobalFilter.getInstance().setRemoveGlobalFilter(false);
+});
 
 describe('Registering the command', () => {
     it('should register the quick search command', () => {
@@ -138,6 +145,26 @@ describe('Rendering matching tasks', () => {
         expect(getLocationTextContent(element)).toEqual('Release.md · Preparation');
         expect(getMetadata(element)).not.toBeNull();
     });
+
+    it.each([
+        [false, '#task Do Stuff'],
+        [true, 'Do Stuff'],
+    ])(
+        'should honour "Remove global filter from description" setting: %s',
+        (removeGlobalFilter: boolean, expectedDescription: string) => {
+            GlobalFilter.getInstance().set('#task');
+            GlobalFilter.getInstance().setRemoveGlobalFilter(removeGlobalFilter);
+
+            const taskListWithGlobalFilter = fromMarkdown('- [ ] #task Do Stuff');
+
+            const modal = new QuickSearchTasksModal({} as any, () => taskListWithGlobalFilter);
+            const element = document.createElement('div');
+
+            modal.renderSuggestion(taskListWithGlobalFilter[0], element);
+
+            expect(getDescriptionTextContent(element)).toEqual(expectedDescription);
+        },
+    );
 
     it('should only check the checkbox for completed tasks', () => {
         const modal = new QuickSearchTasksModal({} as any, () => tasks);


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: #4003

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

Honour the 'Remove global filter' setting in "Quick Search" results display.

If the user has requested Tasks to hide their Global Filter in search results, then also hide it in the Quick Search results.

## Motivation and Context

Fixes #4003.

Removes clutter.

## How has this been tested?

Adding a new automated test.

Manual exploratory testing to confirm that it works in the test vault.


## Screenshots (if appropriate)

### With Global Filter displayed

Settings:

<img width="615" height="479" alt="image" src="https://github.com/user-attachments/assets/164539ee-f4a8-4d98-8c13-207029c72c27" />


<img width="711" height="184" alt="image" src="https://github.com/user-attachments/assets/3fab9ea0-3900-404f-b5ef-777f7defe638" />

### With Global Filter set to be hidden

Settings:

<img width="605" height="459" alt="image" src="https://github.com/user-attachments/assets/eac7daf8-f2ab-4834-a76d-b83785f0b8b8" />


<img width="703" height="178" alt="image" src="https://github.com/user-attachments/assets/fc6f6236-4ac3-480e-988f-5e19af5efc19" />


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

I decided not to mention it in the user docs, as I think this is reasonable expected behaviour by default.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
