### PR TITLE
refactor: Fix more ESLint warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,7 +73,7 @@ const typescriptCommonRules = {
     '@typescript-eslint/no-unsafe-member-access': on_or_off,
     '@typescript-eslint/no-unsafe-return': 1,
     '@typescript-eslint/no-wrapper-object-types': on_or_off,
-    '@typescript-eslint/only-throw-error': on_or_off,
+    '@typescript-eslint/only-throw-error': 1,
     '@typescript-eslint/restrict-plus-operands': on_or_off,
     '@typescript-eslint/restrict-template-expressions': on_or_off,
     '@typescript-eslint/unbound-method': 1,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,7 +72,7 @@ const typescriptCommonRules = {
     '@typescript-eslint/no-unsafe-function-type': on_or_off,
     '@typescript-eslint/no-unsafe-member-access': on_or_off,
     '@typescript-eslint/no-unsafe-return': 1,
-    '@typescript-eslint/no-wrapper-object-types': on_or_off,
+    '@typescript-eslint/no-wrapper-object-types': 1,
     '@typescript-eslint/only-throw-error': 1,
     '@typescript-eslint/restrict-plus-operands': on_or_off,
     '@typescript-eslint/restrict-template-expressions': on_or_off,

--- a/lint.txt
+++ b/lint.txt
@@ -10,8 +10,6 @@ Prefer explicitly defining any function parameters and return type              
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Obsidian/Cache.ts
   240:64  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
-  371:28  warning  Unexpected any. Specify a different type                                @typescript-eslint/no-explicit-any
-  379:12  warning  Unexpected any. Specify a different type                                @typescript-eslint/no-explicit-any
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Obsidian/File.ts
   155:27  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
@@ -138,15 +136,12 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   151:17  warning  Unsafe call of a type that could not be resolved                                   @typescript-eslint/no-unsafe-call
   151:37  warning  Unsafe member access .setType on a type that cannot be resolved                    @typescript-eslint/no-unsafe-member-access
 
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/ui/EditTaskHelpers.ts
-  118:19  warning  Use 'modalEl.ownerDocument.win.createDiv()' instead of 'modalEl.ownerDocument.createElement('div')'  obsidianmd/prefer-create-el
-
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/ui/Menus/DatePicker.ts
   37:9   warning  Promise-returning function provided to property where a void return was expected  @typescript-eslint/no-misused-promises
   76:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 91 problems (0 errors, 91 warnings)
-  0 errors and 12 warnings potentially fixable with the `--fix` option.
+✖ 88 problems (0 errors, 88 warnings)
+  0 errors and 10 warnings potentially fixable with the `--fix` option.
 
 
 ====================================
@@ -155,4 +150,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 26.24s.
+Done in 23.64s.

--- a/lint.txt
+++ b/lint.txt
@@ -120,7 +120,6 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   141:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console  obsidianmd/rule-custom-message
   147:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console  obsidianmd/rule-custom-message
   156:21  warning  [no-console] Avoid unnecessary logging to console. See https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console  obsidianmd/rule-custom-message
-  310:33  warning  Prefer using the primitive `object` as a type name, rather than the upper-cased `Object`                                                                  @typescript-eslint/no-wrapper-object-types
 
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/main.ts
    98:13  warning  Unsafe assignment of an `any` value                                                @typescript-eslint/no-unsafe-assignment
@@ -146,8 +145,8 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   37:9   warning  Promise-returning function provided to property where a void return was expected  @typescript-eslint/no-misused-promises
   76:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 92 problems (0 errors, 92 warnings)
-  0 errors and 13 warnings potentially fixable with the `--fix` option.
+✖ 91 problems (0 errors, 91 warnings)
+  0 errors and 12 warnings potentially fixable with the `--fix` option.
 
 
 ====================================

--- a/lint.txt
+++ b/lint.txt
@@ -8,9 +8,6 @@ Prefer explicitly defining any function parameters and return type              
    714:17  warning  Unsafe call of a `Function` typed value                                                                                                                                                                    @typescript-eslint/no-unsafe-call
   1009:9   warning  Unsafe call of a type that could not be resolved                                                                                                                                                           @typescript-eslint/no-unsafe-call
 
-/Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/DateTime/TasksDate.ts
-  125:32  warning  Expected an error object to be thrown  @typescript-eslint/only-throw-error
-
 /Users/clare/Documents/develop/Obsidian/schemar/obsidian-tasks/src/Obsidian/Cache.ts
   240:64  warning  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
   371:28  warning  Unexpected any. Specify a different type                                @typescript-eslint/no-explicit-any
@@ -149,7 +146,7 @@ Prefer explicitly defining any function parameters and return type  @typescript-
   37:9   warning  Promise-returning function provided to property where a void return was expected  @typescript-eslint/no-misused-promises
   76:38  warning  Promise returned in function argument where a void return was expected            @typescript-eslint/no-misused-promises
 
-✖ 93 problems (0 errors, 93 warnings)
+✖ 92 problems (0 errors, 92 warnings)
   0 errors and 13 warnings potentially fixable with the `--fix` option.
 
 
@@ -159,4 +156,4 @@ Getting Svelte diagnostics...
 
 ====================================
 svelte-check found 0 errors and 0 warnings
-Done in 26.02s.
+Done in 26.24s.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "esbuild-svelte": "^0.8.2",
     "eslint": "9.26.0",
     "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-obsidianmd": "^0.4.1",
+    "eslint-plugin-obsidianmd": "^0.4.2",
     "eslint-plugin-prettier": "^4.2.5",
     "eslint-plugin-svelte": "^3.19.0",
     "globals": "^13.0.0",

--- a/src/DateTime/TasksDate.ts
+++ b/src/DateTime/TasksDate.ts
@@ -122,7 +122,9 @@ export class TasksDate {
     }
 
     public postpone(unitOfTime: moment.unitOfTime.DurationConstructor = 'days', amount: number = 1) {
-        if (!this._date) throw new Notice('Cannot postpone a null date');
+        if (!this._date) {
+            throw new Notice('Cannot postpone a null date');
+        }
 
         const today = window.moment().startOf('day');
         // According to the moment.js docs, isBefore is not stable so we use !isSameOrAfter: https://momentjs.com/docs/#/query/is-before/

--- a/src/DateTime/TasksDate.ts
+++ b/src/DateTime/TasksDate.ts
@@ -123,7 +123,8 @@ export class TasksDate {
 
     public postpone(unitOfTime: moment.unitOfTime.DurationConstructor = 'days', amount: number = 1) {
         if (!this._date) {
-            throw new Notice('Cannot postpone a null date');
+            new Notice('Cannot postpone a null date');
+            throw new Error('Cannot postpone a null date');
         }
 
         const today = window.moment().startOf('day');

--- a/src/DateTime/TasksDate.ts
+++ b/src/DateTime/TasksDate.ts
@@ -123,8 +123,9 @@ export class TasksDate {
 
     public postpone(unitOfTime: moment.unitOfTime.DurationConstructor = 'days', amount: number = 1) {
         if (!this._date) {
-            new Notice('Cannot postpone a null date');
-            throw new Error('Cannot postpone a null date');
+            const message = 'Cannot postpone a null date';
+            new Notice(message);
+            throw new Error(message);
         }
 
         const today = window.moment().startOf('day');

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -381,9 +381,10 @@ export class Cache {
         listItem: ListItemCache,
         line: string,
     ) => {
+        const errorMessage = e instanceof Error ? e.message : JSON.stringify(e);
         const msg = `There was an error reading one of the tasks in this vault.
 The following task has been ignored, to prevent Tasks queries getting stuck with 'Loading Tasks ...'
-Error: ${e}
+Error: ${errorMessage}
 File: ${filePath}
 Line number: ${listItem.position.start.line}
 Task line: ${line}

--- a/src/Obsidian/Cache.ts
+++ b/src/Obsidian/Cache.ts
@@ -368,7 +368,7 @@ export class Cache {
         tasksFile: TasksFile,
         fileContent: string,
         listItems: ListItemCache[],
-        errorReporter: (e: any, filePath: string, listItem: ListItemCache, line: string) => void,
+        errorReporter: (e: unknown, filePath: string, listItem: ListItemCache, line: string) => void,
         logger: Logger,
     ): Task[] {
         const fileParser = new FileParser(tasksFile, fileContent, listItems, logger, errorReporter);
@@ -376,7 +376,7 @@ export class Cache {
     }
 
     private readonly reportTaskParsingErrorToUser = (
-        e: any,
+        e: unknown,
         filePath: string,
         listItem: ListItemCache,
         line: string,

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -307,7 +307,7 @@ const timingMap: TimingMap = {};
  *
  * @return {*}
  */
-export const logCall = (target: Object, propertyKey: string, descriptor: PropertyDescriptor) => {
+export const logCall = (target: object, propertyKey: string, descriptor: PropertyDescriptor) => {
     const originalMethod = descriptor.value as (...args: unknown[]) => unknown;
     //const logger = logging.getLogger('taskssql.perf');
     descriptor.value = function (...args: unknown[]) {

--- a/src/ui/EditTaskHelpers.ts
+++ b/src/ui/EditTaskHelpers.ts
@@ -115,7 +115,7 @@ async function waitUntilAboveKeyboard(el: HTMLElement, modalEl: HTMLElement) {
  * written in - `vh`, `clamp()`, anything - exactly as the browser will.
  */
 function keyboardSpace(modalEl: HTMLElement) {
-    const probe = modalEl.ownerDocument.createElement('div');
+    const probe = modalEl.ownerDocument.createDiv();
     probe.style.cssText =
         'position:absolute;visibility:hidden;pointer-events:none;width:0;' +
         'height:var(--tasks-keyboard-space-allowance, clamp(220px, 35vh, 360px))';

--- a/tests/TestingTools/DOMExtensions.test.ts
+++ b/tests/TestingTools/DOMExtensions.test.ts
@@ -1,7 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import type { HTMLElementWithCreateDiv, HTMLElementWithCreateEl, HTMLElementWithCreateSpan } from './DOMExtensions';
+import type {
+    DocumentWithCreateDiv,
+    HTMLElementWithCreateDiv,
+    HTMLElementWithCreateEl,
+    HTMLElementWithCreateSpan,
+} from './DOMExtensions';
 
 /**
  * Create a parent element typed for tests that exercise createEl().
@@ -218,6 +223,33 @@ describe('global createDiv()', () => {
         expect(div.textContent).toBe('example text content');
         expectCallbackToHaveBeenCalledOnceWith(callback, div);
         expect((callback.mock.calls[0][0] as HTMLDivElement).textContent).toBe('example text content');
+    });
+});
+
+describe('Document.createDiv()', () => {
+    let doc: DocumentWithCreateDiv;
+
+    beforeEach(() => {
+        doc = document as DocumentWithCreateDiv;
+    });
+
+    it('createDiv() should create a div and return it without appending it', () => {
+        const div = doc.createDiv();
+
+        expect(div.tagName).toBe('DIV');
+        expect(div.parentElement).toBeNull();
+    });
+
+    it('createDiv() should apply options and callback', () => {
+        const callback = jest.fn();
+
+        const div = doc.createDiv({ cls: 'single-class-value', text: 'example text content' }, callback);
+
+        expect(div.tagName).toBe('DIV');
+        expect(div.parentElement).toBeNull();
+        expectElementToHaveClasses(div, 'single-class-value');
+        expect(div.textContent).toBe('example text content');
+        expectCallbackToHaveBeenCalledOnceWith(callback, div);
     });
 });
 

--- a/tests/TestingTools/DOMExtensions.ts
+++ b/tests/TestingTools/DOMExtensions.ts
@@ -29,3 +29,7 @@ export type HTMLElementWithCreateDiv = HTMLElement & {
 export type HTMLElementWithCreateSpan = HTMLElement & {
     createSpan(o?: string | CreateSpanOptions, callback?: (el: HTMLSpanElement) => void): HTMLSpanElement;
 };
+
+export type DocumentWithCreateDiv = Document & {
+    createDiv(o?: string | CreateDivOptions, callback?: (el: HTMLDivElement) => void): HTMLDivElement;
+};

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -93,6 +93,20 @@ globalThis.createDiv = function (
 
 /**
  * Provide the minimal Obsidian-style createDiv() behaviour in Jest
+ * for Document instances by delegating to createEl('div').
+ *
+ * Unlike HTMLElement.createDiv(), this does not append the new div anywhere.
+ */
+Document.prototype.createDiv = function (
+    this: Document,
+    o?: string | CreateDivOptions,
+    callback?: (el: HTMLDivElement) => void,
+): HTMLDivElement {
+    return createDiv(o, callback);
+};
+
+/**
+ * Provide the minimal Obsidian-style createDiv() behaviour in Jest
  * by delegating to createEl('div').
  *
  * This is a partial re-implementation of

--- a/yarn.lock
+++ b/yarn.lock
@@ -3788,10 +3788,10 @@ eslint-plugin-no-unsanitized@^4.1.5:
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.5.tgz#036c7c7ac4561ff0ee34c3d126b3b6e86037641c"
   integrity sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==
 
-eslint-plugin-obsidianmd@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.1.tgz#595f8a2784b42332bcae284c0c88cb17cbcef01f"
-  integrity sha512-Nv3593kVsFOS8kir/HWaJ5CR3xcyiPWEPyXst5Pib8mxRYYuLYPpJS2ALMoZXHulHyiGwoYW8AaxvLRc4rhrRg==
+eslint-plugin-obsidianmd@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.2.tgz#f16a9c7d82a4fa55544a3b7f324352488d7325e2"
+  integrity sha512-NFp6wsRSvN0TU6EPi03uF2UQ3GuYyVtzjKDl25KyP8Bnz8gM0unX7R/e+VQ2JtMW2/3DC/VwIXjHnzAhB9JQwg==
   dependencies:
     "@eslint-community/eslint-plugin-eslint-comments" "^4.7.2"
     "@eslint/config-helpers" "^0.4.2"


### PR DESCRIPTION
# Types of changes

Changes done by pairing with @ilandikov.

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Description

- Update to eslint-plugin-obsidianmd version 0.4.2
- Fix all instances of the following, and then turn them on to prevent future recurrences:
    - `@typescript-eslint/no-wrapper-object-types`
    - `@typescript-eslint/only-throw-error`
- Reduce the number of ESLint warnings on `src/` from 93 to 88.

## Motivation and Context

Reducing the number of problems shown in the Scorecard on community.obsidian.md:

https://community.obsidian.md/plugins/obsidian-tasks-plugin

## How has this been tested?

- Automated tests
- Checking some new behaviours manually in the Obsidian console


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
