### PR TITLE
refactor: Fix more ESLint warnings, including all `@typescript-eslint/no-unsafe-return`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,7 +71,7 @@ const typescriptCommonRules = {
     '@typescript-eslint/no-unsafe-call': on_or_off,
     '@typescript-eslint/no-unsafe-function-type': on_or_off,
     '@typescript-eslint/no-unsafe-member-access': on_or_off,
-    '@typescript-eslint/no-unsafe-return': on_or_off,
+    '@typescript-eslint/no-unsafe-return': 1,
     '@typescript-eslint/no-wrapper-object-types': on_or_off,
     '@typescript-eslint/only-throw-error': on_or_off,
     '@typescript-eslint/restrict-plus-operands': on_or_off,

--- a/lint.txt
+++ b/lint.txt
@@ -35,12 +35,7 @@ Prefer explicitly defining any function parameters and return type              
   176:70  warning  Unexpected any. Specify a different type                                       @typescript-eslint/no-explicit-any
   185:34  warning  Unsafe argument of type `any` assigned to a parameter of type `Moment | null`  @typescript-eslint/no-unsafe-argument
   185:42  warning  Unsafe argument of type `any` assigned to a parameter of type `Moment | null`  @typescript-eslint/no-unsafe-argument
-  263:11  warning  Unsafe assignment of an `any` value                                            @typescript-eslint/no-unsafe-assignment
-  289:15  warning  Unsafe assignment of an `any` value                                            @typescript-eslint/no-unsafe-assignment
-
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Query/Group/GroupingTreeNode.ts
-  32:13  warning  Unsafe return of type `Map<any, any>` from function with return type `Map<string[], T[]>`  @typescript-eslint/no-unsafe-return
-  41:9   warning  Unsafe return of type `Map<any, any>` from function with return type `Map<string[], T[]>`  @typescript-eslint/no-unsafe-return
+  271:85  warning  Invalid type "unknown" of template literal expression                          @typescript-eslint/restrict-template-expressions
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Renderer/HtmlColumnQueryResultsRenderer.ts
   61:62  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
@@ -68,14 +63,12 @@ Prefer explicitly defining any function parameters and return type              
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/ExpandPlaceholders.ts
    27:60  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
-   31:9   warning  Unsafe return of a value of type `any`                                                                          @typescript-eslint/no-unsafe-return
-   73:59  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
-   99:19  warning  Unsafe assignment of an `any` value                                                                             @typescript-eslint/no-unsafe-assignment
-  118:19  warning  'result' may use Object's default stringification format ('[object Object]') when stringified                   @typescript-eslint/no-base-to-string
-  121:31  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
-  122:18  warning  Unsafe member access .query on an `any` value                                                                   @typescript-eslint/no-unsafe-member-access
-  148:43  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
-  149:27  warning  Unsafe argument of type `any` assigned to a parameter of type `ArrayLike<unknown> | { [s: string]: unknown; }`  @typescript-eslint/no-unsafe-argument
+   71:59  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  116:19  warning  'result' may use Object's default stringification format ('[object Object]') when stringified                   @typescript-eslint/no-base-to-string
+  119:31  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  120:18  warning  Unsafe member access .query on an `any` value                                                                   @typescript-eslint/no-unsafe-member-access
+  146:43  warning  Unexpected any. Specify a different type                                                                        @typescript-eslint/no-explicit-any
+  147:27  warning  Unsafe argument of type `any` assigned to a parameter of type `ArrayLike<unknown> | { [s: string]: unknown; }`  @typescript-eslint/no-unsafe-argument
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/Expression.ts
    6:60  warning  The `Function` type accepts any function-like value.
@@ -86,16 +79,9 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   29:57  warning  [no-new-func] Using the `Function` constructor is dangerous because it executes arbitrary code, similar to `eval()`      obsidianmd/rule-custom-message
   48:48  warning  The `Function` type accepts any function-like value.
 Prefer explicitly defining any function parameters and return type  @typescript-eslint/no-unsafe-function-type
-  54:5   warning  Unsafe return of a value of type `any`                                                                                   @typescript-eslint/no-unsafe-return
   54:12  warning  Unsafe call of a `Function` typed value                                                                                  @typescript-eslint/no-unsafe-call
-  66:55  warning  The `Function` type accepts any function-like value.
+  67:17  warning  The `Function` type accepts any function-like value.
 Prefer explicitly defining any function parameters and return type  @typescript-eslint/no-unsafe-function-type
-  68:9   warning  Unsafe return of a value of type `any`                                                                                   @typescript-eslint/no-unsafe-return
-
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/TaskExpression.ts
-  45:5  warning  Unsafe return of a value of type `any`  @typescript-eslint/no-unsafe-return
-  81:9  warning  Unsafe return of a value of type `any`  @typescript-eslint/no-unsafe-return
-  95:9  warning  Unsafe return of a value of type `any`  @typescript-eslint/no-unsafe-return
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/TasksFile.ts
    36:13  warning  Unsafe assignment of an `any` value  @typescript-eslint/no-unsafe-assignment
@@ -106,17 +92,12 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   31:24  warning  '_name' is assigned a value but never used  @typescript-eslint/no-unused-vars
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Suggestor/EditorSuggestorPopup.ts
-   95:15  warning  Unsafe assignment of an error typed value                                                                                                @typescript-eslint/no-unsafe-assignment
-  115:9   warning  Unsafe return of a value of type error                                                                                                   @typescript-eslint/no-unsafe-return
   115:16  warning  Unsafe call of a type that could not be resolved                                                                                         @typescript-eslint/no-unsafe-call
   115:26  warning  Unsafe member access .state on a type that cannot be resolved                                                                            @typescript-eslint/no-unsafe-member-access
   126:5   warning  Promise-returning method provided where a void return was expected by extended/implemented type 'EditorSuggest<SuggestInfoWithContext>'  @typescript-eslint/no-misused-promises
   136:13  warning  Unsafe call of an `any` typed value                                                                                                      @typescript-eslint/no-unsafe-call
   136:24  warning  Unexpected any. Specify a different type                                                                                                 @typescript-eslint/no-explicit-any
   136:30  warning  Unsafe member access .cm on an `any` value                                                                                               @typescript-eslint/no-unsafe-member-access
-  211:15  warning  Unsafe assignment of an error typed value                                                                                                @typescript-eslint/no-unsafe-assignment
-  213:19  warning  Unsafe call of a type that could not be resolved                                                                                         @typescript-eslint/no-unsafe-call
-  213:36  warning  Unsafe member access .save on a type that cannot be resolved                                                                             @typescript-eslint/no-unsafe-member-access
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Suggestor/Suggestor.ts
   483:57  warning  Invalid type "string | string[]" of template literal expression  @typescript-eslint/restrict-template-expressions
@@ -138,9 +119,6 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   178:93  warning  Unexpected any. Specify a different type                                                          @typescript-eslint/no-explicit-any
   855:17  warning  'this[el]' may use Object's default stringification format ('[object Object]') when stringified   @typescript-eslint/no-base-to-string
   855:42  warning  'other[el]' may use Object's default stringification format ('[object Object]') when stringified  @typescript-eslint/no-base-to-string
-
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/i18n/i18n.ts
-  71:9  warning  Unsafe return of a value of type `any`  @typescript-eslint/no-unsafe-return
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/lib/ExceptionTools.ts
   12:19  warning  Invalid operand for a '+' operation. Operands must each be a number or string, allowing a string + any of: `any`, `boolean`, `null`, `RegExp`, `undefined`. Got `Error`  @typescript-eslint/restrict-plus-operands
@@ -179,7 +157,7 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   37:9   warning  Promise-returning function provided to property where a void return was expected  @typescript-eslint/no-misused-promises
   76:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 113 problems (0 errors, 113 warnings)
+✖ 97 problems (0 errors, 97 warnings)
   0 errors and 13 warnings potentially fixable with the `--fix` option.
 
 
@@ -189,4 +167,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 30.80s.
+Done in 25.01s.

--- a/lint.txt
+++ b/lint.txt
@@ -1,9 +1,6 @@
 yarn run v1.22.19
 $ eslint ./src       && eslint ./tests       && tsc --noEmit --pretty && svelte-check
 
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Config/Settings.ts
-  224:5  warning  Unsafe assignment of an `any` value  @typescript-eslint/no-unsafe-assignment
-
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Config/SettingsTab.ts
     47:14  warning  This PluginSettingTab does not implement getSettingDefinitions(); its settings will not appear in Obsidian's settings search for users on 1.13.0 or later. Consider adopting the declarative settings API  obsidianmd/settings-tab/prefer-setting-definitions
     51:37  warning  The `Function` type accepts any function-like value.
@@ -83,11 +80,6 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   67:17  warning  The `Function` type accepts any function-like value.
 Prefer explicitly defining any function parameters and return type  @typescript-eslint/no-unsafe-function-type
 
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Scripting/TasksFile.ts
-   36:13  warning  Unsafe assignment of an `any` value  @typescript-eslint/no-unsafe-assignment
-  224:15  warning  Unsafe assignment of an `any` value  @typescript-eslint/no-unsafe-assignment
-  247:15  warning  Unsafe assignment of an `any` value  @typescript-eslint/no-unsafe-assignment
-
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Statuses/StatusValidator.ts
   31:24  warning  '_name' is assigned a value but never used  @typescript-eslint/no-unused-vars
 
@@ -157,7 +149,7 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   37:9   warning  Promise-returning function provided to property where a void return was expected  @typescript-eslint/no-misused-promises
   76:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 97 problems (0 errors, 97 warnings)
+✖ 93 problems (0 errors, 93 warnings)
   0 errors and 13 warnings potentially fixable with the `--fix` option.
 
 
@@ -167,4 +159,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 25.01s.
+Done in 26.02s.

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -221,7 +221,7 @@ export const updateSettings = (newSettings: Partial<Settings>): Settings => {
 };
 
 export const resetSettings = (): Settings => {
-    settings = JSON.parse(JSON.stringify(defaultSettings));
+    settings = JSON.parse(JSON.stringify(defaultSettings)) as Settings;
     return settings;
 };
 

--- a/src/Query/Group/GroupingTreeNode.ts
+++ b/src/Query/Group/GroupingTreeNode.ts
@@ -24,7 +24,7 @@ export class GroupingTreeNode<T> {
      * NOTE: The node itself doesn't get included in the generated paths.
      */
     generateAllPaths(pathSoFar: string[] = []): Map<string[], T[]> {
-        const resultMap = new Map();
+        const resultMap = new Map<string[], T[]>();
         if (this.children.size == 0) {
             // Base case: Leaf node. Populate the results map with the path to
             // this node, and the values that match this path.

--- a/src/Scripting/ExpandPlaceholders.ts
+++ b/src/Scripting/ExpandPlaceholders.ts
@@ -27,9 +27,7 @@ import { JsInTasksQueriesDisabledError } from './JsInTasksQueriesDisabledError';
 export function expandPlaceholders(template: string, view: any): string {
     // Turn off HTML escaping of things like '/' in file paths:
     // https://github.com/janl/mustache.js#variables
-    Mustache.escape = function (text) {
-        return text;
-    };
+    Mustache.escape = (text: string) => text;
 
     try {
         // Preprocess the template to evaluate any placeholders that involve function calls

--- a/src/Scripting/Expression.ts
+++ b/src/Scripting/Expression.ts
@@ -45,7 +45,7 @@ export function parseExpression(paramsArgs: ExpressionParameter[], arg: string):
  * @see parseExpression
  * @see evaluateExpressionOrCatch
  */
-export function evaluateExpression(expression: Function, paramsArgs: ExpressionParameter[]) {
+export function evaluateExpression(expression: Function, paramsArgs: ExpressionParameter[]): unknown {
     if (!EnableJsInTasksQueries.getInstance().get()) {
         throw new JsInTasksQueriesDisabledError();
     }
@@ -63,7 +63,11 @@ export function evaluateExpression(expression: Function, paramsArgs: ExpressionP
  * @see parseExpression
  * @see evaluateExpression
  */
-export function evaluateExpressionOrCatch(expression: Function, paramsArgs: ExpressionParameter[], arg: string) {
+export function evaluateExpressionOrCatch(
+    expression: Function,
+    paramsArgs: ExpressionParameter[],
+    arg: string,
+): unknown {
     try {
         return evaluateExpression(expression, paramsArgs);
     } catch (e) {

--- a/src/Scripting/TaskExpression.ts
+++ b/src/Scripting/TaskExpression.ts
@@ -34,7 +34,7 @@ export function constructArguments(task: Task | null, queryContext: QueryContext
  *
  * See also {@link FunctionField} which exposes this facility to users.
  */
-export function parseAndEvaluateExpression(task: Task, arg: string, queryContext?: QueryContext) {
+export function parseAndEvaluateExpression(task: Task, arg: string, queryContext?: QueryContext): unknown {
     const paramsArgs = constructArguments(task, queryContext || null);
 
     const functionOrError = parseExpression(paramsArgs, arg);
@@ -72,7 +72,7 @@ export class TaskExpression {
      *
      * @see evaluateOrCatch
      */
-    public evaluate(task: Task, queryContext?: QueryContext) {
+    public evaluate(task: Task, queryContext?: QueryContext): unknown {
         if (!this.isValid()) {
             throw new Error(
                 `Error: Cannot evaluate an expression which is not valid: "${this.line}" gave error: "${this.parseError}"`,
@@ -88,7 +88,7 @@ export class TaskExpression {
      *
      * @see evaluate
      */
-    public evaluateOrCatch(task: Task, queryContext: QueryContext) {
+    public evaluateOrCatch(task: Task, queryContext: QueryContext): unknown {
         if (!this.isValid()) {
             return `Error: Cannot evaluate an expression which is not valid: "${this.line}" gave error: "${this.parseError}"`;
         }

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -10,6 +10,8 @@ import { Link } from '../Task/Link';
 
 export type OptionalTasksFile = TasksFile | undefined;
 
+type Frontmatter = Record<string, unknown>;
+
 /**
  * A simple class to provide access to file information via 'task.file' in scripting code.
  */
@@ -19,7 +21,7 @@ export class TasksFile {
 
     private readonly _cachedMetadata: CachedMetadata;
     // Always make TasksFile.frontmatter.tags exist and be empty, even if no frontmatter present:
-    private readonly _frontmatter = { tags: [] } as Record<string, unknown>;
+    private readonly _frontmatter = { tags: [] } as Frontmatter;
     private readonly _tags: string[] = [];
 
     private readonly _outlinksInProperties: Readonly<Link[]> = [];

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -221,7 +221,7 @@ export class TasksFile {
             return false;
         }
 
-        const propertyValue = this.frontmatter[foundKey];
+        const propertyValue: unknown = this.frontmatter[foundKey];
         if (propertyValue === null) {
             return false;
         }
@@ -244,7 +244,7 @@ export class TasksFile {
             return null;
         }
 
-        const propertyValue = this.frontmatter[foundKey];
+        const propertyValue: unknown = this.frontmatter[foundKey];
         if (propertyValue === undefined) {
             return null;
         }

--- a/src/Scripting/TasksFile.ts
+++ b/src/Scripting/TasksFile.ts
@@ -35,7 +35,7 @@ export class TasksFile {
 
         const rawFrontmatter = cachedMetadata.frontmatter;
         if (rawFrontmatter !== undefined) {
-            this._frontmatter = JSON.parse(JSON.stringify(rawFrontmatter));
+            this._frontmatter = JSON.parse(JSON.stringify(rawFrontmatter)) as Frontmatter;
             this._frontmatter.tags = parseFrontMatterTags(rawFrontmatter) ?? [];
         }
         this._outlinksInProperties = this.createLinks(this.cachedMetadata.frontmatterLinks);

--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -110,7 +110,7 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
         );
     }
 
-    private getMarkdownFileInfo(editor: Editor) {
+    private getMarkdownFileInfo(editor: Editor): unknown {
         // @ts-expect-error: TS2339: Property cm does not exist on type Editor
         return editor.cm.state.field(editorInfoField);
     }
@@ -210,7 +210,7 @@ file: '${newTask.path}'
 
         const markdownFileInfo = this.getMarkdownFileInfo(value.context.editor);
         if (this.canSaveEdits(markdownFileInfo)) {
-            await markdownFileInfo.save();
+            await (markdownFileInfo as { save: () => Promise<void> }).save();
         }
     }
 }

--- a/src/Suggestor/EditorSuggestorPopup.ts
+++ b/src/Suggestor/EditorSuggestorPopup.ts
@@ -115,7 +115,7 @@ export class EditorSuggestor extends EditorSuggest<SuggestInfoWithContext> {
         return editor.cm.state.field(editorInfoField);
     }
 
-    private canSaveEdits(markdownFileInfo: unknown) {
+    private canSaveEdits(markdownFileInfo: unknown): markdownFileInfo is MarkdownView {
         return markdownFileInfo instanceof MarkdownView;
     }
 
@@ -210,7 +210,7 @@ file: '${newTask.path}'
 
         const markdownFileInfo = this.getMarkdownFileInfo(value.context.editor);
         if (this.canSaveEdits(markdownFileInfo)) {
-            await (markdownFileInfo as { save: () => Promise<void> }).save();
+            await markdownFileInfo.save();
         }
     }
 }

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -56,12 +56,9 @@ export const initializeI18n = async () => {
 };
 
 export const i18n = new Proxy(i18next, {
-    get(target, prop) {
+    get(target, prop): unknown {
         if (!isInitialized && prop === 't') {
-            /* If you get the following error in tests, add this code block before the first
-               test in the file.
-               (Or add the 'await' line to the existing first beforeAll).
-
+            /* This should never be reached in tests, as the following is called in jest.setup.ts:
                     beforeAll(async () => {
                         await initializeI18n();
                     });


### PR DESCRIPTION
# Types of changes

Done by pairing with @ilandikov.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

Fix all `'@typescript-eslint/no-unsafe-return'` warnings, and leave that option turned on, to prevent future re-occurrences of this message.

This in turn fixed a number of other `@typescript-eslint/no-unsafe...` warnings.

We also fixed some of the remaining `@typescript-eslint/no-unsafe-assignment` warnings.

## Motivation and Context

Wanting to reduce the number of warnings shown on the plugin's Scorecard on the Community site:

https://community.obsidian.md/plugins/obsidian-tasks-plugin

This reduces the remaining warnings in `src/` from 113 to 93.


## How has this been tested?

- Automated tests
- Minimal manual exploratory testing

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
