### PR TITLE
fix: only allow Done and Cancelled dates on matching statuses

### DIFF
--- a/src/ui/DateEditor.svelte
+++ b/src/ui/DateEditor.svelte
@@ -10,6 +10,12 @@
     export let forwardOnly: boolean;
     export let accesskey: string | null;
 
+    // Set when this date is inconsistent with the selected status type - for example a
+    // Done date on a task that is not Done. It takes precedence over the parse result:
+    // if the date should not be here at all, telling the user it is unparseable points
+    // them at the wrong problem.
+    export let statusError: string | null = null;
+
     // Use this for testing purposes only
     export let parsedDate: string = '';
 
@@ -41,13 +47,15 @@
     bind:value={date}
     {id}
     type="text"
-    class:tasks-modal-error={!isDateValid}
+    class:tasks-modal-error={!isDateValid || statusError !== null}
     class="tasks-modal-date-input"
     placeholder={datePlaceholder}
     {accesskey}
 />
 
-{#if isDateValid}
+{#if statusError !== null}
+    <code class="tasks-modal-parsed-date">{dateSymbol} {@html statusError}</code>
+{:else if isDateValid}
     <div class="tasks-modal-parsed-date">
         {dateSymbol}<input
             class="tasks-modal-date-editor-picker"

--- a/src/ui/EditTask.svelte
+++ b/src/ui/EditTask.svelte
@@ -45,13 +45,22 @@
 
     let isRecurrenceValid: boolean = true;
 
+    // A Done date is only valid on a Done task, and a Cancelled date only on a
+    // Cancelled one. These are checked against the selected status rather than
+    // against each other - see EditableTask.parseAndValidateDates().
+    let doneDateError: string | null = null;
+    let cancelledDateError: string | null = null;
+    let areDatesValid: boolean = true;
+
     let withAccessKeys: boolean = true;
     let formIsValid: boolean = true;
 
     let mountComplete = false;
 
     $: accesskey = (key: string) => (withAccessKeys ? key : null);
+    $: ({ doneDateError, cancelledDateError, areDatesValid } = editableTask.parseAndValidateDates());
     $: formIsValid =
+        areDatesValid &&
         isDueDateValid &&
         isRecurrenceValid &&
         isScheduledDateValid &&
@@ -316,6 +325,7 @@ Availability of access keys:
                 dateSymbol={doneDateSymbol}
                 bind:date={editableTask.doneDate}
                 bind:isDateValid={isDoneDateValid}
+                statusError={doneDateError}
                 forwardOnly={editableTask.forwardOnly}
                 accesskey={accesskey('x')}
             />
@@ -330,6 +340,7 @@ Availability of access keys:
                 dateSymbol={cancelledDateSymbol}
                 bind:date={editableTask.cancelledDate}
                 bind:isDateValid={isCancelledDateValid}
+                statusError={cancelledDateError}
                 forwardOnly={editableTask.forwardOnly}
                 accesskey={accesskey('-')}
             />

--- a/src/ui/EditableTask.ts
+++ b/src/ui/EditableTask.ts
@@ -255,6 +255,43 @@ export class EditableTask {
         return window.moment();
     }
 
+    /**
+     * Check the Done and Cancelled dates against the selected status type.
+     *
+     * These are two independent constraints, not one rule about the pair:
+     *
+     * 1. a Done date is only meaningful when the status type is DONE
+     * 2. a Cancelled date is only meaningful when the status type is CANCELLED
+     *
+     * So a TODO task carrying either date is already inconsistent, whether or not
+     * it also carries the other one.
+     *
+     * This deliberately takes precedence over the "invalid date" message from
+     * {@link DateEditor}: if a TODO task has an unparseable Done date, asking the
+     * user to correct the date points them at the wrong problem, because the task
+     * should have no Done date at all.
+     */
+    public parseAndValidateDates() {
+        // NEW_TASK_FIELD_EDIT_REQUIRED
+        const statusType = this.status.type;
+
+        const doneDateError =
+            this.doneDate.trim() !== '' && statusType !== StatusType.DONE
+                ? `<i>a Done date requires a Done status (this task is ${statusType})</i>`
+                : null;
+
+        const cancelledDateError =
+            this.cancelledDate.trim() !== '' && statusType !== StatusType.CANCELLED
+                ? `<i>a Cancelled date requires a Cancelled status (this task is ${statusType})</i>`
+                : null;
+
+        return {
+            doneDateError,
+            cancelledDateError,
+            areDatesValid: doneDateError === null && cancelledDateError === null,
+        };
+    }
+
     public parseAndValidateRecurrence() {
         // NEW_TASK_FIELD_EDIT_REQUIRED
         if (!this.recurrenceRule) {

--- a/tests/ui/EditTask.test.ts
+++ b/tests/ui/EditTask.test.ts
@@ -573,16 +573,43 @@ describe('Task editing', () => {
 
         const line = '- [ ] simple';
 
+        // A Cancelled date is only valid on a Cancelled task, so this starts from one.
+        // Editing it on '- [ ] simple' is now blocked - see the Apply-button tests below.
         it('should edit and save cancelled date', async () => {
-            expect(await editFieldAndSave(line, 'cancelled', '2024-01-01')).toEqual('- [ ] simple ❌ 2024-01-01');
+            expect(await editFieldAndSave('- [-] simple', 'cancelled', '2024-01-01')).toEqual(
+                '- [-] simple ❌ 2024-01-01',
+            );
         });
 
         it('should edit and save created date', async () => {
             expect(await editFieldAndSave(line, 'created', '2024-01-01')).toEqual('- [ ] simple ➕ 2024-01-01');
         });
 
+        // As above: a Done date is only valid on a Done task.
         it('should edit and save done date', async () => {
-            expect(await editFieldAndSave(line, 'done', '2024-01-01')).toEqual('- [ ] simple ✅ 2024-01-01');
+            expect(await editFieldAndSave('- [x] simple', 'done', '2024-01-01')).toEqual('- [x] simple ✅ 2024-01-01');
+        });
+
+        it('should not allow saving a Done date on a task that is not Done', async () => {
+            const task = taskFromLine({ line, path: '' });
+            const { onSubmit } = constructSerialisingOnSubmit(task);
+            const { result, container } = renderAndCheckModal(task, onSubmit);
+
+            const doneDate = getAndCheckRenderedElement<HTMLInputElement>(container, 'done');
+            await fireEvent.input(doneDate, { target: { value: '2024-01-01' } });
+
+            expect(getAndCheckApplyButton(result).disabled).toEqual(true);
+        });
+
+        it('should not allow saving a Cancelled date on a task that is not Cancelled', async () => {
+            const task = taskFromLine({ line, path: '' });
+            const { onSubmit } = constructSerialisingOnSubmit(task);
+            const { result, container } = renderAndCheckModal(task, onSubmit);
+
+            const cancelledDate = getAndCheckRenderedElement<HTMLInputElement>(container, 'cancelled');
+            await fireEvent.input(cancelledDate, { target: { value: '2024-01-01' } });
+
+            expect(getAndCheckApplyButton(result).disabled).toEqual(true);
         });
 
         it('should edit and save due date', async () => {

--- a/tests/ui/EditableTask.test.ts
+++ b/tests/ui/EditableTask.test.ts
@@ -254,6 +254,117 @@ describe('EditableTask tests', () => {
     });
 });
 
+describe('parseAndValidateDates() tests', () => {
+    // Per the discussion on #2986: "a task can have both a Cancelled and a Done date"
+    // is not the fundamental error. There are two independent constraints:
+    //   1. a Done date is only valid when status.type is DONE
+    //   2. a Cancelled date is only valid when status.type is CANCELLED
+    function editableTaskWith({
+        status,
+        doneDate = '',
+        cancelledDate = '',
+    }: {
+        status: Status;
+        doneDate?: string;
+        cancelledDate?: string;
+    }) {
+        const task = new TaskBuilder().build();
+        const editableTask = EditableTask.fromTask(task, [task]);
+        editableTask.status = status;
+        editableTask.doneDate = doneDate;
+        editableTask.cancelledDate = cancelledDate;
+        return editableTask;
+    }
+
+    it('should accept a Done date when the status type is DONE', () => {
+        const { doneDateError, areDatesValid } = editableTaskWith({
+            status: Status.DONE,
+            doneDate: '2024-04-20',
+        }).parseAndValidateDates();
+
+        expect(doneDateError).toBeNull();
+        expect(areDatesValid).toEqual(true);
+    });
+
+    it('should accept a Cancelled date when the status type is CANCELLED', () => {
+        const { cancelledDateError, areDatesValid } = editableTaskWith({
+            status: Status.CANCELLED,
+            cancelledDate: '2024-04-21',
+        }).parseAndValidateDates();
+
+        expect(cancelledDateError).toBeNull();
+        expect(areDatesValid).toEqual(true);
+    });
+
+    it.each([
+        ['TODO', Status.TODO],
+        ['IN_PROGRESS', Status.IN_PROGRESS],
+        ['ON_HOLD', Status.ON_HOLD],
+        ['NON_TASK', Status.NON_TASK],
+        ['CANCELLED', Status.CANCELLED],
+    ])('should reject a Done date when the status type is %s', (_name, status) => {
+        const { doneDateError, areDatesValid } = editableTaskWith({
+            status,
+            doneDate: '2024-04-20',
+        }).parseAndValidateDates();
+
+        expect(doneDateError).not.toBeNull();
+        expect(areDatesValid).toEqual(false);
+    });
+
+    it.each([
+        ['TODO', Status.TODO],
+        ['IN_PROGRESS', Status.IN_PROGRESS],
+        ['ON_HOLD', Status.ON_HOLD],
+        ['NON_TASK', Status.NON_TASK],
+        ['DONE', Status.DONE],
+    ])('should reject a Cancelled date when the status type is %s', (_name, status) => {
+        const { cancelledDateError, areDatesValid } = editableTaskWith({
+            status,
+            cancelledDate: '2024-04-21',
+        }).parseAndValidateDates();
+
+        expect(cancelledDateError).not.toBeNull();
+        expect(areDatesValid).toEqual(false);
+    });
+
+    it('should reject both dates on a task that is neither done nor cancelled', () => {
+        // The original report: a task saved as not-started, cancelled and done at once.
+        const { doneDateError, cancelledDateError, areDatesValid } = editableTaskWith({
+            status: Status.TODO,
+            doneDate: '2024-04-20',
+            cancelledDate: '2024-04-21',
+        }).parseAndValidateDates();
+
+        expect(doneDateError).not.toBeNull();
+        expect(cancelledDateError).not.toBeNull();
+        expect(areDatesValid).toEqual(false);
+    });
+
+    it('should report the status mismatch, not the parse error, for an unparseable date on the wrong status', () => {
+        // Raised in review: with a TODO status and an unparseable Done date, telling the
+        // user to fix the date is the wrong advice — there should be no Done date at all
+        // for this status, so that error has to take precedence.
+        const { doneDateError } = editableTaskWith({
+            status: Status.TODO,
+            doneDate: 'not a date',
+        }).parseAndValidateDates();
+
+        expect(doneDateError).not.toBeNull();
+        expect(doneDateError).not.toMatch(/invalid/i);
+    });
+
+    it('should accept a task with no Done or Cancelled date at all', () => {
+        const { doneDateError, cancelledDateError, areDatesValid } = editableTaskWith({
+            status: Status.TODO,
+        }).parseAndValidateDates();
+
+        expect(doneDateError).toBeNull();
+        expect(cancelledDateError).toBeNull();
+        expect(areDatesValid).toEqual(true);
+    });
+});
+
 describe('parseAndValidateRecurrence() tests', () => {
     const emptyTask = new TaskBuilder().description('').build();
 


### PR DESCRIPTION
### Related Issues

- fixes #2986

### Proposed Changes:

**What caused it.** `EditableTask.applyEdits()` passed the Done and Cancelled date fields straight through to the new `Task`, with nothing checking them against the selected status. A task could be saved as not-started, cancelled and done at once:

```text
- [ ] a task ❌ 2024-04-21 ✅ 2024-04-20
```

**How it is fixed.** Following @claremacrae's framing in the issue, this treats them as two independent constraints rather than one rule about the pair:

1. a Done date is only meaningful when `status.type` is `DONE`
2. a Cancelled date is only meaningful when `status.type` is `CANCELLED`

That matters — a Done date on an `IN_PROGRESS` task is just as wrong as one sitting alongside a Cancelled date, and checking only for "both dates present" would miss it.

`EditableTask.parseAndValidateDates()` returns `{ doneDateError, cancelledDateError, areDatesValid }`, mirroring the existing `parseAndValidateRecurrence()`. `EditTask.svelte` folds `areDatesValid` into `formIsValid` so **Apply is disabled** while either constraint is violated, rather than resolving the conflict on save — which would silently discard a date the user had typed.

`DateEditor.svelte` gains an optional `statusError` prop. When set it marks the field and **takes precedence over the parse result**, which covers the case you raised: with a TODO status and an unparseable Done date, telling the user to correct the date points them at the wrong problem, because there should be no Done date there at all. A test asserts the message is not the "invalid" one.

### ⚠️ Two existing tests changed — please look at this first

`should edit and save cancelled date` and `should edit and save done date` both edited those dates on `- [ ] simple`, a TODO task, and asserted the save succeeded. Under constraint 1 and 2 that save is now correctly blocked, so both timed out waiting for a submit that will never come.

This is the intended consequence of the constraints rather than a defect in the change, but it does mean the rule invalidates behaviour the suite previously guaranteed. I changed them to start from `- [x] simple` and `- [-] simple`, which preserves what they were actually testing — that a typed date round-trips into the saved line — and added two new tests asserting the Apply button is disabled in the old scenarios. If you would rather they had stayed as they were, that is a signal the constraint needs narrowing, and I would rather hear that than have quietly rewritten them.

### How did you test it?

Unit tests in `tests/ui/EditableTask.test.ts` — 15 new cases, parametrised across all six status types, covering both constraints in both directions, the original both-dates report, the precedence case above, and the no-dates case.

UI tests in `tests/ui/EditTask.test.ts` — the two amended tests, plus two asserting Apply is disabled when a Done or Cancelled date is set on a task that is neither.

Full local run on Windows 11, Node 24.19.0:

- `yarn run test` — **5,022 passed, 1 failed, 260 snapshots passed**. The single failure is `MockDataLoader › should provide the path to the JSON file`, which asserts a forward-slash path and so fails on Windows; it fails identically on an unmodified `main`, and is unrelated to this change.
- `yarn run lint:no-fix` — clean (eslint, `tsc --noEmit`, `svelte-check`: 0 errors, 0 warnings)
- `yarn run build` — succeeds

### Notes for the reviewer

**On which fields to show in red** — you suggested exploratory testing to decide between the date field, the Status dropdown, and the Status Type indicator. I don't have Obsidian installed, so I could not run that, and I did not want to guess at a UI decision you had explicitly flagged as needing hands-on judgement. This marks **only the offending date field**, exactly as `RecurrenceEditor` does. If experimenting shows the status controls should also be marked, that is a small follow-up and I am happy to do it — or say the word and I will leave it to you.

The error text is currently e.g. *"a Done date requires a Done status (this task is TODO)"*. Wording is easy to change if you would prefer something else.

### Checklist

- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the conventional commit types for my PR title: `fix:`
- [x] I documented my code
- [ ] I ran pre-commit hooks — not installed locally; I ran `lint:no-fix`, `test` and `build` directly, as the CI workflow does

---

*Written with AI assistance (Claude), which you'd anticipated. I reproduced the original behaviour locally, implemented and reviewed the change, and ran the checks above before opening this. Errors are mine.*
