### PR TITLE
feat: Teach Quick Search command to honour user's Global Query filters

### DIFF
--- a/docs/Editing/Quick Search.md
+++ b/docs/Editing/Quick Search.md
@@ -7,7 +7,7 @@ publish: true
 > [!released]
 > Introduced in Tasks X.Y.Z.
 
-Use the `Tasks: Quick search` command to find an incomplete task recognised by Tasks anywhere in your vault. If you use a [[Global Filter]], only tasks that match it are searchable.
+Use the `Tasks: Quick search` command to find an incomplete task recognised by Tasks anywhere in your vault. If you use a [[Global Filter]], only tasks that match it are searchable. Similarly, if you use a [[Global Query]], only tasks that match it are searchable.
 
 ![The Command Palette showing Tasks: Quick search](../images/quick-search-command-palette.png)
 <span class="caption">The Command Palette showing Tasks: Quick search</span>

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -15,7 +15,12 @@ export interface TaskSearchSuggestionText {
 }
 
 function getGlobalQueryFilters(): Filter[] {
-    return GlobalQuery.getInstance().query().filters;
+    const query = GlobalQuery.getInstance().query();
+    if (query.error !== undefined) {
+        // Silently ignore invalid Global Query
+        return [];
+    }
+    return query.filters;
 }
 
 export function filterIncompleteTasksByDescription(tasks: readonly Task[], query: string): Task[] {

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -23,6 +23,10 @@ function getGlobalQueryFilters(): Filter[] {
     return query.filters;
 }
 
+function applyFiltersToTask(globalQueryFilters: Filter[], task: Task, searchInfo: SearchInfo): boolean {
+    return globalQueryFilters.every((filter) => filter.filterFunction(task, searchInfo));
+}
+
 export function filterIncompleteTasksByDescription(tasks: readonly Task[], query: string): Task[] {
     if (query.trim() === '') {
         return [];
@@ -40,7 +44,7 @@ export function filterIncompleteTasksByDescription(tasks: readonly Task[], query
         return (
             !task.isDone &&
             task.descriptionWithoutTags.toLowerCase().includes(normalizedQuery) &&
-            globalQueryFilters.every((filter) => filter.filterFunction(task, searchInfo))
+            applyFiltersToTask(globalQueryFilters, task, searchInfo)
         );
     });
 }

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -6,11 +6,16 @@ import { getTaskLineAndFile } from '../Obsidian/File';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import { SearchInfo } from '../Query/SearchInfo';
+import type { Filter } from '../Query/Filter/Filter';
 
 export interface TaskSearchSuggestionText {
     description: string;
     source: string;
     heading: string;
+}
+
+function getGlobalQueryFilters(): Filter[] {
+    return GlobalQuery.getInstance().query().filters;
 }
 
 export function filterIncompleteTasksByDescription(tasks: readonly Task[], query: string): Task[] {
@@ -23,7 +28,7 @@ export function filterIncompleteTasksByDescription(tasks: readonly Task[], query
     // Many users will have defined a Global Query in their Tasks settings,
     // such as to tell Tasks to ignore tasks that are in their Template folder.
     // So we want Quick Search to only return tasks that match the filters in the Global Query.
-    const globalQueryFilters = GlobalQuery.getInstance().query().filters;
+    const globalQueryFilters = getGlobalQueryFilters();
     const searchInfo = SearchInfo.fromAllTasks([...tasks]);
 
     return tasks.filter((task) => {

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -4,6 +4,8 @@ import { TaskLayoutComponent } from '../Layout/TaskLayoutOptions';
 import type { Task } from '../Task/Task';
 import { getTaskLineAndFile } from '../Obsidian/File';
 import { GlobalFilter } from '../Config/GlobalFilter';
+import { GlobalQuery } from '../Config/GlobalQuery';
+import { SearchInfo } from '../Query/SearchInfo';
 
 export interface TaskSearchSuggestionText {
     description: string;
@@ -17,7 +19,20 @@ export function filterIncompleteTasksByDescription(tasks: readonly Task[], query
     }
 
     const normalizedQuery = query.toLowerCase();
-    return tasks.filter((task) => !task.isDone && task.descriptionWithoutTags.toLowerCase().includes(normalizedQuery));
+
+    // Many users will have defined a Global Query in their Tasks settings,
+    // such as to tell Tasks to ignore tasks that are in their Template folder.
+    // So we want Quick Search to only return tasks that match the filters in the Global Query.
+    const globalQueryFilters = GlobalQuery.getInstance().query().filters;
+    const searchInfo = SearchInfo.fromAllTasks([...tasks]);
+
+    return tasks.filter((task) => {
+        return (
+            !task.isDone &&
+            task.descriptionWithoutTags.toLowerCase().includes(normalizedQuery) &&
+            globalQueryFilters.every((filter) => filter.filterFunction(task, searchInfo))
+        );
+    });
 }
 
 export function taskSearchSuggestionText(task: Task): TaskSearchSuggestionText {

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -24,7 +24,12 @@ function getGlobalQueryFilters(): Filter[] {
 }
 
 function applyFiltersToTask(globalQueryFilters: Filter[], task: Task, searchInfo: SearchInfo): boolean {
-    return globalQueryFilters.every((filter) => filter.filterFunction(task, searchInfo));
+    try {
+        return globalQueryFilters.every((filter) => filter.filterFunction(task, searchInfo));
+    } catch {
+        // Silently ignore search-time errors from Global Query - just include the task in the search results
+        return true;
+    }
 }
 
 export function filterIncompleteTasksByDescription(tasks: readonly Task[], query: string): Task[] {

--- a/src/Commands/QuickSearchTasks.ts
+++ b/src/Commands/QuickSearchTasks.ts
@@ -7,6 +7,7 @@ import { GlobalFilter } from '../Config/GlobalFilter';
 import { GlobalQuery } from '../Config/GlobalQuery';
 import { SearchInfo } from '../Query/SearchInfo';
 import type { Filter } from '../Query/Filter/Filter';
+import { TasksFile } from '../Scripting/TasksFile';
 
 export interface TaskSearchSuggestionText {
     description: string;
@@ -15,7 +16,17 @@ export interface TaskSearchSuggestionText {
 }
 
 function getGlobalQueryFilters(): Filter[] {
-    const query = GlobalQuery.getInstance().query();
+    // The placeholder presents mechanism results in an exception being thrown
+    // if we do not provide a location for the query source file,
+    // and the Global Query contains placeholder presets as {{preset.simple}}:
+    //     Invalid Global Query: The query looks like it contains a placeholder, with "{{" and "}}"
+    //     but no file path has been supplied, so cannot expand placeholder values.
+    //     The query is:
+    //     {{preset.simple}}
+    // So we create a fake location for the query source file:
+    const dummyTasksFile = new TasksFile('Dummy Path for Quick Search command.md');
+
+    const query = GlobalQuery.getInstance().query(dummyTasksFile);
     if (query.error !== undefined) {
         // Silently ignore invalid Global Query
         return [];

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -86,6 +86,7 @@ describe('Finding matching tasks', () => {
 
 describe('Finding matching tasks, honouring the Global Query', () => {
     it('should honour single-instruction Global Query', () => {
+        const query = 'release';
         const globalQuerySource = 'description includes Write';
         GlobalQuery.getInstance().set(globalQuerySource);
 
@@ -95,7 +96,7 @@ describe('Finding matching tasks, honouring the Global Query', () => {
 
         const tasks = descriptions.map((description) => new TaskBuilder().description(description).build());
 
-        const foundDescriptions = filterIncompleteTasksByDescription(tasks, 'release').map((task) => task.description);
+        const foundDescriptions = filterIncompleteTasksByDescription(tasks, query).map((task) => task.description);
         expect(foundDescriptions).toEqual(expectedFoundDescriptions);
     });
 });

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -93,6 +93,13 @@ describe('Finding matching tasks, honouring the Global Query', () => {
             ['Write release notes', 'Review RELEASE checklist'],
             ['Write release notes'],
         ],
+        [
+            'should ignore Global Query with invalid parse-time instruction',
+            'release',
+            'description includes Write\nUNKNOWN INSTRUCTION RENDERS GLOBAL QUERY INVALID',
+            ['Write release notes', 'Review RELEASE checklist'],
+            ['Write release notes', 'Review RELEASE checklist'],
+        ],
     ])(
         '%s',
         (_, query: string, globalQuerySource: string, descriptions: string[], expectedFoundDescriptions: string[]) => {

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -100,6 +100,13 @@ describe('Finding matching tasks, honouring the Global Query', () => {
             ['Write release notes', 'Review RELEASE checklist'],
             ['Write release notes', 'Review RELEASE checklist'],
         ],
+        [
+            'should ignore Global Query with invalid search-time instruction',
+            'release',
+            'filter by function task.wibble',
+            ['Write release notes', 'Review RELEASE checklist'],
+            ['Write release notes', 'Review RELEASE checklist'],
+        ],
     ])(
         '%s',
         (_, query: string, globalQuerySource: string, descriptions: string[], expectedFoundDescriptions: string[]) => {

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -89,11 +89,13 @@ describe('Finding matching tasks, honouring the Global Query', () => {
         GlobalQuery.getInstance().set('description includes Write');
 
         const descriptions = ['Write release notes', 'Review RELEASE checklist'];
+        // Should not match task whose description is 'Review RELEASE checklist', and does not match the above Global Query
+        const expectedFoundDescriptions = ['Write release notes'];
+
         const tasks = descriptions.map((description) => new TaskBuilder().description(description).build());
 
         const foundDescriptions = filterIncompleteTasksByDescription(tasks, 'release').map((task) => task.description);
-        // Should not match task whose description is 'Review RELEASE checklist', and does not match the above Global Query
-        expect(foundDescriptions).toEqual(['Write release notes']);
+        expect(foundDescriptions).toEqual(expectedFoundDescriptions);
     });
 });
 

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -149,10 +149,7 @@ describe('Finding matching tasks, honouring the Global Query', () => {
             expectedFoundDescriptions: string[],
             presets: PresetsMap,
         ) => {
-            if (presets !== undefined) {
-                updateSettings({ presets });
-            }
-
+            updateSettings({ presets });
             GlobalQuery.getInstance().set(globalQuerySource);
 
             const tasks = descriptions.map((description) => new TaskBuilder().description(description).build());

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -131,6 +131,14 @@ describe('Finding matching tasks, honouring the Global Query', () => {
             ['Write release notes'],
             { simple: 'description includes Write' },
         ],
+        [
+            'should honour placeholder-style presets in the Global Query',
+            'release',
+            '{{preset.simple}}',
+            ['Write release notes', 'Review RELEASE checklist'],
+            ['Write release notes'],
+            { simple: 'description includes Write' },
+        ],
     ])(
         '%s',
         (

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -14,6 +14,7 @@ import { Status } from '../../src/Statuses/Status';
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { fromMarkdown } from '../TestingTools/TestHelpers';
+import { GlobalQuery } from '../../src/Config/GlobalQuery';
 
 jest.mock('obsidian', () => ({
     ...jest.requireActual('../__mocks__/obsidian'),
@@ -44,6 +45,8 @@ const tasks = [
 afterEach(() => {
     GlobalFilter.getInstance().reset();
     GlobalFilter.getInstance().setRemoveGlobalFilter(false);
+
+    GlobalQuery.getInstance().reset();
 });
 
 describe('Registering the command', () => {
@@ -78,6 +81,14 @@ describe('Finding matching tasks', () => {
 
     it('should not match task tags', () => {
         expect(filterIncompleteTasksByDescription(tasks, '#release')).toEqual([]);
+    });
+});
+
+describe('Finding matching tasks, honouring the Global Query', () => {
+    it.failing('should honour single-instruction Global Query', () => {
+        GlobalQuery.getInstance().set('description includes Write');
+        // Should not match tasks[1] whose description is 'Review RELEASE checklist', and does not match the above Global Query
+        expect(filterIncompleteTasksByDescription(tasks, 'release')).toEqual([tasks[0]]);
     });
 });
 

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -88,11 +88,11 @@ describe('Finding matching tasks, honouring the Global Query', () => {
     it('should honour single-instruction Global Query', () => {
         const query = 'release';
         const globalQuerySource = 'description includes Write';
-        GlobalQuery.getInstance().set(globalQuerySource);
-
         const descriptions = ['Write release notes', 'Review RELEASE checklist'];
         // Should not match task whose description is 'Review RELEASE checklist', and does not match the above Global Query
         const expectedFoundDescriptions = ['Write release notes'];
+
+        GlobalQuery.getInstance().set(globalQuerySource);
 
         const tasks = descriptions.map((description) => new TaskBuilder().description(description).build());
 

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -85,7 +85,15 @@ describe('Finding matching tasks', () => {
 });
 
 describe('Finding matching tasks, honouring the Global Query', () => {
-    it.each([
+    type GlobalQueryTestCase = [
+        testName: string,
+        query: string,
+        globalQuerySource: string,
+        descriptions: string[],
+        expectedFoundDescriptions: string[],
+    ];
+
+    it.each<GlobalQueryTestCase>([
         [
             'should honour single-instruction Global Query',
             'release',

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -15,6 +15,8 @@ import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { fromMarkdown } from '../TestingTools/TestHelpers';
 import { GlobalQuery } from '../../src/Config/GlobalQuery';
+import type { PresetsMap } from '../../src/Query/Presets/Presets';
+import { resetSettings, updateSettings } from '../../src/Config/Settings';
 
 jest.mock('obsidian', () => ({
     ...jest.requireActual('../__mocks__/obsidian'),
@@ -47,6 +49,8 @@ afterEach(() => {
     GlobalFilter.getInstance().setRemoveGlobalFilter(false);
 
     GlobalQuery.getInstance().reset();
+
+    resetSettings();
 });
 
 describe('Registering the command', () => {
@@ -91,6 +95,7 @@ describe('Finding matching tasks, honouring the Global Query', () => {
         globalQuerySource: string,
         descriptions: string[],
         expectedFoundDescriptions: string[],
+        presets: PresetsMap,
     ];
 
     it.each<GlobalQueryTestCase>([
@@ -100,6 +105,7 @@ describe('Finding matching tasks, honouring the Global Query', () => {
             'description includes Write',
             ['Write release notes', 'Review RELEASE checklist'],
             ['Write release notes'],
+            {},
         ],
         [
             'should ignore Global Query with invalid parse-time instruction',
@@ -107,6 +113,7 @@ describe('Finding matching tasks, honouring the Global Query', () => {
             'description includes Write\nUNKNOWN INSTRUCTION RENDERS GLOBAL QUERY INVALID',
             ['Write release notes', 'Review RELEASE checklist'],
             ['Write release notes', 'Review RELEASE checklist'],
+            {},
         ],
         [
             'should ignore Global Query with invalid search-time instruction',
@@ -114,10 +121,30 @@ describe('Finding matching tasks, honouring the Global Query', () => {
             'filter by function task.wibble',
             ['Write release notes', 'Review RELEASE checklist'],
             ['Write release notes', 'Review RELEASE checklist'],
+            {},
+        ],
+        [
+            'should honour preset instructions in the Global Query',
+            'release',
+            'preset simple',
+            ['Write release notes', 'Review RELEASE checklist'],
+            ['Write release notes'],
+            { simple: 'description includes Write' },
         ],
     ])(
         '%s',
-        (_, query: string, globalQuerySource: string, descriptions: string[], expectedFoundDescriptions: string[]) => {
+        (
+            _,
+            query: string,
+            globalQuerySource: string,
+            descriptions: string[],
+            expectedFoundDescriptions: string[],
+            presets: PresetsMap,
+        ) => {
+            if (presets !== undefined) {
+                updateSettings({ presets });
+            }
+
             GlobalQuery.getInstance().set(globalQuerySource);
 
             const tasks = descriptions.map((description) => new TaskBuilder().description(description).build());

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -86,7 +86,8 @@ describe('Finding matching tasks', () => {
 
 describe('Finding matching tasks, honouring the Global Query', () => {
     it('should honour single-instruction Global Query', () => {
-        GlobalQuery.getInstance().set('description includes Write');
+        const globalQuerySource = 'description includes Write';
+        GlobalQuery.getInstance().set(globalQuerySource);
 
         const descriptions = ['Write release notes', 'Review RELEASE checklist'];
         // Should not match task whose description is 'Review RELEASE checklist', and does not match the above Global Query

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -85,20 +85,25 @@ describe('Finding matching tasks', () => {
 });
 
 describe('Finding matching tasks, honouring the Global Query', () => {
-    it('should honour single-instruction Global Query', () => {
-        const query = 'release';
-        const globalQuerySource = 'description includes Write';
-        const descriptions = ['Write release notes', 'Review RELEASE checklist'];
-        // Should not match task whose description is 'Review RELEASE checklist', and does not match the above Global Query
-        const expectedFoundDescriptions = ['Write release notes'];
+    it.each([
+        [
+            'should honour single-instruction Global Query',
+            'release',
+            'description includes Write',
+            ['Write release notes', 'Review RELEASE checklist'],
+            ['Write release notes'],
+        ],
+    ])(
+        '%s',
+        (_, query: string, globalQuerySource: string, descriptions: string[], expectedFoundDescriptions: string[]) => {
+            GlobalQuery.getInstance().set(globalQuerySource);
 
-        GlobalQuery.getInstance().set(globalQuerySource);
+            const tasks = descriptions.map((description) => new TaskBuilder().description(description).build());
 
-        const tasks = descriptions.map((description) => new TaskBuilder().description(description).build());
-
-        const foundDescriptions = filterIncompleteTasksByDescription(tasks, query).map((task) => task.description);
-        expect(foundDescriptions).toEqual(expectedFoundDescriptions);
-    });
+            const foundDescriptions = filterIncompleteTasksByDescription(tasks, query).map((task) => task.description);
+            expect(foundDescriptions).toEqual(expectedFoundDescriptions);
+        },
+    );
 });
 
 describe('Describing matching task', () => {

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -85,7 +85,7 @@ describe('Finding matching tasks', () => {
 });
 
 describe('Finding matching tasks, honouring the Global Query', () => {
-    it.failing('should honour single-instruction Global Query', () => {
+    it('should honour single-instruction Global Query', () => {
         GlobalQuery.getInstance().set('description includes Write');
         // Should not match tasks[1] whose description is 'Review RELEASE checklist', and does not match the above Global Query
         expect(filterIncompleteTasksByDescription(tasks, 'release')).toEqual([tasks[0]]);

--- a/tests/Commands/QuickSearchTasks.test.ts
+++ b/tests/Commands/QuickSearchTasks.test.ts
@@ -87,8 +87,13 @@ describe('Finding matching tasks', () => {
 describe('Finding matching tasks, honouring the Global Query', () => {
     it('should honour single-instruction Global Query', () => {
         GlobalQuery.getInstance().set('description includes Write');
-        // Should not match tasks[1] whose description is 'Review RELEASE checklist', and does not match the above Global Query
-        expect(filterIncompleteTasksByDescription(tasks, 'release')).toEqual([tasks[0]]);
+
+        const descriptions = ['Write release notes', 'Review RELEASE checklist'];
+        const tasks = descriptions.map((description) => new TaskBuilder().description(description).build());
+
+        const foundDescriptions = filterIncompleteTasksByDescription(tasks, 'release').map((task) => task.description);
+        // Should not match task whose description is 'Review RELEASE checklist', and does not match the above Global Query
+        expect(foundDescriptions).toEqual(['Write release notes']);
     });
 });
 


### PR DESCRIPTION
# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: #4009
- [x] **Documentation** (prefix: `docs` - improvements to any documentation content **for users**)

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Description

The 'Quick Search' command now only shows tasks which match any Global Query in the user's Tasks settings.

This allows users to prevent clutter like Template tasks showing up in their Quick searches.

If for some reason the Global Query gives an error, for example if it uses `query.file` facilities, and no query file exists during the execution of Quick Search, then the Global Query is ignored and all tasks matching the typed text are shown.

## Motivation and Context

Fixes #4009

## How has this been tested?

- Thorough automated tests added
- Lots of exploratory testing in my own vault, with its complicated Global Query


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
