### PR TITLE
refactor: avoid memory leaks on Svelte modals

### DIFF
--- a/src/Obsidian/OptionsModal.ts
+++ b/src/Obsidian/OptionsModal.ts
@@ -17,6 +17,7 @@ export interface OptionsModalParams {
  */
 export class OptionsModal extends Modal {
     private readonly onSave: () => void;
+    private _modalOptionsEditorComponent: ModalOptionsEditor | undefined;
 
     constructor({ app, onSave }: OptionsModalParams) {
         super(app);
@@ -30,7 +31,7 @@ export class OptionsModal extends Modal {
 
         const { contentEl } = this;
 
-        new ModalOptionsEditor({
+        this._modalOptionsEditorComponent = new ModalOptionsEditor({
             target: contentEl,
             props: {
                 onSave: () => {
@@ -46,6 +47,8 @@ export class OptionsModal extends Modal {
     }
 
     public onClose(): void {
+        this._modalOptionsEditorComponent?.$destroy();
+        this._modalOptionsEditorComponent = undefined;
         const { contentEl } = this;
         contentEl.empty();
     }

--- a/src/Obsidian/TaskModal.ts
+++ b/src/Obsidian/TaskModal.ts
@@ -21,6 +21,7 @@ export class TaskModal extends Modal {
     public readonly onSaveSettings: () => Promise<void>;
     public readonly onSubmit: (updatedTasks: Task[]) => void;
     public readonly allTasks: Task[];
+    private _editTaskComponent: EditTask | undefined;
 
     constructor({ app, task, onSaveSettings, onSubmit, onCancel, allTasks }: TaskModalParams) {
         super(app);
@@ -65,7 +66,7 @@ export class TaskModal extends Modal {
 
         const statusOptions = this.getKnownStatusesAndCurrentTaskStatusIfNotKnown();
 
-        new EditTask({
+        this._editTaskComponent = new EditTask({
             target: contentEl,
             props: {
                 task: this.task,
@@ -91,6 +92,8 @@ export class TaskModal extends Modal {
     }
 
     public onClose(): void {
+        this._editTaskComponent?.$destroy();
+        this._editTaskComponent = undefined;
         const { contentEl } = this;
         contentEl.empty();
     }


### PR DESCRIPTION
# Types of changes

Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)

## Description

The current modal closing code remove the DOM object from the view:

```ts
        const { contentEl } = this;
        contentEl.empty();
```

But nothing is actually destroying these objects in the DOM tree. This PR fixes that.

## Motivation and Context

- Avoid memory leaks

## How has this been tested?

Manual test in demo vault.

Preparation:
1. Open dev tools
2. Go to memory tab
3. Make a snapshot

Test:
1. Open and close modal several times
2. Make a snapshot of memory, filter by selecting objects allocated after the snapshot done at preparation

Task Edit modal before fix:
<img width="672" height="971" alt="Снимок экрана — 2026-09-04 в 07 49 27" src="https://github.com/user-attachments/assets/0e4318cf-7e7e-4599-9cf3-c9d5ad9986f8" />

Task Edit modal after fix:
<img width="720" height="570" alt="Снимок экрана — 2026-09-04 в 07 52 21" src="https://github.com/user-attachments/assets/1b0210a0-c70d-452d-9d38-77e19f4aaa3e" />

Options modal before fix:
<img width="203" height="147" alt="Снимок экрана — 2026-09-04 в 09 35 07" src="https://github.com/user-attachments/assets/37e94cf6-72fb-4d0e-a066-b429daaa104f" />

Options modal after fix:
_same objects not found_ (I probably should have been looking for some kind of objects for Task Edit modal)

## Checklist

- [x] My code changes are on a branch, and not on the `main` branch.
- [x] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).
    - No, hence the manual testing

## Terms

- [x] I am a human submitting this, not an AI, and I have reviewed the changes to ensure that I understand them and could maintain them myself.
- [x] If this PR changes any code in the `src/` directory other than non-trivial typo errors, I have installed the built plugin in an Obsidian vault and tested these changes myself.
- [x] This Pull Request is created from the Pull Request [template](https://raw.githubusercontent.com/obsidian-tasks-group/obsidian-tasks/refs/heads/main/.github/pull_request_template.md), and I have not deleted or reordered any sections from it.
- [x] My contribution follows this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
