### PR TITLE
feat: regroup new settings layout

### DIFF
--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -221,7 +221,6 @@ export class SettingsTab extends PluginSettingTab {
 
     public getSettingDefinitions(): SettingDefinitionItem[] {
         return [
-            this.taskFormatDefinition(),
             this.globalDefaultsGroup(),
             this.searchesGroup(),
             this.datesGroup(),
@@ -233,7 +232,7 @@ export class SettingsTab extends PluginSettingTab {
 
     // ---- Task format (general, no heading) --------------------------------
 
-    private taskFormatDefinition(): SettingDefinitionItem {
+    private taskFormatDefinition(): SettingGroupItem {
         return {
             name: i18n.t('settings.format.name'),
             desc: SettingsTab.createFragmentWithHTML(
@@ -265,6 +264,7 @@ export class SettingsTab extends PluginSettingTab {
             type: 'group',
             heading: i18n.t('settings.globalDefaults.heading'),
             items: [
+                this.taskFormatDefinition(),
                 {
                     name: i18n.t('settings.globalFilter.filter.name'),
                     // Group headings are not searchable, so the first row in

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -315,18 +315,6 @@ export class SettingsTab extends PluginSettingTab {
                         });
                     }),
                 },
-                {
-                    name: i18n.t('settings.globalQuery.heading'),
-                    desc: i18n.t('settings.globalQuery.query.shortDescription'),
-                    render: this.withDocs((setting) => {
-                        setting.addExtraButton((btn) =>
-                            btn
-                                .setIcon('pencil')
-                                .setTooltip(i18n.t('common.edit'))
-                                .onClick(() => this.openGlobalQueryModal()),
-                        );
-                    }, 'https://publish.obsidian.md/tasks/Queries/Global+Query'),
-                },
             ],
         };
     }
@@ -347,6 +335,18 @@ export class SettingsTab extends PluginSettingTab {
             type: 'group',
             heading: i18n.t('settings.searches.heading'),
             items: [
+                {
+                    name: i18n.t('settings.globalQuery.heading'),
+                    desc: i18n.t('settings.globalQuery.query.shortDescription'),
+                    render: this.withDocs((setting) => {
+                        setting.addExtraButton((btn) =>
+                            btn
+                                .setIcon('pencil')
+                                .setTooltip(i18n.t('common.edit'))
+                                .onClick(() => this.openGlobalQueryModal()),
+                        );
+                    }, 'https://publish.obsidian.md/tasks/Queries/Global+Query'),
+                },
                 {
                     name: i18n.t('settings.searches.enableCustomSearches.name'),
                     desc: SettingsTab.createFragmentWithHTML(

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -262,14 +262,10 @@ export class SettingsTab extends PluginSettingTab {
     private globalDefaultsGroup(): SettingDefinitionItem {
         return {
             type: 'group',
-            heading: i18n.t('settings.globalDefaults.heading'),
             items: [
                 this.taskFormatDefinition(),
                 {
                     name: i18n.t('settings.globalFilter.filter.name'),
-                    // Group headings are not searchable, so the first row in
-                    // the group carries the heading as a search alias.
-                    aliases: [i18n.t('settings.globalDefaults.heading')],
                     desc: SettingsTab.createFragmentWithHTML(
                         `<p><b>${i18n.t('settings.globalFilter.filter.description.line1')}</b></p>` +
                             `<p>${i18n.t('settings.globalFilter.filter.description.line2')}</p>` +

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -9,6 +9,7 @@ import {
     Setting,
     type SettingDefinition,
     type SettingDefinitionItem,
+    type SettingGroupItem,
     type ToggleComponent,
     debounce,
     requireApiVersion,
@@ -223,7 +224,6 @@ export class SettingsTab extends PluginSettingTab {
             this.taskFormatDefinition(),
             this.globalDefaultsGroup(),
             this.searchesGroup(),
-            this.presetsPage(),
             this.statusesPage(),
             this.datesGroup(),
             this.datesFromFilenamesGroup(),
@@ -335,6 +335,7 @@ export class SettingsTab extends PluginSettingTab {
             type: 'group',
             heading: i18n.t('settings.searches.heading'),
             items: [
+                this.presetsPage(),
                 {
                     name: i18n.t('settings.globalQuery.heading'),
                     desc: i18n.t('settings.globalQuery.query.shortDescription'),
@@ -476,7 +477,7 @@ export class SettingsTab extends PluginSettingTab {
 
     // ---- Presets (sub-page) ----------------------------------------------
 
-    private presetsPage(): SettingDefinitionItem {
+    private presetsPage(): SettingGroupItem {
         return {
             type: 'page',
             name: i18n.t('settings.presets.name'),

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -224,7 +224,6 @@ export class SettingsTab extends PluginSettingTab {
             this.taskFormatDefinition(),
             this.globalDefaultsGroup(),
             this.searchesGroup(),
-            this.statusesPage(),
             this.datesGroup(),
             this.datesFromFilenamesGroup(),
             this.recurringTasksGroup(),
@@ -315,6 +314,7 @@ export class SettingsTab extends PluginSettingTab {
                         });
                     }),
                 },
+                this.statusesPage(),
             ],
         };
     }
@@ -499,7 +499,7 @@ export class SettingsTab extends PluginSettingTab {
 
     // ---- Statuses (sub-page) ---------------------------------------------
 
-    private statusesPage(): SettingDefinitionItem {
+    private statusesPage(): SettingGroupItem {
         const { statusSettings } = getSettings();
 
         // Lets the custom-statuses search filter on the status symbol, name and type.

--- a/src/i18n/locales/be.json
+++ b/src/i18n/locales/be.json
@@ -202,9 +202,6 @@
       },
       "name": "Фармат задачы"
     },
-    "globalDefaults": {
-      "heading": ""
-    },
     "globalFilter": {
       "filter": {
         "description": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -202,9 +202,6 @@
       },
       "name": "Aufgabenformat"
     },
-    "globalDefaults": {
-      "heading": ""
-    },
     "globalFilter": {
       "filter": {
         "description": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -202,9 +202,6 @@
       },
       "name": "Task format"
     },
-    "globalDefaults": {
-      "heading": "Global defaults"
-    },
     "globalFilter": {
       "filter": {
         "description": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -202,9 +202,6 @@
       },
       "name": "Formato de tarea"
     },
-    "globalDefaults": {
-      "heading": ""
-    },
     "globalFilter": {
       "filter": {
         "description": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -202,9 +202,6 @@
       },
       "name": "Format de tâche"
     },
-    "globalDefaults": {
-      "heading": ""
-    },
     "globalFilter": {
       "filter": {
         "description": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -202,9 +202,6 @@
       },
       "name": "작업 형식"
     },
-    "globalDefaults": {
-      "heading": ""
-    },
     "globalFilter": {
       "filter": {
         "description": {

--- a/src/i18n/locales/pt_br.json
+++ b/src/i18n/locales/pt_br.json
@@ -202,9 +202,6 @@
       },
       "name": "Formato da Tarefa"
     },
-    "globalDefaults": {
-      "heading": ""
-    },
     "globalFilter": {
       "filter": {
         "description": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -202,9 +202,6 @@
       },
       "name": "Формат задач"
     },
-    "globalDefaults": {
-      "heading": ""
-    },
     "globalFilter": {
       "filter": {
         "description": {

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -202,9 +202,6 @@
       },
       "name": "Görev Biçimi"
     },
-    "globalDefaults": {
-      "heading": ""
-    },
     "globalFilter": {
       "filter": {
         "description": {

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -202,9 +202,6 @@
       },
       "name": "Формат задач"
     },
-    "globalDefaults": {
-      "heading": ""
-    },
     "globalFilter": {
       "filter": {
         "description": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -202,9 +202,6 @@
       },
       "name": "Định dạng nhiệm vụ"
     },
-    "globalDefaults": {
-      "heading": ""
-    },
     "globalFilter": {
       "filter": {
         "description": {

--- a/src/i18n/locales/zh_cn.json
+++ b/src/i18n/locales/zh_cn.json
@@ -202,9 +202,6 @@
       },
       "name": "任务格式"
     },
-    "globalDefaults": {
-      "heading": ""
-    },
     "globalFilter": {
       "filter": {
         "description": {


### PR DESCRIPTION
# Types of changes

Done by pairing with @claremacrae 

Changes visible to users:

- [x] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
  - Issue/discussion: None - minor refinements to PR #3955

## Description

This moves related settings sections closer together.

## Motivation and Context

This just makes some minor changes to the code in #3955, so the order of settings feels a bit more logical.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Building and running the plugin in Obsidian, locally.

## Screenshots (if appropriate)

This pair of screenshots shows the elements that have been moved or deleted:

<img width="1419" height="1412" alt="image" src="https://github.com/user-attachments/assets/320bef07-c627-4114-8d2d-013636e734db" />


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://publish.obsidian.md/tasks-contributing/Documentation/About+Documentation) accordingly.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] I am a human submitting this, not an AI, and I have reviewed the changes to ensure that I understand them and could maintain them myself.
- [x] If this PR changes any code in the `src/` directory other than non-trivial typo errors, I have installed the built plugin in an Obsidian vault and tested these changes myself.
- [x] This Pull Request is created from the Pull Request [template](https://raw.githubusercontent.com/obsidian-tasks-group/obsidian-tasks/refs/heads/main/.github/pull_request_template.md), and I have not deleted or reordered any sections from it.
- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
